### PR TITLE
Community pulse: reaction count fix, no hover tooltips, tag 24 sections

### DIFF
--- a/assets/community-pulse/widget.js
+++ b/assets/community-pulse/widget.js
@@ -170,7 +170,6 @@ function buildWidget(sectionId, sectionTitle, initialReactions, initialStance) {
     btn.className = 'cp-widget__button';
     btn.dataset.stance = key;
     btn.setAttribute('aria-label', label);
-    btn.title = label;
     btn.textContent = glyph;
     btn.setAttribute('aria-pressed', initialStance === key ? 'true' : 'false');
     buttons.appendChild(btn);
@@ -200,7 +199,6 @@ function buildWidget(sectionId, sectionTitle, initialReactions, initialStance) {
   share.className = 'cp-widget__share';
   share.dataset.action = 'share';
   share.setAttribute('aria-label', 'Copy link to this section');
-  share.title = 'Copy link';
   share.innerHTML = '<svg viewBox="0 0 16 16" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.35" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="5.5" y="5.5" width="8.5" height="8.5" rx="1"/><path d="M2 10.5V3a1 1 0 0 1 1-1h7.5"/></svg>';
   root.appendChild(share);
 
@@ -212,7 +210,6 @@ function buildWidget(sectionId, sectionTitle, initialReactions, initialStance) {
   noteToggle.setAttribute('aria-expanded', 'false');
   noteToggle.setAttribute('aria-controls', `${widgetId}-note`);
   noteToggle.setAttribute('aria-label', 'Write a private note');
-  noteToggle.title = 'Note';
   noteToggle.innerHTML = '<svg viewBox="0 0 16 16" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.35" stroke-linecap="round" aria-hidden="true"><line x1="3" y1="5" x2="13" y2="5"/><line x1="3" y1="8.5" x2="13" y2="8.5"/><line x1="3" y1="12" x2="10" y2="12"/></svg>';
   root.appendChild(noteToggle);
 

--- a/assets/community-pulse/widget.js
+++ b/assets/community-pulse/widget.js
@@ -48,7 +48,7 @@ export function getStance(db, sectionId) {
 }
 
 /** Upsert a stance record. Stamps updated_at. */
-export function setStance(db, sectionId, { stance, note }) {
+export function setStance(db, sectionId, { stance, note, reacted }) {
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite');
     const store = tx.objectStore(STORE_NAME);
@@ -56,6 +56,7 @@ export function setStance(db, sectionId, { stance, note }) {
       section_id: sectionId,
       stance: stance ?? null,
       note: note ?? '',
+      reacted: reacted === true,
       updated_at: Date.now()
     };
     const req = store.put(record);
@@ -264,6 +265,7 @@ function wireWidget(root, db, sectionId, sectionUrl, sectionTitle, initialRecord
   // Track current state in closure to avoid extra IDB reads.
   let currentStance = initialRecord?.stance ?? null;
   let currentNote = initialRecord?.note ?? '';
+  let currentReacted = initialRecord?.reacted === true;
 
   // Reflect initial note into UI (stance was already reflected by buildWidget's initialStance).
   if (currentNote) {
@@ -272,27 +274,41 @@ function wireWidget(root, db, sectionId, sectionUrl, sectionTitle, initialRecord
     noteToggle.setAttribute('aria-expanded', 'true');
   }
 
+  /** Persist the current stance, note, and reacted state to IndexedDB. */
+  const persist = () => setStance(db, sectionId, {
+    stance: currentStance,
+    note: currentNote,
+    reacted: currentReacted
+  });
+
+  /**
+   * If this user has not yet been counted for this section, fire one
+   * reactions increment and mark them counted. Subsequent calls are no-ops
+   * until the user clears their browser data. Any meaningful interaction
+   * (stance activate, note content, share click) routes through this helper.
+   */
+  async function ensureCounted() {
+    if (currentReacted) return;
+    const result = await incrementReaction(sectionId);
+    if (!result) return; // network failure; try again on the next interaction
+    currentReacted = true;
+    countNum.textContent = `${result.total} reactions`;
+    countDelta.textContent = result.last_24h > 0 ? `+${result.last_24h} today` : '';
+    await persist();
+  }
+
   // Stance button handler.
   buttons.forEach(btn => {
     btn.addEventListener('click', async () => {
       const stanceKey = btn.dataset.stance;
       const currentlyPressed = btn.getAttribute('aria-pressed') === 'true';
       const newStance = currentlyPressed ? null : stanceKey;
-      // Update pressed state immediately.
       buttons.forEach(b => {
         b.setAttribute('aria-pressed', b.dataset.stance === newStance ? 'true' : 'false');
       });
-      // Persist to IndexedDB.
       currentStance = newStance;
-      await setStance(db, sectionId, { stance: currentStance, note: currentNote });
-      // Fire reactions increment only on activate.
-      if (newStance) {
-        const result = await incrementReaction(sectionId);
-        if (result) {
-          countNum.textContent = `${result.total} reactions`;
-          countDelta.textContent = result.last_24h > 0 ? `+${result.last_24h} today` : '';
-        }
-      }
+      await persist();
+      if (newStance) await ensureCounted();
     });
   });
 
@@ -304,25 +320,29 @@ function wireWidget(root, db, sectionId, sectionUrl, sectionTitle, initialRecord
     if (!isOpen) noteField.focus();
   });
 
-  // Note field debounced save.
+  // Note field debounced save. Counts as a reaction only once, the first
+  // time the note contains non-empty text.
   const saveNote = debounce(async () => {
     currentNote = noteField.value;
-    await setStance(db, sectionId, { stance: currentStance, note: currentNote });
+    await persist();
+    if (currentNote.trim().length > 0) await ensureCounted();
   }, 1000);
   noteField.addEventListener('input', saveNote);
 
-  // Share button: always copy the section link to the clipboard.
+  // Share button: always copy the section link to the clipboard. Counts as a reaction once.
   shareBtn.addEventListener('click', async () => {
     if (navigator.clipboard) {
       try {
         await navigator.clipboard.writeText(sectionUrl);
         showToast('Link copied');
+        await ensureCounted();
         return;
       } catch {
         // Fall through to the prompt fallback below.
       }
     }
     window.prompt('Copy this link:', sectionUrl);
+    await ensureCounted();
   });
 }
 

--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -8,7 +8,7 @@ title: "How did we get here?"
     The "board always wants more" skepticism does not fit the record. For sixteen consecutive years the Finance Committee actively did not ask for an override, and said so each year in writing. The shift from 2019 onward tracks real changes in the underlying math, not a shift in FinCom's appetite.
   </div>
 
-  <h2>2005 to 2021: Sixteen years of balanced budgets</h2>
+  <h2 data-stance-section="balanced-budgets-era">2005 to 2021: Sixteen years of balanced budgets</h2>
   <p>Marblehead's last successful operating override was the June 2005 vote that funded a $2.73M supplemental override for the FY2006 budget. For the sixteen fiscal years that followed, the Finance Committee reported balanced budgets and explicitly celebrated the absence of overrides as evidence of disciplined management.</p>
   <p>The 2016 transmittal letter (for the FY17 budget) is typical of the period:</p>
 
@@ -46,7 +46,7 @@ title: "How did we get here?"
 
   <p>This is the first explicit override prediction in the local record. FinCom told residents an override was coming next year. They were right.</p>
 
-  <h2>2023: The failed override</h2>
+  <h2 data-stance-section="failed-override-2023">2023: The failed override</h2>
   <p>The next year, the 2023 transmittal letter (for the FY24 budget) delivered the promised override request:</p>
 
   <blockquote class="quote">
@@ -56,7 +56,7 @@ title: "How did we get here?"
 
   <p>Town Meeting approved the override 534 to 230. It failed at the ballot, 2,992 to 3,399, by a margin of roughly 400 votes. The FY24 budget was delivered as a "reduced services" version instead.</p>
 
-  <h2>2024 and 2025: The structural deficit continues</h2>
+  <h2 data-stance-section="deficit-continues">2024 and 2025: The structural deficit continues</h2>
   <p>With the FY24 override defeated at the ballot, the next two transmittal letters continued the warning, each time with more specificity. From the 2024 letter (for the FY25 budget):</p>
 
   <blockquote class="quote">
@@ -71,7 +71,7 @@ title: "How did we get here?"
     <footer>2025 Finance Committee Annual Report, transmittal letter to the 2025 Annual Town Meeting (for the FY26 budget). <a href="data/FY2026_FinCom_Annual_Report.pdf">PDF</a>.</footer>
   </blockquote>
 
-  <h2>2026: The vote before us</h2>
+  <h2 data-stance-section="vote-2026">2026: The vote before us</h2>
   <p>Here we are. The deficit the Finance Committee first signaled in 2019, explicitly predicted in 2022, partially delivered in 2023 (and defeated at the ballot), continued warning about in 2024, and specifically named for FY27 in 2025 is now on the June 2026 ballot as a three-tier override ranging from $9 million to $15 million. Residents have had roughly seven years of warning, four years of explicit deficit predictions, and three years since the first override attempt was defeated.</p>
 
   <div class="read-next">

--- a/senior-tax-relief.html
+++ b/senior-tax-relief.html
@@ -120,7 +120,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     For a qualifying senior, the state Senior Circuit Breaker formula refunds <em>more</em>, not less, as the property tax bill goes up. The override increases the credit for seniors who are not yet at the $2,820 cap.
   </div>
 
-  <h2>1. The state Senior Circuit Breaker</h2>
+  <h2 data-stance-section="circuit-breaker">1. The state Senior Circuit Breaker</h2>
   <p>The Senior Circuit Breaker is a refundable Massachusetts income tax credit claimed on Schedule CB with your state return. "Refundable" means you get a check even if you owe no state income tax. Social Security income does not disqualify you.</p>
 
   <div class="card">
@@ -221,7 +221,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     <p class="source">Sources: <a href="https://itemlive.com/2025/12/03/marblehead-fy26-valuations-rise/">Itemlive, "Marblehead valuations go high, taxes go low" (Dec 3, 2025)</a>, from the FY26 tax classification hearing.</p>
   </div>
 
-  <h2>2. The local exemption Marblehead voted for</h2>
+  <h2 data-stance-section="local-exemption">2. The local exemption Marblehead voted for</h2>
   <p>At the May 5, 2025 Annual Town Meeting, voters approved <strong>Article 28</strong> by a reported 93% margin. Article 28 is a home rule petition asking the state legislature to authorize Marblehead to create a local means-tested senior exemption on top of the Circuit Breaker. It was filed at the State House as <strong>House Bill H.4225</strong>.</p>
 
   <div class="card">
@@ -293,7 +293,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     <p><strong>Has any other town done this?</strong> Yes. Sudbury was the first in 2006. Concord, Wayland, Lincoln, Boxford, and dozens of other Massachusetts municipalities have since passed similar home rule acts. These are collectively referred to as "Sudbury-style" means-tested senior exemptions. Marblehead is joining an established template, not creating something untested.</p>
   </div>
 
-  <h2>3. Other exemptions that already exist</h2>
+  <h2 data-stance-section="other-exemptions">3. Other exemptions that already exist</h2>
   <p>The following exemptions are available to Marblehead residents today. Veteran exemption amounts were verified from the 2025 Finance Committee Report. The elderly and surviving spouse amounts are set by Town Meeting adoption and need to be confirmed directly with the Assessor's office.</p>
 
   <div class="card">
@@ -350,7 +350,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     <p class="source">Source: <a href="https://marbleheadma.gov/council-aging/pages/property-tax-abatement-program">Marblehead Council on Aging</a>.</p>
   </div>
 
-  <h2>4. The override connection</h2>
+  <h2 data-stance-section="override-connection">4. The override connection</h2>
   <p>For a qualifying Marblehead senior, the combination of the state Circuit Breaker ($2,820 max) and, if H.4225 is enacted, the local Article 28 exemption (Select Board-set cap, first-year funded at $200,000 town-wide from the overlay) can exceed $4,000 per year in combined relief for households at the lower end of the income range. For a household receiving the full state credit and a modest local exemption, that is more than the roughly $1,500 per year an operating override is projected to add to a median bill.</p>
 
   <p>Two points worth holding in mind when reading the override debate:</p>

--- a/what-fails.html
+++ b/what-fails.html
@@ -7,7 +7,7 @@ og_url: https://marbleheaddata.org/what-fails.html
 <h1>What's in the no-override budget?</h1>
   <p>The town published a <a href="https://marbleheadma.gov/wp-content/uploads/2026/04/PROPOSED-FY27-BALANCED-BUDGET-WITH-NO-OVERRIDE.pdf">FY27 Proposed Balanced Budget With No Override</a> in April 2026. It balances using $5M in free cash, staffing reductions across town and school departments, and the elimination of the town's OPEB trust contribution. This page lists the specific line-item changes from that document.</p>
 
-  <h2>Town-side reductions</h2>
+  <h2 data-stance-section="town-side-reductions">Town-side reductions</h2>
 
   <div class="card">
     <h3>22 full-time town positions removed</h3>
@@ -80,7 +80,7 @@ og_url: https://marbleheaddata.org/what-fails.html
 
   <p>The library reduction (-43%) would "significantly reduce services in terms of days that the library can be open," per the <a href="https://www.marbleheadindependent.com/marblehead-advances-122-8m-budget-built-on-cuts-defers-override-decisions/">Marblehead Independent</a>. The library was recently renovated with a separate $8.5M debt exclusion approved by voters in 2021.</p>
 
-  <h2>School-side reductions</h2>
+  <h2 data-stance-section="school-side-reductions">School-side reductions</h2>
 
   <div class="card">
     <h3>14 positions identified, plus additional $1.5M in reductions TBD</h3>
@@ -88,7 +88,7 @@ og_url: https://marbleheaddata.org/what-fails.html
     <p class="source">Source: <a href="https://marbleheadma.gov/wp-content/uploads/2026/04/PROPOSED-FY27-BALANCED-BUDGET-WITH-NO-OVERRIDE.pdf">FY27 Proposed Budget</a>, page 2; Marblehead Independent, <a href="https://www.marbleheadindependent.com/concerns-over-staffing-cuts-shape-marblehead-school-budget-hearing/">"Concerns over staffing cuts shape Marblehead school budget hearing"</a></p>
   </div>
 
-  <h2>What stays the same or goes up</h2>
+  <h2 data-stance-section="what-stays-or-grows">What stays the same or goes up</h2>
 
   <div class="card">
     <h3>Costs that increase regardless of the override outcome</h3>
@@ -121,7 +121,7 @@ og_url: https://marbleheaddata.org/what-fails.html
 
   <p>Health insurance, pensions, debt service, and contracted salary increases continue to grow regardless of the override outcome. The reductions above are what the town finance team determined would be required to balance the budget around these fixed-cost increases.</p>
 
-  <h2>What other MA towns did after similar votes</h2>
+  <h2 data-stance-section="what-other-towns-did">What other MA towns did after similar votes</h2>
 
   <p>Melrose (population ~28,000) rejected a $7.7M override in June 2024 and reduced 61.4 FTEs over two years across teachers, library hours, senior van drivers, and other departments. Elementary class sizes were proposed up to 32 students. The middle and high school shared one principal. Melrose returned to the ballot in November 2025 and passed a $13.5M override, 75% larger than the original ask.</p>
 

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -55,7 +55,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
     <footer>Thatcher Kezer, Town Administrator, and Aleesha Benjamin, Finance Director, Town of Marblehead. <a href="https://marbleheadma.gov/wp-content/uploads/2026/02/2026-State-of-the-Town-Presenation-Final.pdf">2026 State of the Town presentation</a>, slide 9, January 28, 2026.</footer>
   </blockquote>
 
-  <h2>The Three Tiers</h2>
+  <h2 data-stance-section="three-tiers">The Three Tiers</h2>
   <p>The tiers are nested. Each higher tier contains everything in the lower tiers, so the highest tier that gets a majority sets the override amount.</p>
 
   <div class="tier-chart">
@@ -138,7 +138,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
 
   <p>That reading is arithmetically understandable (9+12+15=36) but the ballot does not work that way. Because the tiers are nested, a yes vote on all three still caps the override at the highest tier that passes, $15 million, not $36 million. If the nested structure tripped up a careful attendee at the meeting where it was first presented, it is likely to confuse voters at the polls.</p>
 
-  <h2>How You'll Vote</h2>
+  <h2 data-stance-section="how-youll-vote">How You'll Vote</h2>
   <p>Two ballot questions at the Annual Town Election on June 9, 2026.</p>
 
   <div class="ballot">
@@ -198,7 +198,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
   </div>
   <p>Question 2 is independent of Question 1. Either way, residents pay for trash: the override spreads the cost by home value, while the Board of Health's fallback is a flat fee of roughly $262 per household.</p>
 
-  <h2>What It Costs</h2>
+  <h2 data-stance-section="what-it-costs">What It Costs</h2>
   <p>The override phases in over three years (FY27 to FY29). Year 1 draws only a fraction of the full amount; the full override is active only in Year 3:</p>
 
   <div class="phase-chart">
@@ -254,7 +254,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
 
   <p>See the <a href="charts/override_calculator.html">override cost calculator</a> for year-by-year costs at different home values.</p>
 
-  <h2>History</h2>
+  <h2 data-stance-section="history">History</h2>
   <p>Marblehead's last successful operating override was the June 2005 vote that authorized a $2.73M supplemental override for the FY2006 budget, 21 years ago. Every operating override attempt since has failed. In the full Massachusetts Department of Revenue ballot record, Marblehead voters have approved 4 of 13 operating override attempts since 1990, but 28 of 29 debt exclusion attempts since 1982. They will reliably borrow to build things; they almost never vote to raise taxes for operating costs.</p>
 
   <div class="stat-compare">

--- a/where-has-the-money-gone.html
+++ b/where-has-the-money-gone.html
@@ -114,7 +114,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>The property tax levy doubled from $39M in 2005 to $82M in 2024. Here is where every additional dollar went, who has been checking the books, and what grew faster than it probably should have.</p>
 
   <!-- Act 1: Where it went. Filled by Task 5 (prose and department table) and Task 6 (stacked spending chart). -->
-  <h2>Where it went</h2>
+  <h2 data-stance-section="where-it-went">Where it went</h2>
 
   <p>Marblehead's General Fund spending grew from $70.5 million in 2015 to $106.2 million in 2026, an increase of $35.7 million. These are the town's budgetary-basis General Fund numbers: the money the Finance Committee builds the annual budget around and Town Meeting votes on. They exclude grants, school food service and athletics fees, and state on-behalf payments into the teachers pension fund, which together total roughly $26 million a year in additional money the town does not directly control.</p>
 
@@ -445,7 +445,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </ol>
 
   <!-- Act 2: Who has been checking the books. Filled by Task 7. -->
-  <h2>Who has been checking the books</h2>
+  <h2 data-stance-section="who-checks-books">Who has been checking the books</h2>
 
   <p>Marblehead's finances have been independently reviewed every year going back to at least 2001. What follows is a plain-language list of the outside reviewers who check the town's books, what each review actually looks at, and where to read their findings.</p>
 
@@ -495,7 +495,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>These reviewers do not all agree the town is doing everything right. The Finance Committee has specifically flagged the town's reliance on leftover surplus from prior years to balance the operating budget as a pattern that cannot continue indefinitely, and the next section lists the specific lines that have grown faster than enrollment, inflation, or headcount would explain, including that pattern.</p>
 
   <!-- Act 3: What grew faster. Filled by Task 8. -->
-  <h2>What grew faster</h2>
+  <h2 data-stance-section="what-grew-faster">What grew faster</h2>
 
   <p>Four specific lines in the town's budget have grown faster than enrollment, inflation, or headcount would explain. Each is documented below with its primary sources.</p>
 
@@ -525,7 +525,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 
   <!-- Close. Filled by Task 9. -->
-  <h2>What this means for the override</h2>
+  <h2 data-stance-section="means-for-override">What this means for the override</h2>
 
   <p>The record shows two things worth taking seriously. Most of Marblehead's $35.7 million in General Fund spending growth since 2015 went to schools (which kept a smaller student-to-teacher ratio than its peer towns while paying for mandated out-of-district special education placements), to health insurance (set by the state insurance pool, not by the town), and to pensions and debt payments (both on fixed schedules set outside the annual budget). Independent auditors have issued a clean opinion on the books every year, and the state has certified the town's tax rate every year. Separately, the Finance Committee has flagged, in multiple annual reports, that the town has been balancing the operating budget by drawing down leftover surplus from prior years, a pattern the Committee describes as a structural budget challenge.</p>
 

--- a/why-not-elsewhere.html
+++ b/why-not-elsewhere.html
@@ -134,7 +134,7 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
     </div>
   </div>
 
-  <h2>Residential share of the tax levy, FY2026</h2>
+  <h2 data-stance-section="residential-share">Residential share of the tax levy, FY2026</h2>
   <p>When a homeowner in Marblehead pays their tax bill, 95.5&cent; of every dollar the town collects in property tax comes from residential property. In Cambridge, that figure is 33.8&cent;. The rest comes from commercial, industrial, and personal property taxes. Towns with a large commercial base can spread cost increases across office parks, labs, and retail instead of concentrating them on homeowners; towns without one can't. This isn't a statement about which model is better. It's a statement about what each town's tax revenue depends on.</p>
 
   <div class="peer-chart">
@@ -171,7 +171,7 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
 
   <p class="source">Source: <a href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=propertytaxinformation.taxlevies.leviesbyclass">MA DOR, Tax Levies by Class FY2026</a>. Peer set selected to span residential suburbs, mixed-use suburbs, commercial-anchor cities, and gateway cities.</p>
 
-  <h2>New growth: the other lever</h2>
+  <h2 data-stance-section="new-growth">New growth: the other lever</h2>
   <p>Proposition 2&frac12; caps annual levy growth at 2.5%, but new construction (new homes, new office buildings, additions and renovations) adds to the levy ceiling outside that cap. DOR calls this "new growth." In towns with active development, the levy limit expands every year from new construction alone, without an override vote.</p>
 
   <p>Marblehead's 5-year average new growth is 0.54% of prior-year levy, which works out to roughly $460,000 per year added to the levy ceiling. Needham, the top residential-adjacent suburb in the peer set by this metric, averages 2.83%, about $4.1 million per year. Cambridge averages 2.74% on a levy five times larger than Marblehead's: around $18 million per year. Whether this difference is a structural advantage for the commercial towns or a price paid by their residents (in traffic, scale, or lost small-town character) depends on what you value.</p>
@@ -203,7 +203,7 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
 
   <p class="source">Source: <a href="https://dls-gw.dor.state.ma.us/reports/rdPage.aspx?rdReport=NewGrowth.NewGrowth_dash_v2_test">MA DOR, New Growth Analysis</a>. Bars scaled to the peer set maximum (Boston, 3.15%).</p>
 
-  <h2>Four structural archetypes</h2>
+  <h2 data-stance-section="four-archetypes">Four structural archetypes</h2>
   <p>The peer towns cluster into four groups with different structural profiles. None is "doing it right" or "doing it wrong." Each reflects a different combination of geography, history, demographics, and policy choices that residents and officials made over decades. The same structural profile can be viewed as an advantage or a tradeoff depending on what residents value.</p>
 
   <p class="source"><strong>A note on the columns below.</strong> <em>Res&nbsp;%</em> is the residential share of the property tax levy. <em>CIP&nbsp;%</em> is the commercial, industrial, and personal-property share. <em><a href="#ng-footnote">5yr&nbsp;NG</a></em> is the five-year average new growth: the percent added to the levy ceiling each year from new construction, outside Proposition 2&frac12;'s 2.5% cap.</p>
@@ -277,7 +277,7 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
   </table>
   <p class="source">*Malden held the first Proposition 2&frac12; override vote in its history on <a href="https://www.wgbh.org/news/news-programs/2026-04-01/malden-faces-painful-cuts-after-voter-reject-first-ever-tax-override">March 31, 2026</a>. Both the $5.4M and larger options failed. That Malden didn't put an override on the ballot for more than forty years after Prop 2&frac12; took effect reflects a different combination of state aid, local tax structure, and political dynamics than most suburbs face. Marblehead does not qualify as a gateway city (the designation is based on historical manufacturing employment and median household income) and therefore cannot access most gateway-city state aid programs.</p>
 
-  <h2>What mechanisms exist to move between groups?</h2>
+  <h2 data-stance-section="what-mechanisms-exist">What mechanisms exist to move between groups?</h2>
   <p>The archetypes above aren't permanent. Towns can move between them over time, and the mechanisms that enable those moves are policy choices about zoning, taxation, and development. This section lists the mechanisms that explain most of the differences between groups, along with a note on how each applies (or doesn't) to Marblehead's current situation. None of these is a recommendation; each mechanism has tradeoffs and political costs beyond the scope of this data.</p>
 
   <div class="card">


### PR DESCRIPTION
Three things in this PR, all on top of the already-merged opt-in refactor.

## 1. Fix: one reaction per reader per section

Before: flipping agree ↔ disagree on the same section fired an increment on every click, so the counter went up by one each time. After: every meaningful interaction (stance activate, non-empty note save, share click) routes through a single \`ensureCounted()\` helper that only increments if the user has not already been counted for that section, then marks them counted and persists the flag in IndexedDB.

Result: a reader who agrees, disagrees, writes a note, and shares the link contributes exactly one reaction. Clearing browser data resets the local flag, so a fresh browser can count again.

## 2. Drop hover tooltips on widget buttons

Removes the \`title\` attribute from stance, share, and note buttons. No more browser tooltip on hover. \`aria-label\` values are retained for screen readers and accessibility tools.

## 3. Tag 24 meaningful section headings

Adds \`data-stance-section\` attributes across six content pages so the widget actually appears where it should (previously, after the opt-in refactor merged, the widget appeared nowhere because nothing was tagged). Sections picked:

- **what-fails.html** (4): town-side reductions, school-side reductions, what stays or grows, what other towns did
- **what-is-the-override.html** (4): three tiers, how you'll vote, what it costs, history
- **why-not-elsewhere.html** (4): residential share, new growth, four archetypes, what mechanisms exist
- **senior-tax-relief.html** (4): circuit breaker, local exemption, other exemptions, override connection
- **how-we-got-here.html** (4): balanced budgets era, failed override 2023, deficit continues, vote 2026
- **where-has-the-money-gone.html** (4): where it went, who checks books, what grew faster, means for override

Skipped the meta/reference sections like "Key Terms" and "What this page does and doesn't say" where a reaction is not meaningful.

After merge and GitHub Pages rebuild, you should see the monochrome widget floating right of each tagged heading. If you want any sections added, removed, or renamed, it's a one-line edit per heading.