### PR TITLE
Rewrite about page for personal voice: "Who made this?"

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,9 +1,10 @@
 ---
-title: "About"
+title: "Who made this?"
+og_title: "Who made this?"
 community_pulse: off-sections
 ---
 <style>
-/* Page-scoped: About me and meta pills */
+/* Page-scoped: profile disclosure callout and meta pills */
   .profile-disclosure {
     padding: 14px 18px;
     background: color-mix(in srgb, var(--c-navy) 4%, var(--surface));
@@ -66,6 +67,8 @@ community_pulse: off-sections
   }
 </style>
 
+  <h1>Who made this?</h1>
+
   <div class="profile-disclosure">
     <div class="profile-disclosure-label">Disclosure</div>
     <p>Not on the Select Board, the Finance Committee, or any other town body. My stake in the override is as a Marblehead homeowner and parent.</p>
@@ -73,7 +76,7 @@ community_pulse: off-sections
 
   <p>This vote matters. So before voting, I wanted to understand two things: how we got here, and what each possible outcome would actually mean. Is this about cuts we could make, or costs rising faster than revenue? I honestly don't know. The site is where I'm working that out.</p>
 
-  <h2>About AI usage</h2>
+  <h2>How I use AI</h2>
   <p>An AI assistant (Claude) handles research, analysis, and the site's digital infrastructure. I regularly remind it to stay as neutral as possible, and I own and operate everything it produces. Every number traces to a primary source, but I don't re-verify each one against the original document myself. Errors are possible. When I find one, or a reader catches one, the page gets updated.</p>
 
   <h2>Reactions</h2>


### PR DESCRIPTION
## Summary

The about page title was `"About"` (the universal convention), which was the one institutional-sounding element on an otherwise personal, first-person site. The content is written in first person (*"I wanted to understand..."*, *"I honestly don't know"*), the disclosure callout is personal, and the costs table is a personal accounting. The generic "About" h1 didn't match the page's voice.

Also: the page had **no `<h1>` in the body at all**. It was relying on the Jekyll layout's `<title>` tag, so the page rendered without a visible page title. That's both an accessibility gap (no h1 landmark) and a missed branding opportunity.

## Changes

1. **Frontmatter `title` and new `og_title`:** both become `"Who made this?"`
2. **New `<h1>Who made this?</h1>`** at the top of the body content, immediately before the profile-disclosure callout
3. **`<h2>About AI usage</h2>` renamed to `<h2>How I use AI</h2>`** for first-person voice consistency with the rest of the page
4. **Stale CSS comment** `"Page-scoped: About me and meta pills"` updated to `"Page-scoped: profile disclosure callout and meta pills"` since there's no `.about-me` class

## Nav label stays "About"

Readers look for "About" in the nav; they don't search for "Who made this?". Keeping the universal convention for navigation discoverability while making the page's own h1 and tab title personal. Same pattern as the trash page (nav: "Trash", h1: "Trash: levy or fee?").

## What's not changing

- The disclosure callout and all its content
- The intro paragraph
- "Reactions" and "Costs" h2s (neutral topic labels)
- The costs card, Found a mistake link, and meta-pill strip
- No em-dashes introduced

## Files changed

- `about.html` - 6 insertions, 3 deletions

## Test plan

- [ ] Visit `/about.html` and confirm the page now has a visible h1 "Who made this?" at the top
- [ ] Confirm the browser tab title is "Who made this?"
- [ ] Confirm the "How I use AI" h2 renders (replacing "About AI usage")
- [ ] Confirm the nav label is still "About" on every page
- [ ] Confirm the disclosure callout, intro paragraph, and costs card are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
