### PR TITLE
Add /how-we-got-here.html page tracing the seven-year FinCom warning arc

### DIFF
--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
+<!-- End Google Tag Manager -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-ZK1KEJT3KX');
+</script>
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="color-scheme" content="light dark">
+<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
+<title>How did we get here? - Marblehead Budget Data</title>
+<link rel="icon" href="favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="assets/site.css">
+</head>
+<body>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+<div class="page">
+  <a class="back" href="./">&larr; marbleheaddata.org</a>
+
+  <h1>How did we get here?</h1>
+  <p>The FY27 override vote is not a surprise. It was forecast, warned about, and predicted in writing by Marblehead's Finance Committee for years. Reading FinCom's own annual transmittal letters to Town Meeting, there is a clean arc from "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025. This page traces that arc in FinCom's own words.</p>
+
+  <div class="takeaway takeaway--pos">
+    The "board always wants more" skepticism does not fit the record. For sixteen consecutive years the Finance Committee actively did not ask for an override, and said so each year in writing. The shift from 2019 onward tracks real changes in the underlying math, not a shift in FinCom's appetite.
+  </div>
+
+  <h2>2005 to 2021: Sixteen years of balanced budgets</h2>
+  <p>Marblehead's last successful operating override was approved in FY2005. For the sixteen fiscal years that followed, the Finance Committee reported balanced budgets and explicitly celebrated the absence of overrides as evidence of disciplined management.</p>
+  <p>The 2016 transmittal letter (for the FY17 budget) is typical of the period:</p>
+
+  <blockquote class="quote">
+    <p>"The Finance Committee is pleased to report that we will present to you a balanced budget recommendation for the eleventh consecutive year without proposing a general override of Proposition 2&frac12; to achieve that balance... Her breakdown offered a number of positive factors consistent with a well-managed budget: conservative revenue estimates and no budget deficits across the Town departments and enterprises."</p>
+    <footer>2016 Finance Committee Annual Report, transmittal letter to the 2016 Annual Town Meeting (for the FY17 budget). <a href="data/2016_FinCom_Report.pdf">PDF</a>.</footer>
+  </blockquote>
+
+  <p>Five years later the count had reached sixteen. From the 2021 transmittal letter (for the FY22 budget):</p>
+
+  <blockquote class="quote">
+    <p>"The Finance Committee is pleased to report that we will present to you a balanced budget recommendation for the sixteenth consecutive year without proposing a general override of Proposition 2&frac12; to achieve that balance."</p>
+    <footer>2021 Finance Committee Annual Report, transmittal letter to the 2021 Annual Town Meeting (for the FY22 budget). <a href="data/2021_FinCom_Report.pdf">PDF</a>.</footer>
+  </blockquote>
+
+  <p>This matters because it rebuts the reasonable skepticism that FinCom always wants more money. For sixteen consecutive years, they actively did not. They reported balanced budgets, celebrated the no-override streak, and told residents the town was well-managed.</p>
+
+  <h2>2019: The first signal</h2>
+  <p>The tone began to shift in the 2019 transmittal letter (for the FY20 budget), which introduced a phrase that had not appeared in earlier letters:</p>
+
+  <blockquote class="quote">
+    <p>"This budget cycle was undertaken in an almost unprecedented financial context. Our Town Administrator ascertained that the Town's reliance on free cash to help balance the budget has become unsustainable. In response he asked for and received considerable support from departments to scrub their budgets for savings."</p>
+    <footer>2019 Finance Committee Annual Report, transmittal letter to the 2019 Annual Town Meeting (for the FY20 budget). <a href="data/2019_FinCom_Report.pdf">PDF</a>.</footer>
+  </blockquote>
+
+  <p>No mention of "override" yet. No specific future year named. But "unsustainable" was doing real work. Something had changed in the underlying math.</p>
+
+  <h2>2022: The first explicit warning</h2>
+  <p>Three years later, the 2022 transmittal letter (for the FY23 budget) broke the sixteen-year streak of reassuring language and told residents in writing that an override was coming:</p>
+
+  <blockquote class="quote">
+    <p>"Based on forecasts prepared by Town Finance and presented in January at the annual 'State of the Town' public meeting, it is expected that next year's Fiscal Year 2024 budget, adjusted for all contractual obligations, will not balance without an operating budget proposition 2&frac12; override... These factors are leading to a situation where an operating budget override will likely be required next year to maintain a 'level services' budget. Put differently, Marblehead will likely require an override next year to simply maintain the same Town and School services that residents currently receive."</p>
+    <footer>2022 Finance Committee Annual Report, transmittal letter to the 2022 Annual Town Meeting (for the FY23 budget). <a href="data/2022_FinCom_Report.pdf">PDF</a>.</footer>
+  </blockquote>
+
+  <p>This is the first explicit override prediction in the local record. FinCom told residents an override was coming next year. They were right.</p>
+
+  <h2>2023: The failed override</h2>
+  <p>The next year, the 2023 transmittal letter (for the FY24 budget) delivered the promised override request:</p>
+
+  <blockquote class="quote">
+    <p>"The Finance Committee will present to you a 'reduced services' balanced budget recommendation included in Article 30. Additionally, for the first time since 2005, the Town is recommending a $2.5 million Proposition 2&frac12; override in Article 31 to bring all town departments back up to their 'level service' budget requests."</p>
+    <footer>2023 Finance Committee Annual Report, transmittal letter to the 2023 Annual Town Meeting (for the FY24 budget). <a href="data/2023_FinCom_Report.pdf">PDF</a>.</footer>
+  </blockquote>
+
+  <p>Town Meeting approved the override 534 to 230. It failed at the ballot, 2,992 to 3,399, by a margin of roughly 400 votes. The FY24 budget was delivered as a "reduced services" version instead.</p>
+
+  <h2>2024 and 2025: The structural deficit continues</h2>
+  <p>With the FY24 override defeated at the ballot, the next two transmittal letters continued the warning, each time with more specificity. From the 2024 letter (for the FY25 budget):</p>
+
+  <blockquote class="quote">
+    <p>"Over the past few years, we have consistently highlighted the fact that Marblehead faces a structural deficit where recurring expenses are outpacing recurring revenues... While there is no override request included in this year's Warrant, the Finance Committee anticipates the possibility of such a request being deliberated in the near future. It is not practical to continue reducing level-service budgets year after year to achieve balance."</p>
+    <footer>2024 Finance Committee Annual Report, transmittal letter to the 2024 Annual Town Meeting (for the FY25 budget). <a href="data/2025_FinCom_Report.pdf">PDF</a>.</footer>
+  </blockquote>
+
+  <p>From the 2025 letter (for the FY26 budget), the first-ever three-year operating budget forecast named FY26, FY27, and FY28 as projected deficit years:</p>
+
+  <blockquote class="quote">
+    <p>"At last year's town meeting, the Finance Committee committed to extending our assistance as advisers to our Town leaders in the development of a long-term strategy. This ongoing effort commenced last August with our support of Town leadership in creating a comprehensive three-year forecast for the general fund operating budget... The independent presentations of the three-year operating budget forecast to both the Select Board and the Finance Committee in early December highlighted projected deficits for each of the FY26, FY27, and FY28 periods... Considering both of these measures [free cash and revised local receipts estimates] are one-time adjustments, the Finance Committee anticipates that the projected revenue growth for FY27 will be considerably less than the 6% growth experienced in FY26, leading to significant budgetary challenges ahead."</p>
+    <footer>2025 Finance Committee Annual Report, transmittal letter to the 2025 Annual Town Meeting (for the FY26 budget). <a href="data/FY2026_FinCom_Annual_Report.pdf">PDF</a>.</footer>
+  </blockquote>
+
+  <h2>2026: The vote before us</h2>
+  <p>Here we are. The deficit the Finance Committee first signaled in 2019, explicitly predicted in 2022, partially delivered in 2023 (and defeated at the ballot), continued warning about in 2024, and specifically named for FY27 in 2025 is now on the June 2026 ballot as a three-tier override ranging from $9 million to $15 million. Residents have had roughly seven years of warning, four years of explicit deficit predictions, and three years since the first override attempt was defeated.</p>
+
+  <h2>Key terms and context</h2>
+
+  <div class="term">
+    <p><strong>Finance Committee transmittal letter</strong> -- The signed introduction to the Finance Committee's annual report, addressed "To the Residents of Marblehead," presented in the book distributed to every Town Meeting attendee. The content is the FinCom's official recommendation and context for the coming fiscal year's budget, signed by the Chair and Vice Chairs.</p>
+  </div>
+  <div class="term">
+    <p><strong>Free cash</strong> -- Surplus from prior years, certified annually by the state Department of Revenue. Used to supplement the operating budget. The town has been using $7M-$9M of free cash annually in recent years to balance the budget. The 2019 letter called this reliance "unsustainable."</p>
+  </div>
+  <div class="term">
+    <p><strong>Structural deficit</strong> -- A gap between recurring revenues and recurring expenses that cannot be closed by one-time measures. The Finance Committee began using this term in its transmittal letters starting in 2022.</p>
+  </div>
+
+  <div class="notes">
+    <p>All quotes above are direct excerpts from the signed Finance Committee Annual Reports, which serve as the transmittal letters to each Annual Town Meeting. Local copies of the 2016, 2019, 2021, 2022, 2023, 2025, and 2026 reports are in <a href="data/">/data/</a>. The 2016 transmittal letter's "eleventh consecutive year" count and the 2021 letter's "sixteenth consecutive year" count both refer to the Finance Committee's own tally of balanced budgets presented to Town Meeting without a proposed operating override. Marblehead's last successful operating override before the FY24 attempt was approved in FY2005. The 2023 Town Meeting and ballot vote totals (534-230 at Town Meeting, 2,992-3,399 at the ballot) are from the <a href="https://marbleheadma.gov/wp-content/uploads/2025/03/town_meeting_minutes_2023__0.pdf">2023 Town Meeting minutes</a>. The three-tier override structure ($9M/$12M/$15M) is from the <a href="https://marbleheadma.gov/wp-content/uploads/2026/02/2026-State-of-the-Town-Presenation-Final.pdf">2026 State of the Town presentation</a>.</p>
+  </div>
+</div>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -52,6 +52,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <span class="tag tag-text">Explainer</span>
     </a>
 
+    <a class="question" href="how-we-got-here.html">
+      <h2>How did we get here?</h2>
+      <p>Seven years of Finance Committee warnings, in their own words. From "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025.</p>
+      <span class="tag tag-text">History</span>
+    </a>
+
     <a class="question" href="charts/override_calculator.html">
       <h2>What does it cost me?</h2>
       <p>Monthly cost by home value for each tier, at full phase-in.</p>


### PR DESCRIPTION
New chronological explainer that traces the development of Marblehead's structural deficit through the Finance Committee's own signed transmittal letters, from the 2016 report (celebrating the "eleventh consecutive year" of balanced budgets without a proposed override) through the 2025 report (first three-year forecast naming FY26, FY27, and FY28 as projected deficit years).

Key moves:

- Rebuts "board always wants more" framing with verified quotes from 2016 and 2021 letters celebrating sixteen consecutive override-free years.
- Identifies 2019 as the first explicit warning ("reliance on free cash has become unsustainable").
- Documents 2022 as the first override prediction (delivered the next year as the $2.5M FY24 request that failed at the ballot 2,992-3,399).
- Each section anchored to a verbatim blockquote from the primary-source PDF, linked inline.

Adds homepage tile under "The override" section between "What is the override?" and "What does it cost me?"