### PR TITLE
Improve reaction widget spacing around main content

### DIFF
--- a/assets/community-pulse/widget.css
+++ b/assets/community-pulse/widget.css
@@ -12,6 +12,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem 1rem;
+  margin-bottom: 0.5rem;
 }
 
 .cp-section-row > :first-child {
@@ -34,7 +35,8 @@
   .cp-section-row {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.35rem;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
   }
   .cp-widget {
     font-size: 0.8rem;
@@ -89,6 +91,7 @@
   display: inline-flex;
   align-items: baseline;
   gap: 0.4rem;
+  margin-left: 0.5rem;
   font-size: 0.82rem;
   color: var(--text-muted, #666);
 }


### PR DESCRIPTION
The widget row sat tight against the heading above and the following
paragraph below, and the count text had identical gaps on both sides so
stance buttons, count, and action icons read as one undifferentiated
strip. Add a margin-bottom to the section row (more on mobile where
breathing room matters most), a slightly larger mobile column gap, and
a small margin-left on the count so the stance group and the
count+share+note group are visually distinct.