### PR TITLE
Polish meta-note closing line and trim TL;DR word-count aside

### DIFF
--- a/the-debate.html
+++ b/the-debate.html
@@ -88,6 +88,11 @@ community_pulse: off-sections
   .meta-note p {
     margin: 0;
   }
+  .meta-note-list + p {
+    margin-top: 16px;
+    padding-top: 14px;
+    border-top: 1px solid color-mix(in srgb, var(--c-navy) 18%, transparent);
+  }
   .meta-note-list {
     margin: 14px 0 0;
     padding: 0;
@@ -260,7 +265,7 @@ community_pulse: off-sections
 
   <div class="tldr">
     <div class="tldr-eyebrow">The short version</div>
-    <p class="tldr-sub">The strongest case on each side, in roughly 75 words each. If you read nothing else, read these.</p>
+    <p class="tldr-sub">The strongest case on each side. If you read nothing else, read these.</p>
 
     <div class="perspective perspective--for">
       <div class="perspective-label">For the override</div>


### PR DESCRIPTION
## Summary
- Give the meta-note closing paragraph visible separation from the Facts/Interpretation/Values/Governance list (was colliding with the Governance answer because \`.meta-note p { margin: 0 }\` zeroed both)
- Drop "in roughly 75 words each" from the TL;DR subheader

## Test plan
- [ ] Load /the-debate.html and confirm the closing line "Most real disagreements blend all four..." sits below a subtle divider with clear breathing room
- [ ] Confirm the TL;DR subheader reads "The strongest case on each side. If you read nothing else, read these."