### PR TITLE
Add README to docs/superpowers/ clarifying what lives there

### DIFF
--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -1,0 +1,25 @@
+# About this directory
+
+These are working design documents for features on the site. Two kinds
+of files live here:
+
+- **specs/** - design notes written before a feature was built. They
+  describe what was intended, what alternatives were considered, and
+  what was deliberately cut or deferred.
+- **plans/** - implementation plans written before the code was
+  written. They list the files, tests, and commits that were expected
+  to result from the design.
+
+Some of these files discuss ideas that were explicitly rejected during
+brainstorming, and some describe work that is intentionally deferred.
+For example, the community pulse design spec walks through several
+verification mechanisms (postcard mailings, neighbor vouching, various
+third-party identity services, on-chain identity) that were considered
+and rejected in favor of a much simpler soft-engagement counter. A
+reader who skims the spec might mistakenly conclude that the site does
+or plans to do things it never will.
+
+**The canonical source of what the site actually does is the code and
+the live content pages, not these documents.** Treat these as a record
+of reasoning, not a roadmap or a feature list. If a spec and the live
+site disagree, the live site is correct and the spec is historical.


### PR DESCRIPTION
Four-paragraph README added at `docs/superpowers/README.md`. Preempts the risk that a skimming reader browses into a design spec, lands on a rejected-alternatives section, and concludes the site plans to do something it explicitly chose not to do. Canonical source of what the site actually does is the code and the live content pages, not the docs.