### PR TITLE
Fix back button, restructure About me, rewrite site-intro sentence, G…

### DIFF
--- a/about.html
+++ b/about.html
@@ -37,10 +37,35 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <h1>About this site</h1>
 
   <h2>About me</h2>
-  <p>Andrew Baber. Marblehead homeowner about eight years. Daughter in first grade at Glover. Software engineer. Not on the Select Board, Finance Committee, or any other town body.</p>
+  <div class="card">
+    <div class="cut-item">
+      <span class="cut-item-name">Name</span>
+      <span class="cut-item-amount">Andrew Baber</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">In Marblehead</span>
+      <span class="cut-item-amount">About 8 years</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">Home</span>
+      <span class="cut-item-amount">Owner</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">Family</span>
+      <span class="cut-item-amount">Daughter in 1st grade at Glover</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">Work</span>
+      <span class="cut-item-amount">Software engineer</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">Town roles</span>
+      <span class="cut-item-amount">None</span>
+    </div>
+  </div>
 
   <h2>About the site</h2>
-  <p>This vote matters. I wanted to know how we got here and what it would actually mean before voting. Is this about cuts we could make, or costs rising faster than revenue? I honestly don't know. The site is where I'm working that out.</p>
+  <p>This vote matters. So before voting, I wanted to understand two things: how we got here, and what each possible outcome would actually mean. Is this about cuts we could make, or costs rising faster than revenue? I honestly don't know. The site is where I'm working that out.</p>
   <p>Open source on <a href="https://github.com/agbaber/marblehead">GitHub</a>. Code licensed under <a href="https://opensource.org/licenses/MIT">MIT</a>; content under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
 
   <h2>About AI usage</h2>
@@ -63,7 +88,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
   <p>I'll update this as the bill changes.</p>
 
-  <p><strong>Found a mistake?</strong> Reach me through <a href="https://babersway.com">babersway.com</a>. I'd rather fix an error than win an argument.</p>
+  <p><strong>Found a mistake?</strong> Open an <a href="https://github.com/agbaber/marblehead/issues/new">issue</a> or a <a href="https://github.com/agbaber/marblehead/pulls">pull request</a> on GitHub. I'd rather fix an error than win an argument.</p>
 </div>
 
 </body>

--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -32,7 +32,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 
 <div class="page">
-  <a class="back" href="./">&larr; marbleheaddata.org</a>
+  <a class="back" href="./">&larr;</a>
 
   <h1>How did we get here?</h1>
   <p>The FY27 override vote is not a surprise. It was forecast, warned about, and predicted in writing by Marblehead's Finance Committee for years. Reading FinCom's own annual transmittal letters to Town Meeting, there is a clean arc from "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025. This page traces that arc in FinCom's own words.</p>


### PR DESCRIPTION
…itHub corrections

- how-we-got-here.html: replace old "&larr; marbleheaddata.org" back link with the current "&larr;" pill-button style used on the other four content pages.

- about.html "About me" section: replace flat fragment prose with a structured data card (Name, In Marblehead, Home, Family, Work, Town roles) using the same .cut-item pattern as the "What this costs" card on the same page. Scannable in 5 seconds and matches the site's visual vocabulary.

- about.html "About the site" intro sentence: rewrite ambiguous "what it would actually mean before voting" (whose vote? what is "it"?) as "how we got here, and what each possible outcome would actually mean."

- about.html corrections line: replace babersway.com contact with GitHub issue/PR links. Makes the correction trail public and matches the open-source framing.