### PR TITLE
Group reaction widget into two clusters for clearer layout

### DIFF
--- a/assets/community-pulse/widget.css
+++ b/assets/community-pulse/widget.css
@@ -25,10 +25,23 @@
   display: inline-flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.5rem;
+  /* Wide horizontal gap between the stance-button group and the meta
+     group so the two groups read as distinct. Smaller row gap for when
+     the widget wraps onto a second line on narrow screens. */
+  gap: 0.5rem 1.25rem;
   flex: 0 0 auto;
   font-size: 0.85rem;
   color: var(--text-muted, #666);
+}
+
+/* Tight cluster of reaction count + share + note-toggle. Lives on the
+   right side of the widget, separated from the stance buttons by the
+   wider .cp-widget gap above. */
+.cp-widget__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex: 0 0 auto;
 }
 
 @media (max-width: 640px) {
@@ -91,7 +104,6 @@
   display: inline-flex;
   align-items: baseline;
   gap: 0.4rem;
-  margin-left: 0.5rem;
   font-size: 0.82rem;
   color: var(--text-muted, #666);
 }

--- a/assets/community-pulse/widget.js
+++ b/assets/community-pulse/widget.js
@@ -176,6 +176,13 @@ function buildWidget(sectionId, sectionTitle, initialReactions, initialStance) {
   });
   root.appendChild(buttons);
 
+  // Meta group: reaction count + secondary action icons. Kept as a single
+  // DOM sibling to the stance buttons so CSS can give a clean two-group
+  // layout (stance on the left, meta on the right) with a wider gap
+  // between the groups than within each group.
+  const meta = document.createElement('div');
+  meta.className = 'cp-widget__meta';
+
   // Reaction count + delta. Hidden until real data arrives; no placeholder text.
   const count = document.createElement('span');
   count.className = 'cp-widget__count';
@@ -191,7 +198,7 @@ function buildWidget(sectionId, sectionTitle, initialReactions, initialStance) {
   }
   count.appendChild(countNum);
   count.appendChild(countDelta);
-  root.appendChild(count);
+  meta.appendChild(count);
 
   // Share button (copy link to clipboard). Icon = two overlapping rectangles.
   const share = document.createElement('button');
@@ -200,7 +207,7 @@ function buildWidget(sectionId, sectionTitle, initialReactions, initialStance) {
   share.dataset.action = 'share';
   share.setAttribute('aria-label', 'Copy link to this section');
   share.innerHTML = '<svg viewBox="0 0 16 16" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.35" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="5.5" y="5.5" width="8.5" height="8.5" rx="1"/><path d="M2 10.5V3a1 1 0 0 1 1-1h7.5"/></svg>';
-  root.appendChild(share);
+  meta.appendChild(share);
 
   // Note toggle. Icon = three horizontal lines of decreasing length.
   const noteToggle = document.createElement('button');
@@ -211,7 +218,9 @@ function buildWidget(sectionId, sectionTitle, initialReactions, initialStance) {
   noteToggle.setAttribute('aria-controls', `${widgetId}-note`);
   noteToggle.setAttribute('aria-label', 'Write a private note');
   noteToggle.innerHTML = '<svg viewBox="0 0 16 16" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.35" stroke-linecap="round" aria-hidden="true"><line x1="3" y1="5" x2="13" y2="5"/><line x1="3" y1="8.5" x2="13" y2="8.5"/><line x1="3" y1="12" x2="10" y2="12"/></svg>';
-  root.appendChild(noteToggle);
+  meta.appendChild(noteToggle);
+
+  root.appendChild(meta);
 
   // Note textarea (hidden initially).
   const note = document.createElement('textarea');


### PR DESCRIPTION
## Summary

Follow-up to #31. The stance buttons, count text, and share/note icons previously sat as four sibling flex items with uniform gaps, so the count read as part of the button toolbar rather than as metadata about the section.

- Wrap the count and the share/note-toggle buttons in a new `cp-widget__meta` div so `.cp-widget` has two top-level children (stance group + meta group) instead of four flat siblings.
- Widen the horizontal gap on `.cp-widget` to `0.5rem 1.25rem` (tighter row gap for when the widget wraps, wider column gap between the two clusters).
- Add a `.cp-widget__meta` rule with a tight `0.4rem` gap so the count and action icons cluster together on the right.
- Drop the temporary `margin-left: 0.5rem` on `.cp-widget__count` since separation now happens at the group level.

Visual effect: the widget reads as `[+][-][!]    1 reactions +1 today  📋  ☰` — stance buttons on the left, count + icons clustered together on the right, with clearly more space between the two groups than within each. On very narrow screens where the widget wraps, the whole meta group moves onto its own line under the stance buttons rather than individual items wrapping mid-toolbar.

## Test plan

- [x] `npm test` in `community-pulse/` — all 30 tests pass
- [ ] Verify on mobile (the original screenshot case): stance buttons and meta group visually distinct
- [ ] Verify on desktop: widget still floats to the right of the heading, two-group layout inside
- [ ] Verify note textarea still drops to its own row when opened
- [ ] Verify on very narrow viewport: meta group wraps as a unit, not item-by-item