### PR TITLE
Community pulse polish: inline placement, opt-in, per-page exclude

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@ defaults:
       path: "charts"
     values:
       layout: chart
+      community_pulse: off-sections
 
 exclude:
   - README.md

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,10 +21,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
 <link rel="icon" href="{{ '/' | relative_url }}favicon.svg" type="image/svg+xml">
 <link rel="stylesheet" href="{{ '/' | relative_url }}assets/site.css">
+{% unless page.community_pulse == "off-sections" %}
 <link rel="stylesheet" href="{{ '/' | relative_url }}assets/community-pulse/widget.css">
+<script type="module" src="{{ '/' | relative_url }}assets/community-pulse/widget.js" data-api-base="https://marblehead-community-pulse.agbaber.workers.dev"></script>
+{% endunless %}
 {% if page.og_title %}<meta property="og:title" content="{{ page.og_title }}">{% endif %}
 {% if page.og_description %}<meta property="og:description" content="{{ page.og_description }}">{% endif %}
 {% if page.og_image %}<meta property="og:image" content="{{ page.og_image }}">{% else %}<meta property="og:image" content="https://marbleheaddata.org/favicon.svg">{% endif %}
 {% if page.og_type %}<meta property="og:type" content="{{ page.og_type }}">{% else %}<meta property="og:type" content="article">{% endif %}
 {% if page.og_url %}<meta property="og:url" content="{{ page.og_url }}">{% endif %}
-<script type="module" src="{{ '/' | relative_url }}assets/community-pulse/widget.js" data-api-base="https://marblehead-community-pulse.agbaber.workers.dev"></script>

--- a/about.html
+++ b/about.html
@@ -1,5 +1,6 @@
 ---
 title: "About"
+community_pulse: off-sections
 ---
 <style>
 /* Page-scoped: About me and meta pills */

--- a/assets/community-pulse/widget.css
+++ b/assets/community-pulse/widget.css
@@ -2,17 +2,43 @@
    Reuses CSS custom properties from assets/site.css so the widget
    inherits the site's light and dark themes automatically. */
 
-.cp-widget {
+/* Flex wrapper placed around a tagged heading + its widget.
+   On desktop, the heading takes its natural width and the widget
+   floats right next to it. On narrow screens, the widget stacks
+   below the heading. */
+.cp-section-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.6rem;
-  margin: 0.4rem 0 1.2rem 0;
-  padding: 0.4rem 0.6rem;
+  justify-content: space-between;
+  gap: 0.75rem 1rem;
+}
+
+.cp-section-row > :first-child {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-right: 0;
+}
+
+.cp-widget {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 0 0 auto;
   font-size: 0.85rem;
   color: var(--text-muted, #666);
-  border-top: 1px dashed var(--border, rgba(0,0,0,0.1));
-  border-bottom: 1px dashed var(--border, rgba(0,0,0,0.1));
+}
+
+@media (max-width: 640px) {
+  .cp-section-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+  }
+  .cp-widget {
+    font-size: 0.8rem;
+  }
 }
 
 .cp-widget__buttons {

--- a/assets/community-pulse/widget.js
+++ b/assets/community-pulse/widget.js
@@ -327,42 +327,23 @@ function wireWidget(root, db, sectionId, sectionUrl, sectionTitle, initialRecord
 }
 
 /**
- * Walk every h2 on the page (unless opted out), assign an anchor ID, inject
- * a widget next to it, and wire handlers. Also handle elements with an
- * explicit data-stance-section attribute.
+ * Walk every element with a data-stance-section attribute and inject a
+ * widget next to it. Widgets are opt-in only: authors add the attribute
+ * to the specific headings or blocks they want to capture.
  */
 export async function hydrateWidgets() {
-  // Opt-out check.
+  // Opt-out check (also used as a performance short-circuit via conditional script inclusion in the layout).
   if (document.body.dataset.communityPulse === 'off-sections') return;
 
   const pagePath = location.pathname.replace(/^\//, '') || 'index.html';
   const collectedTargets = [];
   const seenSlugs = new Set();
 
-  // Auto: every h2 on the page. Deduplicate slugs within the page.
-  document.querySelectorAll('h2').forEach(heading => {
-    const text = heading.textContent.trim();
-    let slug = slugify(text);
-    if (!slug) return;
-    if (seenSlugs.has(slug)) {
-      let suffix = 2;
-      while (seenSlugs.has(`${slug}-${suffix}`)) suffix++;
-      slug = `${slug}-${suffix}`;
-    }
-    seenSlugs.add(slug);
-    if (!heading.id) heading.id = slug;
-    collectedTargets.push({
-      element: heading,
-      sectionId: `${pagePath}#${heading.id}`,
-      title: text
-    });
-  });
-
-  // Explicit: elements with data-stance-section override.
+  // Opt-in: elements with an explicit data-stance-section attribute.
   document.querySelectorAll('[data-stance-section]').forEach(el => {
     const slug = el.dataset.stanceSection.trim();
     if (!slug) return;
-    // If this slug is already in use, skip (author should pick a unique slug).
+    // If this slug is already in use on the page, skip (author should pick a unique slug).
     if (seenSlugs.has(slug)) return;
     seenSlugs.add(slug);
     if (!el.id) el.id = slug;
@@ -392,7 +373,9 @@ export async function hydrateWidgets() {
   const allStances = await getAllStances(db);
   const stanceMap = new Map(allStances.map(s => [s.section_id, s]));
 
-  // Build and wire each widget.
+  // Build and wire each widget. Wrap the target element and the widget
+  // in a flex container so the widget floats inline-right of the target
+  // on desktop and stacks below on mobile (handled by CSS).
   for (const target of collectedTargets) {
     const initialReactions = reactionsMap[target.sectionId];
     const initialRecord = stanceMap.get(target.sectionId) || null;
@@ -402,7 +385,13 @@ export async function hydrateWidgets() {
       initialReactions,
       initialRecord?.stance
     );
-    target.element.insertAdjacentElement('afterend', widget);
+    const parent = target.element.parentNode;
+    if (!parent) continue;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'cp-section-row';
+    parent.insertBefore(wrapper, target.element);
+    wrapper.appendChild(target.element);
+    wrapper.appendChild(widget);
     wireWidget(
       widget,
       db,


### PR DESCRIPTION
Three changes to the community pulse widget based on design feedback:

## 1. Widgets are opt-in per section, not automatic

Auto-hydration on every \`<h2>\` is removed. Widgets now appear only on elements you explicitly mark with a \`data-stance-section=\"unique-slug\"\` attribute. Nothing renders unless tagged, so the site looks unchanged until you choose where to place widgets.

To add a widget to a specific heading:

\`\`\`html
<h2 data-stance-section=\"three-tiers\">The three tiers</h2>
\`\`\`

The slug becomes the section ID used in the URL (\`#three-tiers\`) and the backend key (\`what-is-the-override.html#three-tiers\`).

You can also tag non-heading elements if you want a widget on a mid-paragraph claim.

## 2. Inline placement, right of the tagged element

On desktop, the widget now floats right of the heading in the same row. On screens narrower than 640px, it stacks below the heading. Implemented via a flex wrapper (\`.cp-section-row\`) inserted by the widget JS at hydration time.

This is much lower visual weight than the previous full-width strip and respects the reading flow.

## 3. Per-page exclude for about and charts

\`about.html\` and all pages under \`charts/*\` now set \`community_pulse: off-sections\` in their frontmatter (charts via \`_config.yml\` defaults). On those pages, the widget CSS and JS are not loaded at all. No hydration, no bandwidth overhead.

## Testing

- 30/30 widget and worker tests still pass.
- Manually tagged no headings in this PR, so the live site will look exactly the same after merge (no widgets visible anywhere). Next step is to add \`data-stance-section\` attributes to specific headings you want to capture.

## Depends on

This branch is based on \`fix/cp-worker-url\` (PR #23), which points the widget at the deployed Worker. Merge #23 first, then this PR will merge cleanly.