### PR TITLE
Polish debate page: meta-note as list, drop "exogenous", fix duplicate heading

### DIFF
--- a/the-debate.html
+++ b/the-debate.html
@@ -74,7 +74,7 @@ community_pulse: off-sections
     font-style: italic;
   }
 
-  /* Meta-note: the "these tensions aren't all the same kind" paragraph above the TL;DR */
+  /* Meta-note: the "these tensions aren't all the same kind" callout above the TL;DR */
   .meta-note {
     font-size: 14px;
     color: var(--text-muted);
@@ -84,6 +84,28 @@ community_pulse: off-sections
     border-left: 3px solid var(--c-navy);
     background: color-mix(in srgb, var(--c-navy) 4%, var(--surface));
     border-radius: 0 8px 8px 0;
+  }
+  .meta-note p {
+    margin: 0;
+  }
+  .meta-note-list {
+    list-style: none;
+    padding: 0;
+    margin: 10px 0 0;
+  }
+  .meta-note-list li {
+    padding: 7px 0 7px 14px;
+    margin-bottom: 4px;
+    line-height: 1.55;
+    border-left: 2px solid color-mix(in srgb, var(--c-navy) 30%, var(--border));
+  }
+  .meta-note-list li:last-child {
+    margin-bottom: 0;
+  }
+  .meta-note-list strong {
+    color: var(--text);
+    font-weight: 700;
+    margin-right: 4px;
   }
 
   /* TL;DR section: visually promote the summary above the five tensions */
@@ -219,7 +241,15 @@ community_pulse: off-sections
 <h1>The override debate, both sides</h1>
   <p>Marblehead residents are debating whether to approve the FY27 override. This page presents the strongest version of each side in the local debate, organized around the five tensions where voters actually disagree. It is not a recommendation or a summary. It is a map of where the real disagreements are, for readers still deciding how to vote. See <a href="about.html">about this site</a> for the author's disclosure (including that the author is genuinely undecided as of writing).</p>
 
-  <p class="meta-note">These five tensions are not all the same kind of disagreement. Some are mostly about facts: are the cost drivers really growing at the rate claimed? Some are about reading the same facts differently: is a 43% library reduction damage or discipline? Some are about values: is a multi-year reset responsible or irresponsible? And some depend on how you feel about local governance in ways that data alone cannot settle. Each tension below mixes these in different proportions.</p>
+  <div class="meta-note">
+    <p>These five tensions are not all the same kind of disagreement. Each tension below mixes four elements in different proportions:</p>
+    <ul class="meta-note-list">
+      <li><strong>Facts.</strong> Are the cost drivers really growing at the rate claimed?</li>
+      <li><strong>Interpretation.</strong> Is a 43% library reduction damage or discipline?</li>
+      <li><strong>Values.</strong> Is a multi-year reset responsible or irresponsible?</li>
+      <li><strong>Governance.</strong> Do you trust the people making the ask?</li>
+    </ul>
+  </div>
 
   <div class="tldr">
     <div class="tldr-eyebrow">The short version</div>
@@ -321,8 +351,8 @@ community_pulse: off-sections
     <p><strong>Where they actually disagree:</strong> whether past behavior plus transparent process is sufficient evidence that future spending will be responsible. Those for the override read the FinCom arc as evidence of disciplined governance. Those against the override read the same arc as the pattern the override perpetuates rather than interrupts.</p>
   </div>
 
-  <h2 class="tension-heading">Where they actually disagree</h2>
-  <p>The five tensions above are not about different facts. Both sides read the same facts: the same FY27 deficit, the same health insurance trajectory, the same Finance Committee letters, the same no-override budget. They reach different conclusions because they apply different frames. Each tension's crux, side by side:</p>
+  <h2 class="tension-heading">The cruxes, side by side</h2>
+  <p>The five tensions above are not about different facts. Both sides read the same facts: the same FY27 deficit, the same health insurance trajectory, the same Finance Committee letters, the same no-override budget. They reach different conclusions because they apply different frames. Each tension's crux compressed into a phrase:</p>
 
   <div class="crux-map">
     <div class="crux-map-header crux-map-header--tension">Tension</div>
@@ -330,7 +360,7 @@ community_pulse: off-sections
     <div class="crux-map-header crux-map-header--against">Against the override reads it as</div>
 
     <div class="crux-map-label">1. Cost source</div>
-    <div class="crux-map-cell crux-map-cell--for">Exogenous drivers (GIC premiums, PERAC schedules, debt, state aid decline)</div>
+    <div class="crux-map-cell crux-map-cell--for">External drivers outside the town's near-term control (GIC premiums, pension schedules, debt, state aid decline)</div>
     <div class="crux-map-cell crux-map-cell--against">Local policy choices the town can renegotiate over time</div>
 
     <div class="crux-map-label">2. Damage or discipline</div>


### PR DESCRIPTION
## Summary

Three small copy fixes to `the-debate.html` based on user feedback on the content that shipped in #55.

## 1. Meta-note restructured as a list

The callout that explained "these five tensions are not all the same kind of disagreement" packed four category labels and four example questions into a single inline paragraph. The result was hard to scan: the questions got lost in the prose and the categories were hard to distinguish.

Restructured as an intro sentence plus a visually distinct list. Each of the four elements gets its own line with a bold category label:

- **Facts.** Are the cost drivers really growing at the rate claimed?
- **Interpretation.** Is a 43% library reduction damage or discipline?
- **Values.** Is a multi-year reset responsible or irresponsible?
- **Governance.** Do you trust the people making the ask?

The fourth element (Governance) now has an example question of its own that matches the pattern of the other three. Previously it was a non-question observation trailing off the end of the prose.

New `.meta-note-list` CSS handles the list styling with a navy left-border accent that visually mirrors the meta-note container's own left-border treatment.

## 2. Drop "Exogenous" for plain English

The crux map's Tension 1 for-side cell said *"Exogenous drivers (GIC premiums, PERAC schedules, debt, state aid decline)"*. Replaced with *"External drivers outside the town's near-term control"* plus the same parenthetical examples. "Exogenous" is an economics academic term that most residents will not know; the plain-English version conveys the same meaning without jargon.

## 3. Fix duplicate "Where they actually disagree" heading

Every tension's mini-synthesis opens with a bold *"Where they actually disagree:"* prefix. The closing synthesis section also used *"Where they actually disagree"* as its `<h2>`. That meant at the end of Tension 5, the mini-synthesis bold prefix and the `<h2>` below it contained the exact same phrase back-to-back, which read as a typo.

Renamed the `<h2>` to **"The cruxes, side by side"** (which also describes the grid below it better than the old heading did). Also rewrote the section intro to end with *"Each tension's crux compressed into a phrase:"* instead of *"Each tension's crux, side by side:"* to avoid another near-duplication with the new `<h2>`.

## Files changed

- `the-debate.html` - 35 insertions, 5 deletions

## Style guide compliance

- **No em-dashes** - verified, count is 0
- **No jargon** - "exogenous" removed, plain-English equivalents used throughout
- **Neutral framing** - the four meta-note categories are descriptive, not advocacy

## Test plan

- [ ] Visit `/the-debate.html` and confirm the meta-note renders as an intro sentence plus a four-item list
- [ ] Confirm each meta-note list item has a bold category label and a question
- [ ] Scroll to the crux map and confirm the Tension 1 for-cell says "External drivers..." instead of "Exogenous drivers..."
- [ ] Confirm the section above the crux map now reads "The cruxes, side by side" instead of "Where they actually disagree"
- [ ] Confirm the Tension 5 mini-synthesis still opens with "Where they actually disagree:" (the per-tension prefix is unchanged)
- [ ] Test on mobile width and confirm the meta-note list still reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
