### PR TITLE
Refactor to Jekyll layouts: eliminate boilerplate from all pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,29 @@
-theme: jekyll-theme-minimal
 title: Marblehead Budget Data
 description: Open data and charts about Marblehead, MA municipal finances
+last_updated: April 11, 2026
+url: https://marbleheaddata.org
+baseurl: ""
+
+plugins: []
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: page
+  - scope:
+      path: "index.html"
+    values:
+      layout: home
+  - scope:
+      path: "charts"
+    values:
+      layout: chart
+
+exclude:
+  - README.md
+  - STYLE_GUIDE.md
+  - LICENSE
+  - docs/
+  - data/acfr/
+  - data/budgets/

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,4 @@
+<div class="footer">
+  <p>Built by a Marblehead resident. <a href="{{ '/' | relative_url }}about.html">About this site</a>. <a href="https://github.com/agbaber/marblehead">Source on GitHub</a>. Corrections welcome.</p>
+  <p>Last updated {{ site.last_updated }}.</p>
+</div>

--- a/_includes/gtm-noscript.html
+++ b/_includes/gtm-noscript.html
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,23 @@
+<meta charset="utf-8">
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
+<!-- End Google Tag Manager -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-ZK1KEJT3KX');
+</script>
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="color-scheme" content="light dark">
+<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
+<title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+<link rel="icon" href="{{ '/' | relative_url }}favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="{{ '/' | relative_url }}assets/site.css">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,0 +1,11 @@
+<nav class="site-nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="{{ '/' | relative_url }}">MHD Budget</a>
+    <a href="{{ '/' | relative_url }}what-is-the-override.html">Override</a>
+    <a href="{{ '/' | relative_url }}how-we-got-here.html">How We Got Here</a>
+    <a href="{{ '/' | relative_url }}what-fails.html">No-Override Budget</a>
+    <a href="{{ '/' | relative_url }}why-not-elsewhere.html">Peer Towns</a>
+    <a href="{{ '/' | relative_url }}senior-tax-relief.html">Senior Relief</a>
+    <a href="{{ '/' | relative_url }}about.html">About</a>
+  </div>
+</nav>

--- a/_layouts/chart.html
+++ b/_layouts/chart.html
@@ -1,0 +1,10 @@
+---
+layout: default
+body_class: chart-page
+---
+<div class="container">
+  <a class="back" href="{{ '/' | relative_url }}">&larr;</a>
+
+  {{ content }}
+
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+{% include head.html %}
+</head>
+<body{% if page.body_class %} class="{{ page.body_class }}"{% elsif layout.body_class %} class="{{ layout.body_class }}"{% endif %}>
+{% include gtm-noscript.html %}
+
+{{ content }}
+
+</body>
+</html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,10 @@
+---
+layout: default
+---
+{% include nav.html %}
+
+<div class="page">
+  {{ content }}
+
+  {% include footer.html %}
+</div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,12 @@
+---
+layout: default
+---
+{% include nav.html %}
+
+<div class="page">
+  <a class="back" href="{{ '/' | relative_url }}">&larr;</a>
+
+  {{ content }}
+
+  {% include footer.html %}
+</div>

--- a/about.html
+++ b/about.html
@@ -1,31 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>About this site - Marblehead Budget Data</title>
-<link rel="icon" href="favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="assets/site.css">
+---
+title: "About this site"
+---
 <style>
-  /* Page-scoped: About me and meta pills */
+/* Page-scoped: About me and meta pills */
   .profile-intro {
     font-size: 17px;
     line-height: 1.55;
@@ -96,27 +73,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     .meta-pill { padding: 6px 12px; font-size: 12px; }
   }
 </style>
-</head>
-<body>
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
-
-<nav class="site-nav">
-  <div class="nav-inner">
-    <a class="nav-brand" href="./">MHD Budget</a>
-    <a href="what-is-the-override.html">Override</a>
-    <a href="how-we-got-here.html">How We Got Here</a>
-    <a href="what-fails.html">No-Override Budget</a>
-    <a href="why-not-elsewhere.html">Peer Towns</a>
-    <a href="senior-tax-relief.html">Senior Relief</a>
-    <a href="about.html" aria-current="page">About</a>
-  </div>
-</nav>
-
-<div class="page">
-  <h1>About this site</h1>
+<h1>About this site</h1>
 
   <h2>About me</h2>
   <p class="profile-intro">I'm <strong>Andrew Baber</strong>. Software engineer by trade. A Marblehead homeowner since 2017, with my daughter in first grade at Glover.</p>
@@ -163,7 +120,3 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>I'll update this as the bill changes.</p>
 
   <p><strong>Found a mistake?</strong> Open an <a href="https://github.com/agbaber/marblehead/issues/new">issue</a> or a <a href="https://github.com/agbaber/marblehead/pulls">pull request</a> on GitHub.</p>
-</div>
-
-</body>
-</html>

--- a/charts/annual_gap.html
+++ b/charts/annual_gap.html
@@ -1,35 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>New Revenue vs. New Costs - Marblehead Budget Data</title>
-<link rel="icon" href="../favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="../assets/site.css">
-</head>
-<body class="chart-page">
-
-<div class="container">
-  <a class="back" href="../">&larr;</a>
-  <h1 class="h-center">The Structural Gap: New Revenue vs. New Costs</h1>
+---
+title: "New Revenue vs. New Costs"
+---
+<h1 class="h-center">The Structural Gap: New Revenue vs. New Costs</h1>
   <p class="subtitle h-center">Annual increases projected from verified FY26 data using FinCom growth rates.</p>
 
   <div class="legend">
@@ -114,7 +86,3 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <p><span class="footnote-marker"></span>Pension base (~$5.4M) estimated from FY27 increase of $462,735 at 8.5% growth.</p>
     <p><span class="footnote-marker"></span>Growth rates from Finance Committee Annual Report FY2026: HC 9%, pensions 8.5%, salaries 5%, levy ~3%.</p>
   </div>
-</div>
-
-</body>
-</html>

--- a/charts/avg_tax_bill.html
+++ b/charts/avg_tax_bill.html
@@ -1,40 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>Average Tax Bill - Marblehead Budget Data</title>
-<link rel="icon" href="../favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="../assets/site.css">
-</head>
-<body class="chart-page">
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
-
-<div class="container">
-  <a class="back" href="../">&larr;</a>
-
-  <h1 class="h-center">Average Single-Family Tax Bill</h1>
+---
+title: "Average Tax Bill"
+---
+<h1 class="h-center">Average Single-Family Tax Bill</h1>
   <p class="subtitle h-center">What homeowners actually pay, FY2006&ndash;FY2026. Source: MA Department of Revenue.</p>
 
   <div class="legend">
@@ -103,7 +70,3 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <p>Source: MA Department of Revenue, Division of Local Services, "Average Single Family Tax Bill" report.</p>
     <p>The average tax bill reflects both the tax rate and the average home value. Towns with more expensive homes have higher bills even with lower rates. This chart shows what homeowners actually pay, unlike the tax rate chart which shows the rate per dollar of value.</p>
   </div>
-</div>
-
-</body>
-</html>

--- a/charts/enrollment_vs_staffing.html
+++ b/charts/enrollment_vs_staffing.html
@@ -1,47 +1,14 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>Enrollment vs. Staffing - Marblehead Budget Data</title>
-<link rel="icon" href="../favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="../assets/site.css">
+---
+title: "Enrollment vs. Staffing"
+---
 <style>
-  .chart-label {
+.chart-label {
     font-size: 12px; font-weight: 700; text-transform: uppercase;
     letter-spacing: 1px; margin-bottom: 8px; padding-left: 2px;
     color: var(--text-subtle);
   }
 </style>
-</head>
-<body class="chart-page">
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
-
-<div class="container">
-  <a class="back" href="../">&larr;</a>
-
-  <h1 class="h-center">School Enrollment and Education Staffing</h1>
+<h1 class="h-center">School Enrollment and Education Staffing</h1>
   <p class="subtitle h-center">Marblehead Public Schools, FY2001&ndash;FY2024. From audited Annual Comprehensive Financial Reports.</p>
 
   <p class="chart-label">Student enrollment</p>
@@ -168,7 +135,3 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <p>Peer-town chart uses DESE (Massachusetts Department of Elementary and Secondary Education) district profile data, teacher FTE only (classroom teachers, not all staff). This narrower denominator is why Marblehead's FY24 ratio is 10.7 on the peer chart vs. 4.9 using all-staff FTE in the caption above. Different metric, same downward trend. Raw data in <code>data/dese_peer_teachers_enrollment.csv</code>.</p>
     <p>The declining enrollment / flat staffing pattern is common across Massachusetts and is partly driven by special education mandates (IEP-required staffing), out-of-district placements ($4.6M in FY26 school budget), and federal requirements that do not scale with enrollment.</p>
   </div>
-</div>
-
-</body>
-</html>

--- a/charts/four_town_rates.html
+++ b/charts/four_town_rates.html
@@ -1,35 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>Four Town Tax Rates - Marblehead Budget Data</title>
-<link rel="icon" href="../favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="../assets/site.css">
-</head>
-<body class="chart-page">
-
-<div class="container">
-  <a class="back" href="../">&larr;</a>
-  <h1 class="h-center">Residential Tax Rates: Four North Shore Towns</h1>
+---
+title: "Four Town Tax Rates"
+---
+<h1 class="h-center">Residential Tax Rates: Four North Shore Towns</h1>
   <p class="subtitle h-center">Rate per $1,000 assessed value, FY2003&ndash;FY2026, with Marblehead override projections. Source: MA Department of Revenue.</p>
 
   <div class="legend">
@@ -126,7 +98,3 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <p>Melrose FY26 rate includes $13.5M override passed November 2025. Stoneham's $9.3M override (Dec 2025) not yet reflected.</p>
     <p>Marblehead override tiers are estimates: current rate + (override amount / $9.89B assessed value). Tier 1 ($9M) ~$9.46, Tier 2 ($12M) ~$9.76, Tier 3 ($15M) ~$10.06.</p>
   </div>
-</div>
-
-</body>
-</html>

--- a/charts/healthcare_indexed.html
+++ b/charts/healthcare_indexed.html
@@ -1,35 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>Health Insurance & Staffing - Marblehead Budget Data</title>
-<link rel="icon" href="../favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="../assets/site.css">
-</head>
-<body class="chart-page">
-
-<div class="container">
-  <a class="back" href="../">&larr;</a>
-  <h1>Health Insurance Spending and Plan Enrollment</h1>
+---
+title: "Health Insurance & Staffing"
+---
+<h1>Health Insurance Spending and Plan Enrollment</h1>
   <p class="subtitle">Marblehead, FY2006&ndash;FY2027. From audited Annual Comprehensive Financial Reports and Finance Committee reports.</p>
 
   <div class="chart-wrapper">
@@ -95,7 +67,3 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <p>Spending: "Group Insurance" from Annual Comprehensive Financial Report budget schedules (FY06&ndash;FY13) and Finance Committee reports (FY14&ndash;FY25). FY20 not available. FY26&ndash;FY27 proposed (dashed). Includes active employee health insurance, Medicare supplement, and Medicare reimbursement.</p>
     <p>Employees: full-time equivalent from audited financial report statistical sections (FY06&ndash;FY24). FTE counts a 20 hr/wk employee as 0.5. Total headcount (1,185 in FY25 per Marblehead Independent) is higher because many employees are part-time. Historical headcount data is not publicly available.</p>
   </div>
-</div>
-
-</body>
-</html>

--- a/charts/override_calculator.html
+++ b/charts/override_calculator.html
@@ -1,29 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>What the Override Costs You - Marblehead Budget Data</title>
-<link rel="icon" href="../favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="../assets/site.css">
+---
+title: "What the Override Costs You"
+---
 <style>
 .calc-input { margin: 0 auto 22px; max-width: 420px; text-align: center; }
 .calc-input label {
@@ -77,12 +54,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .cost-primary { font-size: 24px; }
 }
 </style>
-</head>
-<body class="chart-page">
-
-<div class="container">
-  <a class="back" href="../">&larr;</a>
-  <h1 class="h-center">What the Override Costs You</h1>
+<h1 class="h-center">What the Override Costs You</h1>
   <p class="subtitle h-center">Enter your home's assessed value to see the cost year-by-year for each override tier.</p>
 
   <div class="calc-input">
@@ -108,7 +80,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <p><span class="footnote-marker"></span>Year 2 and Year 3 are cumulative and permanent: each year's figure is your new total ongoing tax bill once that year's draw kicks in, not a one-time increase.</p>
     <p><span class="footnote-marker"></span>Trash/recycling (Question 2) is not included above. You'll pay for it either way: as a levy increase (~$19/mo on a $1M home) or as a flat fee (~$22/mo per household) if the override fails.</p>
   </div>
-</div>
 
 <script>
 // Anchor: Town Administrator's override presentation, April 8, 2026.
@@ -202,6 +173,3 @@ document.querySelectorAll('.tab').forEach(function(btn) {
 
 update();
 </script>
-
-</body>
-</html>

--- a/charts/premium_per_employee.html
+++ b/charts/premium_per_employee.html
@@ -1,35 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>GIC Family Plan Cost - Marblehead Budget Data</title>
-<link rel="icon" href="../favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="../assets/site.css">
-</head>
-<body class="chart-page">
-
-<div class="container">
-  <a class="back" href="../">&larr;</a>
-  <h1>Annual Cost of One Family Health Insurance Plan</h1>
+---
+title: "GIC Family Plan Cost"
+---
+<h1>Annual Cost of One Family Health Insurance Plan</h1>
   <p class="subtitle">Full premium cost for one family plan before the 83/17 employer-employee split. The town pays 83% of these figures. Harvard Pilgrim plan through the state Group Insurance Commission, FY2019&ndash;FY2026.</p>
 
   <div class="chart-wrapper">
@@ -78,7 +50,3 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <p>Rates from GIC published rate charts: FY19 from Wayback Machine archive, FY20 derived from state employee rate sheet, FY23&ndash;FY26 from current mass.gov. Plan is Harvard Pilgrim Independence Plan (FY19&ndash;FY23) / Access America (FY24&ndash;FY26), the most common broad-network option. FY21&ndash;FY22 rate sheets not publicly available.</p>
     <p>Marblehead pays 83% of the full premium; employees pay 17%. This split is set by agreement with the Public Employee Committee and cannot be changed unilaterally.</p>
   </div>
-</div>
-
-</body>
-</html>

--- a/charts/real_cost_comparison.html
+++ b/charts/real_cost_comparison.html
@@ -1,39 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>Tax Levy vs. Health Insurance - Marblehead Budget Data</title>
-<link rel="icon" href="../favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="../assets/site.css">
-</head>
-<body class="chart-page">
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
-
-<div class="container">
-  <a class="back" href="../">&larr;</a>
-  <h1 class="h-center">Tax Levy vs. Health Insurance Spending</h1>
+---
+title: "Tax Levy vs. Health Insurance"
+---
+<h1 class="h-center">Tax Levy vs. Health Insurance Spending</h1>
   <p class="subtitle h-center">Both lines start at 100 in FY2006 so you can compare how fast each grew. Marblehead, FY2006&ndash;FY2027.</p>
 
   <div class="legend">
@@ -127,7 +95,3 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <p>Rates are set by the state Group Insurance Commission (GIC). The town joined the GIC in FY2012. The GIC sets plan designs and premium rates; the town has no control over either. The GIC voted 10&ndash;7 in February 2026 to drop GLP-1 weight-loss drug coverage effective July 2026, but FY27 rates were already set before that decision.</p>
     <p>Loss ratio and GLP-1 attribution from Sue Shillue of Hill Group (town insurance consultant), reporting to the Public Employee Committee. Quoted in Marblehead Independent, "Possible insurance break gives Marblehead budget outlook a lift." Plan names from GIC published rate sheets (mass.gov). GLP-1 coverage decision from GIC board vote, February 2026.</p>
   </div>
-</div>
-
-</body>
-</html>

--- a/charts/sustainability.html
+++ b/charts/sustainability.html
@@ -1,35 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>Do Override Tiers Close the Gap? - Marblehead Budget Data</title>
-<link rel="icon" href="../favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="../assets/site.css">
-</head>
-<body class="chart-page">
-
-<div class="container">
-  <a class="back" href="../">&larr;</a>
-  <h1 class="h-center">Do the Override Tiers Close the Gap?</h1>
+---
+title: "Do Override Tiers Close the Gap?"
+---
+<h1 class="h-center">Do the Override Tiers Close the Gap?</h1>
   <p class="subtitle h-center">Total projected revenue (4 scenarios) vs total projected expenses, FY2026&ndash;FY2030. FY26&ndash;FY27 from State of the Town presentation. FY28&ndash;FY30 projected using Finance Committee growth rates.</p>
 
   <div class="legend">
@@ -127,7 +99,3 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <p>FY28&ndash;FY30 expenses projected at 5.4%/yr (blended: HC 9%, pensions 8.5%, salaries 5%, other 3%, weighted by FY26 budget share). Revenue: levy at 3%/yr, other sources declining through FY29 then flat. Override amounts phased in per Kezer presentation.</p>
     <p>These projections become less reliable further out. Actual results will depend on GIC rate decisions, collective bargaining outcomes, state aid, property value changes, and other factors not modeled here.</p>
   </div>
-</div>
-
-</body>
-</html>

--- a/charts/tax_comparison.html
+++ b/charts/tax_comparison.html
@@ -1,31 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>Marblehead vs. Swampscott - Marblehead Budget Data</title>
-<link rel="icon" href="../favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="../assets/site.css">
+---
+title: "Marblehead vs. Swampscott"
+---
 <style>
-  /* Page-specific widgets: section dividers, bar race, budget cards */
+/* Page-specific widgets: section dividers, bar race, budget cards */
   .section-divider {
     display: flex; align-items: center; gap: 10px;
     margin: 10px 0 14px;
@@ -135,12 +112,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     .budget-card-sqft { font-size: 32px; }
   }
 </style>
-</head>
-<body class="chart-page">
-
-<div class="container">
-  <a class="back" href="../">&larr;</a>
-  <h1 class="h-center">Marblehead vs. Swampscott</h1>
+<h1 class="h-center">Marblehead vs. Swampscott</h1>
   <p class="subtitle h-center">FY2026 property tax comparison.</p>
 
   <div class="section-divider">
@@ -255,7 +227,3 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <p><span class="footnote-marker"></span>Property taxes are paid per property, not per person. A family of four pays the same as a single resident.</p>
     <p><span class="footnote-marker"></span>Source: Mass.gov FY2026 tax levy data, Swampscott Assessor's Office, Marblehead Assessor's Office.</p>
   </div>
-</div>
-
-</body>
-</html>

--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -1,50 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>How did we get here? - Marblehead Budget Data</title>
-<link rel="icon" href="favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="assets/site.css">
-</head>
-<body>
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
-
-<nav class="site-nav">
-  <div class="nav-inner">
-    <a class="nav-brand" href="./">MHD Budget</a>
-    <a href="what-is-the-override.html">Override</a>
-    <a href="how-we-got-here.html" aria-current="page">How We Got Here</a>
-    <a href="what-fails.html">No-Override Budget</a>
-    <a href="why-not-elsewhere.html">Peer Towns</a>
-    <a href="senior-tax-relief.html">Senior Relief</a>
-    <a href="about.html">About</a>
-  </div>
-</nav>
-
-<div class="page">
-  <h1>How did we get here?</h1>
+---
+title: "How did we get here?"
+---
+<h1>How did we get here?</h1>
   <p>The FY27 override vote is not a surprise. It was forecast, warned about, and predicted in writing by Marblehead's Finance Committee for years. Reading FinCom's own annual transmittal letters to Town Meeting, there is a clean arc from "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025. This page traces that arc in FinCom's own words.</p>
 
   <div class="takeaway takeaway--pos">
@@ -140,7 +97,3 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="notes">
     <p>All quotes above are direct excerpts from the signed Finance Committee Annual Reports, which serve as the transmittal letters to each Annual Town Meeting. Local copies of the 2016, 2019, 2021, 2022, 2023, 2025, and 2026 reports are in <a href="data/">/data/</a>. The 2016 transmittal letter's "eleventh consecutive year" count and the 2021 letter's "sixteenth consecutive year" count both refer to the Finance Committee's own tally of balanced budgets presented to Town Meeting without a proposed operating override. Marblehead's last successful operating override before the FY24 attempt was approved in FY2005. The 2023 Town Meeting and ballot vote totals (534-230 at Town Meeting, 2,992-3,399 at the ballot) are from the <a href="https://marbleheadma.gov/wp-content/uploads/2025/03/town_meeting_minutes_2023__0.pdf">2023 Town Meeting minutes</a>. The three-tier override structure ($9M/$12M/$15M) is from the <a href="https://marbleheadma.gov/wp-content/uploads/2026/02/2026-State-of-the-Town-Presenation-Final.pdf">2026 State of the Town presentation</a>.</p>
   </div>
-</div>
-
-</body>
-</html>

--- a/index.html
+++ b/index.html
@@ -1,50 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>Marblehead Budget Data</title>
-<link rel="icon" href="favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="assets/site.css">
-</head>
-<body>
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
-
-<nav class="site-nav">
-  <div class="nav-inner">
-    <a class="nav-brand" href="./">MHD Budget</a>
-    <a href="what-is-the-override.html">Override</a>
-    <a href="how-we-got-here.html">How We Got Here</a>
-    <a href="what-fails.html">No-Override Budget</a>
-    <a href="why-not-elsewhere.html">Peer Towns</a>
-    <a href="senior-tax-relief.html">Senior Relief</a>
-    <a href="about.html">About</a>
-  </div>
-</nav>
-
-<div class="page">
-  <div class="hero">
+---
+layout: home
+---
+<div class="hero">
     <h1>Marblehead Budget Data</h1>
     <p>An open resource for residents evaluating the FY2027 budget override. Every number is traceable to a primary source.</p>
   </div>
@@ -175,12 +132,3 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </a>
     </div>
   </div>
-
-  <div class="footer">
-    <p>Built by a Marblehead resident. <a href="about.html">About this site</a>. <a href="https://github.com/agbaber/marblehead">Source on GitHub</a>. Corrections welcome.</p>
-    <p>Last updated April 10, 2026.</p>
-  </div>
-</div>
-
-</body>
-</html>

--- a/senior-tax-relief.html
+++ b/senior-tax-relief.html
@@ -1,31 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>Senior Property Tax Relief - Marblehead Budget Data</title>
-<link rel="icon" href="favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="assets/site.css">
+---
+title: "Senior Property Tax Relief"
+---
 <style>
-  /* Page-scoped: Circuit Breaker formula visual */
+/* Page-scoped: Circuit Breaker formula visual */
   .formula {
     background: color-mix(in srgb, var(--c-teal) 7%, var(--surface));
     border: 1px solid color-mix(in srgb, var(--c-teal) 22%, var(--border));
@@ -121,27 +98,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     .tldr li { font-size: 13px; }
   }
 </style>
-</head>
-<body>
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
-
-<nav class="site-nav">
-  <div class="nav-inner">
-    <a class="nav-brand" href="./">MHD Budget</a>
-    <a href="what-is-the-override.html">Override</a>
-    <a href="how-we-got-here.html">How We Got Here</a>
-    <a href="what-fails.html">No-Override Budget</a>
-    <a href="why-not-elsewhere.html">Peer Towns</a>
-    <a href="senior-tax-relief.html" aria-current="page">Senior Relief</a>
-    <a href="about.html">About</a>
-  </div>
-</nav>
-
-<div class="page">
-  <h1>Senior property tax relief</h1>
+<h1>Senior property tax relief</h1>
   <p>Two programs can reduce what a Marblehead senior pays in property tax. The state Senior Circuit Breaker refunds up to <strong>$2,820</strong> per year and is available today. A local exemption approved by Marblehead Town Meeting in May 2025 would stack on top of it, and is currently pending at the State House. This page explains both programs, who qualifies, how to apply, and how each interacts with the override math.</p>
 
   <div class="tldr">
@@ -447,7 +404,3 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <p>Clause 41C, 41A, and 17D current Marblehead amounts and limits are pending confirmation from the Board of Assessors. This page will be updated when those figures are verified from a primary source. In the meantime, residents should contact the Assessor's Office directly for eligibility determination.</p>
     <p>Nothing on this page is tax advice. It is a civic information resource. Talk to a tax professional, the Assessor's Office, or the Council on Aging (781-631-6240) for help with your individual situation.</p>
   </div>
-</div>
-
-</body>
-</html>

--- a/what-fails.html
+++ b/what-fails.html
@@ -1,50 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>What's in the no-override budget? - Marblehead Budget Data</title>
-<link rel="icon" href="favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="assets/site.css">
-</head>
-<body>
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
-
-<nav class="site-nav">
-  <div class="nav-inner">
-    <a class="nav-brand" href="./">MHD Budget</a>
-    <a href="what-is-the-override.html">Override</a>
-    <a href="how-we-got-here.html">How We Got Here</a>
-    <a href="what-fails.html" aria-current="page">No-Override Budget</a>
-    <a href="why-not-elsewhere.html">Peer Towns</a>
-    <a href="senior-tax-relief.html">Senior Relief</a>
-    <a href="about.html">About</a>
-  </div>
-</nav>
-
-<div class="page">
-  <h1>What's in the no-override budget?</h1>
+---
+title: "What's in the no-override budget?"
+---
+<h1>What's in the no-override budget?</h1>
   <p>The town published a <a href="https://marbleheadma.gov/wp-content/uploads/2026/04/PROPOSED-FY27-BALANCED-BUDGET-WITH-NO-OVERRIDE.pdf">FY27 Proposed Balanced Budget With No Override</a> in April 2026. It balances using $5M in free cash, staffing reductions across town and school departments, and the elimination of the town's OPEB trust contribution. This page lists the specific line-item changes from that document.</p>
 
   <h2>Town-side reductions</h2>
@@ -180,7 +137,3 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="notes">
     <p>All figures on this page are from the <a href="https://marbleheadma.gov/wp-content/uploads/2026/04/PROPOSED-FY27-BALANCED-BUDGET-WITH-NO-OVERRIDE.pdf">FY27 Proposed Budget</a> and reporting by the Marblehead Independent and Marblehead Current. The FY27 budget was built to balance without an override using $5M in free cash, staffing reductions, and elimination of the OPEB trust contribution. These are proposed reductions, not final; the actual changes would be determined by department heads and the School Committee after Town Meeting.</p>
   </div>
-</div>
-
-</body>
-</html>

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -1,50 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>What Is the Override? - Marblehead Budget Data</title>
-<link rel="icon" href="favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="assets/site.css">
-</head>
-<body>
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
-
-<nav class="site-nav">
-  <div class="nav-inner">
-    <a class="nav-brand" href="./">MHD Budget</a>
-    <a href="what-is-the-override.html" aria-current="page">Override</a>
-    <a href="how-we-got-here.html">How We Got Here</a>
-    <a href="what-fails.html">No-Override Budget</a>
-    <a href="why-not-elsewhere.html">Peer Towns</a>
-    <a href="senior-tax-relief.html">Senior Relief</a>
-    <a href="about.html">About</a>
-  </div>
-</nav>
-
-<div class="page">
-  <h1>What Is the Override?</h1>
+---
+title: "What Is the Override?"
+---
+<h1>What Is the Override?</h1>
 
   <div class="key-stats">
     <div class="key-stat">
@@ -431,7 +388,3 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <p>Override structure from the <a href="data/2026-04-08_Override_Presentation.pdf">Town Administrator's override presentation</a> (April 8, 2026) and <a href="https://marbleheadcurrent.org/2026/03/25/select-board-backs-tiered-multi-year-override-framework-combining-school-town-requests/">Marblehead Current</a> / <a href="https://www.marbleheadindependent.com/select-board-locks-in-three-tier-override-structure-votes-to-unite-town-and-school-ask/">Marblehead Independent</a> reporting on the March 25, 2026 Select Board meeting. The $8.47M deficit from the <a href="https://marbleheadma.gov/wp-content/uploads/2026/02/2026-State-of-the-Town-Presenation-Final.pdf">2026 State of the Town presentation</a>, page 29. Ballot format from Town Clerk. Statutory references: <a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter59/Section21C">MGL c. 59 s. 21C</a> (Prop 2.5), <a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIV/Chapter32B/Section19">MGL c. 32B s. 19</a> (PEC).</p>
     <p>Quoted material is cited inline with each quotation. Finance Committee transmittal letters from the 2019, 2022, 2025, and 2026 Annual Town Meeting reports are archived locally in the <code>/data/</code> folder and are primary sources signed by the named FinCom chairs. 2023 override opposition voices are drawn from the Marblehead Current archives (signed letter from Jack Buba, February 18, 2023; and direct quotes from Jim Nye, May 24, 2023, and Sue MacInnis, June 14, 2023). April 8, 2026 Select Board meeting quotes as reported by Will Dowd in the <a href="https://www.marbleheadindependent.com/kezer-presents-9m-to-15m-tiered-override-plan-and-separate-2-2m-trash-tax-option/">Marblehead Independent</a>; the town's own meeting minutes for April 8, 2026 had not been posted at time of publication and are expected at <a href="https://marbleheadma.gov/category/select-board/">marbleheadma.gov/category/select-board/</a>. The 2023 Town Meeting vote record (Article 31 paper ballot, 534-230) is in the <a href="https://marbleheadma.gov/wp-content/uploads/2025/03/town_meeting_minutes_2023__0.pdf">2023 Annual Town Meeting minutes</a>; the June 20, 2023 ballot result (2,992-3,399) is from contemporaneous Marblehead Current coverage. Override history from Marblehead Current, "Overriding Considerations" series.</p>
   </div>
-</div>
-
-</body>
-</html>

--- a/why-not-elsewhere.html
+++ b/why-not-elsewhere.html
@@ -1,31 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="color-scheme" content="light dark">
-<meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#0B1620" media="(prefers-color-scheme: dark)">
-<title>Why do some MA towns run overrides and others don't? - Marblehead Budget Data</title>
-<link rel="icon" href="favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="assets/site.css">
+---
+title: "Why do some MA towns run overrides and others don't?"
+---
 <style>
-  /* Page-specific: archetype-colored bar charts and data tables */
+/* Page-specific: archetype-colored bar charts and data tables */
   .peer-chart {
     background: var(--surface);
     border-radius: var(--radius-md);
@@ -136,27 +113,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     table.peer-table th, table.peer-table td { padding: 7px 4px; }
   }
 </style>
-</head>
-<body>
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
-
-<nav class="site-nav">
-  <div class="nav-inner">
-    <a class="nav-brand" href="./">MHD Budget</a>
-    <a href="what-is-the-override.html">Override</a>
-    <a href="how-we-got-here.html">How We Got Here</a>
-    <a href="what-fails.html">No-Override Budget</a>
-    <a href="why-not-elsewhere.html" aria-current="page">Peer Towns</a>
-    <a href="senior-tax-relief.html">Senior Relief</a>
-    <a href="about.html">About</a>
-  </div>
-</nav>
-
-<div class="page">
-  <h1>Why do some MA towns run overrides and others don't?</h1>
+<h1>Why do some MA towns run overrides and others don't?</h1>
   <p>Massachusetts has 351 cities and towns. Some are running Proposition 2&frac12; override votes this year, some never have, and some haven't in decades. What separates the groups isn't primarily about management or spending levels. It's structural. Two metrics from the MA Department of Revenue explain most of the variation: what share of a town's property tax levy falls on residential homeowners, and how much new construction expands the levy ceiling each year.</p>
 
   <p>This page walks through those two metrics for a 21-town peer set spanning residential suburbs, mixed-use suburbs, commercial-anchor cities, and gateway cities. Whether any given town's situation constitutes a "problem" is a separate judgment that depends on values, priorities, and what residents want from their local government. The data here is meant to inform that judgment, not to make it.</p>
@@ -366,7 +323,3 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <p><strong>Note on "new growth."</strong> The DOR metric shown is <em>total new growth applied to the levy limit as a percent of the prior-year levy limit</em>. This captures how much the levy ceiling expands each year from new construction, outside Proposition 2&frac12;'s 2.5% cap. It does not include annual 2.5% growth, value increases from reassessment, or debt exclusions.</p>
     <p><strong>Note on gateway cities.</strong> "Gateway city" is a statutory designation under MGL Chapter 23A, Section 3A, based on historical manufacturing employment and median household income. The 26 designated gateway cities receive specialized state grants, formula aid, and zoning tools not available to other municipalities.</p>
   </div>
-</div>
-
-</body>
-</html>


### PR DESCRIPTION
Introduces a layout system so shared elements (head tags, GTM, GA, nav, back button, footer) are defined once:

  _layouts/default.html  - shared shell (head, GTM, GA, body)
  _layouts/home.html     - nav + page wrapper + footer
  _layouts/page.html     - back button + page wrapper + footer
  _layouts/chart.html    - chart-page body class + container wrapper

  _includes/head.html        - meta, analytics, viewport, favicon, CSS
  _includes/gtm-noscript.html - GTM noscript fallback
  _includes/nav.html         - site navigation
  _includes/footer.html      - footer with last_updated from config

Each page is now just frontmatter + content. Changing the footer, adding a nav link, or updating analytics is a one-file edit.