### PR TITLE
Stacked spending chart: strokes between layers + direct end-labels

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1000,7 +1000,23 @@ svg.chart .data-dot {
 }
 svg.chart .data-fill {
   fill: currentColor;
-  stroke: none;
+  /* Thin stroke in the page background color creates crisp visual
+     separation between adjacent stacked-area layers, even when hues
+     are similar. */
+  stroke: var(--bg);
+  stroke-width: 1.5;
+  stroke-linejoin: round;
+}
+
+/* Stacked-area chart: direct end-labels on desktop, legend above on
+   mobile. The end-labels become unreadable when the SVG is scaled
+   down to phone width, so switch to the legend pattern there. The
+   double-class selector beats plain .legend specificity. */
+.legend.legend--stacked-mobile { display: none; }
+svg.chart--stacked .end-label { display: block; }
+@media (max-width: 600px) {
+  .legend.legend--stacked-mobile { display: flex; }
+  svg.chart--stacked .end-label { display: none; }
 }
 
 /* Series color assignments via `color` so currentColor cascades */

--- a/where-has-the-money-gone.html
+++ b/where-has-the-money-gone.html
@@ -88,7 +88,8 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
       Pensions      -> s-stoneham   (plum)
       Everything    -> s-everything (light slate, dedicated catch-all token)
   -->
-  <div class="legend">
+  <!-- Mobile-only legend. On desktop the SVG shows direct end-labels instead. -->
+  <div class="legend legend--stacked-mobile">
     <div class="legend-item s-marblehead"><span class="legend-swatch"></span><span class="legend-text">Schools</span></div>
     <div class="legend-item s-melrose"><span class="legend-swatch"></span><span class="legend-text">Health insurance</span></div>
     <div class="legend-item s-tier-1"><span class="legend-swatch"></span><span class="legend-text">Public safety</span></div>
@@ -98,7 +99,7 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
   </div>
 
   <div class="chart-wrapper">
-    <svg class="chart" viewBox="0 0 760 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stacked area chart of Marblehead general fund spending by category from FY2015 to FY2026, showing schools, health insurance, public safety, debt payments, pensions, and everything else. Total rises from 70.5 million in FY2015 to 106.2 million in FY2026. Schools is the largest layer throughout. FY2025 is expended and FY2026 is budget; the rest are audited actuals.">
+    <svg class="chart chart--stacked" viewBox="0 0 820 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stacked area chart of Marblehead general fund spending by category from FY2015 to FY2026, showing schools, health insurance, public safety, debt payments, pensions, and everything else. Total rises from 70.5 million in FY2015 to 106.2 million in FY2026. Schools is the largest layer throughout. FY2025 is expended and FY2026 is budget; the rest are audited actuals.">
       <!--
         X axis: x = 60 + (FY - 2015) * 60, so FY15 = 60, FY26 = 720.
         Y axis: y = 280 - dollars * 240 / 110_000_000, so $0 = 280, $110M = 40.
@@ -180,6 +181,16 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
       <text class="tick-label tick-label--major" x="600" y="300" text-anchor="middle">FY24</text>
       <text class="tick-label tick-label--minor annotation--hide-sm" x="660" y="300" text-anchor="middle">FY25</text>
       <text class="tick-label tick-label--major" x="720" y="300" text-anchor="middle">FY26</text>
+
+      <!-- Direct end-labels at the right edge of each layer. Y values are
+           the midpoint of each layer's FY26 right-edge, rounded to avoid
+           collision with neighbors. Replaces the above-chart legend. -->
+      <text class="end-label s-marblehead" x="728" y="230">Schools</text>
+      <text class="end-label s-melrose"    x="728" y="160">Health ins.</text>
+      <text class="end-label s-tier-1"     x="728" y="132">Public safety</text>
+      <text class="end-label s-swampscott" x="728" y="110">Debt</text>
+      <text class="end-label s-stoneham"   x="728" y="94">Pensions</text>
+      <text class="end-label s-everything" x="728" y="68">Everything else</text>
     </svg>
   </div>
 


### PR DESCRIPTION
## Summary
Two UX fixes on the 6-layer stacked area chart on `where-has-the-money-gone.html`.

1. **Thin 1.5px strokes between polygon layers** in the page background color. Solves the issue where Schools (navy) and Public safety (teal) were both cool light blues and the eye struggled to parse adjacent layers. No color changes — just crisp visual boundaries. Works in both light and dark mode since `--bg` resolves to `--c-fog`.

2. **Direct end-labels on desktop, legend above on mobile.** Replaced the above-chart legend with inline `<text class="end-label s-*">` at the right edge of each layer. Matches the STYLE_GUIDE preference: *"Direct label lines at endpoints. Legends only when 4+ series and end labels would overlap."* ViewBox expanded from `0 0 760 320` to `0 0 820 320` to make room for the label strip. On mobile (`<= 600px`) the SVG scales too small for inline text to be legible, so the end-labels hide and a restored `.legend` block above the chart takes over.

## Why
Reviewing the live chart with Andrew flagged two specific complaints:
- Adjacent blue layers (navy Schools, teal Public safety) blended together
- Reading the chart required constant round-trips to the legend at top

Neither required a recolor — the stroke fix solves boundary parsing, and the end-labels remove the round-trip.

## Scoped changes
- New `.chart--stacked` class on the SVG and `.legend--stacked-mobile` modifier on the legend div, so the behavior only applies to this chart. Other charts using `.end-label` or `.legend` are unaffected.
- The `.data-fill` stroke rule does apply globally, but `.data-fill` is only used on this one chart (verified).
- Double-class selector `.legend.legend--stacked-mobile` is used to beat the plain `.legend { display: flex }` source-order specificity fight.

## Test plan
- [x] Desktop (1000px): layers have crisp boundaries, end-labels visible on right, no legend above chart, each layer self-identifies
- [x] Mobile (390px): end-labels hidden via media query, legend restored above chart, layer strokes still visible and helpful
- [x] Color-unchanged: no `--c-*` tokens modified; existing series assignments preserved
- [x] No regression to other charts that use `.end-label` (annual_gap.html) or `.legend` (various) — changes are scoped via new classes
- [x] Followed STYLE_GUIDE rules: no inline styles on SVG, no em-dashes, no green/red semantic coding, no new tokens