### PR TITLE
Drop "Read" tag from homepage cards; document tag convention

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -33,6 +33,20 @@ Title Case applies to files under `charts/` because chart pages are product-like
 
 Both the frontmatter `title` and the `<h1>` on a given page must use the same casing. Don't mix.
 
+### Homepage card tag convention
+
+Homepage question cards (`.question` inside a `.question-list`) can have an optional tag pill. The rule:
+
+| Card content | Tag |
+|---|---|
+| Prose / article / explainer | **no tag** |
+| Chart or data visualization | `<span class="tag tag-charts">Chart</span>` |
+| Interactive calculator | `<span class="tag tag-charts">Calculator</span>` |
+
+The purpose of the tag is to flag cards that behave *differently* from a standard reading experience. If a card is just text, it gets no tag, because every card is text by default and labeling them all is visual noise. A reader skimming the homepage sees most cards as unlabeled and the few pill tags as signals: "this one is a chart, this one is a calculator, they'll scan/work differently."
+
+Do not reintroduce `Explainer`, `History`, `Analysis`, `Guide`, `Read`, or any other prose-content label. The category is "not a chart or calculator" and the correct representation of that category is the absence of a tag.
+
 ## Required `<head>` Elements (Every Page)
 
 ```html

--- a/index.html
+++ b/index.html
@@ -22,13 +22,11 @@ og_url: https://marbleheaddata.org/
     <a class="question" href="what-is-the-override.html">
       <h2>What is the override?</h2>
       <p>The three-tier structure, what each tier funds, key terms, and history.</p>
-      <span class="tag tag-text">Read</span>
     </a>
 
     <a class="question" href="how-we-got-here.html">
       <h2>How did we get here?</h2>
       <p>Seven years of Finance Committee warnings, in their own words. From "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025.</p>
-      <span class="tag tag-text">Read</span>
     </a>
 
     <a class="question" href="charts/override_calculator.html">
@@ -40,13 +38,11 @@ og_url: https://marbleheaddata.org/
     <a class="question" href="no-override-budget.html">
       <h2>What's in the no-override budget?</h2>
       <p>22 town positions removed, 14 school positions, library reduced 43%, and what other MA towns did after similar votes.</p>
-      <span class="tag tag-text">Read</span>
     </a>
 
     <a class="question" href="question-2-trash.html">
       <h2>What is Question 2 (trash)?</h2>
       <p>The second ballot question. A $2.3M override for curbside trash, or a ~$262/household fee if it fails. What has already been decided, what each option costs by home value, and how other MA towns fund curbside.</p>
-      <span class="tag tag-text">Read</span>
     </a>
 
     <a class="question" href="charts/sustainability.html">
@@ -58,13 +54,11 @@ og_url: https://marbleheaddata.org/
     <a class="question" href="senior-tax-relief.html">
       <h2>What relief can seniors claim?</h2>
       <p>The state Circuit Breaker (up to $2,820), Marblehead's pending means-tested exemption (H.4225), and how both interact with the override.</p>
-      <span class="tag tag-text">Read</span>
     </a>
 
     <a class="question" href="what-you-can-do.html">
       <h2>What can you do?</h2>
       <p>Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight of the town budget.</p>
-      <span class="tag tag-text">Read</span>
     </a>
   </div>
 
@@ -73,7 +67,6 @@ og_url: https://marbleheaddata.org/
     <a class="question" href="where-has-the-money-gone.html">
       <h2>Where has Marblehead's money gone?</h2>
       <p>A ten-year walkthrough of how the town has actually spent the tax levy, who has been checking the books, and where the biggest line-item changes landed.</p>
-      <span class="tag tag-text">Read</span>
     </a>
   </div>
 
@@ -109,7 +102,6 @@ og_url: https://marbleheaddata.org/
     <a class="question" href="why-not-elsewhere.html">
       <h2>Why do some MA towns run overrides and others don't?</h2>
       <p>Residential share of tax levy, new growth rates, and override history for 21 Massachusetts peer towns, grouped into four structural archetypes.</p>
-      <span class="tag tag-text">Read</span>
     </a>
 
     <a class="question" href="charts/four_town_rates.html">


### PR DESCRIPTION
## Summary
Path B from the original tag audit. The "Read" label from #67 was low-information — every homepage card is a reading experience by default, so labeling text cards "Read" added noise without signal. Dropping it entirely makes the remaining Chart/Calculator tags actually mean something ("this one is different").

## Changes
- **`index.html`**: removed all 8 `<span class="tag tag-text">Read</span>` elements. Chart (×8) and Calculator (×1) tags preserved. Featured debate card was already tag-free after #67.
- **`STYLE_GUIDE.md`**: new **Homepage card tag convention** subsection under Page Types. Documents the rule (prose cards → no tag; chart/calculator → pill) and includes an explicit "do not reintroduce Explainer/History/Analysis/Guide/Read" line so the next copy-paste doesn't drift back.

## What stays
`.tag-text` CSS class and its `--tag-text-*` color tokens remain in `site.css`. They're now dead code (no HTML references) but `.featured-card .tag` still references the tokens, and removing dead CSS is a separate cleanup. Not in scope here.

## Test plan
- [x] `grep -c 'tag-text' index.html` → 0
- [x] `grep -c '>Chart<\|>Calculator<' index.html` → 9 (unchanged)
- [x] Homepage renders cleanly with no visual regression; Chart/Calculator pills now the only tag pills on the page
- [x] STYLE_GUIDE.md explicitly forbids the old labels so the next copy-paste catches the convention