### PR TITLE
Polish meta-note list: category labels as uppercase eyebrows, questions below

### DIFF
--- a/the-debate.html
+++ b/the-debate.html
@@ -89,23 +89,25 @@ community_pulse: off-sections
     margin: 0;
   }
   .meta-note-list {
-    list-style: none;
+    margin: 14px 0 0;
     padding: 0;
-    margin: 10px 0 0;
   }
-  .meta-note-list li {
-    padding: 7px 0 7px 14px;
-    margin-bottom: 4px;
-    line-height: 1.55;
-    border-left: 2px solid color-mix(in srgb, var(--c-navy) 30%, var(--border));
-  }
-  .meta-note-list li:last-child {
-    margin-bottom: 0;
-  }
-  .meta-note-list strong {
-    color: var(--text);
+  .meta-note-list dt {
+    font-size: 10px;
     font-weight: 700;
-    margin-right: 4px;
+    text-transform: uppercase;
+    letter-spacing: 1.3px;
+    color: var(--c-navy);
+    margin-bottom: 3px;
+  }
+  .meta-note-list dt:not(:first-of-type) {
+    margin-top: 14px;
+  }
+  .meta-note-list dd {
+    margin: 0;
+    color: var(--text);
+    font-size: 14px;
+    line-height: 1.55;
   }
 
   /* TL;DR section: visually promote the summary above the five tensions */
@@ -243,12 +245,16 @@ community_pulse: off-sections
 
   <div class="meta-note">
     <p>These five tensions are not all the same kind of disagreement. Each tension below mixes four elements in different proportions:</p>
-    <ul class="meta-note-list">
-      <li><strong>Facts.</strong> Are the cost drivers really growing at the rate claimed?</li>
-      <li><strong>Interpretation.</strong> Is a 43% library reduction damage or discipline?</li>
-      <li><strong>Values.</strong> Is a multi-year reset responsible or irresponsible?</li>
-      <li><strong>Governance.</strong> Do you trust the people making the ask?</li>
-    </ul>
+    <dl class="meta-note-list">
+      <dt>Facts</dt>
+      <dd>Are the cost drivers really growing at the rate claimed?</dd>
+      <dt>Interpretation</dt>
+      <dd>Is a 43% library reduction damage or discipline?</dd>
+      <dt>Values</dt>
+      <dd>Is a multi-year reset responsible or irresponsible?</dd>
+      <dt>Governance</dt>
+      <dd>Do you trust the people making the ask?</dd>
+    </dl>
   </div>
 
   <div class="tldr">


### PR DESCRIPTION
## Summary

Polish the meta-note list on the debate page so it's easier to read and visually cleaner. Based on user feedback on the previous rendering.

## Problems with the previous version

1. **Doubled-up borders.** Each list item had its own left-border accent, but so does the `.meta-note` container. The per-item borders visually clashed with the container's border, creating noisy decoration.

2. **Category and question on the same line.** The bold category label and the question after it were on one line together. The labels were supposed to function as mini-headers for the questions, but inline rendering meant they competed for attention with the questions instead of introducing them.

## Fix

Restructure as a definition list (`<dl>` / `<dt>` / `<dd>`) which is the semantic HTML pattern for "term: definition" content:

- **`<dt>`** renders as a small uppercase letter-spaced label in the navy brand color. Matches the `.perspective-label` pattern already used on the perspective blocks for visual consistency.
- **`<dd>`** renders as body text on its own line below the label, in the full text color (not muted).
- **No per-item borders.** The `.meta-note` container's own left border provides the only accent.

Visually each item becomes:

```
FACTS
Are the cost drivers really growing at the rate claimed?

INTERPRETATION
Is a 43% library reduction damage or discipline?

VALUES
...
```

The labels read as quiet section markers above each question; the questions are the primary readable content.

## Files changed

- `the-debate.html` - 24 insertions, 18 deletions (HTML structure change and CSS rules for `dl`/`dt`/`dd`)

## Test plan

- [ ] Visit `/the-debate.html` and confirm the meta-note renders with uppercase navy category labels on their own lines
- [ ] Confirm questions render as body text below each label
- [ ] Confirm no per-item borders compete with the container's border-left
- [ ] Test dark mode and confirm the navy category labels adapt via the CSS custom property
- [ ] Test mobile width and confirm the list still reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
