### PR TITLE
Replace Override-supporter/Skeptic labels with For/Against the override

### DIFF
--- a/the-debate.html
+++ b/the-debate.html
@@ -15,11 +15,11 @@ community_pulse: off-sections
     border-left: 4px solid var(--border);
     box-shadow: var(--shadow-sm);
   }
-  .perspective--supporter {
+  .perspective--for {
     border-left-color: var(--c-teal);
     background: color-mix(in srgb, var(--c-teal) 5%, var(--surface));
   }
-  .perspective--skeptic {
+  .perspective--against {
     border-left-color: var(--c-brass);
     background: color-mix(in srgb, var(--c-brass) 5%, var(--surface));
   }
@@ -93,26 +93,26 @@ community_pulse: off-sections
 
   <h2 class="tension-heading">The short version</h2>
 
-  <div class="perspective perspective--supporter">
-    <div class="perspective-label">Override-supporter reading</div>
+  <div class="perspective perspective--for">
+    <div class="perspective-label">For the override</div>
     <p>Marblehead's FY27 deficit is the predictable result of health insurance and pension costs growing faster than revenue under Proposition 2&frac12;, in a town whose 95.5%-residential tax base offers few structural alternatives. The Finance Committee has been warning about this arc since 2019. The no-override budget removes 22 town positions, 14 school positions, reduces the library 43%, and eliminates the OPEB trust contribution. These are services residents use, and the reductions would be hard to reverse.</p>
   </div>
 
-  <div class="perspective perspective--skeptic">
-    <div class="perspective-label">Skeptic reading</div>
+  <div class="perspective perspective--against">
+    <div class="perspective-label">Against the override</div>
     <p>The same FY27 deficit reflects local choices the town made and keeps making: overhiring, an 83%/17% benefits split more generous than peers, enrollment down while school staffing grew, and a Select Board whose answer to every year's budget is "more." The override pattern won't stop, because the cost drivers don't stop. The honest path is spending discipline and structural reform now, not a bigger tax bill to postpone the reckoning.</p>
   </div>
 
   <h2 class="tension-heading">Tension 1. Where does the cost pressure come from?</h2>
   <p class="tension-framing">Both sides agree costs are rising faster than revenue. They disagree on whether the town chose those costs or they happened to it.</p>
 
-  <div class="perspective perspective--supporter">
-    <div class="perspective-label">Override-supporter reading</div>
+  <div class="perspective perspective--for">
+    <div class="perspective-label">For the override</div>
     <p>The FY27 deficit is driven by categories the town cannot meaningfully negotiate in the twelve weeks before Town Meeting. Health insurance premiums are set through the Group Insurance Commission, which raised Marblehead's rates 11% for FY27 (+$1.65M on a single line item). Pension obligations (+9%, +$463K) come from a PERAC-certified actuarial schedule with no local discretion. Debt service (+19%, +$1.78M) reflects contractual obligations on bonds already issued. State aid has declined sharply in real terms since 2002, a statewide trend documented in the MMA's 2025 <em>Perfect Storm</em> report. These are real pressures from outside the town's short-term decision-making horizon. Within the FY27 budget cycle they are effectively fixed, and calling them "just choices" conflates long-horizon policy with near-term fiscal reality.</p>
   </div>
 
-  <div class="perspective perspective--skeptic">
-    <div class="perspective-label">Skeptic reading</div>
+  <div class="perspective perspective--against">
+    <div class="perspective-label">Against the override</div>
     <p>Calling FY27's cost growth "external" obscures the local choices inside it. Marblehead pays 83% of health insurance premiums while employees contribute 17%. Many comparable towns use stricter splits that shift more cost to employees. The town extends health benefits to part-time employees working as few as 20 hours per week, the floor the GIC allows rather than a fiscal necessity. School enrollment has declined from its peak while education FTE has grown. The benefits structure, the hiring pace, and the premium split are town policies, not state mandates or market forces. Any cost the town can in principle renegotiate is a cost the town is choosing to carry. Treating them as external costs abdicates the responsibility to examine whether they remain appropriate.</p>
   </div>
 
@@ -123,30 +123,30 @@ community_pulse: off-sections
   <h2 class="tension-heading">Tension 2. Are the proposed reductions damage or discipline?</h2>
   <p class="tension-framing">The no-override budget is published. Both sides have read it and reached opposite conclusions. See <a href="what-fails.html">what's in the no-override budget</a>.</p>
 
-  <div class="perspective perspective--supporter">
-    <div class="perspective-label">Override-supporter reading</div>
+  <div class="perspective perspective--for">
+    <div class="perspective-label">For the override</div>
     <p>The FY27 no-override budget removes 22 town positions (18-19 filled), 14 school positions, reduces the library 43%, eliminates the OPEB trust contribution, reduces Community Development 59%, and reduces Public Buildings 38%. These are not administrative line items. They are services Marblehead residents use every week. The library was renovated in 2021 with a separate $8.5 million debt exclusion that voters approved; the proposed reduction would hollow out a building the town just invested in. The reductions are structured to balance the budget in one year, but reversing them later would require rehiring, rebuilding programs, and re-earning trust from staff who leave for more stable districts. Melrose and Stoneham both lived through this after failed overrides. The word for what happened there is not discipline. It is damage, and it took larger overrides to begin reversing.</p>
   </div>
 
-  <div class="perspective perspective--skeptic">
-    <div class="perspective-label">Skeptic reading</div>
-    <p>Every department's budget has slack, and when departments are asked to cut, they find they can. The FY27 no-override budget's "reductions" are measured against a FY26 baseline that the skeptic case treats as the peak of years of accumulated growth, not an appropriate floor. Staffing declined 12% in this budget because staffing grew before it. The library at -43% gets the most attention, but the library is one line item in a budget that grew steadily around it. If the town cannot absorb a correction after years of accumulated budget growth, that is evidence the expansion itself was too fast, not evidence that the correction is cruel. Hard choices are painful. The question is whether the pain signals over-reach or under-funding.</p>
+  <div class="perspective perspective--against">
+    <div class="perspective-label">Against the override</div>
+    <p>Every department's budget has slack, and when departments are asked to cut, they find they can. The FY27 no-override budget's "reductions" are measured against a FY26 baseline that is itself the peak of years of accumulated growth, not an appropriate floor. Staffing declined 12% in this budget because staffing grew before it. The library at -43% gets the most attention, but the library is one line item in a budget that grew steadily around it. If the town cannot absorb a correction after years of accumulated budget growth, that is evidence the expansion itself was too fast, not evidence that the correction is cruel. Hard choices are painful. The question is whether the pain signals over-reach or under-funding.</p>
   </div>
 
   <div class="mini-synthesis">
-    <p><strong>Where they actually disagree:</strong> whether FY26 is the correct baseline against which to measure cuts. Pro-override treats FY26 as the level of service residents have chosen and should maintain. The skeptic treats FY26 as the peak of a trajectory that should have been corrected earlier.</p>
+    <p><strong>Where they actually disagree:</strong> whether FY26 is the correct baseline against which to measure cuts. Those for the override treat FY26 as the level of service residents have chosen and should maintain. Those against the override treat FY26 as the peak of a trajectory that should have been corrected earlier.</p>
   </div>
 
   <h2 class="tension-heading">Tension 3. Is this a one-time reset or the start of annual asks?</h2>
   <p class="tension-framing">If the override passes, does the problem go away for years, or does the same pressure rebuild immediately?</p>
 
-  <div class="perspective perspective--supporter">
-    <div class="perspective-label">Override-supporter reading</div>
+  <div class="perspective perspective--for">
+    <div class="perspective-label">For the override</div>
     <p>The three-tier structure ($9M / $12M / $15M) was designed as a multi-year correction, not a one-year patch. The Finance Committee's three-year operating budget forecast projects structural deficits only under the no-override scenario. Tier 2 ("stabilize") builds baseline capacity for recurring costs; Tier 3 ("invest") adds a cushion to absorb future pressure without returning to the ballot. The 2025 Finance Committee transmittal letter (see <a href="how-we-got-here.html">how we got here</a>) named FY26, FY27, and FY28 as the projected deficit years. The override is scoped to resolve that window. "Will they ask again?" is a reasonable question, and the answer depends on the cost environment several years from now. In the near term, approval at Tier 2 or Tier 3 eliminates the immediate ask.</p>
   </div>
 
-  <div class="perspective perspective--skeptic">
-    <div class="perspective-label">Skeptic reading</div>
+  <div class="perspective perspective--against">
+    <div class="perspective-label">Against the override</div>
     <p>Passing an override does not pause the cost drivers that caused the deficit. Health insurance premiums will keep rising. Pension obligations will keep accruing. Debt service will keep scaling with each new borrowing. The override buys one to three years before the same pressure reaches the same place, and then the town faces the same question with a higher baseline. Melrose illustrates the pattern: a $7.7M override failed in 2024, and a $13.5M override passed the next year, 75% larger. Each failed ask is followed by a larger successful one because the underlying math does not wait for a political moment. Saying "this is a one-time reset" assumes that reforms will come during the breathing room the override creates. If those reforms do not materialize, the next ask is already on its way.</p>
   </div>
 
@@ -157,13 +157,13 @@ community_pulse: off-sections
   <h2 class="tension-heading">Tension 4. Do meaningful alternatives exist?</h2>
   <p class="tension-framing">The debate turns on whether the town has real options other than override versus reductions. See <a href="why-not-elsewhere.html">why some MA towns run overrides and others don't</a> for the structural data underneath this tension.</p>
 
-  <div class="perspective perspective--supporter">
-    <div class="perspective-label">Override-supporter reading</div>
+  <div class="perspective perspective--for">
+    <div class="perspective-label">For the override</div>
     <p>The peer-town analysis shows Marblehead at the extremes of every structural metric: 95.5% residential share of the tax levy, the highest in a 21-town peer set, and a 0.54% five-year average new growth rate, the lowest. The policy levers other towns use (CIP shift, commercial development, state aid, gateway-city designation) either do not exist in Marblehead or do not scale. A CIP shift on a 4.5% commercial base produces a trivial burden transfer. Commercial development is constrained by peninsula geography, historic districts, and zoning any rezoning debate would take years to resolve. State aid formulas exclude high-wealth suburbs by design. Benefits reform is on the town's longer agenda but cannot be enacted in time to close the FY27 gap. The "alternatives" argument assumes a planning horizon the fiscal year does not have.</p>
   </div>
 
-  <div class="perspective perspective--skeptic">
-    <div class="perspective-label">Skeptic reading</div>
+  <div class="perspective perspective--against">
+    <div class="perspective-label">Against the override</div>
     <p>"No alternatives exist" is itself a policy position, not a fact. Benefits reform, though politically difficult, is possible. Other Massachusetts towns have moved to stricter eligibility thresholds and less generous premium splits. Commercial development is constrained by geography and zoning, but those zoning choices can be revisited over time if the town decides it wants to. State aid formulas exclude Marblehead, but active advocacy for reform is absent from the town's agenda. These alternatives require longer planning horizons than a 12-week budget cycle, which is exactly the point: the override is being asked for in lieu of the harder, slower conversation about what the town could change structurally over five years. Voting for the override because "nothing else will work in three months" is true, and ignores that three months is the wrong time horizon.</p>
   </div>
 
@@ -174,18 +174,18 @@ community_pulse: off-sections
   <h2 class="tension-heading">Tension 5. Can we trust the people asking?</h2>
   <p class="tension-framing">Most Prop 2&frac12; debates are about money. In Marblehead this tension is also about who decides, what they tell residents, and whether residents believe them.</p>
 
-  <div class="perspective perspective--supporter">
-    <div class="perspective-label">Override-supporter reading</div>
+  <div class="perspective perspective--for">
+    <div class="perspective-label">For the override</div>
     <p>The <a href="how-we-got-here.html">how we got here</a> page documents Marblehead's Finance Committee transmittal letters from 2016 through 2025. For sixteen consecutive years FinCom reported balanced budgets without an override, and said so each year in writing. The shift began in 2019 with the Town Administrator's "unsustainable" characterization of free cash reliance and became an explicit override prediction in the 2022 transmittal letter, one year before the FY24 override attempt. The 2025 transmittal letter named FY26, FY27, and FY28 as the projected deficit years. This is not a board that "always wants more." It is a board that actively did not ask for an override for sixteen years, told residents exactly when the math changed, and predicted the current vote four years in advance. Trust in future decisions is reasonable when past decisions have tracked the underlying math.</p>
   </div>
 
-  <div class="perspective perspective--skeptic">
-    <div class="perspective-label">Skeptic reading</div>
-    <p>Transparency of documents is not the same as accountability for outcomes. The Select Board and Finance Committee have presided over years of budget growth that the skeptic case sees as unchecked, and now ask voters to fund the gap that growth created. Questions about efficiency, benefits structure, and specific line items get redirected into state formulas or insurance market forces. The sense that town leadership does not work <em>for</em> residents but instead asks residents to trust their judgment is a fact about the local political climate, regardless of whether anyone can point to a specific failure. A yes vote is a vote to extend credit to an institution that has not yet demonstrated it will spend the next dollar differently than the last twenty years of dollars. The skeptic case is not that the board is malicious; it is that past behavior is not sufficient evidence of future discipline.</p>
+  <div class="perspective perspective--against">
+    <div class="perspective-label">Against the override</div>
+    <p>Transparency of documents is not the same as accountability for outcomes. The Select Board and Finance Committee have presided over years of unchecked budget growth, and now ask voters to fund the gap that growth created. Questions about efficiency, benefits structure, and specific line items get redirected into state formulas or insurance market forces. The sense that town leadership does not work <em>for</em> residents but instead asks residents to trust their judgment is a fact about the local political climate, regardless of whether anyone can point to a specific failure. A yes vote is a vote to extend credit to an institution that has not yet demonstrated it will spend the next dollar differently than the last twenty years of dollars. The argument is not that the board is malicious; it is that past behavior is not sufficient evidence of future discipline.</p>
   </div>
 
   <div class="mini-synthesis">
-    <p><strong>Where they actually disagree:</strong> whether past behavior plus transparent process is sufficient evidence that future spending will be responsible. Pro-override reads the FinCom arc as evidence of disciplined governance. The skeptic reads the same arc as the pattern the override perpetuates rather than interrupts.</p>
+    <p><strong>Where they actually disagree:</strong> whether past behavior plus transparent process is sufficient evidence that future spending will be responsible. Those for the override read the FinCom arc as evidence of disciplined governance. Those against the override read the same arc as the pattern the override perpetuates rather than interrupts.</p>
   </div>
 
   <h2 class="tension-heading">Where they actually disagree</h2>


### PR DESCRIPTION
## Summary

Replace the `Override-supporter reading` / `Skeptic reading` labels on the debate page with `For the override` / `Against the override`.

## Why

The original labels were asymmetric in a way that biased the page:

- **"Override-supporter"** is a descriptive label (what they affirmatively support).
- **"Skeptic"** is a relational label (what they doubt about the other side).

That pairing implicitly made the pro-override position the affirmative case and the anti-override position the reactive case. Both sides actually make affirmative arguments (spending discipline, benefit reform, alternatives, etc.), so the framing was wrong.

"Skeptic" has also picked up cultural baggage in recent years ("climate skeptic", "vaccine skeptic") that carries a "refuses to accept evidence" connotation. Unfair to a thoughtful no-override voter.

## Why "for / against"

- **Symmetric** - both sides get descriptive labels of their position
- **Zero jargon** - these are the oldest words in English for two-sided debate
- **No hidden connotations** - neither "for" nor "against" carries cultural baggage
- **Matches ballot action** - the reader is being asked to vote yes (for) or no (against)
- **Natural in prose** - "those for the override" and "those against the override" parse cleanly as noun phrases in the mini-synthesis

## Changes

1. **12 visible labels** in perspective blocks (6 pairs: TL;DR + 5 tensions)
2. **2 CSS class renames** (`.perspective--supporter` -> `.perspective--for`, `.perspective--skeptic` -> `.perspective--against`) so the code matches the visible labels
3. **4 mini-synthesis prose edits** (tensions 2 and 5) to use the new noun phrases
4. **3 in-block prose simplifications** where the old text self-referenced "the skeptic case" as attribution. That self-reference is no longer needed because the block label now performs the attribution function. Simplified to direct assertions.

## What didn't change

- No changes to the mini-synthesis structure, the tension spine, or the closing synthesis section
- No changes to other pages
- No changes to the color accents (teal for pro, brass for against - deliberately avoiding red/green)
- No changes to the featured card on the home page (it refers to "the best case for each side" which is still accurate)

## Files changed

- `the-debate.html` - 30 insertions, 30 deletions (one line each for the label changes, a few lines for prose rewrites)

## Test plan

- [ ] Visit `/the-debate.html` and confirm the TL;DR section shows "For the override" / "Against the override" labels
- [ ] Confirm all 5 tensions use the new labels
- [ ] Confirm the mini-synthesis text reads cleanly with "Those for the override" / "Those against the override" phrasing
- [ ] Confirm the visual styling (teal for pro, brass for against) still renders correctly in both light and dark mode
- [ ] Confirm the page still works on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
