### PR TITLE
Sentence case on explainer pages; document casing convention

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -20,6 +20,19 @@ One shared stylesheet (`assets/site.css`) with CSS custom properties. All pages 
 
 The home page uses the wider `--chart-max` container to accommodate a 2-column question-card grid on desktop (&ge;720px). Below that breakpoint the cards stack single-column. A lone `.question` in a `.question-list` spans both grid columns via `:only-child`, so sections with a single card don't leave an empty right column.
 
+### Title casing convention
+
+| Page type | Casing | Example |
+|-----------|--------|---------|
+| **Index** and **Explainer** | Sentence case | "What is the override?", "How did we get here?" |
+| **Chart** | Title Case | "Residential Tax Rates: Four North Shore Towns" |
+
+Sentence case (only the first word and proper nouns capitalized) applies to the home page, explainer pages, the debate page, and homepage card titles. It matches the editorial, voter-facing tone of the prose pages.
+
+Title Case applies to files under `charts/` because chart pages are product-like (dashboards, calculators) where Title Case is conventional. The frontmatter `title` on chart pages may be a shorter label than the `<h1>` (the title becomes the browser tab and social share title; the h1 is the full descriptive headline).
+
+Both the frontmatter `title` and the `<h1>` on a given page must use the same casing. Don't mix.
+
 ## Required `<head>` Elements (Every Page)
 
 ```html

--- a/charts/sustainability.html
+++ b/charts/sustainability.html
@@ -1,7 +1,7 @@
 ---
 title: "Do Override Tiers Close the Gap?"
 ---
-<h1 class="h-center">Do the Override Tiers Close the Gap?</h1>
+<h1 class="h-center">Do Override Tiers Close the Gap?</h1>
   <p class="subtitle h-center">Total projected revenue (4 scenarios) vs total projected expenses, FY2026&ndash;FY2030. FY26&ndash;FY27 from State of the Town presentation. FY28&ndash;FY30 projected using Finance Committee growth rates.</p>
 
   <div class="legend">

--- a/senior-tax-relief.html
+++ b/senior-tax-relief.html
@@ -1,5 +1,5 @@
 ---
-title: "Senior Property Tax Relief"
+title: "Senior property tax relief"
 og_title: Senior property tax relief in Marblehead
 og_description: "How Marblehead's senior tax-relief programs actually work: the Clause 41C exemption, the tax deferral, verified examples, and the formulas."
 og_url: https://marbleheaddata.org/senior-tax-relief.html

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -1,10 +1,10 @@
 ---
-title: "What Is the Override?"
+title: "What is the override?"
 og_title: What is the override?
 og_description: The three-tier structure of the proposed Marblehead override, what each tier funds, key terms, and historical context.
 og_url: https://marbleheaddata.org/what-is-the-override.html
 ---
-<h1>What Is the Override?</h1>
+<h1>What is the override?</h1>
 
   <div class="key-stats">
     <div class="key-stat">

--- a/where-has-the-money-gone.html
+++ b/where-has-the-money-gone.html
@@ -1,5 +1,5 @@
 ---
-title: "Where Has Marblehead's Money Gone?"
+title: "Where has Marblehead's money gone?"
 og_title: "Where has Marblehead's money gone?"
 og_description: Marblehead's general fund grew from $70.5M to $106.2M between FY2015 and FY2026. Here's where the $35.7M went, who has been checking the books, and which lines grew faster than enrollment, inflation, or headcount would explain.
 og_url: https://marbleheaddata.org/where-has-the-money-gone.html
@@ -48,7 +48,7 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
     background: color-mix(in srgb, var(--c-teal) 10%, transparent);
   }
 </style>
-<h1>Where Has Marblehead's Money Gone?</h1>
+<h1>Where has Marblehead's money gone?</h1>
 
   <div class="key-stats">
     <div class="key-stat">


### PR DESCRIPTION
## Summary
Four casing fixes and a new STYLE_GUIDE rule. Explainer pages now use sentence case uniformly; chart pages stay in Title Case.

## Why
The homepage card titles were all sentence case ("What is the override?") but the destination pages used Title Case ("What Is the Override?"). A reader clicked one and landed on a page whose h1 shifted casing on the exact word they just clicked. Inconsistent, avoidable. The recent #60 homepage copy PR already moved the site toward sentence case ("Weighing the FY2027 override?"); this PR finishes the job.

## Files changed

| File | Change |
|---|---|
| `what-is-the-override.html` | Frontmatter `title` and `<h1>` both "What Is the Override?" → "What is the override?". `og_title` was already sentence case. |
| `where-has-the-money-gone.html` | Frontmatter `title` and `<h1>` both "Where Has Marblehead's Money Gone?" → "Where has Marblehead's money gone?". `og_title` was already sentence case. |
| `senior-tax-relief.html` | Frontmatter `title` "Senior Property Tax Relief" → "Senior property tax relief" to match the existing h1 on the same page. |
| `charts/sustainability.html` | `<h1>` "Do the Override Tiers Close the Gap?" → "Do Override Tiers Close the Gap?" to match the frontmatter title (dropped a stray "the"). |
| `STYLE_GUIDE.md` | New **Title casing convention** subsection under Page Types. Explainer pages use sentence case, chart pages use Title Case. Frontmatter `title` and `<h1>` must match. |

## Notes
- "What Is the Override?" was also non-standard Title Case — Chicago and AP both lowercase short verbs like "is" in titles, so strict Title Case would have been "What is the Override?". Sentence case avoids the ambiguity.
- Not touched: chart pages with intentional short `title` vs long `<h1>` patterns (e.g., `enrollment_vs_staffing.html` title "Enrollment vs. Staffing" vs h1 "School Enrollment and Education Staffing"). Those are fine under the new rule — same casing, different length.

## Test plan
- [x] All 4 files: `title` frontmatter and `<h1>` text match in casing
- [x] Homepage cards ("What is the override?", "Where has Marblehead's money gone?") now land on pages with matching casing
- [x] STYLE_GUIDE.md updated so the next person has a rule to follow
- [x] No other files needed changes (spot-checked all explainer pages and chart pages)