### PR TITLE
Point community pulse widget at deployed Worker URL

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -27,4 +27,4 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 {% if page.og_image %}<meta property="og:image" content="{{ page.og_image }}">{% else %}<meta property="og:image" content="https://marbleheaddata.org/favicon.svg">{% endif %}
 {% if page.og_type %}<meta property="og:type" content="{{ page.og_type }}">{% else %}<meta property="og:type" content="article">{% endif %}
 {% if page.og_url %}<meta property="og:url" content="{{ page.og_url }}">{% endif %}
-<script type="module" src="{{ '/' | relative_url }}assets/community-pulse/widget.js" data-api-base="https://marblehead-community-pulse.example.workers.dev"></script>
+<script type="module" src="{{ '/' | relative_url }}assets/community-pulse/widget.js" data-api-base="https://marblehead-community-pulse.agbaber.workers.dev"></script>


### PR DESCRIPTION
Replaces the `example.workers.dev` placeholder in `_includes/head.html` with the real deployed Worker (`marblehead-community-pulse.agbaber.workers.dev`).

This commit was originally on `community-pulse-v1` but landed after PR #22 was merged, so it missed the merge window.

Once this merges, the widget will fetch reaction counts from the live Worker instead of a 404.