### PR TITLE
Narrow the CPI/inflation rule to target rhetorical misuse only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ Before making any content or design change, read:
 If you touch CSS, charts, or page copy without reading STYLE_GUIDE first,
 you will violate a rule in it. (Examples of easy-to-miss rules: no
 em-dashes in site copy, no inline `style=""` on SVG elements, no
-CPI/inflation comparisons for municipal cost categories, no green/red
-value judgments on comparisons.)
+standalone CPI/inflation comparisons as the sole benchmark for a
+municipal cost category, no green/red value judgments on comparisons.)
 
 ## Editorial stance
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -103,4 +103,12 @@ All SVGs should have `class="chart"`. Use these classes instead of inline styles
 - No inline `style=""` attributes on SVG elements (use CSS classes)
 - No inline `font-family`, `fill`, `stroke` on SVG text/lines (use CSS classes)
 - No data presented without a traceable source
-- No CPI/inflation comparisons for municipal cost categories
+- No standalone CPI/inflation comparisons as the sole or primary benchmark for a
+  municipal cost category. CPI may appear when it is one of several benchmarks
+  presented alongside more directly relevant yardsticks (enrollment, headcount,
+  revenue, service levels), when it is disclosed as real-dollar context for a
+  single number, or when inflation-adjusted comparison is the standard metric in
+  the relevant field (e.g. DESE per-pupil spending in constant dollars). The
+  rule is against rhetorical "beat inflation" framings that imply waste without
+  analytical support, not against honest disclosure that a number is
+  inflation-adjusted.


### PR DESCRIPTION
## Summary

Narrow the `STYLE_GUIDE.md` rule on CPI/inflation comparisons so it prevents rhetorical misuse without forbidding analytically defensible cases.

## Why

The original rule was **"No CPI/inflation comparisons for municipal cost categories."** It was written to stop the site from producing claims shaped like *"HC spending is up 300% since 2006, way more than inflation!"* — a rhetorical move that sounds like an indictment of town management but is trivially true of every MA municipality, because healthcare costs grow well above CPI nationally.

But as written, the rule also forbids:

- **Multi-benchmark comparisons** where CPI is one of several yardsticks — e.g. `where-has-the-money-gone.html`'s *"grown faster than enrollment, inflation, or headcount would explain"* framing, which is a legitimate analytical structure because it tests the claim against three independent explanations and rejects all three
- **Standard education-finance metrics** like per-pupil spending adjusted for inflation, which is how DESE and every state-level policy analyst report school spending
- **Honest real-dollar disclosure** alongside nominal numbers, e.g. *"state aid has declined sharply in real terms since 2002"* — which is context, not a rhetorical implication of waste

## What the refined rule allows

CPI/inflation may appear when:
1. It is **one of several benchmarks** presented alongside more directly relevant yardsticks (enrollment, headcount, revenue, service levels)
2. It is **disclosed as real-dollar context** for a single number
3. It is the **standard metric in the relevant field** (e.g. DESE per-pupil spending in constant dollars)

## What the refined rule still forbids

- **Standalone CPI as the sole or primary benchmark** for a municipal cost category — the *"beat inflation"* framing that implies waste without analytical support

## Effect on existing pages

- `where-has-the-money-gone.html` — previously in conflict with the rule (uses "+10% real — Schools after inflation" key stat). Now compliant because it uses enrollment, headcount, and inflation as three independent benchmarks.
- `the-debate.html` — the Tension 1 supporter block currently says "declined sharply in real terms since 2002". Could be restored to the more specific "25% below its 2002 level after inflation" language under the new rule, though the current phrasing is also fine. Not changing in this PR.
- `CLAUDE.md` — summary paragraph updated to match the refined rule.

## Files changed

- `STYLE_GUIDE.md` — rule text replaced in the "What Not To Do" section
- `CLAUDE.md` — brief restatement in the "Read these first" section updated

## Test plan

- [ ] Grep the site for "inflation" / "real terms" / "CPI" and confirm every remaining instance fits one of the three allowed patterns
- [ ] Confirm `where-has-the-money-gone.html` is now style-guide-compliant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
