### PR TITLE
Link What You Can Do from top nav and two content read-nexts

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -8,6 +8,7 @@
     <a href="{{ '/' | relative_url }}no-override-budget.html">No-Override</a>
     <a href="{{ '/' | relative_url }}why-not-elsewhere.html">Peer Towns</a>
     <a href="{{ '/' | relative_url }}senior-tax-relief.html">Senior Relief</a>
+    <a href="{{ '/' | relative_url }}what-you-can-do.html">Civic Guide</a>
     <a href="{{ '/' | relative_url }}about.html">About</a>
   </div>
 </nav>

--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -82,6 +82,10 @@ title: "How did we get here?"
       <div class="read-next-title">What's in the no-override budget? &rarr;</div>
       <div class="read-next-desc">The specific staffing and service cuts in the FY27 balanced budget without an override, line by line.</div>
     </a>
+    <a class="read-next-link" href="what-you-can-do.html">
+      <div class="read-next-title">What can you do? &rarr;</div>
+      <div class="read-next-desc">Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight.</div>
+    </a>
   </div>
 
   <h2>Key terms and context</h2>

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -466,6 +466,10 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
       <div class="read-next-title">How did we get here? &rarr;</div>
       <div class="read-next-desc">Seven years of Finance Committee warnings, in their own words. The FY27 override was predicted, in writing, as far back as 2019.</div>
     </a>
+    <a class="read-next-link" href="what-you-can-do.html">
+      <div class="read-next-title">What can you do? &rarr;</div>
+      <div class="read-next-desc">Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight.</div>
+    </a>
   </div>
 
   <h2>Key Terms</h2>


### PR DESCRIPTION
Follow-up to PR #58. Before this change, `what-you-can-do.html` was reachable only from the homepage tile and one read-next card on `no-override-budget.html`. A reader on any other content page had no direct path to it.

Three additions:

1. **Top-nav entry "Civic Guide"** in `_includes/nav.html`, between Senior Relief and About. Reachable from every page.
2. **Second read-next card on `how-we-got-here.html`** alongside the existing link to `no-override-budget.html`. A reader who finishes the FinCom warning arc naturally asks "so what do I do?"
3. **Second read-next card on `what-is-the-override.html`** alongside the existing link to `how-we-got-here.html`. Same reasoning.

"Civic Guide" matches the Guide tag on the homepage tile for consistency.