### PR TITLE
Simplify about page: drop headers, rename Costs, move pills to bottom

### DIFF
--- a/about.html
+++ b/about.html
@@ -26,9 +26,10 @@ title: "About"
   }
   .meta-strip {
     display: flex;
+    justify-content: center;
     gap: 8px;
     flex-wrap: wrap;
-    margin: 12px 0 24px;
+    margin: 40px 0 8px;
   }
   .meta-pill {
     display: inline-flex;
@@ -63,35 +64,18 @@ title: "About"
     .meta-pill { padding: 6px 12px; font-size: 12px; }
   }
 </style>
-<h1>About</h1>
 
-  <h2>About me</h2>
   <div class="profile-disclosure">
     <div class="profile-disclosure-label">Disclosure</div>
-    <p>Not on the Select Board, the Finance Committee, or any other town body. My stake in the override is the same ordinary homeowner-and-parent stake as any other Marblehead resident.</p>
+    <p>Not on the Select Board, the Finance Committee, or any other town body. My stake in the override is as a Marblehead homeowner and parent.</p>
   </div>
 
-  <h2>About the site</h2>
   <p>This vote matters. So before voting, I wanted to understand two things: how we got here, and what each possible outcome would actually mean. Is this about cuts we could make, or costs rising faster than revenue? I honestly don't know. The site is where I'm working that out.</p>
-  <div class="meta-strip">
-    <a class="meta-pill" href="https://github.com/agbaber/marblehead">
-      <span class="meta-pill-label">Source</span>
-      <span class="meta-pill-value">GitHub</span>
-    </a>
-    <a class="meta-pill" href="https://opensource.org/licenses/MIT">
-      <span class="meta-pill-label">Code</span>
-      <span class="meta-pill-value">MIT</span>
-    </a>
-    <a class="meta-pill" href="https://creativecommons.org/licenses/by/4.0/">
-      <span class="meta-pill-label">Content</span>
-      <span class="meta-pill-value">CC BY 4.0</span>
-    </a>
-  </div>
 
   <h2>About AI usage</h2>
   <p>An AI assistant (Claude) handles research, analysis, and the site's digital infrastructure. I regularly remind it to stay as neutral as possible, and I own and operate everything it produces. Every number traces to a primary source, but I don't re-verify each one against the original document myself. Errors are possible. When I find one, or a reader catches one, the page gets updated.</p>
 
-  <h2>What this costs</h2>
+  <h2>Costs</h2>
   <div class="card">
     <div class="cut-item">
       <span class="cut-item-name">Domain registration</span>
@@ -106,6 +90,20 @@ title: "About"
       <span class="cut-item-amount">None</span>
     </div>
   </div>
-  <p>I'll update this as the bill changes.</p>
 
   <p><strong>Found a mistake?</strong> Open an <a href="https://github.com/agbaber/marblehead/issues/new">issue</a> or a <a href="https://github.com/agbaber/marblehead/pulls">pull request</a> on GitHub.</p>
+
+  <div class="meta-strip">
+    <a class="meta-pill" href="https://github.com/agbaber/marblehead">
+      <span class="meta-pill-label">Source</span>
+      <span class="meta-pill-value">GitHub</span>
+    </a>
+    <a class="meta-pill" href="https://opensource.org/licenses/MIT">
+      <span class="meta-pill-label">Code</span>
+      <span class="meta-pill-value">MIT</span>
+    </a>
+    <a class="meta-pill" href="https://creativecommons.org/licenses/by/4.0/">
+      <span class="meta-pill-label">Content</span>
+      <span class="meta-pill-value">CC BY 4.0</span>
+    </a>
+  </div>


### PR DESCRIPTION
- Drop h1 "About" and the h2 "About me" and "About the site" headers. The sections remain; only the headers are removed. The disclosure callout and intro paragraph carry their own visual weight without needing a label.
- Rename "What this costs" h2 to just "Costs" for brevity.
- Remove the "I'll update this as the bill changes." line from the costs section. It didn't add anything the costs card doesn't already imply.
- Move the three meta pills (Source/Code/Content) from the "About the site" section to the bottom of the page, centered. License metadata reads more naturally as a page-footer element than as mid-page content.
- Add justify-content: center to .meta-strip so pills center horizontally.
- Adjust .meta-strip margin for bottom-of-page placement.
- Rewrite disclosure stake sentence for brevity: "My stake in the override is as a Marblehead homeowner and parent." (was "...the same ordinary homeowner-and-parent stake as any other Marblehead resident.")