### PR TITLE
Replace override-history claims with DOR primary data

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1156,6 +1156,112 @@ blockquote.quote footer a:hover {
 }
 
 /* ==========================================================================
+   Ballot-timeline strip plot (Marblehead Prop 2.5 ballot history)
+   ========================================================================== */
+
+.ballot-timeline {
+  margin: 22px 0 24px;
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: 18px 18px 14px;
+}
+.ballot-timeline h3 {
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.1px;
+  color: var(--text-subtle);
+  margin: 0 0 6px;
+}
+.ballot-timeline .ballot-timeline-intro {
+  font-size: 12px;
+  color: var(--text-subtle);
+  margin: 0 0 10px;
+  line-height: 1.5;
+}
+.ballot-timeline svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+.ballot-timeline .row-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  fill: var(--text);
+}
+.ballot-timeline .row-sub {
+  font-size: 10px;
+  fill: var(--text-subtle);
+}
+.ballot-timeline .axis-line {
+  stroke: var(--border);
+  stroke-width: 1;
+}
+.ballot-timeline .grid-line {
+  stroke: var(--divider);
+  stroke-width: 1;
+  stroke-dasharray: 2 3;
+}
+.ballot-timeline .tick-label {
+  font-size: 10px;
+  fill: var(--text-subtle);
+}
+.ballot-timeline .vote-dot {
+  stroke: var(--surface);
+  stroke-width: 1.5;
+}
+.ballot-timeline .vote-dot--win {
+  fill: var(--c-sage);
+}
+.ballot-timeline .vote-dot--loss {
+  fill: var(--c-buoy);
+}
+.ballot-timeline .annotation {
+  font-size: 10px;
+  fill: var(--text-mid);
+}
+.ballot-timeline .annotation--buoy {
+  fill: var(--c-buoy);
+  font-weight: 600;
+}
+.ballot-timeline .annotation--sage {
+  fill: var(--c-sage);
+  font-weight: 600;
+}
+.ballot-timeline .future-line {
+  stroke: var(--c-buoy);
+  stroke-width: 1.5;
+  stroke-dasharray: 4 3;
+  opacity: 0.7;
+}
+.ballot-timeline-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 20px;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--divider);
+  font-size: 11px;
+  color: var(--text-subtle);
+}
+.ballot-timeline-legend .li { display: inline-flex; align-items: center; gap: 6px; }
+.ballot-timeline-legend .sw {
+  width: 10px; height: 10px; border-radius: 50%;
+  display: inline-block;
+}
+.ballot-timeline-legend .sw--win { background: var(--c-sage); }
+.ballot-timeline-legend .sw--loss { background: var(--c-buoy); }
+
+@media (max-width: 600px) {
+  .ballot-timeline { padding: 14px 12px 10px; }
+  .ballot-timeline .row-label { font-size: 10px; }
+  .ballot-timeline .annotation { font-size: 9px; }
+}
+
+/* ==========================================================================
    Tier stack chart (nested tiers visualization)
    ========================================================================== */
 

--- a/data/SOURCES.md
+++ b/data/SOURCES.md
@@ -55,6 +55,34 @@ All data for the Marblehead levy comparison chart. Use this to verify/challenge 
 
 **For the chart:** The `total_per_pupil` value is used (matches the headline number cited in state reports).
 
+## `marblehead_prop25_votes.csv`: Marblehead Proposition 2½ ballot history
+
+**Source:** Massachusetts Department of Revenue, Division of Local Services (DLS), Municipal Databank. Two reports combined:
+
+- Operating override and underride votes: https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride (filtered to Marblehead, DOR municipality code 168)
+- Debt exclusion votes: https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.debtexclusionvotes (filtered to Marblehead)
+
+**Coverage:** All Marblehead ballot questions in the DOR record. Earliest vote date: June 19, 1982 (debt exclusion for sewer reconstruction). Latest vote date: June 30, 2025. Data pulled April 11, 2026.
+
+**Row counts:**
+- Operating overrides: 20 questions (6 WIN, 14 LOSS). The DOR operating-override record for Marblehead starts with the FY1991 ballot (vote date June 1, 1990); there are no pre-1990 operating override records.
+- Debt exclusions: 50 questions (49 WIN, 1 LOSS). The single loss is the FY2003 Tucker's Wharf bond (vote date June 24, 2002).
+
+**Schema:**
+- `measure_type`: `Override` (operating override under MGL c. 59 s. 21C(g)) or `Debt Exclusion` (temporary exclusion for specific borrowing under MGL c. 59 s. 21C(k)).
+- `fiscal_year`: Fiscal year of first collection, as assigned by DOR. For debt exclusions in particular, `fiscal_year` often lags `vote_date` by several years because borrowing may not begin immediately.
+- `vote_date`: The date of the ballot vote (ISO format, yyyy-mm-dd).
+- `win_loss`: `WIN` or `LOSS` at the ballot.
+- `yes_votes`, `no_votes`: Raw vote totals.
+- `department`: DOR's department classification. Casing differs between the two source reports (override report uses ALL CAPS, debt exclusion report uses Title Case); preserved as-is from source.
+- `description`: DOR's description of the ballot question. Verbatim, including spelling errors.
+- `amount`: Dollar amount of the override. Populated for operating overrides; blank for debt exclusions (DOR does not report dollar amounts in the debt exclusion table).
+
+**Notes:**
+- The FY2025 "Fix Clerk Error" row (vote date June 30, 2025) has 0 yes votes, 0 no votes, and $0 amount. This is a procedural/corrective record from DOR, not a substantive ballot attempt. Charts and narrative counts should consider whether to include or exclude it.
+- The FY2005 ballot (vote date June 21, 2004) contained six distinct operating override line items: three won (school supplementals, library expenses, waste collection) and three lost (two police items, general operating). The "last successful operating override" commonly cited as "2005" refers to the calendar-year 2005 vote (June 15, 2005) that authorized the $2.73M FY2006 supplemental override. That is DOR's FY2006 record.
+- "Since 1982" is supportable for debt exclusions (earliest DOR vote date 1982-06-19) but NOT for operating overrides (earliest DOR vote date 1990-06-01). Any "since 1982" framing should be scoped to debt exclusions or to "in the DOR ballot record."
+
 ## Chart methodology
 
 All lines normalized to 2000 = 100 (FY2000 for Marblehead levy) for direct visual comparison. Marblehead per-pupil line normalized at its first available year (FY2008) to its value *relative to where the other lines are at FY2008*, so the starting points align visually. Specifically: the per-pupil line is scaled so that its FY2008 value shows where Marblehead per-pupil would be indexed if we assumed it had tracked exactly with CPI from 2000-2008. This is labeled explicitly on the chart to avoid confusion.

--- a/data/case_studies.md
+++ b/data/case_studies.md
@@ -49,8 +49,10 @@ Even after living through cuts, the larger amount STILL nearly failed. 43 votes.
   - Auburn: $500K failed, $1.3M passed 33 days later (+160%)
   - Reading: $250K failed, $4.5M passed 42 days later (+1,700%)
   - Melrose: $7.7M failed, $13.5M passed 17 months later (+75%)
-- Operating override success rate historically: ~60-65% (vs 81% for debt exclusions)
-- Marblehead's own history: 3 of 21 operating overrides approved (86% failure rate). Last success: June 2005.
+- Operating override success rate historically: ~60-65% statewide (vs ~81% statewide for debt exclusions)
+- Marblehead's own history (MA DOR primary data, pulled 2026-04-11, see `data/marblehead_prop25_votes.csv`):
+  - Operating overrides: 4 of 13 ballot attempts approved (31% success rate) since 1990, the earliest year in the DOR record. Last success: June 2005 vote, $2.73M supplemental override for the FY2006 budget.
+  - Debt exclusions: 28 of 29 ballot attempts approved (97% success rate) since 1982. The only loss in 43 years was the June 2002 Tucker's Wharf bond by 136 votes.
 
 ---
 

--- a/data/marblehead_prop25_votes.csv
+++ b/data/marblehead_prop25_votes.csv
@@ -1,0 +1,71 @@
+measure_type,fiscal_year,vote_date,win_loss,yes_votes,no_votes,department,description,amount
+Override,1991,1990-06-01,LOSS,2664,4539,GENERAL OPERATING,General Operating Budget,1000000
+Override,1992,1991-06-17,LOSS,1629,2598,GENERAL OPERATING,General Operating Expenseds,575000
+Override,1992,1991-08-19,LOSS,564,935,GENERAL OPERATING,Funding Salaries For Town Clerks Office,15716
+Override,1992,1991-08-19,LOSS,716,782,HEALTH AND HUMAN SERVICE,Funding Meals On Wheels,508
+Override,1996,1995-06-05,LOSS,2473,2553,SCHOOL,School Department Salaries,348929
+Override,1997,1996-06-10,LOSS,2737,3376,SCHOOL,School Department Expenses,870084
+Override,2001,2000-06-19,LOSS,833,1150,GENERAL GOVERNMENT,Improvements At The Old Town House,149000
+Override,2002,2001-06-18,WIN,3016,1482,PUBLIC WORKS & FACILITIES,Construction Of Sewers And Surface Drains,300000
+Override,2004,2003-06-16,WIN,3936,2350,GENERAL GOVERNMENT,Supplemental Budget Expenses,1381017
+Override,2005,2004-06-21,LOSS,2419,2661,PUBLIC SAFETY,Cruiser For Police Dept.-Van For Dog Officer-Front End Loader And Backlhoe For Waste Coll. Dept.,482590
+Override,2005,2004-06-21,WIN,2857,2289,SCHOOL,Supplemental Expenses For School Department,422246
+Override,2005,2004-06-21,LOSS,2288,2758,PUBLIC SAFETY,Supplemental Expenses Of Police Department,132500
+Override,2005,2004-06-21,WIN,2849,2240,PUBLIC WORKS & FACILITIES,Supplemental Expenses For Waste Collection,17100
+Override,2005,2004-06-21,LOSS,1639,3384,GENERAL OPERATING,General Operating Expenditures,55000
+Override,2005,2004-06-21,WIN,2775,2323,CULTURE AND RECREATION,Library Expenses,73051
+Override,2006,2005-06-15,WIN,3869,3456,GENERAL GOVERNMENT,Supplemental Expenses Of Several Town Departments,2730167
+Override,2012,2011-06-14,LOSS,2531,3567,GENERAL GOVERNMENT,"Final Design, Public Bidding And Construction For Improvements To The Old Town House",667793
+Override,2023,2022-06-21,LOSS,1802,3929,SCHOOL,School Department Operating Budget,3051093
+Override,2024,2023-06-20,LOSS,2996,3414,GENERAL GOVERNMENT,General Government Operating Budget,2472056
+Override,2025,2025-06-30,LOSS,0,0,FUNDS,Fix Clerk Error,0
+Debt Exclusion,1990,1988-06-01,WIN,2322,2167,School,Schools,
+Debt Exclusion,1991,1990-06-01,WIN,3904,3241,School,Remodel/Repair Mid.Sch Heat System,
+Debt Exclusion,1993,1990-03-01,WIN,3593,1404,School,Remodel/Repair H Sch Sci Labs,
+Debt Exclusion,1997,1992-06-01,WIN,2481,1631,School,School Renovations,
+Debt Exclusion,1998,1996-06-10,WIN,3666,2363,Public Works and Facilities,Surface Drain Construction,
+Debt Exclusion,1999,1995-06-05,WIN,3237,1785,School,Repairs To Schools,
+Debt Exclusion,2000,1990-03-01,WIN,3468,1526,Culture and Recreation,Remodel/Equip Exsisting Library,
+Debt Exclusion,2000,1994-06-01,WIN,1058,506,Public Works and Facilities,Surface-Drains Construction,
+Debt Exclusion,2000,1994-06-01,WIN,993,575,School,School Renovation,
+Debt Exclusion,2000,1995-06-05,WIN,2946,2064,Public Safety,Repairs To Police And Inspectors Build.,
+Debt Exclusion,2000,1995-06-05,WIN,2994,2032,Health and Human Service,Const. Building For Council On Aging,
+Debt Exclusion,2000,1995-06-05,WIN,3028,1973,School,Computers For School Department,
+Debt Exclusion,2000,1995-06-05,WIN,3386,1607,Public Works and Facilities,Surface Storm Drains,
+Debt Exclusion,2000,1996-06-10,WIN,3394,2671,School,Computer Equipment For School Dept.,
+Debt Exclusion,2000,1996-06-10,WIN,3454,2594,Public Safety,Equipment For Fire Department,
+Debt Exclusion,2000,1996-06-10,WIN,3538,2530,School,Repair-Construct-Equip School Bldgs.,
+Debt Exclusion,2000,1997-06-09,WIN,1797,1702,School,Remodeling Of Several Town Schools,
+Debt Exclusion,2000,1998-06-08,WIN,2569,1267,School,Repairs To Several Schools,
+Debt Exclusion,2000,1998-06-08,WIN,2323,1503,School,Computers And Software For School Dept.,
+Debt Exclusion,2000,1999-06-14,WIN,4659,2976,School,Const.Equip-Furnish New High School,
+Debt Exclusion,2001,1982-06-19,WIN,1373,625,Public Works and Facilities,Reconst Sewers For Drainage Purposes,
+Debt Exclusion,2002,2000-06-19,WIN,1361,635,Public Works and Facilities,Repairs To Existing Drainage Infrastruction,
+Debt Exclusion,2002,2001-06-18,WIN,2916,1639,School,Plans For Conversion Of Schools,
+Debt Exclusion,2003,2001-12-10,WIN,2849,1434,School,"Bonds Issued To Plan, Remodel, Reconstruct Additions To Existing High School And Convert To Middle School",
+Debt Exclusion,2003,2002-06-24,LOSS,1049,1185,Culture and Recreation,"Bonds Issued For Remodeling, Reconstruction And Making Repairs To Tucker's Wharf",
+Debt Exclusion,2005,2004-06-21,WIN,2931,2133,Public Safety,Purchase Fire Pumper Truck,
+Debt Exclusion,2006,2005-06-15,WIN,4384,2778,General Government,Purchase Equipment For Several Town Departments,
+Debt Exclusion,2006,2005-06-15,WIN,4937,2315,General Government,Purchase 3 Certain Parcels Of Land Owned By Robinson Farm Realty Trust,
+Debt Exclusion,2008,2007-06-25,WIN,1565,1061,Public Works and Facilities,"Construct, Reconstruct Ocean Ave Causewayl",
+Debt Exclusion,2008,2007-06-25,WIN,1747,864,Public Works and Facilities,"Landfill Cap, Transfer Station, Drop Off",
+Debt Exclusion,2009,2008-06-17,WIN,2365,1311,School,Feasibility Study For The Glover School Project,
+Debt Exclusion,2009,2008-06-17,WIN,2464,1213,School,Village School Project -Reconstruction,
+Debt Exclusion,2012,2011-06-14,WIN,3394,2753,School,"Funding The Design, Project Management And Construction Of A New Elementary School",
+Debt Exclusion,2012,2011-06-14,WIN,3416,2681,Public Works and Facilities,"Funding The Permitting, Public Bidding And Construction Of A Cap For The Encompassing The Old Landfill, Etc",
+Debt Exclusion,2014,2012-06-21,WIN,1905,1542,Public Safety,Quint Fire Truck,
+Debt Exclusion,2014,2012-06-21,WIN,1990,1475,General Government,Old Town House Accessibility Project,
+Debt Exclusion,2014,2012-06-21,WIN,2263,1216,General Government,Lead Mills Land Acquisition,
+Debt Exclusion,2014,2012-06-21,WIN,2394,1067,Public Works and Facilities,Pleasant Street Area Drainage Project,
+Debt Exclusion,2014,2013-06-25,WIN,3186,2235,Public Works and Facilities,Green Street Remediation,
+Debt Exclusion,2014,2013-06-25,WIN,3888,1617,General Government,Abbot Hall Tower Repairs,
+Debt Exclusion,2018,2015-06-16,WIN,1934,666,Public Works and Facilities,Bonds To Pay For Repair And Replacement Of Drainage Pipe And Construction Of New Xfer Station,
+Debt Exclusion,2018,2016-06-14,WIN,2176,875,School,Bonds For Study, Renovation And Recon Of Elbridge Gerry School,
+Debt Exclusion,2018,2016-06-14,WIN,2403,628,Public Safety,Bonds For A Pumper Truck For The Fire Dept,
+Debt Exclusion,2020,2018-06-21,WIN,1555,326,Public Works and Facilities,Costs Of Constructing And Reconstructing Seawalls And Fences,
+Debt Exclusion,2020,2019-06-18,WIN,3440,1976,School,Bonds For New Gerry School,
+Debt Exclusion,2020,2019-06-18,WIN,4492,903,General Government,Bonds For Repairs To Fort Sewall,
+Debt Exclusion,2023,2021-06-22,WIN,3021,1346,Culture and Recreation,Renovation Of Abbot Public Library,
+Debt Exclusion,2023,2021-06-22,WIN,3418,894,Public Safety,New Fire Pumper Truck,
+Debt Exclusion,2024,2022-06-21,WIN,3347,2178,General Operating,"Roof Replacements, Road & Sidewalk Improvements, Smart Panels, Hvac, Salt Shed, Hs Boiler",
+Debt Exclusion,2026,2025-06-10,WIN,4088,1857,General Government,Mary Alley Building Improvement & Hvac,

--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -9,7 +9,7 @@ title: "How did we get here?"
   </div>
 
   <h2>2005 to 2021: Sixteen years of balanced budgets</h2>
-  <p>Marblehead's last successful operating override was approved in FY2005. For the sixteen fiscal years that followed, the Finance Committee reported balanced budgets and explicitly celebrated the absence of overrides as evidence of disciplined management.</p>
+  <p>Marblehead's last successful operating override was the June 2005 vote that funded a $2.73M supplemental override for the FY2006 budget. For the sixteen fiscal years that followed, the Finance Committee reported balanced budgets and explicitly celebrated the absence of overrides as evidence of disciplined management.</p>
   <p>The 2016 transmittal letter (for the FY17 budget) is typical of the period:</p>
 
   <blockquote class="quote">

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -17,7 +17,7 @@ title: "What Is the Override?"
       <div class="key-stat-label">Override Range</div>
     </div>
     <div class="key-stat">
-      <div class="key-stat-value">FY2005</div>
+      <div class="key-stat-value">2005</div>
       <div class="key-stat-label">Last Approved</div>
     </div>
   </div>
@@ -252,20 +252,119 @@ title: "What Is the Override?"
   <p>See the <a href="charts/override_calculator.html">override cost calculator</a> for year-by-year costs at different home values.</p>
 
   <h2>History</h2>
-  <p>Marblehead's last successful operating override was in FY2005, 21 years ago. Since 1982, voters have rejected 18 of 21 operating override attempts. They are far more willing to fund capital projects:</p>
+  <p>Marblehead's last successful operating override was the June 2005 vote that authorized a $2.73M supplemental override for the FY2006 budget, 21 years ago. Every operating override attempt since has failed. In the full Massachusetts Department of Revenue ballot record, Marblehead voters have approved 4 of 13 operating override attempts since 1990, but 28 of 29 debt exclusion attempts since 1982. They will reliably borrow to build things; they almost never vote to raise taxes for operating costs.</p>
 
   <div class="stat-compare">
     <div class="stat-row">
       <div class="stat-label">Operating overrides</div>
-      <div class="stat-bar"><div class="stat-fill" style="width: 14.29%"></div></div>
-      <div class="stat-value">14%<span>3 of 21 approved</span></div>
+      <div class="stat-bar"><div class="stat-fill" style="width: 30.77%"></div></div>
+      <div class="stat-value">31%<span>4 of 13 approved</span></div>
     </div>
     <div class="stat-row">
       <div class="stat-label">Debt exclusions</div>
-      <div class="stat-bar"><div class="stat-fill" style="width: 80.95%"></div></div>
-      <div class="stat-value">81%<span>68 of 84 approved</span></div>
+      <div class="stat-bar"><div class="stat-fill" style="width: 96.55%"></div></div>
+      <div class="stat-value">97%<span>28 of 29 approved</span></div>
     </div>
-    <p class="stat-caption">Marblehead ballot outcomes by measure type, 1982 to present.</p>
+    <p class="stat-caption">Marblehead ballot outcomes by measure type. Each attempt is one trip to the polls; a ballot with multiple items counts as one attempt and is marked approved if at least one item passed. Debt exclusions cover 1982&ndash;2025; operating overrides cover 1990&ndash;2025 (the earliest year in the DOR record).</p>
+  </div>
+
+  <div class="ballot-timeline">
+    <h3>Every Prop 2&frac12; ballot attempt in Marblehead</h3>
+    <p class="ballot-timeline-intro">Each dot is one ballot attempt. Green if the town approved it, red if it was rejected. Debt exclusions sail through almost without exception. Operating overrides are a different story: four successes clustered in the early 2000s, then a 17-year quiet, then three straight losses leading into the FY2027 vote.</p>
+    <svg viewBox="0 0 800 230" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Strip-plot timeline of every Marblehead Prop 2.5 ballot attempt, 1982 to 2026. Operating overrides on top row, debt exclusions on bottom row, dots colored green for approved or red for rejected.">
+      <!-- Row labels -->
+      <text class="row-label" x="10" y="58">Operating</text>
+      <text class="row-label" x="10" y="71">overrides</text>
+      <text class="row-sub" x="10" y="84">4 of 13</text>
+      <text class="row-label" x="10" y="130">Debt</text>
+      <text class="row-label" x="10" y="143">exclusions</text>
+      <text class="row-sub" x="10" y="156">28 of 29</text>
+
+      <!-- Grid lines per decade -->
+      <line class="grid-line" x1="185.8" y1="40" x2="185.8" y2="175"/>
+      <line class="grid-line" x1="343.1" y1="40" x2="343.1" y2="175"/>
+      <line class="grid-line" x1="500.4" y1="40" x2="500.4" y2="175"/>
+      <line class="grid-line" x1="657.8" y1="40" x2="657.8" y2="175"/>
+
+      <!-- Row baselines -->
+      <line class="axis-line" x1="60" y1="85" x2="760" y2="85"/>
+      <line class="axis-line" x1="60" y1="175" x2="760" y2="175"/>
+
+      <!-- FY27 vote upcoming indicator -->
+      <line class="future-line" x1="759" y1="40" x2="759" y2="175"/>
+      <text class="annotation annotation--buoy" x="762" y="52">FY2027</text>
+      <text class="annotation annotation--buoy" x="762" y="64">vote</text>
+      <text class="annotation annotation--buoy" x="762" y="76">Jun 9</text>
+
+      <!-- Operating override dots (13 attempts, chronological) -->
+      <circle class="vote-dot vote-dot--loss" cx="192.4" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--loss" cx="208.8" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--loss" cx="211.5" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--loss" cx="271.2" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--loss" cx="287.1" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--loss" cx="350.5" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="366.1" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="397.5" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="413.5" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="428.9" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--loss" cx="523.2" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--loss" cx="696.6" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--loss" cx="712.3" cy="70" r="6"/>
+
+      <!-- Annotation: last successful operating override -->
+      <line class="grid-line" x1="428.9" y1="80" x2="428.9" y2="100"/>
+      <text class="annotation annotation--sage" x="428.9" y="113" text-anchor="middle">Last operating win</text>
+      <text class="annotation" x="428.9" y="125" text-anchor="middle">June 2005 &middot; $2.7M</text>
+
+      <!-- Debt exclusion dots (29 attempts, chronological) -->
+      <circle class="vote-dot vote-dot--win"  cx="67.3"  cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="160.9" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="188.4" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="192.4" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="223.8" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="255.3" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="271.2" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="287.1" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="302.8" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="318.5" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="334.5" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="350.5" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="366.1" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="373.7" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--loss" cx="382.1" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="413.5" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="428.9" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="460.8" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="476.2" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="523.2" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="539.3" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="555.2" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="586.3" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="601.9" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="633.7" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="649.3" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="680.9" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="696.6" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--win"  cx="743.3" cy="140" r="6"/>
+
+      <!-- Annotation: only debt exclusion loss -->
+      <line class="grid-line" x1="382.1" y1="150" x2="382.1" y2="168"/>
+      <text class="annotation annotation--buoy" x="382.1" y="192" text-anchor="middle">Only debt-exclusion loss</text>
+      <text class="annotation" x="382.1" y="204" text-anchor="middle">2002 &middot; Tucker's Wharf bonds</text>
+
+      <!-- X-axis tick labels -->
+      <text class="tick-label" x="67"  y="222" text-anchor="middle">1982</text>
+      <text class="tick-label" x="186" y="222" text-anchor="middle">1990</text>
+      <text class="tick-label" x="343" y="222" text-anchor="middle">2000</text>
+      <text class="tick-label" x="500" y="222" text-anchor="middle">2010</text>
+      <text class="tick-label" x="658" y="222" text-anchor="middle">2020</text>
+      <text class="tick-label" x="752" y="222" text-anchor="middle">2026</text>
+    </svg>
+    <div class="ballot-timeline-legend">
+      <div class="li"><span class="sw sw--win"></span> Approved at the ballot</div>
+      <div class="li"><span class="sw sw--loss"></span> Rejected at the ballot</div>
+      <div class="li">Source: <a href="data/marblehead_prop25_votes.csv">marblehead_prop25_votes.csv</a> (MA DOR Municipal Databank, pulled April 11, 2026)</div>
+    </div>
   </div>
 
   <p>The structural problem this override addresses is not new. Signed transmittal letters from the Finance Committee show a steadily sharpening warning across seven years, ending in the override request now before voters.</p>


### PR DESCRIPTION
## Summary
- Commits `data/marblehead_prop25_votes.csv` (70 rows: 20 operating overrides + 50 debt exclusions) pulled fresh from the MA DOR Override/Underride and Debt Exclusion Votes reports on 2026-04-11. Documents both URLs in `data/SOURCES.md`.
- Updates the History section of `what-is-the-override.html` to use DOR-accurate counts, with a new strip-plot timeline chart showing every Prop 2½ ballot attempt Marblehead has held.
- Propagates the correction through `how-we-got-here.html` and `data/case_studies.md` for consistency.

## Why
The existing stat-compare block on `what-is-the-override.html` repeated "3 of 21 operating overrides approved, 68 of 84 debt exclusions approved" which trace back to a Marblehead Current article series (per commit `0618a35`). News-paraphrase sourcing doesn't meet the site's own data standards, and the numbers are materially different from what DOR actually has.

## The recount (1 attempt = 1 ballot date)
| Measure | Before (MC article) | After (DOR primary) |
|---|---|---|
| Operating overrides | 3 of 21 (14%) | **4 of 13 (31%)** |
| Debt exclusions | 68 of 84 (81%) | **28 of 29 (97%)** |
| Coverage | "1982 to present" | Operating: 1990–2025. Debt exclusion: 1982–2025. |

The corrected numbers actually *strengthen* the site's argument. The contrast between operating overrides and debt exclusions is sharper (97% vs 31%, a 66-point gap), and the single debt exclusion loss in 43 years was a 2002 Tucker's Wharf bond by 136 votes. Marblehead reliably borrows to build things; it almost never raises operating taxes.

## Notable findings from the pull
- The FY2005 framing was calendar-year shorthand. The DOR record calls the last successful operating override FY2006 — vote date June 15, 2005, $2.73M "Supplemental Expenses Of Several Town Departments." "21 years ago" is correct; "FY2005" was mixing conventions. Fixed in both pages and the key-stat card.
- DOR's earliest operating override record for Marblehead is June 1, 1990 (FY1991, $1M general operating budget, failed). There are no pre-1990 operating override records in DOR. "Since 1982" is supportable for debt exclusions but not for operating overrides.
- DOR has one procedural "Fix Clerk Error" row (FY2025, $0 amount, 0 yes, 0 no) that should not count as a real attempt. The CSV keeps it for completeness; the analysis excludes it.

## The chart
New `.ballot-timeline` SVG component on `what-is-the-override.html`, below the stat-compare bars. Two-row strip plot:
- **Operating overrides** (top): 13 dots, 4 green wins (all clustered 2001–2005), 9 red losses
- **Debt exclusions** (bottom): 29 dots, 28 green, 1 red (Tucker's Wharf, annotated)
- Dashed vertical marker for FY2027 vote (June 9, 2026)
- Source link at bottom points to the committed CSV
- Styles use existing `--c-sage` and `--c-buoy` color tokens (no new palette), added to `assets/site.css` near the existing `.stat-compare` section

## Test plan
- [x] Desktop (1000px): chart renders with both rows of dots, annotations position correctly over "last operating win" (June 2005) and "only debt exclusion loss" (2002 Tucker's Wharf), FY2027 dashed line at right edge
- [x] Mobile (390px): chart scales down, dots remain distinguishable, annotations readable
- [x] stat-compare bars scale to correct 30.77% / 96.55% widths
- [x] CSV parses cleanly in Python, all 70 rows valid, vote_date range 1982-06-19 to 2025-06-30
- [x] History prose paragraph reflows around updated numbers
- [x] how-we-got-here.html and case_studies.md updated for consistency

## Follow-ups not in this PR
- The "$8.47M" and other FY27 figures on the History page are unchanged. This PR is scoped to the ballot history section.
- The key-stats card at top of `what-is-the-override.html` shows "2005" (corrected from "FY2005"). If you'd rather it say "Jun 2005" or similar to be more specific, say the word.