### PR TITLE
Homepage tags: simplify labels, align to bottom of cards

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -558,7 +558,15 @@ p a:hover { text-decoration: underline; }
   padding: 20px 24px;
   text-decoration: none;
   color: inherit;
-  display: block;
+  /* Flex column so the tag can be pushed to the bottom of the card
+     via margin-top: auto. In the desktop grid, sibling cards stretch
+     to equal height, so bottom-aligning the tag keeps the pill at a
+     consistent position across a row regardless of description length.
+     The gap replaces the old per-element margin-top on the tag and
+     gives uniform spacing on non-stretched mobile cards. */
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   transition: box-shadow 0.2s, transform 0.2s;
   min-height: 72px;
 }
@@ -577,8 +585,14 @@ p a:hover { text-decoration: underline; }
 }
 .question .tag {
   display: inline-block; font-size: 10px; font-weight: 700;
-  padding: 3px 9px; border-radius: 100px; margin-top: 10px;
+  padding: 3px 9px; border-radius: 100px;
   letter-spacing: 0.3px;
+  /* Push to bottom of the flex column, stay at the left edge. On
+     stretched cards in the desktop grid this puts all row-sibling
+     tags at the same y-position. On non-stretched cards the 6px
+     flex-gap on .question carries the visual separation. */
+  margin-top: auto;
+  align-self: flex-start;
 }
 .tag-charts { background: var(--tag-chart-bg); color: var(--tag-chart-fg); }
 .tag-text   { background: var(--tag-text-bg);  color: var(--tag-text-fg); }

--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@ og_url: https://marbleheaddata.org/
     <div class="featured-card-eyebrow">Still deciding?</div>
     <div class="featured-card-title">The override debate, the best case for each side</div>
     <div class="featured-card-desc">Five tensions in the local debate, with the strongest version of each case. Neither a recommendation nor a summary. A map of the real disagreements, for readers still working through their vote.</div>
-    <span class="tag">Analysis</span>
   </a>
 
   <p class="section-label">The override</p>
@@ -23,13 +22,13 @@ og_url: https://marbleheaddata.org/
     <a class="question" href="what-is-the-override.html">
       <h2>What is the override?</h2>
       <p>The three-tier structure, what each tier funds, key terms, and history.</p>
-      <span class="tag tag-text">Explainer</span>
+      <span class="tag tag-text">Read</span>
     </a>
 
     <a class="question" href="how-we-got-here.html">
       <h2>How did we get here?</h2>
       <p>Seven years of Finance Committee warnings, in their own words. From "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025.</p>
-      <span class="tag tag-text">History</span>
+      <span class="tag tag-text">Read</span>
     </a>
 
     <a class="question" href="charts/override_calculator.html">
@@ -41,7 +40,7 @@ og_url: https://marbleheaddata.org/
     <a class="question" href="no-override-budget.html">
       <h2>What's in the no-override budget?</h2>
       <p>22 town positions removed, 14 school positions, library reduced 43%, and what other MA towns did after similar votes.</p>
-      <span class="tag tag-text">Analysis</span>
+      <span class="tag tag-text">Read</span>
     </a>
 
     <a class="question" href="charts/sustainability.html">
@@ -53,13 +52,13 @@ og_url: https://marbleheaddata.org/
     <a class="question" href="senior-tax-relief.html">
       <h2>What relief can seniors claim?</h2>
       <p>The state Circuit Breaker (up to $2,820), Marblehead's pending means-tested exemption (H.4225), and how both interact with the override.</p>
-      <span class="tag tag-text">Explainer</span>
+      <span class="tag tag-text">Read</span>
     </a>
 
     <a class="question" href="what-you-can-do.html">
       <h2>What can you do?</h2>
       <p>Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight of the town budget.</p>
-      <span class="tag tag-text">Guide</span>
+      <span class="tag tag-text">Read</span>
     </a>
   </div>
 
@@ -68,7 +67,7 @@ og_url: https://marbleheaddata.org/
     <a class="question" href="where-has-the-money-gone.html">
       <h2>Where has Marblehead's money gone?</h2>
       <p>A ten-year walkthrough of how the town has actually spent the tax levy, who has been checking the books, and where the biggest line-item changes landed.</p>
-      <span class="tag tag-text">Analysis</span>
+      <span class="tag tag-text">Read</span>
     </a>
   </div>
 
@@ -104,7 +103,7 @@ og_url: https://marbleheaddata.org/
     <a class="question" href="why-not-elsewhere.html">
       <h2>Why do some MA towns run overrides and others don't?</h2>
       <p>Residential share of tax levy, new growth rates, and override history for 21 Massachusetts peer towns, grouped into four structural archetypes.</p>
-      <span class="tag tag-text">Analysis</span>
+      <span class="tag tag-text">Read</span>
     </a>
 
     <a class="question" href="charts/four_town_rates.html">


### PR DESCRIPTION
## Summary
Path A from the tag audit: simplify the fuzzy text-side labels and fix the "weird spots" complaint by bottom-aligning tags consistently across cards.

## Changes

1. **Label simplification** — four text labels collapsed to one.

   | Before | After |
   |---|---|
   | Explainer (×2) | Read |
   | History (×1) | Read |
   | Analysis (×3) | Read |
   | Guide (×1) | Read |

   Chart (×8) and Calculator (×1) stay distinct. The Chart/Calculator vs prose distinction matters for a skimming reader; the Explainer/History/Analysis distinction was slippery and same-colored.

2. **Bottom alignment** — `.question` is now a flex column and the tag has `margin-top: auto`. In the desktop 2-column grid, sibling cards in a row stretch to equal height, so tags now sit at identical y-positions. Verified with `getBoundingClientRect`: tags in row 1 of "The override" section are at y=183, `tagBottomFromCard=20`, pixel-perfect across the row.

3. **Featured card tag removed.** The `<span class="tag">Analysis</span>` was redundant with the "Still deciding?" eyebrow, which already classifies the hero. Removed.

4. **Flex gap for rhythm.** Added `gap: 6px` to `.question` so the visual spacing between `h2`, `p`, and `tag` is uniform on non-stretched mobile cards. Replaces the old per-element `margin-top: 10px` on the tag.

## Why
From the audit: "the tags are half-working. They do one useful job well — flagging 'this is a chart' vs 'this is prose' via color. But the text-side labels are fuzzy: Explainer, History, Analysis are all stylistically identical (same blue pill, same font), and a reader can't tell why one card is History and another is Analysis. The weird spots problem: variable-height descriptions put tags at different vertical positions in the grid."

Path A keeps tags but makes them work: fewer labels + consistent placement.

## Test plan
- [x] Desktop grid: tags in the same row are pixel-aligned (verified y=183 across row 1)
- [x] Mobile single-column: tags sit below the description with uniform 6px flex gap
- [x] Featured debate card has no tag (eyebrow carries the classification)
- [x] All text cards say "Read"; all chart cards say "Chart"; the one calculator card still says "Calculator"
- [x] STYLE_GUIDE not updated — the rule "use neutral semantic colors" still applies, and the new label set is simpler (3 distinct labels instead of 6+)