### PR TITLE
Fix race in ensureCounted: claim reacted flag synchronously

### DIFF
--- a/assets/community-pulse/widget.js
+++ b/assets/community-pulse/widget.js
@@ -283,12 +283,21 @@ function wireWidget(root, db, sectionId, sectionUrl, sectionTitle, initialRecord
    * reactions increment and mark them counted. Subsequent calls are no-ops
    * until the user clears their browser data. Any meaningful interaction
    * (stance activate, note content, share click) routes through this helper.
+   *
+   * The currentReacted flag is set synchronously before awaiting the
+   * network call, so a second caller that lands between the await and the
+   * server's response sees the flag already set and skips. If the network
+   * call fails, the flag is reverted so a retry can happen on the next
+   * interaction.
    */
   async function ensureCounted() {
     if (currentReacted) return;
-    const result = await incrementReaction(sectionId);
-    if (!result) return; // network failure; try again on the next interaction
     currentReacted = true;
+    const result = await incrementReaction(sectionId);
+    if (!result) {
+      currentReacted = false;
+      return;
+    }
     countNum.textContent = `${result.total} reactions`;
     countDelta.textContent = result.last_24h > 0 ? `+${result.last_24h} today` : '';
     await persist();


### PR DESCRIPTION
Rapid-fire clicks on stance buttons could double-count because two concurrent handler invocations would both see \`currentReacted\` as false (the first's await on \`incrementReaction\` had not yet resolved), and both would fire their own increment.

Fix: set \`currentReacted = true\` synchronously before awaiting the network call, so a second caller that lands between the await and the server response sees the flag already set and returns early. On network failure, revert the flag so a retry can happen on the next interaction.

Two-line diff, plus a longer doc comment explaining the reasoning. All 30 tests still pass.