### PR TITLE
Question-form titles for senior-tax-relief and what-you-can-do

### DIFF
--- a/senior-tax-relief.html
+++ b/senior-tax-relief.html
@@ -1,6 +1,6 @@
 ---
-title: "Senior property tax relief"
-og_title: Senior property tax relief in Marblehead
+title: "What relief can seniors claim?"
+og_title: "What relief can seniors claim? (Marblehead)"
 og_description: "How Marblehead's senior tax-relief programs actually work: the Clause 41C exemption, the tax deferral, verified examples, and the formulas."
 og_url: https://marbleheaddata.org/senior-tax-relief.html
 ---
@@ -146,7 +146,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     .tldr li { font-size: 13px; }
   }
 </style>
-<h1>Senior property tax relief</h1>
+<h1>What relief can seniors claim?</h1>
   <p>Two programs can reduce what a Marblehead senior pays in property tax. The state Senior Circuit Breaker refunds up to <strong>$2,820</strong> per year and is available today. A local exemption approved by Marblehead Town Meeting in May 2025 (Article 28, now H.4225) would stack on top of it; the bill passed the Massachusetts House on March 30, 2026 and is awaiting Senate action. This page explains both programs, who qualifies, how to apply, and how each interacts with the override math.</p>
 
   <div class="tldr">

--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -1,7 +1,7 @@
 ---
-title: "What you can do"
+title: "What can you do?"
 community_pulse: off-sections
-og_title: "What you can do"
+og_title: "What can you do?"
 og_description: "How to engage with Marblehead budget decisions beyond voting yes or no on the override: who decides what, when residents can input, and what longer-term oversight looks like."
 og_url: https://marbleheaddata.org/what-you-can-do.html
 ---
@@ -110,7 +110,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
   }
 </style>
 
-<h1>What you can do</h1>
+<h1>What can you do?</h1>
 
 <p>The ballot has four possible outcomes: one of three override tiers passes, or no override. Structural reforms that could affect future budgets are real, but they are slow, and none of them change what is on this year's ballot. Everything below is about influencing what comes next.</p>
 


### PR DESCRIPTION
## Summary

Two small title cleanups to match the site's question-form page title convention:

1. `senior-tax-relief.html` - "Senior property tax relief" -> "What relief can seniors claim?" (matches the index card)
2. `what-you-can-do.html` - "What you can do" -> "What can you do?" (adds the missing verb inversion)

Both changes update frontmatter `title`, `og_title`, and the `<h1>` in the body. Nav labels unchanged.

## Test plan

- [ ] Visit `/senior-tax-relief.html` and confirm h1 and browser tab title match
- [ ] Visit `/what-you-can-do.html` and confirm h1 and browser tab title match
- [ ] Confirm nav labels are unchanged (Senior Relief, Civic Guide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
