### PR TITLE
Replace "override win" with "passed" for neutral framing

### DIFF
--- a/why-not-elsewhere.html
+++ b/why-not-elsewhere.html
@@ -213,7 +213,7 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
 
   <table class="peer-table">
     <thead>
-      <tr><th>Town</th><th>Res&nbsp;%</th><th>CIP&nbsp;%</th><th>5yr&nbsp;NG</th><th>Last override win</th></tr>
+      <tr><th>Town</th><th>Res&nbsp;%</th><th>CIP&nbsp;%</th><th>5yr&nbsp;NG</th><th>Passed</th></tr>
     </thead>
     <tbody>
       <tr class="mh"><td>Marblehead</td><td>95.5%</td><td>4.5%</td><td>0.54%</td><td>FY2006</td></tr>
@@ -228,14 +228,14 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
       <tr><td>Stoneham</td><td>83.0%</td><td>17.0%</td><td>1.57%</td><td>FY2027</td></tr>
     </tbody>
   </table>
-  <p class="source">Marblehead and Swampscott last passed an override in 2006, 20 years ago. Cohasset's last override win was FY2005. Every other town in this group has passed an override more recently or is voting on one this spring.</p>
+  <p class="source">Marblehead and Swampscott last passed an override in 2006, 20 years ago. Cohasset last passed an override in FY2005. Every other town in this group has passed an override more recently or is voting on one this spring.</p>
 
   <h3>2. Suburbs with meaningful commercial presence</h3>
   <p>Similar demographics to the first group, but with enough office parks, biotech, retail, or routes along I-90 / Route 9 to carry 17&ndash;33% of the tax levy. New growth rates are materially higher too. These towns still hold override votes periodically, but the interval between votes tends to be longer.</p>
 
   <table class="peer-table">
     <thead>
-      <tr><th>Town</th><th>Res&nbsp;%</th><th>CIP&nbsp;%</th><th>5yr&nbsp;NG</th><th>Last override win</th></tr>
+      <tr><th>Town</th><th>Res&nbsp;%</th><th>CIP&nbsp;%</th><th>5yr&nbsp;NG</th><th>Passed</th></tr>
     </thead>
     <tbody>
       <tr><td>Natick</td><td>82.8%</td><td>17.2%</td><td>1.51%</td><td>FY2026</td></tr>
@@ -327,7 +327,7 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
   <div class="notes">
     <p><strong>Sources.</strong> Residential and CIP levy shares: <a href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=propertytaxinformation.taxlevies.leviesbyclass">MA DOR Tax Levies by Class FY2026</a>. New growth: <a href="https://dls-gw.dor.state.ma.us/reports/rdPage.aspx?rdReport=NewGrowth.NewGrowth_dash_v2_test">MA DOR New Growth Analysis</a> (5-year average, FY2022&ndash;2026). Override history: <a href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride">MA DOR Proposition 2&frac12; Override &amp; Underride Votes</a>. Statewide fiscal context: <a href="https://www.mma.org/wp-content/uploads/2025/10/MMA-APerfectStorm-HistoricFiscalPressures-report-10.9.25.pdf">MMA, <em>A Perfect Storm: Cities and Towns Face Historic Fiscal Pressures</em> (October 2025)</a>. Malden vote result: <a href="https://www.wgbh.org/news/news-programs/2026-04-01/malden-faces-painful-cuts-after-voter-reject-first-ever-tax-override">GBH News (April 1, 2026)</a>.</p>
     <p><strong>Data files.</strong> Raw peer-town CSVs: <a href="data/peer_tax_levies_by_class_FY22-26.csv">tax levies by class</a>, <a href="data/peer_new_growth_FY22-26.csv">new growth</a>, <a href="data/peer_override_history.csv">override history</a>.</p>
-    <p><strong>Data currency.</strong> DOR data was pulled April 10, 2026. The DOR override database reflects results through late March 2026 (Arlington's $14.8M override won March 28; Stoneham's $9.3M won December 2025). Malden's March 31 failed override had not yet appeared in the DOR database at time of pull but is referenced in the table above from contemporaneous news sources. Winchester held a failed override vote in March 2026 that is also not yet reflected in DOR data; the "last override win" column shows the last successful vote of record, not all recent attempts.</p>
+    <p><strong>Data currency.</strong> DOR data was pulled April 10, 2026. The DOR override database reflects results through late March 2026 (Arlington's $14.8M override passed March 28; Stoneham's $9.3M passed December 2025). Malden's March 31 failed override had not yet appeared in the DOR database at time of pull but is referenced in the table above from contemporaneous news sources. Winchester held a failed override vote in March 2026 that is also not yet reflected in DOR data; the "Passed" column shows the last override that passed, not all recent attempts.</p>
     <p id="ng-footnote"><strong>Note on "new growth."</strong> The DOR metric shown is <em>total new growth applied to the levy limit as a percent of the prior-year levy limit</em>. This captures how much the levy ceiling expands each year from new construction, outside Proposition 2&frac12;'s 2.5% cap. It does not include annual 2.5% growth, value increases from reassessment, or debt exclusions.</p>
     <p><strong>Note on gateway cities.</strong> "Gateway city" is a statutory designation under MGL Chapter 23A, Section 3A, based on historical manufacturing employment and median household income. The 26 designated gateway cities receive specialized state grants, formula aid, and zoning tools not available to other municipalities.</p>
   </div>


### PR DESCRIPTION
"Win" frames a passed override as a victory for one side over another. "Passed" is the plain procedural term used by state elections officials and local news when describing a ballot measure that cleared threshold. Matches the site's editorial stance and already-used "passed" language elsewhere in the same file.

All occurrences are in `why-not-elsewhere.html`:

- Peer-town table column header: `Last override win` → `Passed` (short single-word header to match the sibling columns like `Res %` and `5yr NG`; cell values are years, so the meaning is unambiguous)
- Caption prose: `Cohasset's last override win was FY2005` → `Cohasset last passed an override in FY2005` for parallelism with the adjacent clause
- Data currency note: `override won` → `override passed` for Arlington and Stoneham, and the `'last override win' column` reference updated to match the new header

`Failed` stays as-is; it is the standard procedural term and is not parallel-loaded to "win".