### PR TITLE
Add Debate to nav; shorten How We Got Here and Spending Story

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,10 +2,11 @@
   <div class="nav-inner">
     <a class="nav-brand" href="{{ '/' | relative_url }}">MHD Budget</a>
     <a href="{{ '/' | relative_url }}what-is-the-override.html">Override</a>
-    <a href="{{ '/' | relative_url }}how-we-got-here.html">How We Got Here</a>
-    <a href="{{ '/' | relative_url }}where-has-the-money-gone.html">Spending Story</a>
+    <a href="{{ '/' | relative_url }}how-we-got-here.html">History</a>
+    <a href="{{ '/' | relative_url }}where-has-the-money-gone.html">Spending</a>
     <a href="{{ '/' | relative_url }}what-fails.html">No-Override Budget</a>
     <a href="{{ '/' | relative_url }}why-not-elsewhere.html">Peer Towns</a>
+    <a href="{{ '/' | relative_url }}the-debate.html">Debate</a>
     <a href="{{ '/' | relative_url }}senior-tax-relief.html">Senior Relief</a>
     <a href="{{ '/' | relative_url }}about.html">About</a>
   </div>


### PR DESCRIPTION
## Summary

Two small nav adjustments to surface the debate page and improve consistency.

## Changes

1. **"How We Got Here" -> "History"**. Shorter, scannable. "How We Got Here" remains the page title; "History" is the nav label.

2. **"Spending Story" -> "Spending"**. One word, parallels "History" as its companion. The two pages answer symmetric historical questions: FinCom warned residents the math was changing (History) and where the money actually went during those years (Spending).

3. **Add "Debate" -> `the-debate.html`**. Positioned between Peer Towns and Senior Relief, where it reads as the culminating decision-making resource after the factual/analytical cluster.

## Why the debate page belongs in the nav

It was shipped in PR #39 as the site's both-sides page for undecided voters, but only accessible via the "Still deciding?" featured card on the home page. A reader who lands on any other content page (which is where most search traffic arrives) had no navigation path to the debate page without returning home. For a page that is central to the site's stated mission of helping undecided voters think through both sides, not being in the nav was an inconsistency.

## Nav density

Goes from 7 to 8 items. The nav already scrolls horizontally at narrow widths (per `.site-nav .nav-inner { overflow-x: auto }` in `assets/site.css`), so the increased density is functionally fine on mobile.

## Files changed

- `_includes/nav.html` - three label changes and one new link (the nav is a Jekyll include so all pages pick up the change automatically)

## Test plan

- [ ] Visit any content page and confirm the nav shows "Override | History | Spending | No-Override Budget | Peer Towns | Debate | Senior Relief | About"
- [ ] Click "Debate" and confirm navigation to `the-debate.html`
- [ ] Click "History" and confirm navigation to `how-we-got-here.html`
- [ ] Click "Spending" and confirm navigation to `where-has-the-money-gone.html`
- [ ] Test on mobile width (375px) and confirm the nav scrolls horizontally without breaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)
