### PR TITLE
Merge avg_tax_bill into four_town_rates as one peer-comparison page

### DIFF
--- a/charts/avg_tax_bill.html
+++ b/charts/avg_tax_bill.html
@@ -1,72 +1,18 @@
 ---
-title: "Average Tax Bill"
+title: "Moved to rate and bill comparison"
+permalink: /charts/avg_tax_bill.html
+sitemap: false
 ---
-<h1 class="h-center">Average Single-Family Tax Bill</h1>
-  <p class="subtitle h-center">What homeowners actually pay, FY2006&ndash;FY2026. Source: MA Department of Revenue.</p>
-
-  <div class="legend">
-    <div class="legend-item s-marblehead"><span class="legend-swatch"></span><span class="legend-text">Marblehead</span></div>
-    <div class="legend-item s-swampscott"><span class="legend-swatch"></span><span class="legend-text">Swampscott</span></div>
-    <div class="legend-item s-melrose"><span class="legend-swatch"></span><span class="legend-text">Melrose</span></div>
-    <div class="legend-item s-stoneham"><span class="legend-swatch"></span><span class="legend-text">Stoneham</span></div>
-  </div>
-
-  <div class="chart-wrapper">
-    <svg class="chart" viewBox="0 0 840 330" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart showing average single-family tax bills for Marblehead, Swampscott, Melrose, and Stoneham from FY2006 to FY2026.">
-      <!-- Grid -->
-      <line class="axis-base" x1="60" y1="280" x2="600" y2="280"/>
-      <line class="grid-minor" x1="60" y1="252" x2="600" y2="252"/>
-      <line class="grid-minor" x1="60" y1="197" x2="600" y2="197"/>
-      <line class="grid-minor" x1="60" y1="141" x2="600" y2="141"/>
-      <line class="grid-minor" x1="60" y1="86" x2="600" y2="86"/>
-      <line class="grid-minor" x1="60" y1="30" x2="600" y2="30"/>
-
-      <!-- Y labels -->
-      <text class="tick-label" x="53" y="199" text-anchor="end">$6K</text>
-      <text class="tick-label" x="53" y="143" text-anchor="end">$8K</text>
-      <text class="tick-label" x="53" y="88" text-anchor="end">$10K</text>
-      <text class="tick-label" x="53" y="32" text-anchor="end">$12K</text>
-
-      <!-- X labels -->
-      <text class="tick-label tick-label--major" x="60"  y="300" text-anchor="middle">FY06</text>
-      <text class="tick-label tick-label--minor" x="168" y="300" text-anchor="middle">FY10</text>
-      <text class="tick-label tick-label--minor" x="276" y="300" text-anchor="middle">FY14</text>
-      <text class="tick-label tick-label--minor" x="384" y="300" text-anchor="middle">FY18</text>
-      <text class="tick-label tick-label--minor" x="492" y="300" text-anchor="middle">FY22</text>
-      <text class="tick-label tick-label--major" x="600" y="300" text-anchor="middle">FY26</text>
-
-      <!-- Stoneham -->
-      <polyline class="data-line data-line--thin s-stoneham"
-                points="60,250 87,247 114,244 141,240 168,235 195,232 222,227 249,225 276,216 303,213 330,210 357,205 384,201 411,196 438,194 465,190 492,187 519,161 546,155 573,146 600,139"/>
-
-      <!-- Melrose -->
-      <polyline class="data-line data-line--bold s-melrose"
-                points="60,250 87,245 114,241 141,236 168,231 195,226 222,222 249,219 276,214 303,209 330,204 357,199 384,194 411,189 438,168 465,163 492,157 519,151 546,145 573,138 600,91"/>
-
-      <!-- Marblehead -->
-      <polyline class="data-line data-line--bold s-marblehead"
-                points="60,202 87,199 114,194 141,189 168,181 195,178 222,170 249,166 276,159 303,150 330,142 357,133 384,124 411,118 438,111 465,102 492,87 519,77 546,64 573,57 600,56"/>
-
-      <!-- Swampscott -->
-      <polyline class="data-line data-line--thin s-swampscott"
-                points="60,186 87,171 114,161 141,154 168,145 195,144 222,131 249,126 276,125 303,114 330,112 357,107 384,111 411,113 438,113 465,113 492,110 519,95 546,77 573,68 600,44"/>
-
-      <!-- Melrose override spike annotation -->
-      <circle class="data-dot s-melrose" cx="600" cy="91" r="3"/>
-
-      <!-- End labels -->
-      <text class="end-label s-swampscott" x="608" y="41">$11,478 Swampscott</text>
-      <text class="end-label s-marblehead" x="608" y="53">$11,055 Marblehead</text>
-      <text class="end-label s-melrose" x="608" y="88">$9,787 Melrose</text>
-      <text class="end-label s-stoneham" x="608" y="142">$8,059 Stoneham</text>
-    </svg>
-  </div>
-
-  <p class="caption">
-    Average single-family property tax bill for four North Shore towns, FY2006&ndash;FY2026. Marblehead's bill ($11,055) is the second-highest, behind Swampscott ($11,478). Melrose's FY26 spike reflects the $13.5M override. Marblehead's bill is higher than Melrose and Stoneham because Marblehead homes are worth more (median assessed value $1,010,100 vs $853,264 in Melrose), not because the tax rate is higher. Marblehead's tax rate ($8.56) is the lowest of all four towns.
-  </p>
-
-  <div class="notes">
-    <p>Source: MA Department of Revenue, Division of Local Services, "Average Single Family Tax Bill" report.</p>
-    <p>The average tax bill reflects both the tax rate and the average home value. Towns with more expensive homes have higher bills even with lower rates. This chart shows what homeowners actually pay, unlike the tax rate chart which shows the rate per dollar of value.</p>
-  </div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="0; url=/charts/four_town_rates.html">
+<link rel="canonical" href="https://marbleheaddata.org/charts/four_town_rates.html">
+<title>Moved to rate and bill comparison</title>
+<meta name="robots" content="noindex">
+</head>
+<body>
+<p>This chart has moved to <a href="/charts/four_town_rates.html">/charts/four_town_rates.html</a>, where you can see both the tax rate and the average tax bill side by side.</p>
+</body>
+</html>

--- a/charts/four_town_rates.html
+++ b/charts/four_town_rates.html
@@ -1,8 +1,14 @@
 ---
-title: "Four Town Tax Rates"
+title: "Rate and Bill Comparison"
 ---
-<h1 class="h-center">Residential Tax Rates: Four North Shore Towns</h1>
-  <p class="subtitle h-center">Rate per $1,000 assessed value, FY2003&ndash;FY2026, with Marblehead override projections. Source: MA Department of Revenue.</p>
+<h1 class="h-center">Rate and Bill: Four North Shore Towns</h1>
+  <p class="subtitle h-center">Two views of the same question. Marblehead, Swampscott, Melrose, and Stoneham, FY2003&ndash;FY2026. Source: MA Department of Revenue.</p>
+
+  <p>Tax rate and tax bill answer different questions. The <strong>rate</strong> is the price per $1,000 of assessed value, set by the town each year after the levy is certified by the state. The <strong>bill</strong> is what a homeowner actually pays, which depends on both the rate and the home's value. Two towns with the same tax rate can have very different average bills if their home values differ.</p>
+
+  <p>Marblehead has the lowest rate of the four towns and the second-highest average bill. The gap is explained by home values: Marblehead's median assessed home value ($1,010,100 in FY2026) is materially higher than Melrose ($853,264) or Stoneham.</p>
+
+  <h2 class="h-center">Tax rate, per $1,000 assessed value</h2>
 
   <div class="legend">
     <div class="legend-item s-marblehead"><span class="legend-swatch"></span><span class="legend-text">Marblehead</span></div>
@@ -92,9 +98,68 @@ title: "Four Town Tax Rates"
     Residential tax rates for four North Shore towns, FY2003&ndash;FY2026. Marblehead's rate has been the lowest throughout the period. Dashed lines show projected Marblehead rates with each override tier at full phase-in. The Melrose FY26 spike reflects a $13.5M override passed in November 2025. Tax rates move inversely with property values and do not directly indicate total tax burden or spending efficiency.
   </p>
 
+  <h2 class="h-center">Average single-family tax bill</h2>
+
+  <div class="chart-wrapper">
+    <svg class="chart" viewBox="0 0 840 330" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart showing average single-family tax bills for Marblehead, Swampscott, Melrose, and Stoneham from FY2006 to FY2026.">
+      <!-- Grid -->
+      <line class="axis-base" x1="60" y1="280" x2="600" y2="280"/>
+      <line class="grid-minor" x1="60" y1="252" x2="600" y2="252"/>
+      <line class="grid-minor" x1="60" y1="197" x2="600" y2="197"/>
+      <line class="grid-minor" x1="60" y1="141" x2="600" y2="141"/>
+      <line class="grid-minor" x1="60" y1="86" x2="600" y2="86"/>
+      <line class="grid-minor" x1="60" y1="30" x2="600" y2="30"/>
+
+      <!-- Y labels -->
+      <text class="tick-label" x="53" y="199" text-anchor="end">$6K</text>
+      <text class="tick-label" x="53" y="143" text-anchor="end">$8K</text>
+      <text class="tick-label" x="53" y="88" text-anchor="end">$10K</text>
+      <text class="tick-label" x="53" y="32" text-anchor="end">$12K</text>
+
+      <!-- X labels -->
+      <text class="tick-label tick-label--major" x="60"  y="300" text-anchor="middle">FY06</text>
+      <text class="tick-label tick-label--minor" x="168" y="300" text-anchor="middle">FY10</text>
+      <text class="tick-label tick-label--minor" x="276" y="300" text-anchor="middle">FY14</text>
+      <text class="tick-label tick-label--minor" x="384" y="300" text-anchor="middle">FY18</text>
+      <text class="tick-label tick-label--minor" x="492" y="300" text-anchor="middle">FY22</text>
+      <text class="tick-label tick-label--major" x="600" y="300" text-anchor="middle">FY26</text>
+
+      <!-- Stoneham -->
+      <polyline class="data-line data-line--thin s-stoneham"
+                points="60,250 87,247 114,244 141,240 168,235 195,232 222,227 249,225 276,216 303,213 330,210 357,205 384,201 411,196 438,194 465,190 492,187 519,161 546,155 573,146 600,139"/>
+
+      <!-- Melrose -->
+      <polyline class="data-line data-line--bold s-melrose"
+                points="60,250 87,245 114,241 141,236 168,231 195,226 222,222 249,219 276,214 303,209 330,204 357,199 384,194 411,189 438,168 465,163 492,157 519,151 546,145 573,138 600,91"/>
+
+      <!-- Marblehead -->
+      <polyline class="data-line data-line--bold s-marblehead"
+                points="60,202 87,199 114,194 141,189 168,181 195,178 222,170 249,166 276,159 303,150 330,142 357,133 384,124 411,118 438,111 465,102 492,87 519,77 546,64 573,57 600,56"/>
+
+      <!-- Swampscott -->
+      <polyline class="data-line data-line--thin s-swampscott"
+                points="60,186 87,171 114,161 141,154 168,145 195,144 222,131 249,126 276,125 303,114 330,112 357,107 384,111 411,113 438,113 465,113 492,110 519,95 546,77 573,68 600,44"/>
+
+      <!-- Melrose override spike annotation -->
+      <circle class="data-dot s-melrose" cx="600" cy="91" r="3"/>
+
+      <!-- End labels -->
+      <text class="end-label s-swampscott" x="608" y="41">$11,478 Swampscott</text>
+      <text class="end-label s-marblehead" x="608" y="53">$11,055 Marblehead</text>
+      <text class="end-label s-melrose" x="608" y="88">$9,787 Melrose</text>
+      <text class="end-label s-stoneham" x="608" y="142">$8,059 Stoneham</text>
+    </svg>
+  </div>
+
+  <p class="caption">
+    Average single-family property tax bill for four North Shore towns, FY2006&ndash;FY2026. Marblehead's bill ($11,055) is the second-highest, behind Swampscott ($11,478), despite Marblehead having the lowest rate ($8.56) in the group. The difference is home values: Marblehead's median assessed value is $1,010,100 vs $853,264 in Melrose. The average bill reflects both the rate and the average home value, so towns with more expensive homes have higher bills even when their rates are lower.
+  </p>
+
   <div class="notes">
-    <p>Source: MA Department of Revenue, Division of Local Services, Tax Rates by Class FY2003&ndash;FY2026.</p>
+    <p>Rate chart source: MA Department of Revenue, Division of Local Services, Tax Rates by Class FY2003&ndash;FY2026.</p>
+    <p>Bill chart source: MA Department of Revenue, Division of Local Services, "Average Single Family Tax Bill" report, FY2006&ndash;FY2026.</p>
     <p>All four towns use split tax rates (residential vs commercial) except Marblehead, which uses a single rate for all property classes.</p>
-    <p>Melrose FY26 rate includes $13.5M override passed November 2025. Stoneham's $9.3M override (Dec 2025) not yet reflected.</p>
-    <p>Marblehead override tiers are estimates: current rate + (override amount / $9.89B assessed value). Tier 1 ($9M) ~$9.46, Tier 2 ($12M) ~$9.76, Tier 3 ($15M) ~$10.06.</p>
+    <p>Melrose FY26 rate and bill reflect a $13.5M override passed November 2025. Stoneham's $9.3M override (Dec 2025) not yet reflected.</p>
+    <p>Marblehead override tiers on the rate chart are estimates: current rate + (override amount / $9.89B assessed value). Tier 1 ($9M) ~$9.46, Tier 2 ($12M) ~$9.76, Tier 3 ($15M) ~$10.06.</p>
+    <p>The rate and bill charts use different start years because the underlying DOR reports have different coverage.</p>
   </div>

--- a/index.html
+++ b/index.html
@@ -106,19 +106,13 @@ og_url: https://marbleheaddata.org/
 
     <a class="question" href="charts/four_town_rates.html">
       <h2>How does Marblehead compare?</h2>
-      <p>Tax rates for four North Shore towns over 24 years, with override projections.</p>
+      <p>Both the tax rate (lowest in the group) and the average bill (second-highest) for four North Shore towns, with override projections.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
 
     <a class="question" href="charts/tax_comparison.html">
       <h2>Marblehead vs. Swampscott, side by side</h2>
       <p>Tax rates, home values, median bills, and what $750K buys you in each town.</p>
-      <span class="tag tag-charts">Chart</span>
-    </a>
-
-    <a class="question" href="charts/avg_tax_bill.html">
-      <h2>What do homeowners actually pay?</h2>
-      <p>Average single-family tax bill for four North Shore towns, FY2006-FY2026. From MA DOR.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
   </div>


### PR DESCRIPTION
## Summary
The two charts (`four_town_rates.html` and `avg_tax_bill.html`) were answering the same question — "how does Marblehead compare to peer towns?" — from different angles (rate vs. bill). The narrative that actually matters — *"Marblehead has the lowest rate but the second-highest bill, because home values are higher"* — only became clear when a reader stitched both pages together. That synthesis should happen on one page.

## Changes

1. **`charts/four_town_rates.html`** — rewritten as a combined "Rate and Bill" page:
   - New h1: **"Rate and Bill: Four North Shore Towns"**
   - Intro prose up front explaining the rate-vs-bill distinction and the home-value reason they diverge
   - First h2 **"Tax rate, per $1,000 assessed value"** above the existing rate chart and caption
   - New h2 **"Average single-family tax bill"** above the bill chart (verbatim SVG and caption from `avg_tax_bill.html`)
   - Notes block consolidates sources and flags that the two charts use different start years (because the underlying DOR reports differ)

2. **`charts/avg_tax_bill.html`** — replaced with a meta-refresh redirect stub pointing to `/charts/four_town_rates.html`. Preserves any existing bookmarks / shared links. Added `robots: noindex` so it drops out of search.

3. **`index.html`**:
   - Removed the "What do homeowners actually pay?" card from the Peer Comparison section (content is now on the merged page)
   - Rewrote the "How does Marblehead compare?" card description so readers know the page now contains both charts: *"Both the tax rate (lowest in the group) and the average bill (second-highest) for four North Shore towns, with override projections."*

## Why
From the chart audit: `avg_tax_bill.html` was a near-duplicate with `four_town_rates.html` (same 4 towns, same question, just dollar bills instead of rate per $1K). The narrative even explained why both views were needed, but a reader had to navigate away to see both. Merging them:
- Cuts one homepage card (4 → 3 in Peer Comparison)
- Tightens the chart page count under `charts/` (9 → 8 active, plus a redirect stub)
- Makes the rate-vs-bill point explicit instead of implicit

## Test plan
- [x] Desktop 1100px: both charts render stacked, intro prose frames the rate-vs-bill distinction, captions on each chart still scoped correctly
- [x] Mobile 390px: nav + fade, h1 wraps cleanly, intro reads well, both charts scale down
- [x] `avg_tax_bill.html` is a meta-refresh redirect (0s) to `/charts/four_town_rates.html`
- [x] Redirect stub has `robots: noindex` so it won't appear in search results
- [x] Homepage Peer Comparison section has 3 cards instead of 4
- [x] No internal links to `avg_tax_bill.html` except the removed homepage card (verified with grep)
- [x] STYLE_GUIDE followed: chart page uses Title Case for h1 + frontmatter title