### PR TITLE
Rewrite trash page title as "Trash: levy or fee?"

### DIFF
--- a/question-2-trash.html
+++ b/question-2-trash.html
@@ -1,6 +1,6 @@
 ---
-title: "Question 2: trash funding"
-og_title: "Question 2: trash funding"
+title: "Trash: levy or fee?"
+og_title: "Trash: levy or fee? (Question 2)"
 og_description: The $2.3 million Question 2 trash ask, in plain English. What is actually being decided, what has already been decided, what it costs at different home values, how other Massachusetts towns handle curbside trash, and the long-term options Marblehead has considered (or hasn't).
 og_url: https://marbleheaddata.org/question-2-trash.html
 ---
@@ -294,7 +294,7 @@ og_url: https://marbleheaddata.org/question-2-trash.html
   }
 </style>
 
-<h1>Question 2: trash funding</h1>
+<h1>Trash: levy or fee?</h1>
 
 <div class="key-stats">
   <div class="key-stat">


### PR DESCRIPTION
## Summary

Rename the trash page from `"Question 2: trash funding"` to **`"Trash: levy or fee?"`**. The old title was accurate but flat. The new one tells a reader the actual decision in five words.

## Why

The old title labeled the topic without naming the choice. A reader scanning the nav or a search result could tell the page was about Q2 and trash, but not what was being decided.

"Trash: levy or fee?" names the choice residents actually face. It is short enough to survive social media sharing and matches the site's plain-English voice better than the bureaucratic-labeled original.

## What about discoverability?

"Question 2" stays in the `og_title` as a parenthetical (`"Trash: levy or fee? (Question 2)"`), so Facebook / Twitter / search previews still include the Q2 reference for anyone searching that term. The intro paragraph below the h1 also names Question 2 explicitly, so the connection is clear.

## Files changed

- `question-2-trash.html` - frontmatter `title`, `og_title`, and `<h1>` (3 lines total)

## Test plan

- [ ] Visit `/question-2-trash.html` and confirm the browser tab title reads "Trash: levy or fee?"
- [ ] Confirm the h1 on the page reads the same
- [ ] Confirm a social card preview (og_title) shows "Trash: levy or fee? (Question 2)"
- [ ] Confirm the intro paragraph still names Question 2 explicitly so readers arriving via the new title understand the connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
