### PR TITLE
Switch override calculator tier rows to horizontal on mobile

### DIFF
--- a/charts/override_calculator.html
+++ b/charts/override_calculator.html
@@ -49,9 +49,11 @@ title: "What the Override Costs You"
   font-variant-numeric: tabular-nums; margin-top: 3px;
 }
 @media (max-width: 520px) {
-  .tier-row { flex-direction: column; align-items: flex-start; gap: 4px; padding: 12px 2px; }
-  .tier-row-cost { text-align: left; align-self: flex-start; padding-left: 24px; }
-  .cost-primary { font-size: 24px; }
+  .tier-row { gap: 12px; padding: 12px 2px; }
+  .tier-row-label { font-size: 14px; min-width: 0; }
+  .cost-primary { font-size: 20px; }
+  .cost-primary .cost-unit { font-size: 12px; }
+  .cost-secondary { font-size: 11px; }
 }
 </style>
 <h1 class="h-center">What the Override Costs You</h1>


### PR DESCRIPTION
## Summary
- The previous column-stacked mobile layout left a big empty gutter on the right and split each tier into three visually-unrelated fragments (label, big price, grey /yr).
- Keep the desktop horizontal layout on mobile and just shrink the fonts: label 14px, primary cost 20px, cost unit 12px, secondary 11px.
- `min-width: 0` on the label lets it shrink if needed so the cost block never gets pushed off the row.

## Test plan
- [ ] Load `/charts/override_calculator.html` at iPhone widths (≤375px) and confirm each tier's label and `$X/mo` share a row without wrapping.
- [ ] Confirm the widest label ("Tier 2 ($12M), Stabilize") still fits next to `$132/mo` at 375px.
- [ ] Confirm desktop (>520px) layout is unchanged.
- [ ] Sanity-check the calculator still updates when the assessed value changes and when switching between Year 1/2/3 tabs.

https://claude.ai/code/session_01BrZDUC6jfHUheX5jgR831r