### PR TITLE
Add /about.html with author disclosure

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
+<!-- End Google Tag Manager -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-ZK1KEJT3KX');
+</script>
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="color-scheme" content="light dark">
+<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
+<title>About this site - Marblehead Budget Data</title>
+<link rel="icon" href="favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="assets/site.css">
+</head>
+<body>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+<div class="page">
+  <a class="back" href="./">&larr; marbleheaddata.org</a>
+
+  <h1>About this site</h1>
+
+  <p>I'm Andrew Baber. I've lived in Marblehead for about eight years, long enough to own a home and send my daughter to first grade at Glover. I'm a software engineer by trade, and the kind of person whose job involves coming up to speed fast on subjects I don't know well. I'm not on the Select Board, the Finance Committee, or any other town body. My stakes in the override outcome are the ones every Marblehead homeowner and parent has, and nothing beyond that.</p>
+
+  <p>This vote matters. I wanted to know how we got here and what the result would actually mean before voting on it. So I started digging, and the site is what I found: primary sources, arguments from every side, and my own corrections when I got something wrong.</p>
+
+  <p>The more I dig, the more I see we need. More data. More transparency. More reason to trust or distrust the people making decisions for us. Tax dollars should be spent well, even when that means less for my daughter's school. But "well" is the hard part. Is this about cuts we could make, or costs rising faster than revenue? I honestly don't know.</p>
+
+  <p>Every number on the site traces to a primary source: town budgets, Finance Committee reports, state DOR filings, Massachusetts General Laws, or named reporting from the Marblehead Current, Independent, or Itemlive. An AI assistant (Claude) does the research and drafts the pages. I review before publishing. I don't personally re-verify every source against the original document, so errors are possible. When I find one, or a reader catches one, the page gets updated.</p>
+
+  <p>If you find something that's wrong, tell me. The fastest way is through my personal site at <a href="https://babersway.com">babersway.com</a>. I'd rather fix an error than win an argument.</p>
+</div>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 
   <div class="footer">
-    <p>Built by a Marblehead resident. <a href="https://github.com/agbaber/marblehead">Source on GitHub</a>. Corrections welcome.</p>
+    <p>Built by a Marblehead resident. <a href="about.html">About this site</a>. <a href="https://github.com/agbaber/marblehead">Source on GitHub</a>. Corrections welcome.</p>
     <p>Last updated April 10, 2026.</p>
   </div>
 </div>


### PR DESCRIPTION
Personal introduction, motivation for the site, the two open questions driving it ("cuts we could make" vs "costs rising faster than revenue"), an honest AI-use disclosure that names Claude and acknowledges the author does not personally re-verify every primary source, and a corrections contact through babersway.com.

Linked from the homepage footer.