### PR TITLE
Rewrite debate page title to "Both sides of the override debate"

### DIFF
--- a/the-debate.html
+++ b/the-debate.html
@@ -1,6 +1,6 @@
 ---
-title: "The override debate, both sides"
-og_title: "The override debate, both sides"
+title: "Both sides of the override debate"
+og_title: "Both sides of the override debate"
 og_description: The five tensions in the FY27 override debate, presented as the strongest version of each side's case. Not a recommendation or a summary. A map of where the real disagreements are, for readers still working through their vote.
 og_url: https://marbleheaddata.org/the-debate.html
 community_pulse: off-sections
@@ -240,7 +240,7 @@ community_pulse: off-sections
   }
 </style>
 
-<h1>The override debate, both sides</h1>
+<h1>Both sides of the override debate</h1>
   <p>Marblehead residents are debating whether to approve the FY27 override. This page presents the strongest version of each side in the local debate, organized around the five tensions where voters actually disagree. It is not a recommendation or a summary. It is a map of where the real disagreements are, for readers still deciding how to vote. See <a href="about.html">about this site</a> for the author's disclosure (including that the author is genuinely undecided as of writing).</p>
 
   <div class="meta-note">


### PR DESCRIPTION
## Summary

Rename the debate page title from **"The override debate, both sides"** to **"Both sides of the override debate"**.

## Why

The old title was a comma construction that read more like a telegraphic label than a title. A reader parses it as "here's a thing [the override debate], and I'm adding a qualifier [both sides]." It works but it feels hesitant.

**"Both sides of the override debate"** is the standard English construction for this kind of title ("Both sides of the immigration debate", "Both sides of the Brexit story", etc.). It reads immediately as a declarative: here are the two positions on the override. It also matches the site's pattern of direct declarative page titles (*"What's in the no-override budget?"*, *"Why do some MA towns run overrides and others don't?"*, *"How did we get here?"*).

## What's updated

- Frontmatter `title`
- Frontmatter `og_title`
- `<h1>` on the page itself

## What's NOT updated

- **The featured card on `index.html`** still says *"The override debate, the best case for each side"*. That is deliberate: the featured card is an invitation/description, not the page's own title. "Best case for each side" is the invitation to click; "Both sides of the override debate" is the page's own declarative title.
- **Nav label** ("Debate") is just one word and isn't affected.
- **The page's `og_description`** still references "the FY27 override debate" inline and doesn't need changing.

## Files changed

- `the-debate.html` - 3 lines (frontmatter title, frontmatter og_title, `<h1>`)

## Test plan

- [ ] Visit `/the-debate.html` and confirm the page `<h1>` reads "Both sides of the override debate"
- [ ] Check browser tab title matches
- [ ] Verify the featured card on the home page still says "The override debate, the best case for each side"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
