### PR TITLE
Move community pulse widget to end of section, right-aligned

### DIFF
--- a/assets/community-pulse/widget.css
+++ b/assets/community-pulse/widget.css
@@ -2,31 +2,13 @@
    Reuses CSS custom properties from assets/site.css so the widget
    inherits the site's light and dark themes automatically. */
 
-/* Flex wrapper placed around a tagged heading + its widget.
-   On desktop, the heading takes its natural width and the widget
-   floats right next to it. On narrow screens, the widget stacks
-   below the heading. */
-.cp-section-row {
+/* Right-aligned end-of-section container. Holds the widget on its own
+   row after the last paragraph of the section, so readers see the
+   reaction affordance after they finish reading the claim, not before. */
+.cp-section-end {
   display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 0.75rem 1rem;
-  margin-bottom: 0.5rem;
-}
-
-/* Nudge the widget down so it sits just above the heading's baseline
-   rather than vertically centered on the heading's line box. Without
-   this, buttons look like they hover above the heading because the
-   heading's line-height is taller than the button's content box. */
-.cp-section-row > .cp-widget {
-  margin-bottom: 0.35rem;
-}
-
-.cp-section-row > :first-child {
-  flex: 1 1 auto;
-  min-width: 0;
-  margin-right: 0;
+  justify-content: flex-end;
+  margin: 1rem 0 2rem 0;
 }
 
 .cp-widget {
@@ -53,11 +35,9 @@
 }
 
 @media (max-width: 640px) {
-  .cp-section-row {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.5rem;
-    margin-bottom: 0.75rem;
+  .cp-section-end {
+    justify-content: flex-start;
+    margin: 0.75rem 0 1.5rem 0;
   }
   .cp-widget {
     font-size: 0.8rem;

--- a/assets/community-pulse/widget.js
+++ b/assets/community-pulse/widget.js
@@ -420,13 +420,27 @@ export async function hydrateWidgets() {
       initialReactions,
       initialRecord?.stance
     );
-    const parent = target.element.parentNode;
+    const anchor = target.element;
+    const parent = anchor.parentNode;
     if (!parent) continue;
-    const wrapper = document.createElement('div');
-    wrapper.className = 'cp-section-row';
-    parent.insertBefore(wrapper, target.element);
-    wrapper.appendChild(target.element);
-    wrapper.appendChild(widget);
+
+    // Insert the widget at the END of the section (after the reader has
+    // scanned the heading and body), not inline with the heading. The
+    // section boundary is the next h2 or the next element with a
+    // data-stance-section attribute, whichever comes first.
+    let cursor = anchor.nextElementSibling;
+    while (cursor && !cursor.matches('h2, h3, [data-stance-section]')) {
+      cursor = cursor.nextElementSibling;
+    }
+    const endRow = document.createElement('div');
+    endRow.className = 'cp-section-end';
+    endRow.appendChild(widget);
+    if (cursor) {
+      parent.insertBefore(endRow, cursor);
+    } else {
+      parent.appendChild(endRow);
+    }
+
     wireWidget(
       widget,
       db,


### PR DESCRIPTION
Moves the reaction widget from inline-right-of-heading to end-of-section, right-aligned. Reasons (see the UX discussion in the thread):

- Reader behavior matches placement. The reader scans the heading, reads the body, forms an opinion, then reacts. The widget shows up where the reader's eye lands when they are ready.
- No more wrap bugs. The widget is always on its own row, never fighting with long heading text.
- No visual competition with the heading. Headings stay clean.

## Implementation

In \`hydrateWidgets\`, instead of wrapping the tagged element and the widget in a \`.cp-section-row\` flex container, the hydration now walks forward from the tagged element through siblings until it hits the next \`h2\`, \`h3\`, or \`data-stance-section\` boundary, then inserts a right-aligned \`.cp-section-end\` container holding the widget just before that boundary (or at the end of the parent if the section is the last one).

CSS:
- \`.cp-section-row\` rules are removed.
- \`.cp-section-end\` is a simple \`display: flex; justify-content: flex-end\` container with vertical margins.
- Mobile breakpoint switches to left-aligned with slightly smaller margins.

30/30 tests still pass.