### PR TITLE
Add second-order-constraint notes to Tension 1 and Tension 4 mini-syntheses

### DIFF
--- a/the-debate.html
+++ b/the-debate.html
@@ -117,7 +117,7 @@ community_pulse: off-sections
   </div>
 
   <div class="mini-synthesis">
-    <p><strong>Where they actually disagree:</strong> whether a cost the town could in principle renegotiate counts as "external" depends on whether you are looking at a 12-week budget cycle or a 5-year planning horizon. Both sides are answering different versions of the question.</p>
+    <p><strong>Where they actually disagree:</strong> whether a cost the town could in principle renegotiate counts as "external" depends on whether you are looking at a 12-week budget cycle or a 5-year planning horizon. Both sides are answering different versions of the question. Most of the items the against side names (the 83/17 split, the 20-hour benefits threshold, contract provisions) are subject to collective bargaining under MGL c. 150E and can only be renegotiated at contract renewal, typically every 2&ndash;3 years. Long-horizon controllable; short-horizon fixed.</p>
   </div>
 
   <h2 class="tension-heading">Tension 2. Are the proposed reductions damage or discipline?</h2>
@@ -168,7 +168,7 @@ community_pulse: off-sections
   </div>
 
   <div class="mini-synthesis">
-    <p><strong>Where they actually disagree:</strong> whether "meaningful alternatives" is measured over a 12-week budget cycle or a 5-year planning horizon. Both sides are answering different versions of the same question.</p>
+    <p><strong>Where they actually disagree:</strong> whether "meaningful alternatives" is measured over a 12-week budget cycle or a 5-year planning horizon. Both sides are answering different versions of the same question. The same time-horizon asymmetry applies in specifics: benefits reform is possible at contract renewal, zoning changes require Town Meeting votes and face historic-district and neighborhood constraints, and state aid reform requires state-level advocacy. None of these is impossible; none is fast.</p>
   </div>
 
   <h2 class="tension-heading">Tension 5. Can we trust the people asking?</h2>


### PR DESCRIPTION
## Summary

The debate page was understating the second-order constraints on items the "against the override" side labels as locally controllable. Adding a sentence to the Tension 1 and Tension 4 mini-syntheses to honestly surface the constraint structure that both sides are implicitly arguing around.

## The problem

**Tension 1** (cost source): the against block names the 83/17 health insurance split, the 20-hour benefits threshold, and contract provisions as items the town is "choosing to carry." The for block counters that these are "effectively fixed" in the 12-week budget cycle. Both were right, but the page left implicit *why* they were both right. Specifically: most of those items are subject to collective bargaining under MGL c. 150E. The town cannot change them unilaterally; it can only renegotiate them at contract renewal, typically every 2-3 years.

**Tension 4** (alternatives): the against side says "alternatives exist and haven't been seriously tried" and names benefits reform, commercial development, and state aid advocacy. The for side says "alternatives assume a 5-year horizon." Again both right, but the page didn't spell out the specific time-and-process constraints: benefits reform at contract renewal, zoning changes through Town Meeting and subject to historic district and neighborhood review, state aid requiring state-level advocacy.

## Why the mini-synthesis and not the perspective blocks

The perspective blocks present each side as its proponents would make it, uncaveated. That's the steelmanning structure. Adding constraints *inside* a perspective block would undo the steelmanning by having each side weaken its own case.

The mini-synthesis is the right place for meta-commentary: it's where the page does the "here's where they're talking past each other" work. Both sentences go there.

## Changes

Two additions, 4 sentences total, both inside existing `<div class="mini-synthesis">` blocks. The perspective blocks themselves are unchanged.

### Tension 1 mini-synthesis, appended:

> Most of the items the against side names (the 83/17 split, the 20-hour benefits threshold, contract provisions) are subject to collective bargaining under MGL c. 150E and can only be renegotiated at contract renewal, typically every 2-3 years. Long-horizon controllable; short-horizon fixed.

### Tension 4 mini-synthesis, appended:

> The same time-horizon asymmetry applies in specifics: benefits reform is possible at contract renewal, zoning changes require Town Meeting votes and face historic-district and neighborhood constraints, and state aid reform requires state-level advocacy. None of these is impossible; none is fast.

## Style guide compliance

- **No em-dashes** - verified via grep. Used commas, semicolons, and `&ndash;` for the 2-3 year range.
- **Primary-source language** - MGL c. 150E is the Massachusetts public-employee collective bargaining statute, cited directly.
- **Neutral framing** - neither addition privileges a side; both clarify that each side's claim is partly right and partly wrong in a specific, nameable way.

## Files changed

- `the-debate.html` - 2 lines changed (one sentence appended to each of two mini-synthesis paragraphs)

## Test plan

- [ ] Visit `/the-debate.html` and confirm Tension 1 and Tension 4 mini-synthesis paragraphs now include the constraint sentences
- [ ] Confirm no other tensions were modified
- [ ] Confirm the perspective blocks (for/against) are unchanged
- [ ] Grep for em-dashes on the page and confirm count is still 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
