### PR TITLE
Replace "crossover" with "break-even" on the trash page

### DIFF
--- a/question-2-trash.html
+++ b/question-2-trash.html
@@ -339,7 +339,7 @@ og_url: https://marbleheaddata.org/question-2-trash.html
   </div>
   <div class="key-stat">
     <div class="key-stat-value">$1.14M</div>
-    <div class="key-stat-label">Crossover value</div>
+    <div class="key-stat-label">Break-even value</div>
   </div>
   <div class="key-stat">
     <div class="key-stat-value">~$1M</div>
@@ -503,7 +503,7 @@ og_url: https://marbleheaddata.org/question-2-trash.html
   </tbody>
 </table>
 
-<p>The crossover point, where the two options cost the same, is at roughly $1,140,000 in assessed value. Below that, the levy is cheaper; above it, the flat fee is cheaper. The median single-family home in Marblehead is assessed at $1,010,000, so the typical homeowner pays slightly less under the levy. The average single-family assessment of $1,291,000 is skewed upward by a smaller number of high-value properties, so the average homeowner pays slightly less under the fee.</p>
+<p>The break-even point, where the two options cost the same, is at roughly $1,140,000 in assessed value. Below that, the levy is cheaper; above it, the flat fee is cheaper. The median single-family home in Marblehead is assessed at $1,010,000, so the typical homeowner pays slightly less under the levy. The average single-family assessment of $1,291,000 is skewed upward by a smaller number of high-value properties, so the average homeowner pays slightly less under the fee.</p>
 
 <p>A note on the shape of the choice: the flat fee is regressive compared to the levy. A household in a $500,000 home pays the same $262 as a household in a $3 million home. Under the levy, the $3 million home pays $699 (nearly 2.7 times the flat fee) while the $500,000 home pays $117 (less than half the flat fee). Whether that progressive distribution is better or worse depends on who you think should bear the cost.</p>
 


### PR DESCRIPTION
## Summary

Swap "crossover" for "break-even" throughout the trash page. "Crossover" is technically precise but slightly academic; "break-even" is the plain-English term readers recognize from everyday financial analysis.

Two instances replaced:

- Key-stats label: `Crossover value` -> `Break-even value`
- Prose in distributional analysis: "The crossover point, where the two options cost the same..." -> "The break-even point, where the two options cost the same..."

No other content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
