### PR TITLE
Drop "Not a recommendation or a summary" from debate intro

### DIFF
--- a/the-debate.html
+++ b/the-debate.html
@@ -1,7 +1,7 @@
 ---
 title: "Both sides of the override debate"
 og_title: "Both sides of the override debate"
-og_description: The five tensions in the FY27 override debate, presented as the strongest version of each side's case. Not a recommendation or a summary. A map of where the real disagreements are, for readers still working through their vote.
+og_description: The five tensions in the FY27 override debate, presented as the strongest version of each side's case. A map of where the real disagreements are, for readers still working through their vote.
 og_url: https://marbleheaddata.org/the-debate.html
 community_pulse: off-sections
 ---
@@ -246,7 +246,7 @@ community_pulse: off-sections
 </style>
 
 <h1>Both sides of the override debate</h1>
-  <p>Marblehead's override is on the June ballot. If you're working through how to vote, this page is for you. It maps the five tensions in the debate, with the strongest version of each side of each one. Not a recommendation or a summary.</p>
+  <p>Marblehead's override is on the June ballot. If you're working through how to vote, this page is for you. It maps the five tensions in the debate, with the strongest version of each side of each one.</p>
 
   <div class="meta-note">
     <p>The override debate isn't one argument. It's four kinds, mixed together:</p>


### PR DESCRIPTION
Small cleanup. The sentence was doing work already done one sentence earlier (`with the strongest version of each side of each one` already implies neutrality), and the `or a summary` half was ambiguous — the page IS a summary in the ordinary sense; what the author wanted to disclaim was the claim to be THE summary, which isn't how most readers hear it. The bottom-of-page author disclosure block still carries the explicit disclaimer for readers who scroll that far.

Also drops the same phrase from the og_description meta tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)