### PR TITLE
Rewrite two index card titles to drop loaded framings

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@ og_url: https://marbleheaddata.org/
     </a>
 
     <a class="question" href="charts/sustainability.html">
-      <h2>Will they ask again?</h2>
+      <h2>Is this a one-time reset?</h2>
       <p>Total revenue vs total expenses through FY2030 under each override scenario.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
@@ -81,7 +81,7 @@ og_url: https://marbleheaddata.org/
     </a>
 
     <a class="question" href="charts/healthcare_indexed.html">
-      <h2>Is it a hiring problem?</h2>
+      <h2>Did hiring drive health insurance growth?</h2>
       <p>Health insurance spending vs employee headcount. Spending doubled; staffing data is flat.</p>
       <span class="tag tag-charts">Chart</span>
     </a>


### PR DESCRIPTION
## Summary

Rewrite two index card titles that were carrying subtle advocacy framings, inconsistent with the site's stated editorial stance of helping residents form their own opinions rather than pushing a direction.

## 1. "Will they ask again?" -> "Is this a one-time reset?"

The old framing packed two advocacy tells into four words:

- **"They"** frames the town government as an adversarial outsider rather than a body residents elect. Override skeptics tend to use "they" and "them" when discussing the Select Board and Finance Committee; supporters tend to say "the town" or "we."
- **"Again"** carries implicit weariness. The word only makes sense if the previous override ask already felt like a burden.

Combined, *"Will they ask again?"* is *exactly* how an override skeptic would frame the question at a kitchen table or in a Facebook post. The site was picking up one side's framing as its own voice on an index card that points to a neutral chart.

**Worse**, this exact question is one of the five tensions in the debate page shipped in PR #39 (Tension 3: *"Is this a one-time reset or the start of annual asks?"*) where the site explicitly presents both sides. The "Will they ask again?" card contradicted the debate page's neutrality by adopting the skeptic's framing.

New title **"Is this a one-time reset?"** matches the debate page's Tension 3 vocabulary, drops the adversarial pronoun, and reads as a factual question the linked chart (`charts/sustainability.html`) directly addresses.

## 2. "Is it a hiring problem?" -> "Did hiring drive health insurance growth?"

The old framing *"Is it a hiring problem?"* assumes hiring is a problem and asks only whether the assumption holds. But the chart actually shows that headcount is flat while health insurance spending doubled, which refutes the framing.

The old title set up a hypothesis the chart then rebutted. That's an interesting rhetorical structure but it's not neutral - it implies a hypothesis the chart is there to knock down.

New title **"Did hiring drive health insurance growth?"** is a clean yes/no factual question. Chart says no. No loaded setup, no implied hypothesis.

Also parallels the adjacent card style (*"Did enrollment drive the budget?"*) for visual consistency.

## `docs/` exclude

Checked `_config.yml` while working on this PR - `docs/` is already in the exclude list, so no change needed for that part of the plan.

## Files changed

- `index.html` - two `<h2>` text changes, no other modifications

## Test plan

- [ ] Visit the home page and confirm the card above "What relief can seniors claim?" now reads "Is this a one-time reset?"
- [ ] Confirm the card between "How fast are insurance costs rising?" and "Did enrollment drive the budget?" now reads "Did hiring drive health insurance growth?"
- [ ] Confirm the descriptions under each card are unchanged
- [ ] Click through each card and confirm navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
