### PR TITLE
Polish homepage copy: hero, subtitle, cards, section label

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,14 @@ og_type: website
 og_url: https://marbleheaddata.org/
 ---
 <div class="hero">
-    <h1>Marblehead Budget Data</h1>
-    <p>An open resource for residents evaluating the FY2027 budget override. Every number is traceable to a primary source. <a href="#data-sources">See all sources.</a></p>
+    <h1>Weighing the FY2027 override?</h1>
+    <p>Every claim on this site cites a primary source. Every dollar traces to a town document. Make your own call. <a href="#data-sources">See all sources.</a></p>
   </div>
 
   <a class="featured-card" href="the-debate.html">
     <div class="featured-card-eyebrow">Still deciding?</div>
     <div class="featured-card-title">The override debate, the best case for each side</div>
-    <div class="featured-card-desc">Five tensions in the local debate, with the strongest version of each case. Neither a recommendation nor a summary. A map of where the real disagreements are, for readers still working through their vote.</div>
+    <div class="featured-card-desc">Five tensions in the local debate, with the strongest version of each case. Neither a recommendation nor a summary. A map of the real disagreements, for readers still working through their vote.</div>
     <span class="tag">Analysis</span>
   </a>
 
@@ -40,7 +40,7 @@ og_url: https://marbleheaddata.org/
 
     <a class="question" href="what-fails.html">
       <h2>What's in the no-override budget?</h2>
-      <p>22 town positions, 14 school positions, library reduced 43%, and what other MA towns did after similar votes.</p>
+      <p>22 town positions removed, 14 school positions, library reduced 43%, and what other MA towns did after similar votes.</p>
       <span class="tag tag-text">Analysis</span>
     </a>
 
@@ -57,11 +57,11 @@ og_url: https://marbleheaddata.org/
     </a>
   </div>
 
-  <p class="section-label">The record</p>
+  <p class="section-label">Spending</p>
   <div class="question-list">
     <a class="question" href="where-has-the-money-gone.html">
       <h2>Where has Marblehead's money gone?</h2>
-      <p>A ten-year walkthrough of how the town has actually spent the tax levy, who has been checking the books, and what grew faster than enrollment or inflation would explain.</p>
+      <p>A ten-year walkthrough of how the town has actually spent the tax levy, who has been checking the books, and where the biggest line-item changes landed.</p>
       <span class="tag tag-text">Analysis</span>
     </a>
   </div>
@@ -88,7 +88,7 @@ og_url: https://marbleheaddata.org/
 
     <a class="question" href="charts/enrollment_vs_staffing.html">
       <h2>Did enrollment drive the budget?</h2>
-      <p>Student enrollment down 21% from peak while education staffing grew to 537 FTE.</p>
+      <p>Student enrollment down 21% from its FY14 peak while education staffing grew to 537 FTE.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
   </div>


### PR DESCRIPTION
## Summary
Seven targeted copy edits on `index.html` after an end-to-end review for clarity, neutrality, and STYLE_GUIDE compliance. Pure copy, no structural or CSS changes.

## Changes

| # | What | Before | After |
|---|---|---|---|
| 1 | **H1** | Marblehead Budget Data | Weighing the FY2027 override? |
| 2 | **Subtitle** | An open resource for residents evaluating the FY2027 budget override. Every number is traceable to a primary source. | Every claim on this site cites a primary source. Every dollar traces to a town document. Make your own call. |
| 3 | **Debate card desc** | A map of where the real disagreements are | A map of the real disagreements |
| 4 | **No-override card** | 22 town positions | 22 town positions removed |
| 5 | **Section label** | The record | Spending |
| 6 | **Spending card desc** | what grew faster than enrollment or inflation would explain | where the biggest line-item changes landed |
| 7 | **Enrollment card** | down 21% from peak | down 21% from its FY14 peak |

## Rationale

- **#1** (H1): The old H1 was a site name, not a headline. A voter landing cold learned what database this is, not why they should read it. The new question headline addresses the voter's state directly and makes the homepage feel like a briefing.

- **#2** (subtitle): Leads with the unique value (primary sourcing), ends with the editorial stance from CLAUDE.md ("form their own opinions based on facts, not rhetoric"). The "open resource" NGO-speak is gone.

- **#3** (debate desc): Tightening — same meaning, four fewer words.

- **#4** (no-override): "22 town positions" is technically ambiguous (removed? added?) without context. "removed" disambiguates for readers scanning without context.

- **#5** (section label): "The record" was vague. The section contains exactly one card about spending history. "Spending" says what the section contains.

- **#6** (spending desc): 🚩 **STYLE_GUIDE fix.** The rule is "no standalone CPI/inflation comparisons as the sole benchmark for a municipal cost category." The old description literally advertised that the page uses "enrollment or inflation" as the yardsticks. The new description points at the same underlying content (department-by-department table, Town Counsel +142%, free cash pattern, etc.) without naming inflation as the evaluation criterion.

- **#7** (enrollment): The 21% figure is accurate per `charts/enrollment_vs_staffing.html` (FY14 peak of 3,327 students to 2,617 in FY24). "From peak" was honest but vague enough to invite peak-picking critique. Naming FY14 explicitly makes the baseline transparent.

## Scope note
One logical change: homepage copy review. Does not touch the other two open homepage PRs (#46 mobile/desktop polish, #56 home grid layout). All three PRs touch different files and will merge cleanly in any order.

## Test plan
- [x] `git diff` reviewed for exactly 7 line changes, no accidental edits
- [x] No em-dashes introduced
- [x] No green/red value judgments
- [x] No advocacy framing ("crisis", "shocking", etc.)
- [x] "from its FY14 peak" matches the data on `charts/enrollment_vs_staffing.html` (peak: 3,327, FY14, declining to 2,617)
- [x] "where the biggest line-item changes landed" matches what the spending page actually shows (dept table + Town Counsel + free cash cards)