### PR TITLE
Move Debate to first nav position to match home page emphasis

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,12 +1,12 @@
 <nav class="site-nav">
   <div class="nav-inner">
     <a class="nav-brand" href="{{ '/' | relative_url }}">MHD Budget</a>
+    <a href="{{ '/' | relative_url }}the-debate.html">Debate</a>
     <a href="{{ '/' | relative_url }}what-is-the-override.html">Override</a>
     <a href="{{ '/' | relative_url }}how-we-got-here.html">History</a>
     <a href="{{ '/' | relative_url }}where-has-the-money-gone.html">Spending</a>
     <a href="{{ '/' | relative_url }}what-fails.html">No-Override Budget</a>
     <a href="{{ '/' | relative_url }}why-not-elsewhere.html">Peer Towns</a>
-    <a href="{{ '/' | relative_url }}the-debate.html">Debate</a>
     <a href="{{ '/' | relative_url }}senior-tax-relief.html">Senior Relief</a>
     <a href="{{ '/' | relative_url }}about.html">About</a>
   </div>


### PR DESCRIPTION
## Summary

Move the Debate nav link from position 6 to position 1 so the nav matches the home page's visual hierarchy.

## Why

On the home page, `the-debate.html` is presented as a **featured card above all three section grids**, explicitly elevated above every other content page. It is the first thing a reader sees under the hero.

In the previous nav (after #49), Debate was at position 6 of 8. That contradicted the home page's hierarchy:

- A reader reaching the site via the home page got *"Debate is the primary decision-making resource"*
- A reader reaching it via any content page got *"Debate is one of many secondary resources"*

The fix is to move Debate to position 1, right after the MHD Budget brand link, so the nav matches the home page emphasis on every page.

## New order

```
MHD Budget | Debate | Override | History | Spending | No-Override Budget | Peer Towns | Senior Relief | About
```

Reads as:
- **Debate** - if still deciding
- **Override** - what you're voting on
- **History** - how we got here
- **Spending** - where the money went
- **No-Override Budget** - what happens if no
- **Peer Towns** - structural context
- **Senior Relief** - audience-specific
- **About** - site metadata

## Files changed

- `_includes/nav.html` - one line moved (the Debate link). No other content changes, no reordering elsewhere.

## Test plan

- [ ] Visit any content page and confirm Debate is the first nav link after the brand
- [ ] Confirm Override is second, matching the old narrative flow
- [ ] Click through Debate and confirm navigation works
- [ ] Test on mobile width and confirm horizontal scrolling still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
