### PR TITLE
Rename what-fails.html to no-override-budget.html

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -15,7 +15,7 @@ One shared stylesheet (`assets/site.css`) with CSS custom properties. All pages 
 | Type | Body class | Max width | Examples |
 |------|-----------|-----------|----------|
 | **Index** | `.page--home` on wrapper | `--chart-max` (880px) | `index.html` |
-| **Explainer** | (none) | `--page-max` (720px) | `what-is-the-override.html`, `what-fails.html` |
+| **Explainer** | (none) | `--page-max` (720px) | `what-is-the-override.html`, `no-override-budget.html` |
 | **Chart** | `chart-page` | `--chart-max` (880px) | All files in `charts/` |
 
 The home page uses the wider `--chart-max` container to accommodate a 2-column question-card grid on desktop (&ge;720px). Below that breakpoint the cards stack single-column. A lone `.question` in a `.question-list` spans both grid columns via `:only-child`, so sections with a single card don't leave an empty right column.

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -5,7 +5,7 @@
     <a href="{{ '/' | relative_url }}what-is-the-override.html">Override</a>
     <a href="{{ '/' | relative_url }}how-we-got-here.html">History</a>
     <a href="{{ '/' | relative_url }}where-has-the-money-gone.html">Spending</a>
-    <a href="{{ '/' | relative_url }}what-fails.html">No-Override</a>
+    <a href="{{ '/' | relative_url }}no-override-budget.html">No-Override</a>
     <a href="{{ '/' | relative_url }}why-not-elsewhere.html">Peer Towns</a>
     <a href="{{ '/' | relative_url }}senior-tax-relief.html">Senior Relief</a>
     <a href="{{ '/' | relative_url }}about.html">About</a>

--- a/community-pulse/tests/api.test.js
+++ b/community-pulse/tests/api.test.js
@@ -15,21 +15,21 @@ describe('reactions API client', () => {
     global.fetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        'what-fails.html#staffing-cuts': { total: 47, last_24h: 12 },
-        'what-fails.html#melrose-comparison': { total: 13, last_24h: 2 }
+        'no-override-budget.html#staffing-cuts': { total: 47, last_24h: 12 },
+        'no-override-budget.html#melrose-comparison': { total: 13, last_24h: 2 }
       })
     });
 
     const result = await fetchReactions([
-      'what-fails.html#staffing-cuts',
-      'what-fails.html#melrose-comparison'
+      'no-override-budget.html#staffing-cuts',
+      'no-override-budget.html#melrose-comparison'
     ]);
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     const call = global.fetch.mock.calls[0];
     expect(call[0]).toMatch(/^https:\/\/pulse\.example\.com\/api\/reactions\?section_ids=/);
-    expect(call[0]).toContain(encodeURIComponent('what-fails.html#staffing-cuts'));
-    expect(result['what-fails.html#staffing-cuts'].total).toBe(47);
+    expect(call[0]).toContain(encodeURIComponent('no-override-budget.html#staffing-cuts'));
+    expect(result['no-override-budget.html#staffing-cuts'].total).toBe(47);
   });
 
   it('fetchReactions returns an empty object on network error', async () => {
@@ -56,13 +56,13 @@ describe('reactions API client', () => {
       json: async () => ({ total: 48, last_24h: 13 })
     });
 
-    const result = await incrementReaction('what-fails.html#staffing-cuts');
+    const result = await incrementReaction('no-override-budget.html#staffing-cuts');
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     const [url, opts] = global.fetch.mock.calls[0];
     expect(url).toBe('https://pulse.example.com/api/reactions');
     expect(opts.method).toBe('POST');
-    expect(JSON.parse(opts.body)).toEqual({ section_id: 'what-fails.html#staffing-cuts' });
+    expect(JSON.parse(opts.body)).toEqual({ section_id: 'no-override-budget.html#staffing-cuts' });
     expect(result.total).toBe(48);
   });
 

--- a/community-pulse/tests/store.test.js
+++ b/community-pulse/tests/store.test.js
@@ -11,17 +11,17 @@ beforeEach(async () => {
 describe('stance store', () => {
   it('returns null for an unknown section', async () => {
     const db = await openStore();
-    const result = await getStance(db, 'what-fails.html#unknown');
+    const result = await getStance(db, 'no-override-budget.html#unknown');
     expect(result).toBeNull();
   });
 
   it('writes and reads back a stance', async () => {
     const db = await openStore();
-    await setStance(db, 'what-fails.html#staffing-cuts', {
+    await setStance(db, 'no-override-budget.html#staffing-cuts', {
       stance: 'agree',
       note: 'This matches the Fin Com report.'
     });
-    const result = await getStance(db, 'what-fails.html#staffing-cuts');
+    const result = await getStance(db, 'no-override-budget.html#staffing-cuts');
     expect(result.stance).toBe('agree');
     expect(result.note).toBe('This matches the Fin Com report.');
     expect(result.updated_at).toBeGreaterThan(0);

--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -78,7 +78,7 @@ title: "How did we get here?"
 
   <div class="read-next">
     <div class="read-next-label">Read next</div>
-    <a class="read-next-link" href="what-fails.html">
+    <a class="read-next-link" href="no-override-budget.html">
       <div class="read-next-title">What's in the no-override budget? &rarr;</div>
       <div class="read-next-desc">The specific staffing and service cuts in the FY27 balanced budget without an override, line by line.</div>
     </a>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ og_url: https://marbleheaddata.org/
       <span class="tag tag-charts">Calculator</span>
     </a>
 
-    <a class="question" href="what-fails.html">
+    <a class="question" href="no-override-budget.html">
       <h2>What's in the no-override budget?</h2>
       <p>22 town positions removed, 14 school positions, library reduced 43%, and what other MA towns did after similar votes.</p>
       <span class="tag tag-text">Analysis</span>

--- a/no-override-budget.html
+++ b/no-override-budget.html
@@ -2,7 +2,7 @@
 title: "What's in the no-override budget?"
 og_title: "What's in the no-override budget?"
 og_description: The line-item changes in the town's FY27 No-Override Balanced Budget: 22 town positions, 14 school positions, the library reduced 43 percent, and what comparable Massachusetts towns did after similar votes.
-og_url: https://marbleheaddata.org/what-fails.html
+og_url: https://marbleheaddata.org/no-override-budget.html
 ---
 <h1>What's in the no-override budget?</h1>
   <p>The town published a <a href="https://marbleheadma.gov/wp-content/uploads/2026/04/PROPOSED-FY27-BALANCED-BUDGET-WITH-NO-OVERRIDE.pdf">FY27 Proposed Balanced Budget With No Override</a> in April 2026. It balances using $5M in free cash, staffing reductions across town and school departments, and the elimination of the town's OPEB trust contribution. This page lists the specific line-item changes from that document.</p>

--- a/the-debate.html
+++ b/the-debate.html
@@ -290,7 +290,7 @@ community_pulse: off-sections
   </div>
 
   <h2 class="tension-heading">Tension 2. Are the proposed reductions damage or discipline?</h2>
-  <p class="tension-framing">The no-override budget is published. Both sides have read it and reached opposite conclusions. See <a href="what-fails.html">what's in the no-override budget</a>.</p>
+  <p class="tension-framing">The no-override budget is published. Both sides have read it and reached opposite conclusions. See <a href="no-override-budget.html">what's in the no-override budget</a>.</p>
 
   <div class="perspective perspective--for">
     <div class="perspective-label">For the override</div>
@@ -387,7 +387,7 @@ community_pulse: off-sections
   </div>
 
   <div class="notes">
-    <p><strong>Sources and methodology.</strong> Each tension's factual claims are sourced on the linked pages: FY27 budget numbers and the no-override cut list on <a href="what-fails.html">what's in the no-override budget</a>; the Finance Committee transmittal letter arc on <a href="how-we-got-here.html">how we got here</a>; the ten-year spending walkthrough (which lines grew, by how much, and under which reviewers) on <a href="where-has-the-money-gone.html">where has Marblehead's money gone</a>; the peer-town structural data on <a href="why-not-elsewhere.html">why some MA towns run overrides and others don't</a>; the three-tier override structure and the ballot mechanics on <a href="what-is-the-override.html">what is the override</a>. Statewide fiscal context: MMA, <a href="https://www.mma.org/wp-content/uploads/2025/10/MMA-APerfectStorm-HistoricFiscalPressures-report-10.9.25.pdf"><em>A Perfect Storm: Cities and Towns Face Historic Fiscal Pressures</em> (October 2025)</a>.</p>
+    <p><strong>Sources and methodology.</strong> Each tension's factual claims are sourced on the linked pages: FY27 budget numbers and the no-override cut list on <a href="no-override-budget.html">what's in the no-override budget</a>; the Finance Committee transmittal letter arc on <a href="how-we-got-here.html">how we got here</a>; the ten-year spending walkthrough (which lines grew, by how much, and under which reviewers) on <a href="where-has-the-money-gone.html">where has Marblehead's money gone</a>; the peer-town structural data on <a href="why-not-elsewhere.html">why some MA towns run overrides and others don't</a>; the three-tier override structure and the ballot mechanics on <a href="what-is-the-override.html">what is the override</a>. Statewide fiscal context: MMA, <a href="https://www.mma.org/wp-content/uploads/2025/10/MMA-APerfectStorm-HistoricFiscalPressures-report-10.9.25.pdf"><em>A Perfect Storm: Cities and Towns Face Historic Fiscal Pressures</em> (October 2025)</a>.</p>
     <p><strong>What this page doesn't do.</strong> It does not argue for or against the override, does not summarize "the" debate, and does not engage with the minority of voters who would reject any override regardless of the specifics. Each side here is the persuadable version of its position, not the version that treats the debate as already decided.</p>
     <p><strong>Author disclosure.</strong> See <a href="about.html">about this site</a>. The author is a Marblehead homeowner who is genuinely undecided and uses this page as a tool to work through both sides.</p>
   </div>

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -93,7 +93,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
 
   <div class="card tier-card--1">
     <p class="tier-label">Tier 1: Restore ($9 million)</p>
-    <h3>Bring back services cut from the <a href="what-fails.html">no-override budget</a></h3>
+    <h3>Bring back services cut from the <a href="no-override-budget.html">no-override budget</a></h3>
     <ul class="tier-list">
       <li>Firefighter position</li>
       <li>School resource officer</li>

--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -11,17 +11,17 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
 
 <p>Everything below is about influencing what comes next: how the budget gets built, who decides what, when residents can input, and what longer-term reforms exist.</p>
 
-<p>Still deciding on this year's ballot? See <a href="what-is-the-override.html">what is the override</a> and <a href="what-fails.html">what is in the no-override budget</a>. Otherwise, keep reading.</p>
+<p>Still deciding on this year's ballot? See <a href="what-is-the-override.html">what is the override</a> and <a href="no-override-budget.html">what is in the no-override budget</a>. Otherwise, keep reading.</p>
 
 <h2>Pick the goal that matches your view</h2>
 
 <p><strong>"I want the override to pass."</strong> Vote yes on one or more tiers. The tiers are nested, so the highest one that gets a majority sets the amount. Read <a href="what-is-the-override.html">what is the override</a> for the tier breakdown. Talk to neighbors. Attend the May 4 Town Meeting to support the budget motion.</p>
 
-<p><strong>"I want the override to fail."</strong> Vote no on all three tiers. Attend the May 4 Town Meeting to oppose specific line items. Read <a href="what-fails.html">what is in the no-override budget</a> to understand what takes effect if no override passes: this is a real outcome, not a hypothetical.</p>
+<p><strong>"I want the override to fail."</strong> Vote no on all three tiers. Attend the May 4 Town Meeting to oppose specific line items. Read <a href="no-override-budget.html">what is in the no-override budget</a> to understand what takes effect if no override passes: this is a real outcome, not a hypothetical.</p>
 
 <p><strong>"I want specific cuts avoided regardless of the vote outcome."</strong> Depends on the cut. School positions: the School Committee sets priorities within the school budget. Town positions: the Town Administrator and Select Board make operational hiring decisions. The override vote sets the overall size; reallocation within it is a different decision, made by different people.</p>
 
-<p><strong>"I don't know yet; I want to understand the system."</strong> Read the town charter, the most recent <a href="https://marbleheadma.gov/finance-committee/">Finance Committee annual report</a>, and the FY27 proposed budget (linked from <a href="what-fails.html">what is in the no-override budget</a>). Attend any Finance Committee or Select Board meeting: they are public, hybrid, and often have a public comment period at the start. Join a committee when seats become available.</p>
+<p><strong>"I don't know yet; I want to understand the system."</strong> Read the town charter, the most recent <a href="https://marbleheadma.gov/finance-committee/">Finance Committee annual report</a>, and the FY27 proposed budget (linked from <a href="no-override-budget.html">what is in the no-override budget</a>). Attend any Finance Committee or Select Board meeting: they are public, hybrid, and often have a public comment period at the start. Join a committee when seats become available.</p>
 
 <h2>Better oversight, regardless of the vote</h2>
 


### PR DESCRIPTION
The old slug was a relic from an earlier framing. The page title is now "What's in the no-override budget?" and the URL now matches.

Clean rename, no redirect plugin. All internal links updated across `_includes/nav.html`, `index.html`, `what-is-the-override.html`, `how-we-got-here.html`, `the-debate.html`, `what-you-can-do.html`, `STYLE_GUIDE.md`, and the community-pulse test fixtures.

**Side effect to know about:** the four reaction counts on tagged sections of this page (`town-side-reductions`, `school-side-reductions`, `what-stays-or-grows`, `what-other-towns-did`) will reset to zero after merge because the section ID format is `pagepath#slug`. Any local IndexedDB stances a reader had on this page will also orphan. Both had low volume since launch, so the reset is minimal.