### PR TITLE
Add existing-funding context to the Question 2 trash card

### DIFF
--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -126,7 +126,8 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
   <div class="card tier-card--trash">
     <p class="tier-label">Separate Question: Trash ($2.3 million)</p>
     <h3>Fund curbside trash/recycling through the levy instead of a flat fee</h3>
-    <p>Independent of the tiers. If it fails, the Board of Health will implement a flat fee of roughly $262 per household. Either way, residents pay for trash. The override spreads the cost by home value; the fee is the same for everyone.</p>
+    <p>Independent of the tiers. Curbside trash and recycling are already paid for through general property taxes via the Waste Collection department (FY26 budget: $2.94 million). The FY27 budget restructures this by carving curbside service out into a new dedicated line item and reducing the existing Waste Collection budget by roughly the same amount. Question 2 asks voters to fund that new line via a $2.3 million levy addition. If it fails, the Board of Health will implement a flat fee of roughly $262 per household instead.</p>
+    <p>Either way, residents pay for trash. The difference is the distribution: the levy scales with assessed home value (a $500K home pays less than a $3M home), while the flat fee is the same for everyone.</p>
   </div>
 
   <p>The nesting matters more than it looks. At the April 8, 2026 Select Board meeting where the tiered structure was first presented, one resident added the three dollar amounts together and described the ballot as a $36 million ask.</p>


### PR DESCRIPTION
## Summary

Correct the Question 2 trash card on `what-is-the-override.html` to disclose that curbside trash has been funded via general property taxes through the Waste Collection department all along, and that Q2 is a restructure rather than a new obligation.

## Why

A resident flagged on Facebook that the $2.3M trash override is being framed as if curbside trash is a newly-identified need, when in reality residents already pay for it through the existing Waste Collection department. Verified against primary sources.

## Verification against primary sources

**FY26 General Fund Budget (`data/budgets/FY26_General_Fund_Budget.xlsx`):**

| Waste Collection category | Amount |
|---|---:|
| Personnel (salaries, OT, longevity) | $544,798 |
| Disposal + Collection contracts | $2,167,709 |
| Other operational (R&M, fuel, etc) | $230,895 |
| **FY26 Waste Collection total** | **$2,943,402** |

The $2.17M in disposal and collection contracts includes specific line items for `WC-TRASH COLLECTION` ($1.05M), `WC-TRASH DISPOSAL` ($717K), and `WC-GRINDING/COMPOST REMOVAL` ($200K), among others. Curbside trash is clearly and unambiguously paid for from the current general fund budget.

**FY27 Proposed Budget With No Override (`data/budgets/FY27_Proposed_Budget_No_Override.pdf`):**

| Line | FY26 | FY27 | Change |
|---|---:|---:|---:|
| Waste Collection | $2,943,402 | $1,790,344 | -$1,153,058 |
| **NEW Curbside Collection** (marked `NEW` in red) | $0 | $2,186,516 | +$2,186,516 |
| **Total** | $2,943,402 | $3,976,860 | +$1,033,458 |

The FY27 budget carves curbside service out of the existing Waste Collection department into a new dedicated line item, cuts the existing Waste Collection line by roughly the amount being moved out, and adds the new Curbside Collection line (which is the one Question 2 would fund via the $2.3M levy addition).

**Net:** total trash spending rises $1.03M year-over-year (contract cost growth), and the $2.3M override is approximately equal to the new Curbside Collection line plus growth phased in through FY29 (per `data/override_trash_schedule.csv`).

## What's actually misleading about the old framing

The old card said *"Either way, residents pay for trash. The override spreads the cost by home value; the fee is the same for everyone."* That is technically true but leaves a reader thinking trash is currently unfunded. The context that matters:

- Residents already pay for curbside trash through property taxes
- Q2 is a restructure of how that funding flows, not a new obligation
- The distributional question (levy vs flat fee) is real and worth engaging, but it's a question about **which mechanism**, not **whether to pay**

## What's in this PR

- Rewrites the `.tier-card--trash` card text on `what-is-the-override.html` to spell out:
  - Current state: curbside already funded via Waste Collection ($2.94M in FY26)
  - FY27 restructure: carve-out + existing budget reduction
  - Question 2's actual choice: levy at ~$2.3M versus flat fee ~$262/household
  - Distributional framing: levy scales with home value, flat fee is identical across households
- Splits the card into two paragraphs so the mechanics and distribution points land separately
- No em-dashes (verified)
- No link to a dedicated trash page yet - that page is being built as a follow-up. Can add the link in a later PR when the destination exists.

## Files changed

- `what-is-the-override.html` - one card rewrite, no other changes

## What's coming next

A dedicated `question-2-trash.html` page with the full restructure analysis, distributional crossover table, peer-town comparison (how other MA towns fund curbside), regional shared-services exploration (can Marblehead bargain with Salem or adjacent towns?), and long-term alternatives (PAYT, etc.). Separate PR.

## Test plan

- [ ] Visit `/what-is-the-override.html` and scroll to the Question 2 trash card
- [ ] Confirm the card now mentions existing Waste Collection funding and the FY27 restructure
- [ ] Confirm the ballot section lower on the same page still shows the correct Q2 language
- [ ] Confirm no other sections of the page were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
