### PR TITLE
Add site nav to chart pages

### DIFF
--- a/_layouts/chart.html
+++ b/_layouts/chart.html
@@ -2,6 +2,8 @@
 layout: default
 body_class: chart-page
 ---
+{% include nav.html %}
+
 <div class="container">
   <a class="back" href="{{ '/' | relative_url }}">&larr;</a>
 

--- a/assets/site.css
+++ b/assets/site.css
@@ -401,12 +401,11 @@ nav.site-nav a[aria-current="page"] {
   padding: 40px var(--gutter) 48px;
 }
 
-/* Chart pages are centered with a surface container */
-.chart-page {
-  display: flex;
-  justify-content: center;
-  padding: 32px var(--gutter);
-}
+/* Chart pages: site nav sits above a centered surface container.
+   The body used to be a flex container that centered .container
+   horizontally, but that blocked the nav include from stacking
+   above. Now the body is a normal block and .container centers
+   itself with margin auto and a max-width minus gutters. */
 .container {
   background: var(--surface);
   border: 1px solid var(--divider);
@@ -414,13 +413,18 @@ nav.site-nav a[aria-current="page"] {
   box-shadow: var(--shadow-sm);
   padding: 32px 36px 28px;
   max-width: var(--chart-max);
-  width: 100%;
+  margin: 32px auto;
+  width: calc(100% - 2 * var(--gutter));
 }
 
 @media (max-width: 600px) {
-  .page        { padding: 24px var(--gutter) 40px; }
-  .chart-page  { padding: 16px 12px 32px; }
-  .container   { padding: 20px 16px 18px; border-radius: 12px; }
+  .page { padding: 24px var(--gutter) 40px; }
+  .container {
+    padding: 20px 16px 18px;
+    border-radius: 12px;
+    margin: 16px auto 32px;
+    width: calc(100% - 24px);
+  }
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
Chart pages were missing the top nav bar on every viewport. The chart layout (`_layouts/chart.html`) didn't include `nav.html`, and the `.chart-page` body was `display: flex; justify-content: center` so even if you added the include, the nav wouldn't stack above the container.

## Changes
- **`_layouts/chart.html`**: added `{% include nav.html %}` above the `.container` div, matching `_layouts/page.html` and `_layouts/home.html`.
- **`assets/site.css`**: removed `display: flex; justify-content: center` from `.chart-page`. Body is now a normal block, nav renders at the top, and `.container` centers itself via `margin: 32px auto` + existing `max-width: var(--chart-max)` + `width: calc(100% - 2 * var(--gutter))` to preserve gutter padding. Mobile rules consolidated under the `.container` selector.

## Why
A reader landing directly on a chart page (from search, shared link, or the homepage question card) had no way back to the rest of the site except the small `←` back arrow inside the container. They couldn't discover the site's structure from the chart view at all. Adding the nav fixes that on every viewport and matches the rest of the site.

## Test plan
- [x] Desktop 1200px: nav bar shows all links at top, container centers below with same visual treatment as before
- [x] Mobile 390px: nav bar with fade-edge affordance at top, container renders below with rounded corners and proper gutters
- [x] Container still uses `--chart-max` (880px) max-width
- [x] Back arrow inside container still works
- [x] No regression to page layout (body is now block-level like `.page` body, not flex)

## Scope note
All 9 chart pages in `charts/` use the `chart` layout, so this single fix covers them all.