### PR TITLE
Rewrite debate intro and four-category framing block

### DIFF
--- a/the-debate.html
+++ b/the-debate.html
@@ -241,20 +241,21 @@ community_pulse: off-sections
 </style>
 
 <h1>Both sides of the override debate</h1>
-  <p>Marblehead residents are debating whether to approve the FY27 override. This page presents the strongest version of each side in the local debate, organized around the five tensions where voters actually disagree. It is not a recommendation or a summary. It is a map of where the real disagreements are, for readers still deciding how to vote. See <a href="about.html">about this site</a> for the author's disclosure.</p>
+  <p>Marblehead's override is on the June ballot. If you're working through how to vote, this page is for you. It maps the five tensions in the debate, with the strongest version of each side of each one. Not a recommendation or a summary.</p>
 
   <div class="meta-note">
-    <p>These five tensions are not all the same kind of disagreement. Each tension below mixes four elements in different proportions:</p>
+    <p>The override debate isn't one argument. It's four kinds, mixed together:</p>
     <dl class="meta-note-list">
       <dt>Facts</dt>
-      <dd>Are the cost drivers really growing at the rate claimed?</dd>
+      <dd>Are costs rising from things we can't control, or from choices we made?</dd>
       <dt>Interpretation</dt>
-      <dd>Is a 43% library reduction damage or discipline?</dd>
+      <dd>Are budget cuts damage or discipline?</dd>
       <dt>Values</dt>
-      <dd>Is a multi-year reset responsible or irresponsible?</dd>
+      <dd>Is current spending about right, or is there more to cut?</dd>
       <dt>Governance</dt>
-      <dd>Do you trust the people making the ask?</dd>
+      <dd>Do you trust the town to spend more money wisely?</dd>
     </dl>
+    <p>Most real disagreements blend all four. Helping you answer them for yourself is the whole point of this site. Notice which one feels loudest as you read the tensions below.</p>
   </div>
 
   <div class="tldr">


### PR DESCRIPTION
## Summary
- Reframes the-debate.html intro as reader-first ("working through how to vote") and drops the meta "map of disagreements" phrasing and numbers
- Rewrites the Facts/Interpretation/Values/Governance questions as plain-language gut-checks both sides should immediately recognize
- Adds a closing line tying the exercise back to the site's purpose

## Test plan
- [ ] Visit /the-debate.html locally and confirm intro + framing block render cleanly
- [ ] Verify no em-dashes, no numbers in the intro, and that the four questions read as gut-checks