### PR TITLE
Drop "fix an error vs win an argument" platitude from corrections line

### DIFF
--- a/about.html
+++ b/about.html
@@ -162,7 +162,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
   <p>I'll update this as the bill changes.</p>
 
-  <p><strong>Found a mistake?</strong> Open an <a href="https://github.com/agbaber/marblehead/issues/new">issue</a> or a <a href="https://github.com/agbaber/marblehead/pulls">pull request</a> on GitHub. I'd rather fix an error than win an argument.</p>
+  <p><strong>Found a mistake?</strong> Open an <a href="https://github.com/agbaber/marblehead/issues/new">issue</a> or a <a href="https://github.com/agbaber/marblehead/pulls">pull request</a> on GitHub.</p>
 </div>
 
 </body>


### PR DESCRIPTION
The line didn't earn its space. It sounded clever without saying anything concrete, and the GitHub issue/PR link above already communicates the intent.