### PR TITLE
Add brief reactions note to about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -76,6 +76,9 @@ community_pulse: off-sections
   <h2>About AI usage</h2>
   <p>An AI assistant (Claude) handles research, analysis, and the site's digital infrastructure. I regularly remind it to stay as neutral as possible, and I own and operate everything it produces. Every number traces to a primary source, but I don't re-verify each one against the original document myself. Errors are possible. When I find one, or a reader catches one, the page gets updated.</p>
 
+  <h2>Reactions</h2>
+  <p>Some sections let you react as you read. Your reactions stay in this browser, and no one else can see which one you picked. The number next to each section is a rough measure of interest, not a poll.</p>
+
   <h2>Costs</h2>
   <div class="card">
     <div class="cut-item">


### PR DESCRIPTION
Adds a three-sentence 'Reactions' section to about.html, placed between 'About AI usage' and 'Costs'. Content:

> Some sections let you react as you read. Your reactions stay in this browser, and no one else can see which one you picked. The number next to each section is a rough measure of interest, not a poll.

Plain language, no jargon, no mention of specific buttons or mechanics a reader can see for themselves. Honest about the limits (rough, not a poll) and about the private-per-browser scope.