### PR TITLE
Add Claude subscription ($100/month) to site costs

### DIFF
--- a/about.html
+++ b/about.html
@@ -57,8 +57,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <span class="cut-item-amount">Free</span>
     </div>
     <div class="cut-item">
-      <span class="cut-item-name">AI assistant subscription<span class="cut-item-note">A tool I already pay for; not tracked as a site-specific cost.</span></span>
-      <span class="cut-item-amount">Not tracked</span>
+      <span class="cut-item-name">Claude (research, analysis, infrastructure)<span class="cut-item-note">A tool I already pay for; I use it for this site and for other things.</span></span>
+      <span class="cut-item-amount">$100/month</span>
     </div>
     <div class="cut-item">
       <span class="cut-item-name">Advertising, donations, outside funding</span>


### PR DESCRIPTION
Replaces the "not tracked" placeholder with the actual subscription amount for honesty. Notes that it's a general-purpose tool used for this site and other things.