### PR TITLE
Shorten No-Override Budget nav label to No-Override

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -5,7 +5,7 @@
     <a href="{{ '/' | relative_url }}what-is-the-override.html">Override</a>
     <a href="{{ '/' | relative_url }}how-we-got-here.html">History</a>
     <a href="{{ '/' | relative_url }}where-has-the-money-gone.html">Spending</a>
-    <a href="{{ '/' | relative_url }}what-fails.html">No-Override Budget</a>
+    <a href="{{ '/' | relative_url }}what-fails.html">No-Override</a>
     <a href="{{ '/' | relative_url }}why-not-elsewhere.html">Peer Towns</a>
     <a href="{{ '/' | relative_url }}senior-tax-relief.html">Senior Relief</a>
     <a href="{{ '/' | relative_url }}about.html">About</a>


### PR DESCRIPTION
## Summary

Shorten the `what-fails.html` nav label from **"No-Override Budget"** (18 characters, longest in the nav) to **"No-Override"** (11 characters). Everything else in the nav is 5-13 characters; this brings the outlier in line.

## Why this label and not alternatives

Considered and rejected:

- **"Cuts"** (4 characters) - pro-override framing. The page itself is titled *"What's in the no-override budget?"* - we deliberately moved away from advocacy framings mid-session when rewriting from *"What Happens If It Fails?"*. A nav label of "Cuts" partly undoes that work by priming the reader to see the page as damage-showcase rather than as a neutral description of an alternative budget.
- **"Reductions"** (10 characters) - same framing problem as "Cuts"
- **"If No"** (5 characters) - too cryptic
- **"Balanced Budget"** (15 characters) - ambiguous, doesn't parse in context

**"No-Override"** is the cleanest shortening that:

- Keeps the page's neutral framing (no-override = the alternative to the override, not a pro-override flag)
- Pairs visually with "Override" in the nav - the two options read as siblings
- Drops 7 characters without losing meaning

## What's not in this PR

- **The URL stays `what-fails.html`.** Earlier in the session the decision was made to preserve the URL to avoid breaking any external links shared on Facebook, in local papers, or in private conversations. That decision still holds. Only the nav label changes.
- No changes to the page's content or own h1, which is still *"What's in the no-override budget?"*

## Files changed

- `_includes/nav.html` - one line, label text only

## Test plan

- [ ] Visit any content page and confirm the nav shows "No-Override" instead of "No-Override Budget"
- [ ] Click through and confirm navigation still goes to `what-fails.html`
- [ ] Confirm the nav reads cleanly: "Debate | Override | History | Spending | No-Override | Peer Towns | Senior Relief | About"
- [ ] Test on mobile width and confirm the nav still fits reasonably

🤖 Generated with [Claude Code](https://claude.com/claude-code)
