### PR TITLE
Align override calculator prices under tier labels on mobile

### DIFF
--- a/charts/override_calculator.html
+++ b/charts/override_calculator.html
@@ -50,7 +50,7 @@ title: "What the Override Costs You"
 }
 @media (max-width: 520px) {
   .tier-row { flex-direction: column; align-items: flex-start; gap: 4px; padding: 12px 2px; }
-  .tier-row-cost { text-align: left; align-self: flex-start; }
+  .tier-row-cost { text-align: left; align-self: flex-start; padding-left: 24px; }
   .cost-primary { font-size: 24px; }
 }
 </style>


### PR DESCRIPTION
On mobile the label's swatch + gap pushed the tier name right by 24px,
but the cost block started flush left, so the prices hung visibly left
of the label text. Indent the cost block by the same 24px on narrow
viewports so each tier's name and price share a left edge.

https://claude.ai/code/session_01BrZDUC6jfHUheX5jgR831r