### PR TITLE
Remove profile intro paragraph and "About this site" phrasing

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,17 +1,8 @@
 ---
-title: "About this site"
+title: "About"
 ---
 <style>
 /* Page-scoped: About me and meta pills */
-  .profile-intro {
-    font-size: 17px;
-    line-height: 1.55;
-    color: var(--text);
-    margin: 8px 0 16px;
-  }
-  .profile-intro strong {
-    font-weight: 700;
-  }
   .profile-disclosure {
     padding: 14px 18px;
     background: color-mix(in srgb, var(--c-navy) 4%, var(--surface));
@@ -69,14 +60,12 @@ title: "About this site"
     font-weight: 600;
   }
   @media (max-width: 600px) {
-    .profile-intro { font-size: 16px; }
     .meta-pill { padding: 6px 12px; font-size: 12px; }
   }
 </style>
-<h1>About this site</h1>
+<h1>About</h1>
 
   <h2>About me</h2>
-  <p class="profile-intro">I'm <strong>Andrew Baber</strong>. Software engineer by trade. A Marblehead homeowner since 2017, with my daughter in first grade at Glover.</p>
   <div class="profile-disclosure">
     <div class="profile-disclosure-label">Disclosure</div>
     <p>Not on the Select Board, the Finance Committee, or any other town body. My stake in the override is the same ordinary homeowner-and-parent stake as any other Marblehead resident.</p>


### PR DESCRIPTION
- Drop the "I'm Andrew Baber. Software engineer by trade. A Marblehead homeowner since 2017..." intro paragraph. The disclosure callout remains and carries the "ordinary homeowner-and-parent stake" framing on its own.
- Title: "About this site - Marblehead Budget Data" to "About - ..."
- H1: "About this site" to "About"
- Clean up orphaned .profile-intro CSS rules.