### PR TITLE
Redesign about page: four sections, cost transparency, licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,65 @@
+Marblehead Budget Data — Licensing
+
+This repository is dual-licensed:
+
+  Code (HTML, CSS, JavaScript, build scripts, configuration) — MIT License
+  Content (writing, charts, analysis, data compilations) — CC BY 4.0
+
+----------------------------------------------------------------------------
+MIT License (code)
+----------------------------------------------------------------------------
+
+Copyright (c) 2026 Andrew Baber
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+----------------------------------------------------------------------------
+Creative Commons Attribution 4.0 International (content)
+----------------------------------------------------------------------------
+
+Copyright (c) 2026 Andrew Baber
+
+The written content, charts, analysis, and data compilations on this site
+are licensed under a Creative Commons Attribution 4.0 International License.
+
+You are free to:
+  Share  — copy and redistribute the material in any medium or format
+  Adapt  — remix, transform, and build upon the material for any purpose,
+           even commercially
+
+Under the following terms:
+  Attribution — You must give appropriate credit, provide a link to the
+                license, and indicate if changes were made.
+  No additional restrictions — You may not apply legal terms or technological
+                               measures that legally restrict others from
+                               doing anything the license permits.
+
+Full legal text: https://creativecommons.org/licenses/by/4.0/legalcode
+Summary:         https://creativecommons.org/licenses/by/4.0/
+
+----------------------------------------------------------------------------
+Third-party material
+----------------------------------------------------------------------------
+
+Primary-source documents linked or referenced on this site (town budgets,
+Finance Committee reports, state DOR filings, news articles from the
+Marblehead Current, Marblehead Independent, Itemlive, and others) remain
+the property of their original publishers and are not covered by this
+license. Links and fair-use excerpts are provided for informational and
+civic purposes.

--- a/about.html
+++ b/about.html
@@ -36,15 +36,38 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
   <h1>About this site</h1>
 
-  <p>I'm Andrew Baber. I've lived in Marblehead for about eight years, long enough to own a home and send my daughter to first grade at Glover. I'm a software engineer by trade, and the kind of person whose job involves coming up to speed fast on subjects I don't know well. I'm not on the Select Board, the Finance Committee, or any other town body. My stakes in the override outcome are the ones every Marblehead homeowner and parent has, and nothing beyond that.</p>
+  <h2>About me</h2>
+  <p>Andrew Baber. Marblehead homeowner about eight years. Daughter in first grade at Glover. Software engineer. Not on the Select Board, Finance Committee, or any other town body.</p>
 
-  <p>This vote matters. I wanted to know how we got here and what the result would actually mean before voting on it. So I started digging, and the site is what I found: primary sources, arguments from every side, and my own corrections when I got something wrong.</p>
+  <h2>About the site</h2>
+  <p>This vote matters. I wanted to know how we got here and what it would actually mean before voting. Is this about cuts we could make, or costs rising faster than revenue? I honestly don't know. The site is where I'm working that out.</p>
+  <p>Open source on <a href="https://github.com/agbaber/marblehead">GitHub</a>. Code licensed under <a href="https://opensource.org/licenses/MIT">MIT</a>; content under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
 
-  <p>The more I dig, the more I see we need. More data. More transparency. More reason to trust or distrust the people making decisions for us. Tax dollars should be spent well, even when that means less for my daughter's school. But "well" is the hard part. Is this about cuts we could make, or costs rising faster than revenue? I honestly don't know.</p>
+  <h2>About AI usage</h2>
+  <p>An AI assistant (Claude) handles research, analysis, and the site's digital infrastructure. I regularly remind it to stay as neutral as possible, and I own and operate everything it produces. Every number traces to a primary source, but I don't re-verify each one against the original document myself. Errors are possible. When I find one, or a reader catches one, the page gets updated.</p>
 
-  <p>Every number on the site traces to a primary source: town budgets, Finance Committee reports, state DOR filings, Massachusetts General Laws, or named reporting from the Marblehead Current, Independent, or Itemlive. An AI assistant (Claude) does the research and drafts the pages. I review before publishing. I don't personally re-verify every source against the original document, so errors are possible. When I find one, or a reader catches one, the page gets updated.</p>
+  <h2>What this costs</h2>
+  <div class="card">
+    <div class="cut-item">
+      <span class="cut-item-name">Domain registration</span>
+      <span class="cut-item-amount">~$8/year</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">GitHub Pages hosting</span>
+      <span class="cut-item-amount">Free</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">AI assistant subscription<span class="cut-item-note">A tool I already pay for; not tracked as a site-specific cost.</span></span>
+      <span class="cut-item-amount">Not tracked</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">Advertising, donations, outside funding</span>
+      <span class="cut-item-amount">None</span>
+    </div>
+  </div>
+  <p>I'll update this as the bill changes.</p>
 
-  <p>If you find something that's wrong, tell me. The fastest way is through my personal site at <a href="https://babersway.com">babersway.com</a>. I'd rather fix an error than win an argument.</p>
+  <p><strong>Found a mistake?</strong> Reach me through <a href="https://babersway.com">babersway.com</a>. I'd rather fix an error than win an argument.</p>
 </div>
 
 </body>


### PR DESCRIPTION
Replaces the initial prose-heavy draft (~380 words) with a structured four-section layout (~200 words):

- "About me" — minimal identification (name, homeowner status, daughter at Glover, career, no town roles)
- "About the site" — motivation framed as the two-diagnosis question (cuts we could make vs costs rising faster than revenue), open-source status, license references
- "About AI usage" — honest division of labor: Claude handles research, analysis, and digital infrastructure; author owns and operates and reviews but does not personally re-verify every primary source
- "What this costs" — transparency card listing domain (~$8/year), hosting (free), AI subscription (not tracked, pre-existing tool), and explicit "no ads, donations, or outside funding"

Add LICENSE file with dual license: MIT for code, CC BY 4.0 for content. Note that third-party primary sources remain the property of their publishers.