### PR TITLE
Rewrite tax_comparison card title to stop presupposing the conclusion

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@ og_url: https://marbleheaddata.org/
     </a>
 
     <a class="question" href="charts/tax_comparison.html">
-      <h2>Are we overtaxed vs Swampscott?</h2>
+      <h2>Marblehead vs. Swampscott, side by side</h2>
       <p>Tax rates, home values, median bills, and what $750K buys you in each town.</p>
       <span class="tag tag-charts">Chart</span>
     </a>


### PR DESCRIPTION
## Summary

The index card for `charts/tax_comparison.html` asks **"Are we overtaxed vs Swampscott?"** — a framing that presupposes Marblehead *might be* overtaxed (which is the question the chart is meant to let the reader answer, not assume).

Replace with **"Marblehead vs. Swampscott, side by side"**, which matches the chart page's own neutral `<h1>`. The description text stays the same because it's already neutral.

## Why

From `about.html`: *"help residents form their own opinions based on facts, not rhetoric."* The word "overtaxed" is an advocacy framing — it's what an anti-override flyer would lead with, not what a neutral data resource should ask. Removing it costs nothing and brings the card title in line with the rest of the site's framings, which are mostly questions-of-fact ("How does Marblehead compare?", "What do homeowners actually pay?") or descriptive statements.

## Files changed

- `index.html` — one line change, card title only

## Test plan

- [ ] Visit the home page and confirm the card above "What do homeowners actually pay?" now reads "Marblehead vs. Swampscott, side by side"
- [ ] Click through and confirm the chart page still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
