### PR TITLE
Homepage: widen container and grid question cards on desktop

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -14,9 +14,11 @@ One shared stylesheet (`assets/site.css`) with CSS custom properties. All pages 
 
 | Type | Body class | Max width | Examples |
 |------|-----------|-----------|----------|
-| **Index** | (none) | `--page-max` (720px) | `index.html` |
-| **Explainer** | (none) | `--page-max` (680px) | `what-is-the-override.html`, `what-fails.html` |
+| **Index** | `.page--home` on wrapper | `--chart-max` (880px) | `index.html` |
+| **Explainer** | (none) | `--page-max` (720px) | `what-is-the-override.html`, `what-fails.html` |
 | **Chart** | `chart-page` | `--chart-max` (880px) | All files in `charts/` |
+
+The home page uses the wider `--chart-max` container to accommodate a 2-column question-card grid on desktop (&ge;720px). Below that breakpoint the cards stack single-column. A lone `.question` in a `.question-list` spans both grid columns via `:only-child`, so sections with a single card don't leave an empty right column.
 
 ## Required `<head>` Elements (Every Page)
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,7 +3,7 @@ layout: default
 ---
 {% include nav.html %}
 
-<div class="page">
+<div class="page page--home">
   {{ content }}
 
   {% include footer.html %}

--- a/assets/site.css
+++ b/assets/site.css
@@ -531,6 +531,26 @@ p a:hover { text-decoration: underline; }
 .question-list {
   display: flex; flex-direction: column; gap: 12px;
 }
+
+/* Home page breaks out of the narrow reading column and uses a 2-col
+   grid on desktop so the question cards are scannable at a glance
+   instead of stacked vertically. The narrow column is still fine for
+   explainer pages; only .page--home opts in. */
+.page.page--home {
+  max-width: var(--chart-max);
+}
+@media (min-width: 720px) {
+  .page--home .question-list {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+  /* Lone card in a section fills the full row instead of leaving
+     a blank right column. */
+  .page--home .question-list .question:only-child {
+    grid-column: 1 / -1;
+  }
+}
 .question {
   background: var(--surface);
   border-radius: var(--radius-md);


### PR DESCRIPTION
## Summary
On desktop (≥720px), the homepage now uses a 2-column grid for the question cards in each section, inside a wider 880px container. The featured debate card stays full-width above the grids as the hero. Mobile is unchanged — cards still stack single-column below 720px.

## Why
At 1200px the homepage was using the narrow 720px reading column and stacking all 15+ cards single-file. A desktop visitor had to scroll through them one at a time instead of seeing the menu at a glance, and the content column used less than half the viewport width.

## Changes
- **`_layouts/home.html`**: added `page--home` modifier class to the wrapper so home-specific styles can target it without affecting explainer pages.
- **`assets/site.css`**:
  - `.page.page--home` max-width bumped from `--page-max` (720px) to `--chart-max` (880px).
  - At ≥720px, `.page--home .question-list` switches from flex column to `grid-template-columns: repeat(2, 1fr)`. Gap of 12px matches the existing flex gap.
  - `.question:only-child` gets `grid-column: 1 / -1` so single-card sections like "Where has Marblehead's money gone?" fill the full row instead of leaving an empty right column.
  - Mobile (<720px) is unchanged.
- **`STYLE_GUIDE.md`**: updated the Page Types table from `--page-max (720px)` to `--chart-max (880px)` for Index, added the `.page--home` modifier to the Body class column, and added a note explaining the grid behavior and the `:only-child` full-span rule.

## Test plan
- [x] Desktop (1200px): 4-6 question cards visible at once, featured debate card stays full-width, single-card sections span the full row
- [x] Mobile (390px): cards stack single-column as before, no grid behavior
- [x] "Where has Marblehead's money gone?" card (single-child section) spans both columns, no empty gap to its right
- [x] Other sections with 4 cards render as 2x2 grids cleanly
- [x] Existing featured card, section labels, and data section are unchanged
- [x] Followed STYLE_GUIDE: new class `.page--home` added to the Page Types table; the style guide is now in sync with the new home width