### PR TITLE
Fix citation anchor scroll offset (land below sticky nav)

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -2244,6 +2244,8 @@ sup.cite a {
   font-weight: 600;
   padding: 0 2px;
   border-radius: 2px;
+  /* Keep back-nav target clear of the sticky nav (min-height 48px + breathing room). */
+  scroll-margin-top: 72px;
 }
 sup.cite a:hover {
   text-decoration: underline;
@@ -2277,6 +2279,8 @@ sup.cite a:target {
 .sources-list-ol li {
   margin-bottom: 6px;
   padding-left: 4px;
+  /* Keep footnote target clear of the sticky nav (min-height 48px + breathing room). */
+  scroll-margin-top: 72px;
 }
 .sources-list-ol li:target {
   background: color-mix(in srgb, var(--c-teal) 12%, transparent);


### PR DESCRIPTION
Both directions of citation navigation (superscript → footnote and footnote → back-reference) were scrolling the target under the sticky nav bar.

Fix: `scroll-margin-top: 72px` on `sup.cite a` and `.sources-list-ol li`. Value = nav min-height (48px) plus ~24px breathing room.

Back-navigation already works as designed — each source list entry has a `↩` (or `a/b/c` for multi-cited sources) back-link that returns to the originating in-text reference. This fix corrects the scroll landing for both directions.

## Test plan

- [ ] Click a superscript on /the-debate.html — the matching Sources entry should land below the nav with breathing room
- [ ] Click the back-arrow (`↩`) on a source — the original superscript should land below the nav, not under it
- [ ] Verify the teal highlight on the target element is visible (i.e., not clipped by the nav)

🤖 Generated with [Claude Code](https://claude.com/claude-code)