### PR TITLE
Remove AI subscription row from about page costs card

### DIFF
--- a/about.html
+++ b/about.html
@@ -57,10 +57,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <span class="cut-item-amount">Free</span>
     </div>
     <div class="cut-item">
-      <span class="cut-item-name">AI assistant subscription<span class="cut-item-note">A tool I already pay for; not tracked as a site-specific cost.</span></span>
-      <span class="cut-item-amount">Not tracked</span>
-    </div>
-    <div class="cut-item">
       <span class="cut-item-name">Advertising, donations, outside funding</span>
       <span class="cut-item-amount">None</span>
     </div>


### PR DESCRIPTION
The $100/month Claude subscription is a general-purpose tool, not a site-specific operating cost. Listing it invites "why are you spending so much" derails that work against the trust purpose of the costs card. Drop the row entirely; domain, hosting, and "no outside funding" still make the transparency point.