### PR TITLE
Shorten key-stats labels on trash page so they stop wrapping

### DIFF
--- a/question-2-trash.html
+++ b/question-2-trash.html
@@ -331,19 +331,19 @@ og_url: https://marbleheaddata.org/question-2-trash.html
 <div class="key-stats">
   <div class="key-stat">
     <div class="key-stat-value">$2.30M</div>
-    <div class="key-stat-label">Override (Question 2)</div>
+    <div class="key-stat-label">Override ask</div>
   </div>
   <div class="key-stat">
     <div class="key-stat-value">$262</div>
-    <div class="key-stat-label">Flat fee alternative</div>
+    <div class="key-stat-label">Flat fee</div>
   </div>
   <div class="key-stat">
     <div class="key-stat-value">$1.14M</div>
-    <div class="key-stat-label">Crossover home value</div>
+    <div class="key-stat-label">Crossover value</div>
   </div>
   <div class="key-stat">
     <div class="key-stat-value">~$1M</div>
-    <div class="key-stat-label">New contract growth</div>
+    <div class="key-stat-label">Contract growth</div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary

The key-stats labels on the trash page were wrapping into two lines with orphaned fragments ("2)", "VALUE", "GROWTH"), making the strip visually uneven.

Fix: shorten each label to the 2-word convention the site uses elsewhere (matching `what-is-the-override.html`'s "FY27 Deficit", "Ballot Vote", "Override Range", "Last Approved").

| Old (wraps) | New (single line) |
|---|---|
| Override (Question 2) | Override ask |
| Flat fee alternative | Flat fee |
| Crossover home value | Crossover value |
| New contract growth | Contract growth |

One file changed, four label swaps, no other content or CSS modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
