### PR TITLE
Use the "Read" tag on the Question 2 trash card

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@ og_url: https://marbleheaddata.org/
     <a class="question" href="question-2-trash.html">
       <h2>What is Question 2 (trash)?</h2>
       <p>The second ballot question. A $2.3M override for curbside trash, or a ~$262/household fee if it fails. What has already been decided, what each option costs by home value, and how other MA towns fund curbside.</p>
-      <span class="tag tag-text">Analysis</span>
+      <span class="tag tag-text">Read</span>
     </a>
 
     <a class="question" href="charts/sustainability.html">


### PR DESCRIPTION
## Summary
The Question 2 trash card on `index.html` uses `<span class="tag tag-text">Analysis</span>`, which was the old tag convention. PR #67 collapsed all text-side card tags (Explainer, History, Analysis, Guide) to a single "Read" label. The trash card was added in #69 with a copy-paste of the pre-#67 pattern and drifted from the convention.

One-line fix: `Analysis` → `Read` in that one card.

## Test plan
- [x] `curl` of the live homepage confirmed exactly 1 `>Analysis<` remaining on the card after #67/#69 merged
- [x] All other text-side card tags are already "Read" (verified 7 × `>Read<`)
- [x] No other files changed; no CSS changes; pure content drift fix