### PR TITLE
Disclose Claude subscription and Cloudflare Worker in about costs

### DIFF
--- a/about.html
+++ b/about.html
@@ -82,12 +82,20 @@ community_pulse: off-sections
   <h2>Costs</h2>
   <div class="card">
     <div class="cut-item">
+      <span class="cut-item-name">Claude AI subscription<span class="cut-item-note">Not exclusive to this site.</span></span>
+      <span class="cut-item-amount">~$100/month</span>
+    </div>
+    <div class="cut-item">
       <span class="cut-item-name">Domain registration</span>
       <span class="cut-item-amount">~$8/year</span>
     </div>
     <div class="cut-item">
       <span class="cut-item-name">GitHub Pages hosting</span>
       <span class="cut-item-amount">Free</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">Cloudflare Worker (reaction counts)</span>
+      <span class="cut-item-amount">Free tier</span>
     </div>
     <div class="cut-item">
       <span class="cut-item-name">Advertising, donations, outside funding</span>


### PR DESCRIPTION
## Summary

- Adds two missing rows to the Costs card on `about.html`: Claude subscription (~$100/month) and Cloudflare Worker (reaction counts, free tier).
- Uses the existing `cut-item-note` convention (see `no-override-budget.html:104`, `senior-tax-relief.html:190`) to surface "Not exclusive to this site." directly under the Claude row, keeping the caveat at point of use per the site's disclosure rules in `CLAUDE.md`.
- Orders rows biggest-number-first so the real paid cost lands before the list of free services, rather than the previous "free, free, free, none" arc that made the site look like it runs for $8/year.

## Why

Reader feedback flagged that the Costs card omitted the Claude AI subscription even though the "About AI usage" section above it names Claude as the tool behind the site. Cloudflare Worker was also absent despite powering the reaction counters. This disclosure reflects the real stack, not a flattering subset.

## Test plan

- [ ] View `about.html` and confirm the Costs card shows five rows in the intended order (Claude, Domain, GitHub Pages, Cloudflare Worker, Advertising).
- [ ] Confirm the "Not exclusive to this site." sub-line renders under the Claude row, styled by `.cut-item-note` in `assets/site.css`.
- [ ] Confirm mobile layout: the longer "Cloudflare Worker (reaction counts)" row name wraps cleanly without pushing the amount off-screen.

Generated with [Claude Code](https://claude.com/claude-code)