### PR TITLE
Add "What you can do" civic engagement page

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,12 @@ og_url: https://marbleheaddata.org/
       <p>The state Circuit Breaker (up to $2,820), Marblehead's pending means-tested exemption (H.4225), and how both interact with the override.</p>
       <span class="tag tag-text">Explainer</span>
     </a>
+
+    <a class="question" href="what-you-can-do.html">
+      <h2>What can you do?</h2>
+      <p>Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight of the town budget.</p>
+      <span class="tag tag-text">Guide</span>
+    </a>
   </div>
 
   <p class="section-label">The record</p>

--- a/what-fails.html
+++ b/what-fails.html
@@ -135,6 +135,10 @@ og_url: https://marbleheaddata.org/what-fails.html
       <div class="read-next-title">Why do some MA towns run overrides and others don't? &rarr;</div>
       <div class="read-next-desc">Structural archetypes by residential tax share and new-growth rate, across 21 peer Massachusetts communities.</div>
     </a>
+    <a class="read-next-link" href="what-you-can-do.html">
+      <div class="read-next-title">What can you do? &rarr;</div>
+      <div class="read-next-desc">Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight.</div>
+    </a>
   </div>
 
   <div class="notes">

--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -1,0 +1,182 @@
+---
+title: "What you can do"
+community_pulse: off-sections
+og_title: "What you can do"
+og_description: "How to engage with Marblehead budget decisions beyond voting yes or no on the override: who decides what, when residents can input, and what longer-term oversight looks like."
+og_url: https://marbleheaddata.org/what-you-can-do.html
+---
+<h1>What you can do</h1>
+
+<p><strong>The ballot has four possible outcomes: one of three override tiers passes, or no override.</strong> Structural reforms that could affect future budgets are real, but they are slow, and none of them change what is on this year's ballot.</p>
+
+<p>Everything below is about influencing what comes next: how the budget gets built, who decides what, when residents can input, and what longer-term reforms exist.</p>
+
+<p>Still deciding on this year's ballot? See <a href="what-is-the-override.html">what is the override</a> and <a href="what-fails.html">what is in the no-override budget</a>. Otherwise, keep reading.</p>
+
+<h2>Pick the goal that matches your view</h2>
+
+<p><strong>"I want the override to pass."</strong> Vote yes on one or more tiers. The tiers are nested, so the highest one that gets a majority sets the amount. Read <a href="what-is-the-override.html">what is the override</a> for the tier breakdown. Talk to neighbors. Attend the May 4 Town Meeting to support the budget motion.</p>
+
+<p><strong>"I want the override to fail."</strong> Vote no on all three tiers. Attend the May 4 Town Meeting to oppose specific line items. Read <a href="what-fails.html">what is in the no-override budget</a> to understand what takes effect if no override passes: this is a real outcome, not a hypothetical.</p>
+
+<p><strong>"I want specific cuts avoided regardless of the vote outcome."</strong> Depends on the cut. School positions: the School Committee sets priorities within the school budget. Town positions: the Town Administrator and Select Board make operational hiring decisions. The override vote sets the overall size; reallocation within it is a different decision, made by different people.</p>
+
+<p><strong>"I don't know yet; I want to understand the system."</strong> Read the town charter, the most recent <a href="https://marbleheadma.gov/finance-committee/">Finance Committee annual report</a>, and the FY27 proposed budget (linked from <a href="what-fails.html">what is in the no-override budget</a>). Attend any Finance Committee or Select Board meeting: they are public, hybrid, and often have a public comment period at the start. Join a committee when seats become available.</p>
+
+<h2>Better oversight, regardless of the vote</h2>
+
+<p>Budget rigor and clear explanations are not contested goals. The question is how you get there.</p>
+
+<p><strong>What exists today.</strong> The Finance Committee reviews every department's budget and holds public hearings on each warrant article. Its annual Super Saturday hearings are a full day of department-by-department justification, open to the public. Town Meeting itself can amend warrant line items from the floor, including cutting them (though not adding). The Finance Committee publishes an <a href="https://marbleheadma.gov/finance-committee/">annual report</a> before each Town Meeting, and the town publishes an independent annual audit every year. The state <a href="https://www.mass.gov/orgs/division-of-local-services">Division of Local Services</a> also publishes a Municipal Finance Trend Dashboard for every Massachusetts town, showing revenues, expenditures, operating position, debt, demographics, and Proposition 2&frac12; data over time. Attending these meetings, reading these reports, and asking questions is the most direct form of budget oversight a resident can exercise today.</p>
+
+<p><strong>Two concrete things that could exist, with precedent elsewhere.</strong></p>
+
+<p>The first is a <a href="https://www.mass.gov/info-details/financial-management-reviews">DLS Financial Management Review</a>. The state's Financial Management Resource Bureau conducts these for towns on request from the Select Board. They cover government structure, fiscal planning, ongoing financial procedures, and information technology, and they produce a published report with specific recommendations. Three Massachusetts towns received one in the last 18 months: <a href="https://www.mass.gov/doc/southborough-financial-management-review-august-2024/download">Southborough</a> (August 2024), <a href="https://www.mass.gov/doc/dudley-financial-management-review-december-2024/download">Dudley</a> (December 2024), and <a href="https://www.mass.gov/doc/wareham-financial-management-review-september-2025/download">Wareham</a> (September 2025). A Marblehead resident pushing for this would ask the Select Board to request the review. The review is free and the report is independent of town officials.</p>
+
+<p>The second is performance-goal and departmental-detail reporting inside the annual budget document itself. <a href="https://www.westboroughma.gov/DocumentCenter/View/4558/FY2026-Budget-Overview">Westborough's FY26 budget</a> presents each department's detailed budget along with performance goals and organizational charts. Marblehead's current budget format is more compact. A resident pushing for this would ask the Town Administrator or Finance Committee to adopt a similar structure for the FY28 budget. This does not require a warrant article; it is a choice about how the annual budget is presented.</p>
+
+<p>Both of these are slow. Neither changes this year's vote. Both have concrete precedent in Massachusetts towns of similar or smaller size.</p>
+
+<h2>Who decides what</h2>
+
+<p>Most civic decisions in Marblehead are distributed across several bodies, each with different authority. Knowing which body handles which decision is the difference between writing the right email and writing to no one.</p>
+
+<table class="peer-table">
+  <thead>
+    <tr>
+      <th>Decision</th>
+      <th>Who decides</th>
+      <th>How residents engage</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Annual operating budget</strong></td>
+      <td>Town Administrator drafts &rarr; Select Board reviews &rarr; Finance Committee recommends &rarr; Town Meeting votes</td>
+      <td>Attend Select Board and Finance Committee meetings during the budget cycle; speak and vote at Town Meeting</td>
+    </tr>
+    <tr>
+      <td><strong>Proposition 2&frac12; override or debt exclusion</strong></td>
+      <td>Select Board puts the question on the ballot; Town Meeting approves or rejects the corresponding budget; voters decide at the ballot</td>
+      <td>Speak and vote at Town Meeting; vote at the ballot</td>
+    </tr>
+    <tr>
+      <td><strong>Operational decisions (hiring, scheduling, procurement)</strong></td>
+      <td>Town Administrator and department heads, with Select Board oversight</td>
+      <td>Contact the Town Administrator or the relevant Select Board member</td>
+    </tr>
+    <tr>
+      <td><strong>School spending priorities</strong> (within the overall school budget Town Meeting approves)</td>
+      <td>School Committee</td>
+      <td>Attend School Committee meetings; contact members directly</td>
+    </tr>
+    <tr>
+      <td><strong>Tax classification (single vs. split residential / commercial rate)</strong></td>
+      <td>Select Board, annually at a public hearing</td>
+      <td>Attend the annual tax classification hearing</td>
+    </tr>
+    <tr>
+      <td><strong>Zoning and land use bylaws</strong></td>
+      <td>Planning Board proposes; Town Meeting votes</td>
+      <td>Attend Planning Board hearings; speak at Town Meeting; petition a warrant article</td>
+    </tr>
+    <tr>
+      <td><strong>Town bylaws and warrant articles</strong></td>
+      <td>Town Meeting votes (some require Attorney General approval)</td>
+      <td>Petition a warrant article with 10 registered-voter signatures for the Annual Town Meeting, or support one</td>
+    </tr>
+    <tr>
+      <td><strong>Licensing (alcohol, food, entertainment, lodging)</strong></td>
+      <td>Select Board</td>
+      <td>Contact Select Board members directly</td>
+    </tr>
+    <tr>
+      <td><strong>State aid, pension contribution formulas, health insurance (GIC)</strong></td>
+      <td>Massachusetts legislature and state agencies</td>
+      <td>Contact your state senator or state representative</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Two things worth noticing:</p>
+
+<ol>
+  <li><strong>Most meaningful budget decisions run through Town Meeting.</strong> If you care about the overall size of the town's operating budget, the warrant articles, or any structural change to how the town is governed, the lever is Town Meeting. Contacting individual Select Board members is effective for operational questions but does not change the total budget size.</li>
+  <li><strong>Some things that feel local are actually state decisions.</strong> Health insurance rates, pension contribution formulas, and most forms of state aid are set at the state level. A resident pushing to change them talks to their state legislator, not the Select Board. This is not a dodge; it is where the legal authority sits.</li>
+</ol>
+
+<h2>How to reach each body</h2>
+
+<p>All of the bodies listed below are public. Most meetings are hybrid (in-person plus Zoom). Agendas are posted on the <a href="https://marbleheadma.gov/">town calendar</a> at least 48 hours before each meeting.</p>
+
+<h3>Select Board</h3>
+<ul>
+  <li><strong>Members:</strong> Dan Fox (Chair, term ends 2027), Moses Grader (2027), Erin Noonan (2026), Alexa Singer (2026), James Zisson (2028). Each member has an individual email at <code>&lt;lastname&gt;&lt;firstletter&gt;@marbleheadma.gov</code>.</li>
+  <li><strong>Meets:</strong> 2nd and 4th Wednesday of each month at 7 PM, Select Board's Room, Abbot Hall.</li>
+  <li><strong>General office:</strong> (781) 631-0000. Page: <a href="https://marbleheadma.gov/select-board/">marbleheadma.gov/select-board/</a>.</li>
+  <li><strong>Authority:</strong> Chief executive body of the town. Handles licensing, budget development, fiscal oversight, policy, and appointments.</li>
+</ul>
+
+<h3>Finance Committee</h3>
+<ul>
+  <li><strong>Members:</strong> 9 volunteers appointed by the Select Board to staggered 3-year terms. Currently: Alec Goolsby (Chair), Pat Franklin and Molly Teets (Vice Chairs), and members Timothy Shotmeyer, Michael O'Neil, Eric Knight, Michael Janko, Lindsay Dube, and Ramon Garcia.</li>
+  <li><strong>Meets:</strong> Monthly June through November, more frequently December through May in the lead-up to Town Meeting. Meetings held at Mary Alley Municipal Building lower-level conference room.</li>
+  <li><strong>Phone:</strong> (781) 631-1705. Page: <a href="https://marbleheadma.gov/finance-committee/">marbleheadma.gov/finance-committee/</a>.</li>
+  <li><strong>Spring hearings:</strong> "Super Saturday" budget hearings run before Town Meeting, open to the public, with department heads presenting each line.</li>
+  <li><strong>Annual report:</strong> Published before each Town Meeting, with a recommendation on every warrant article.</li>
+  <li><strong>Authority:</strong> Advisory. Reviews every department's budget and recommends on each warrant article. The committee does not appropriate money; Town Meeting does.</li>
+</ul>
+
+<h3>School Committee</h3>
+<ul>
+  <li><strong>Meets:</strong> 1st and 3rd Thursday of each month at 6 PM.</li>
+  <li><strong>Contact:</strong> Through the School Department at (781) 639-3141, 9 Widger Road.</li>
+  <li><strong>Members, agendas, subcommittees:</strong> <a href="https://www.marbleheadschools.org/school-committee">marbleheadschools.org/school-committee</a>.</li>
+  <li><strong>Authority:</strong> Sets spending priorities and policy within the overall school budget approved by Town Meeting.</li>
+</ul>
+
+<h3>Town Administrator</h3>
+<ul>
+  <li><strong>Thatcher W. Kezer III.</strong> Email: kezert@marbleheadma.gov. Phone: (781) 631-0000. Office: Abbot Hall, 188 Washington Street.</li>
+  <li><strong>Role:</strong> Drafts and recommends the annual operating budget and capital plan for review by the Select Board and approval by Town Meeting. Oversees 11 town departments.</li>
+</ul>
+
+<h3>Town Clerk</h3>
+<ul>
+  <li><strong>Role:</strong> Handles voter registration, elections, and warrant article petitions. First stop for filing a warrant article or verifying voter registration.</li>
+  <li><strong>Contact:</strong> Listed on <a href="https://marbleheadma.gov/">marbleheadma.gov</a>.</li>
+</ul>
+
+<h3>State and federal representatives</h3>
+<ul>
+  <li><strong>State Senator (Third Essex District):</strong> <a href="https://malegislature.gov/Legislators/Profile/BPC0">Brendan Crighton</a> (D-Lynn). District includes Lynn, Lynnfield, Marblehead, Nahant, Saugus, and Swampscott.</li>
+  <li><strong>State Representative:</strong> <a href="https://malegislature.gov/Legislators/Profile/JBA1">Jennifer Balinsky Armini</a>. Email: Jennifer.Armini@mahouse.gov. Phone: (617) 722-2140. Office: Room 21, 24 Beacon Street, Boston.</li>
+  <li><strong>U.S. Representative (MA-6):</strong> Seth Moulton.</li>
+</ul>
+
+<h3>What to expect at Town Meeting</h3>
+
+<p>Town Meeting is the legal decision-making body of the town. Any registered voter can attend, speak on any article under consideration, and vote.</p>
+
+<p>The meeting is held at Marblehead High School and can run multiple nights across a week until all business is concluded. Attendance is self-selected. The Moderator controls who gets recognized to speak: you raise your hand, wait to be called on, state your name and address, and confine your remarks to the motion on the floor. Speakers who wander into unrelated material can be ruled out of order.</p>
+
+<p>Budget articles often pass with limited floor debate when the Finance Committee has recommended in favor. Contested articles draw longer discussion. Votes are usually by show of hands; nine or more voters can call for a written ballot.</p>
+
+<p>First Town Meetings can feel procedurally dense. Reading the warrant and the Finance Committee report in advance is the main thing that makes it easier to follow. A few practical things to know before you go:</p>
+
+<ul>
+  <li>The warrant (the list of articles to be voted on) is published in advance. Pick the articles you actually care about. You do not have to pay attention to the rest.</li>
+  <li>The Finance Committee's annual report explains each article and gives a recommendation on each. It will tell you what you are voting on and why.</li>
+  <li>If you just want to vote, you do not have to speak at all.</li>
+  <li>The auditorium is warm. Bring water.</li>
+  <li>If Town Meeting adjourns before reaching your article, it resumes on a later night. Check the town calendar for the continuation date.</li>
+  <li>If you do speak, keep it short. State your position in your first sentence ("I am in favor of Article X" or "I am opposed to Article X"), address the specific motion on the table, and aim for a minute or less. Longer speeches rarely change votes and often test the Moderator's patience.</li>
+</ul>
+
+<p>Town Meeting is the only place residents vote directly on the town budget and on warrant articles. Every registered voter in the room has the same vote as anyone else.</p>
+
+<h3>Petitioning a warrant article</h3>
+
+<p>To place an article on the warrant for Annual Town Meeting, gather signatures from 10 registered Marblehead voters and submit the petition to the Select Board at least 60 days before the meeting. For a Special Town Meeting, the threshold is 100 signatures. The Town Clerk's office provides the petition form and can answer procedural questions about filing requirements.</p>
+
+<p>Articles submitted on time appear in the printed warrant mailed to registered voters before Town Meeting. Each article gets a Finance Committee recommendation in the annual report. Citizens can sponsor articles on any subject the Town Meeting is legally allowed to act on, including appropriations, bylaws, instructions to town officials, and resolutions.</p>


### PR DESCRIPTION
New page at \`what-you-can-do.html\` covering how a Marblehead resident can engage with budget decisions beyond voting yes or no on the override. Every factual claim about town government structure traces to a primary source (marbleheadma.gov, malegislature.gov, mass.gov DLS, cited news reports).

## Structure

1. **Honest framing.** The June 2026 ballot has four possible outcomes (one of three override tiers passes, or no override). Structural reform is real but slow and does not change this year's vote.
2. **Pick the goal that matches your view.** Four goal-indexed sections: pass, fail, specific cuts avoided, understand the system. Each has concrete levers.
3. **Better oversight, regardless of the vote.** Names two concrete mechanisms with precedent elsewhere: DLS Financial Management Review (Southborough, Dudley, Wareham all received one in the last 18 months) and departmental performance reporting a la Westborough's FY26 budget.
4. **Who decides what.** A nine-row decision-authority table mapping decisions to the body that makes them and how residents engage with each.
5. **How to reach each body.** Contact blocks for Select Board, Finance Committee, School Committee, Town Administrator, Town Clerk, state senator, state representative, and U.S. representative. Includes a \"What to expect at Town Meeting\" subsection and a warrant article petition block.

## Editorial discipline

- No advocacy for specific reforms. The goal-indexed structure puts the choosing in the reader's hands and leaves the author's role as diagnostician rather than advocate.
- \"Better oversight\" (the universal-goal section) does not assert aggregate resident opinions. It opens with \"Budget rigor and clear explanations are not contested goals. The question is how you get there,\" which is a defensible claim about goal structure rather than a sociological assertion.
- Town Meeting subsection is descriptive about the procedural experience without editorializing about the institution. First-timer honesty is limited to \"first Town Meetings can feel procedurally dense\" and concrete practical tips.
- \"Failed\" stays as the official procedural term (not parallel-loaded to \"win\", which was replaced elsewhere).

## Discovery

- Added as the 7th tile under the \"The override\" section of \`index.html\`, tagged \"Guide\".
- Added as a second read-next card on \`what-fails.html\` so readers who finish the no-override budget page have a clear path to the engagement options.

## Known gaps (for future follow-up)

- Town Clerk specific contact info (not easily findable via web; left as \"listed on marbleheadma.gov\")
- Current School Committee member names (not reliably fetched from marbleheadschools.org; the link is included)
- FY28 budget calendar (exact dates not yet public; would be a placeholder section if included, so left out for now)

No widgets on the page (\`community_pulse: off-sections\` in frontmatter) because the content is reference and instructional rather than contested claims.