### PR TITLE
Make question-2-trash page intro easier to read and add key stats strip

### DIFF
--- a/question-2-trash.html
+++ b/question-2-trash.html
@@ -169,6 +169,40 @@ og_url: https://marbleheaddata.org/question-2-trash.html
     color: var(--text);
   }
 
+  /* "This page walks through:" intro list */
+  .page-covers-lead {
+    margin: 18px 0 4px;
+    font-size: 14px;
+    color: var(--text-muted);
+  }
+  .page-covers {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 24px;
+  }
+  .page-covers li {
+    padding: 7px 0 7px 22px;
+    margin: 0;
+    line-height: 1.5;
+    font-size: 14px;
+    color: var(--text);
+    position: relative;
+    border-bottom: 1px solid var(--divider);
+  }
+  .page-covers li:last-child {
+    border-bottom: none;
+  }
+  .page-covers li::before {
+    content: "";
+    position: absolute;
+    left: 6px;
+    top: 16px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--c-navy);
+  }
+
   @media (max-width: 600px) {
     .trash-tldr { padding: 16px 18px 18px; }
     .trash-tldr h2 { font-size: 17px; }
@@ -176,14 +210,43 @@ og_url: https://marbleheaddata.org/question-2-trash.html
     .dist-table th, .dist-table td,
     .peer-trash th, .peer-trash td { padding: 9px 5px; }
     .already-decided { padding: 12px 14px; }
+    .page-covers li { font-size: 13px; padding: 6px 0 6px 20px; }
   }
 </style>
 
 <h1>Question 2: trash funding</h1>
 
-<p>On the June 9, 2026 ballot, Marblehead residents will see a second override question, separate from the main FY27 override (Question 1). Question 2 asks voters to approve adding $2,298,575 to the property tax levy for curbside trash and recycling. It is widely described as a choice between a levy increase and a flat household fee, which is accurate as far as it goes. The more complete picture is that the Select Board has already decided to move curbside trash out of the general property tax budget, and Question 2 is only about which funding mechanism replaces it.</p>
+<div class="key-stats">
+  <div class="key-stat">
+    <div class="key-stat-value">$2.30M</div>
+    <div class="key-stat-label">Override (Question 2)</div>
+  </div>
+  <div class="key-stat">
+    <div class="key-stat-value">$262</div>
+    <div class="key-stat-label">Flat fee alternative</div>
+  </div>
+  <div class="key-stat">
+    <div class="key-stat-value">$1.14M</div>
+    <div class="key-stat-label">Crossover home value</div>
+  </div>
+  <div class="key-stat">
+    <div class="key-stat-value">~$1M</div>
+    <div class="key-stat-label">New contract growth</div>
+  </div>
+</div>
 
-<p>This page walks through what Question 2 actually does, what was decided before the ballot question existed, what each outcome means for residents at different home values, how other Massachusetts towns handle curbside trash, and the longer-term options the town has (or has not) explored.</p>
+<p>Marblehead has two override questions on the June 9, 2026 ballot. Question 2, separate from the main FY27 override, asks voters to add $2,298,575 to the property tax levy for curbside trash and recycling. It can pass or fail independently of Question 1.</p>
+
+<p>Question 2 is usually described as a choice between a levy increase and a flat household fee. That is accurate but incomplete. The Select Board already decided to move curbside trash out of the general property tax budget. Question 2 only decides how to replace the funding.</p>
+
+<p class="page-covers-lead">This page walks through:</p>
+<ul class="page-covers">
+  <li>What Question 2 actually decides</li>
+  <li>What was already decided before the ballot</li>
+  <li>What each outcome costs residents at different home values</li>
+  <li>How other Massachusetts towns fund curbside trash</li>
+  <li>Longer-term options Marblehead has, or has not, explored</li>
+</ul>
 
 <div class="trash-tldr">
   <div class="trash-tldr-eyebrow">The short version</div>


### PR DESCRIPTION
## Summary

Two readability improvements to `question-2-trash.html`:

1. Rewrite the intro paragraphs to use shorter sentences and cut filler
2. Add a key-stats strip at the top (the pattern used on `what-is-the-override.html`) so skimming readers see the four most important numbers before they read anything

## What was wrong with the old intro

**Paragraph 1** was four sentences packed into one paragraph, with two rhetorical moves ("widely described", "The more complete picture is that") that added length without adding clarity. Hard to scan.

**Paragraph 2** was a single sentence listing five topics the page covers. Sentences that long with five coordinated items are slow to read and easy to lose track of.

## What changed

**Intro rewrite:**

- Split into two shorter paragraphs, each with 3-4 short sentences
- Cut filler: "as far as it goes" and "The more complete picture is that"
- Front-loaded the "two ballot questions" framing instead of burying it
- Converted the five-item sentence into an actual bullet list with a "This page walks through:" lead-in

**Key stats strip at top:**

- `$2.30M` Override (Question 2)
- `$262` Flat fee alternative
- `$1.14M` Crossover home value
- `~$1M` New contract growth

Uses the existing `.key-stats` / `.key-stat` pattern from `what-is-the-override.html`, so no new global CSS. A reader who only looks at the strip walks away with the core tradeoff (levy vs fee, crossover threshold) plus the reason any of this is happening (contract growth).

## CSS additions (page-scoped)

- `.page-covers-lead` for the "This page walks through:" intro line
- `.page-covers` bullet list with navy dot markers and subtle between-item dividers
- Mobile breakpoint tightens padding and font size

## Files changed

- `question-2-trash.html` - intro replaced, new HTML for key stats strip and bullet list, page-scoped CSS for the list style

## Test plan

- [ ] Visit `/question-2-trash.html` and confirm the key-stats strip renders at the top with four numbers
- [ ] Confirm the intro paragraphs are visibly shorter and easier to scan
- [ ] Confirm the "This page walks through:" list renders as a bulleted list with navy markers
- [ ] Test at 375px mobile width and confirm the key stats wrap cleanly and the bullet list stays readable
- [ ] Test dark mode and confirm the key stats strip adapts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
