### PR TITLE
Polish community pulse widget: mono icons, copy-only share, drop privacy

### DIFF
--- a/assets/community-pulse/widget.css
+++ b/assets/community-pulse/widget.css
@@ -23,16 +23,20 @@
 .cp-widget__button {
   display: inline-flex;
   align-items: center;
-  gap: 0.2rem;
-  padding: 0.25rem 0.55rem;
-  font-size: 0.95rem;
+  justify-content: center;
+  min-width: 1.8rem;
+  padding: 0.2rem 0.5rem;
+  font-size: 1rem;
   font-family: inherit;
-  color: inherit;
+  font-variant-emoji: text;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--text-muted, #666);
   background: transparent;
   border: 1px solid var(--border, rgba(0,0,0,0.15));
-  border-radius: 0.35rem;
+  border-radius: 0.3rem;
   cursor: pointer;
-  transition: background 0.12s ease, border-color 0.12s ease;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
 }
 
 .cp-widget__button:hover {
@@ -47,6 +51,12 @@
 .cp-widget__button[aria-pressed="true"] {
   background: var(--surface, rgba(0,0,0,0.06));
   border-color: var(--text, #333);
+  color: var(--text, #222);
+}
+
+.cp-widget__count-num:empty,
+.cp-widget__delta:empty {
+  display: none;
 }
 
 .cp-widget__count {
@@ -63,33 +73,35 @@
 }
 
 .cp-widget__share,
-.cp-widget__privacy {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.25rem 0.4rem;
-  font-size: 0.82rem;
-  color: var(--text-muted, #666);
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  text-decoration: none;
-}
-
-.cp-widget__share:hover,
-.cp-widget__privacy:hover {
-  color: var(--text, #222);
-  text-decoration: underline;
-}
-
 .cp-widget__note-toggle {
   display: inline-flex;
   align-items: center;
-  padding: 0.25rem 0.4rem;
-  font-size: 0.82rem;
+  justify-content: center;
+  min-width: 1.8rem;
+  padding: 0.2rem 0.35rem;
   color: var(--text-muted, #666);
   background: transparent;
-  border: none;
+  border: 1px solid transparent;
+  border-radius: 0.3rem;
   cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.cp-widget__share:hover,
+.cp-widget__note-toggle:hover {
+  color: var(--text, #222);
+  background: var(--surface, rgba(0,0,0,0.04));
+}
+
+.cp-widget__share:focus-visible,
+.cp-widget__note-toggle:focus-visible {
+  outline: 2px solid var(--c-teal, #2F7D8E);
+  outline-offset: 2px;
+}
+
+.cp-widget__share svg,
+.cp-widget__note-toggle svg {
+  display: block;
 }
 
 .cp-widget__note {

--- a/assets/community-pulse/widget.js
+++ b/assets/community-pulse/widget.js
@@ -143,9 +143,9 @@ export async function incrementReaction(sectionId) {
 // ---- Widget rendering and hydration -------------------------------------
 
 const STANCE_BUTTONS = [
-  { key: 'agree',    emoji: '👍', label: 'Agree' },
-  { key: 'disagree', emoji: '👎', label: 'Disagree' },
-  { key: 'alert',    emoji: '!',  label: 'Alert: something here caught my eye' }
+  { key: 'agree',    glyph: '+', label: 'Agree' },
+  { key: 'disagree', glyph: '−', label: 'Disagree' },
+  { key: 'alert',    glyph: '!', label: 'Alert: something here caught my eye' }
 ];
 
 let widgetCounter = 0;
@@ -163,62 +163,56 @@ function buildWidget(sectionId, sectionTitle, initialReactions, initialStance) {
   // Stance buttons.
   const buttons = document.createElement('div');
   buttons.className = 'cp-widget__buttons';
-  STANCE_BUTTONS.forEach(({ key, emoji, label }) => {
+  STANCE_BUTTONS.forEach(({ key, glyph, label }) => {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'cp-widget__button';
     btn.dataset.stance = key;
     btn.setAttribute('aria-label', label);
     btn.title = label;
-    btn.textContent = emoji;
+    btn.textContent = glyph;
     btn.setAttribute('aria-pressed', initialStance === key ? 'true' : 'false');
     buttons.appendChild(btn);
   });
   root.appendChild(buttons);
 
-  // Reaction count + delta.
+  // Reaction count + delta. Hidden until real data arrives; no placeholder text.
   const count = document.createElement('span');
   count.className = 'cp-widget__count';
   const countNum = document.createElement('span');
   countNum.className = 'cp-widget__count-num';
-  countNum.textContent = initialReactions
-    ? `${initialReactions.total} reactions`
-    : '...'; // ellipsis placeholder until the GET /api/reactions batch resolves
   const countDelta = document.createElement('span');
   countDelta.className = 'cp-widget__delta';
-  if (initialReactions && initialReactions.last_24h > 0) {
-    countDelta.textContent = `+${initialReactions.last_24h} today`;
+  if (initialReactions) {
+    countNum.textContent = `${initialReactions.total} reactions`;
+    if (initialReactions.last_24h > 0) {
+      countDelta.textContent = `+${initialReactions.last_24h} today`;
+    }
   }
   count.appendChild(countNum);
-  if (countDelta.textContent) count.appendChild(countDelta);
+  count.appendChild(countDelta);
   root.appendChild(count);
 
-  // Share button.
+  // Share button (copy link to clipboard). Icon = two overlapping rectangles.
   const share = document.createElement('button');
   share.type = 'button';
   share.className = 'cp-widget__share';
   share.dataset.action = 'share';
-  share.setAttribute('aria-label', 'Share this section');
-  share.title = 'Share this section';
-  share.textContent = 'Share';
+  share.setAttribute('aria-label', 'Copy link to this section');
+  share.title = 'Copy link';
+  share.innerHTML = '<svg viewBox="0 0 16 16" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.35" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="5.5" y="5.5" width="8.5" height="8.5" rx="1"/><path d="M2 10.5V3a1 1 0 0 1 1-1h7.5"/></svg>';
   root.appendChild(share);
 
-  // Privacy link.
-  const privacy = document.createElement('a');
-  privacy.className = 'cp-widget__privacy';
-  privacy.href = '/privacy.html';
-  privacy.title = 'How this feature handles your data';
-  privacy.textContent = 'Privacy';
-  root.appendChild(privacy);
-
-  // Note toggle.
+  // Note toggle. Icon = three horizontal lines of decreasing length.
   const noteToggle = document.createElement('button');
   noteToggle.type = 'button';
   noteToggle.className = 'cp-widget__note-toggle';
   noteToggle.dataset.action = 'toggle-note';
   noteToggle.setAttribute('aria-expanded', 'false');
   noteToggle.setAttribute('aria-controls', `${widgetId}-note`);
-  noteToggle.textContent = 'Note';
+  noteToggle.setAttribute('aria-label', 'Write a private note');
+  noteToggle.title = 'Note';
+  noteToggle.innerHTML = '<svg viewBox="0 0 16 16" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.35" stroke-linecap="round" aria-hidden="true"><line x1="3" y1="5" x2="13" y2="5"/><line x1="3" y1="8.5" x2="13" y2="8.5"/><line x1="3" y1="12" x2="10" y2="12"/></svg>';
   root.appendChild(noteToggle);
 
   // Note textarea (hidden initially).
@@ -317,26 +311,18 @@ function wireWidget(root, db, sectionId, sectionUrl, sectionTitle, initialRecord
   }, 1000);
   noteField.addEventListener('input', saveNote);
 
-  // Share button.
+  // Share button: always copy the section link to the clipboard.
   shareBtn.addEventListener('click', async () => {
-    const shareData = { title: sectionTitle, url: sectionUrl };
-    if (navigator.share) {
-      try {
-        await navigator.share(shareData);
-      } catch {
-        // User cancelled or share failed silently.
-      }
-    } else if (navigator.clipboard) {
+    if (navigator.clipboard) {
       try {
         await navigator.clipboard.writeText(sectionUrl);
         showToast('Link copied');
+        return;
       } catch {
-        showToast('Copy failed');
+        // Fall through to the prompt fallback below.
       }
-    } else {
-      // Last-resort fallback: show the URL in a prompt so the user can copy it manually.
-      window.prompt('Copy this link:', sectionUrl);
     }
+    window.prompt('Copy this link:', sectionUrl);
   });
 }
 

--- a/community-pulse/worker/wrangler.toml
+++ b/community-pulse/worker/wrangler.toml
@@ -5,7 +5,7 @@ compatibility_date = "2026-04-01"
 [[d1_databases]]
 binding = "DB"
 database_name = "community-pulse"
-database_id = "REPLACE_WITH_DATABASE_ID_AFTER_CREATE"
+database_id = "e6c6e7ad-b93e-4d80-aeea-58e50e4ba43e"
 
 [vars]
 ALLOWED_ORIGIN = "https://marbleheaddata.org"


### PR DESCRIPTION
Stance buttons use plain +/-/! text glyphs with font-variant-emoji:text instead of color emoji. Share always copies to clipboard (no native share sheet) and uses an inline SVG copy icon instead of the word "Share". Note toggle uses an inline SVG lines icon instead of the word "Note". Privacy link removed from the widget. Reactions count is hidden via CSS when the count-num span is empty, so pages show no placeholder ellipsis before the Worker responds.

Also records the deployed D1 database_id in wrangler.toml.