### PR TITLE
Merge 3 healthcare charts into one article

### DIFF
--- a/charts/healthcare_costs.html
+++ b/charts/healthcare_costs.html
@@ -1,0 +1,180 @@
+---
+title: "Why Health Insurance Keeps Rising"
+og_title: "Why health insurance keeps rising"
+og_description: "Tax levy vs health insurance indexed, spending vs FTE, and the GIC family plan premium. Three views of the same question in Marblehead's budget."
+og_url: https://marbleheaddata.org/charts/healthcare_costs.html
+---
+<h1 class="h-center">Why Health Insurance Is Outpacing the Tax Levy</h1>
+  <p class="subtitle h-center">Three charts and one loss ratio. Marblehead, FY2006&ndash;FY2027. Source: Annual Comprehensive Financial Reports, Finance Committee reports, and GIC published rate sheets.</p>
+
+  <p>Health insurance is the single line in the Marblehead budget growing faster than the property tax levy, year after year. It is not headcount. It is not any particular plan year. The evidence is three separate views of the same underlying data, each ruling out a different alternative explanation and pointing back to the same cause: per-employee unit cost set by a state insurance pool the town does not control.</p>
+
+  <h2 class="h-center">1. Health insurance vs. the tax levy, indexed</h2>
+
+  <div class="legend">
+    <div class="legend-item s-revenue"><span class="legend-swatch"></span><span class="legend-text">Total tax levy</span></div>
+    <div class="legend-item s-neutral"><span class="legend-swatch"></span><span class="legend-text">Health insurance spending</span></div>
+  </div>
+
+  <div class="chart-wrapper">
+    <svg class="chart" viewBox="0 0 760 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart comparing tax levy growth and health insurance spending growth from FY2006 to FY2027, both indexed to FY2006 equals 100. Health insurance grew faster for most of the period, with both converging near 200 by FY2027.">
+      <line class="axis-base" x1="60" y1="246" x2="620" y2="246"/>
+
+      <line class="tick" x1="56" y1="246" x2="60" y2="246"/>
+      <text class="tick-label" x="53" y="250" text-anchor="end">100</text>
+      <line class="tick" x1="56" y1="160" x2="60" y2="160"/>
+      <text class="tick-label" x="53" y="164" text-anchor="end">150</text>
+      <line class="tick" x1="56" y1="74" x2="60" y2="74"/>
+      <text class="tick-label" x="53" y="78" text-anchor="end">200</text>
+
+      <text class="tick-label tick-label--major" x="60"  y="292" text-anchor="middle">FY06</text>
+      <text class="tick-label tick-label--minor" x="140" y="292" text-anchor="middle">FY09</text>
+      <text class="tick-label tick-label--major" x="220" y="292" text-anchor="middle">FY12</text>
+      <text class="tick-label tick-label--minor" x="300" y="292" text-anchor="middle">FY15</text>
+      <text class="tick-label tick-label--minor" x="380" y="292" text-anchor="middle">FY18</text>
+      <text class="tick-label tick-label--minor" x="460" y="292" text-anchor="middle">FY21</text>
+      <text class="tick-label tick-label--major" x="540" y="292" text-anchor="middle">FY24</text>
+      <text class="tick-label tick-label--major" x="620" y="292" text-anchor="middle">FY27</text>
+
+      <line class="annotation-line" x1="540" y1="42" x2="540" y2="260" style="stroke-dasharray:2 4"/>
+      <text class="annotation annotation--hide-sm" x="500" y="50" text-anchor="end">actual</text>
+      <text class="annotation annotation--hide-sm" x="548" y="50">projected</text>
+
+      <line class="annotation-line" x1="220" y1="60" x2="220" y2="260"/>
+      <text class="annotation annotation--hide-sm" x="224" y="68">Joined GIC (state insurance pool)</text>
+
+      <polyline class="data-line s-revenue"
+                points="60,246 87,242 113,236 140,231 167,223 193,218 220,209 247,205 273,197 300,188 327,179 353,169 380,160 407,154 433,146 460,137 487,121 513,110 540,98"/>
+      <polyline class="data-line data-line--thin data-line--dashed s-revenue"
+                points="540,98 567,89 593,79 620,69"/>
+
+      <polyline class="data-line s-neutral"
+                points="60,246 87,234 113,216 140,187 167,201 193,191 220,164 247,184 273,168 300,156 327,145 353,136 380,135 407,127"/>
+      <polyline class="data-line data-line--thin data-line--dashed s-neutral"
+                points="407,127 460,120"/>
+      <polyline class="data-line s-neutral"
+                points="460,120 487,105 513,89 540,117"/>
+      <polyline class="data-line data-line--thin data-line--dashed s-neutral"
+                points="540,117 567,122 593,92 620,56"/>
+
+      <text class="end-label s-neutral" x="628" y="53">+110% health ins.</text>
+      <text class="end-label s-revenue" x="628" y="78">+103% levy</text>
+    </svg>
+  </div>
+
+  <p class="caption">Both lines start at 100 in FY2006 so you can compare growth rates directly. Health insurance spending grew faster than the tax levy for most of FY2006&ndash;FY2023. Through FY24 (actual): levy +86%, health insurance +75%. Through FY27 (projected): levy +103%, health insurance +110%. Solid lines are actual data, dashed lines after FY24 are projected.</p>
+
+  <h2 class="h-center">2. It is not headcount</h2>
+
+  <p>If the spending line went up because the town hired more people, you would see full-time-equivalent employee count rise alongside it. It did not. The town's FTE headcount has been roughly stable around 700 for the entire period, while total health insurance spending roughly doubled in nominal dollars. The growth is per-employee unit cost, not employee count.</p>
+
+  <div class="chart-wrapper">
+    <svg class="chart" viewBox="0 0 800 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Two-panel chart. Top: health insurance spending FY06-FY27. Bottom: full-time equivalent employees FY06-FY24. Spending roughly doubled while FTE stayed near 700.">
+      <line class="axis-base" x1="70" y1="180" x2="640" y2="180"/>
+
+      <line class="tick" x1="66" y1="153" x2="70" y2="153"/>
+      <text class="tick-label" x="63" y="157" text-anchor="end">$8M</text>
+      <line class="tick" x1="66" y1="100" x2="70" y2="100"/>
+      <text class="tick-label" x="63" y="104" text-anchor="end">$12M</text>
+      <line class="tick" x1="66" y1="47" x2="70" y2="47"/>
+      <text class="tick-label" x="63" y="51" text-anchor="end">$16M</text>
+
+      <polyline class="data-line s-cost"
+                points="70,154 97,147 124,136 151,117 178,126 205,120 232,103 260,116 287,106 314,99 341,91 368,86 395,85 422,80 476,76 503,67 530,57 557,75 584,78"/>
+      <polyline class="data-line data-line--thin data-line--dashed s-cost"
+                points="584,78 611,59 640,37"/>
+
+      <text class="end-label s-cost" x="646" y="40">$16.8M</text>
+
+      <line class="annotation-line" x1="232" y1="20" x2="232" y2="180"/>
+      <text class="annotation annotation--hide-sm" x="236" y="28">Joined state insurance pool</text>
+
+      <line class="grid-minor" x1="70" y1="195" x2="640" y2="195"/>
+
+      <line class="axis-base" x1="70" y1="320" x2="640" y2="320"/>
+
+      <line class="tick" x1="66" y1="254" x2="70" y2="254"/>
+      <text class="tick-label" x="63" y="258" text-anchor="end">700</text>
+      <line class="tick" x1="66" y1="298" x2="70" y2="298"/>
+      <text class="tick-label" x="63" y="302" text-anchor="end">600</text>
+
+      <polyline class="data-line data-line--thin s-neutral"
+                points="70,274 97,268 124,266 151,263 179,262 206,262 233,265 260,260 287,260 314,260 341,265 369,265 396,258 423,267 450,268 477,269 504,268 531,250 559,251"/>
+
+      <text class="annotation" x="565" y="254">706 full-time equivalent</text>
+
+      <text class="tick-label tick-label--major" x="70"  y="342" text-anchor="middle">FY06</text>
+      <text class="tick-label tick-label--minor" x="151" y="342" text-anchor="middle">FY09</text>
+      <text class="tick-label tick-label--major" x="232" y="342" text-anchor="middle">FY12</text>
+      <text class="tick-label tick-label--minor" x="314" y="342" text-anchor="middle">FY15</text>
+      <text class="tick-label tick-label--minor" x="395" y="342" text-anchor="middle">FY18</text>
+      <text class="tick-label tick-label--minor" x="476" y="342" text-anchor="middle">FY21</text>
+      <text class="tick-label tick-label--major" x="557" y="342" text-anchor="middle">FY24</text>
+      <text class="tick-label tick-label--major" x="640" y="342" text-anchor="middle">FY27</text>
+    </svg>
+  </div>
+
+  <p class="caption">Top: health insurance spending by fiscal year (from annual budgets). Bottom: full-time equivalent employees (annual from audited financial reports). FTE counts part-time employees as fractions. Total headcount is higher (1,185 in FY25 per contemporaneous reporting) but historical headcount data is not publicly available. The spending line doubled; the staffing line is essentially flat.</p>
+
+  <h2 class="h-center">3. One family plan, published premiums</h2>
+
+  <p>If it is not headcount, it is price per employee. Here is the actual price of one Harvard Pilgrim family plan through the state Group Insurance Commission, taken directly from the GIC's published rate sheets. This is the full premium before the 83/17 employer-employee split; the town pays 83% of the figures below under the Public Employee Committee agreement.</p>
+
+  <div class="chart-wrapper">
+    <svg class="chart" viewBox="0 0 760 310" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart: annual Harvard Pilgrim family plan premium rose from $24,107 in FY19 to $38,562 in FY26.">
+      <line class="axis-base" x1="80" y1="270" x2="620" y2="270"/>
+
+      <line class="tick" x1="76" y1="215" x2="80" y2="215"/>
+      <text class="tick-label" x="73" y="219" text-anchor="end">$25K</text>
+      <line class="tick" x1="76" y1="161" x2="80" y2="161"/>
+      <text class="tick-label" x="73" y="165" text-anchor="end">$30K</text>
+      <line class="tick" x1="76" y1="106" x2="80" y2="106"/>
+      <text class="tick-label" x="73" y="110" text-anchor="end">$35K</text>
+      <line class="tick" x1="76" y1="52" x2="80" y2="52"/>
+      <text class="tick-label" x="73" y="56" text-anchor="end">$40K</text>
+
+      <text class="tick-label tick-label--major" x="80"  y="290" text-anchor="middle">FY19</text>
+      <text class="tick-label tick-label--minor" x="157" y="290" text-anchor="middle">FY20</text>
+      <text class="tick-label tick-label--minor" x="389" y="290" text-anchor="middle">FY23</text>
+      <text class="tick-label tick-label--minor" x="466" y="290" text-anchor="middle">FY24</text>
+      <text class="tick-label tick-label--minor" x="543" y="290" text-anchor="middle">FY25</text>
+      <text class="tick-label tick-label--major" x="620" y="290" text-anchor="middle">FY26</text>
+
+      <polyline class="data-line s-cost"
+                points="80,225 157,204 389,180 466,144 543,121 620,68"/>
+
+      <circle class="data-dot s-cost" cx="80" cy="225" r="4"/>
+      <circle class="data-dot s-cost" cx="157" cy="204" r="4"/>
+      <circle class="data-dot s-cost" cx="389" cy="180" r="4"/>
+      <circle class="data-dot s-cost" cx="466" cy="144" r="4"/>
+      <circle class="data-dot s-cost" cx="543" cy="121" r="4"/>
+      <circle class="data-dot s-cost" cx="620" cy="68" r="4"/>
+
+      <text class="value-label" x="80" y="243" text-anchor="middle">$24,107</text>
+      <text class="end-label s-cost" x="620" y="58" text-anchor="middle">$38,562</text>
+
+      <text class="end-label s-cost" x="640" y="140">+60%</text>
+      <text class="annotation" x="640" y="153">in 7 years</text>
+    </svg>
+  </div>
+
+  <p class="caption">Full annual premium for one Harvard Pilgrim family plan through the state Group Insurance Commission. Rose from $24,107 (FY19) to $38,562 (FY26), +60% in seven years. FY20 data point is derived from state employee rates, not directly from the municipal rate sheet. FY21&ndash;FY22 rate sheets were not publicly available. Plan name changed from Independence Plan to Access America in FY24.</p>
+
+  <h2>Why it is rising this fast</h2>
+
+  <p>The state regulator's explanation comes from Hill Group consultants, reporting to Marblehead's Public Employee Committee. They put Marblehead's <strong>loss ratio</strong> (claims paid out by the GIC on Marblehead's behalf divided by the premiums Marblehead paid in) at <strong>114% in FY2024</strong>, rising to <strong>119% through April of FY2025</strong>. A ratio above 100% means the town draws more from the insurance pool than it contributes in premiums, which is the direct mechanism by which Marblehead's GIC rates keep climbing even as it shares a pool with dozens of other municipalities. The Hill Group consultants identified <strong>GLP-1 weight-loss drugs</strong> as a notable cost driver. <a href="https://www.marbleheadindependent.com/possible-insurance-break-gives-marblehead-budget-outlook-a-lift/" target="_blank" rel="noopener">Source: Marblehead Independent.</a></p>
+
+  <p><strong>The FY24 dip</strong> in the first chart is the one year the pattern broke. In FY24 the GIC replaced the Harvard Pilgrim Independence Plan with Access America. Per-employee premiums still rose 11.6%, but the plan change let total town spending fall 8.7% that year. Staffing was flat. It was a one-time plan swap, not a lasting reversal.</p>
+
+  <p><strong>The FY26&ndash;FY27 spike</strong> is the 119% loss ratio working through the GIC's rate-setting process. The FY27 budget projects a 15% increase over FY26. In February 2026 the GIC board voted 10&ndash;7 to drop GLP-1 weight-loss drug coverage starting July 2026, which may slow future growth, but FY27 rates were already set before that decision. Rate relief, if it comes, would not show up until FY28 or later.</p>
+
+  <p>The town does not set its own rates or plan designs. Those are decisions made at the state level by the GIC board. Marblehead's option is to cover whatever rates the GIC sets, with the town paying 83% and employees paying 17% under an agreement with the Public Employee Committee that cannot be changed unilaterally.</p>
+
+  <div class="notes">
+    <p><strong>Tax levy:</strong> MA Department of Revenue, Division of Local Services, FY06&ndash;FY24 levy reports (includes debt exclusions). FY25&ndash;FY27 projected at 3% annual growth (Finance Committee rate for levy + new growth).</p>
+    <p><strong>Health insurance spending:</strong> "Group Insurance" line from Annual Comprehensive Financial Report budget schedules (FY06&ndash;FY13), Finance Committee reports (FY14&ndash;FY25), and proposed budgets (FY26&ndash;FY27). FY20 not publicly available (shown as dashed connector). Includes active employee health insurance, Medicare supplement, and Medicare reimbursement for all town and school employees.</p>
+    <p><strong>Employees:</strong> Full-time equivalent from audited financial report statistical sections (FY06&ndash;FY24). FTE counts a 20 hr/wk employee as 0.5. Total headcount (1,185 in FY25 per Marblehead Independent) is higher because many employees are part-time.</p>
+    <p><strong>Family plan premiums:</strong> Rates from GIC published rate charts: FY19 from Wayback Machine archive, FY20 derived from state employee rate sheet, FY23&ndash;FY26 from current mass.gov. Plan is Harvard Pilgrim Independence Plan (FY19&ndash;FY23) / Access America (FY24&ndash;FY26), the most common broad-network option. FY21&ndash;FY22 rate sheets not publicly available.</p>
+    <p><strong>Loss ratio and GLP-1 attribution:</strong> Sue Shillue of Hill Group (the town's insurance consultant), reporting to the Public Employee Committee, quoted in Marblehead Independent, <a href="https://www.marbleheadindependent.com/possible-insurance-break-gives-marblehead-budget-outlook-a-lift/" target="_blank" rel="noopener">"Possible insurance break gives Marblehead budget outlook a lift."</a> GLP-1 coverage decision from GIC board vote, February 2026, 10&ndash;7 to drop coverage effective July 2026. GIC rate control authority under MGL c. 32B s. 19 (the PEC statute).</p>
+    <p><strong>Employer-employee split:</strong> Marblehead pays 83% of every GIC premium; employees pay 17%. Set by agreement with the Public Employee Committee and cannot be changed unilaterally by the town.</p>
+  </div>

--- a/charts/healthcare_indexed.html
+++ b/charts/healthcare_indexed.html
@@ -1,69 +1,18 @@
 ---
-title: "Health Insurance & Staffing"
+title: "Moved to healthcare costs"
+permalink: /charts/healthcare_indexed.html
+sitemap: false
 ---
-<h1>Health Insurance Spending and Plan Enrollment</h1>
-  <p class="subtitle">Marblehead, FY2006&ndash;FY2027. From audited Annual Comprehensive Financial Reports and Finance Committee reports.</p>
-
-  <div class="chart-wrapper">
-    <svg class="chart" viewBox="0 0 800 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Two-panel chart. Top: health insurance spending FY06-FY27. Bottom: full-time equivalent employees FY06-FY24.">
-      <!-- === TOP PANEL === -->
-      <line class="axis-base" x1="70" y1="180" x2="640" y2="180"/>
-
-      <line class="tick" x1="66" y1="153" x2="70" y2="153"/>
-      <text class="tick-label" x="63" y="157" text-anchor="end">$8M</text>
-      <line class="tick" x1="66" y1="100" x2="70" y2="100"/>
-      <text class="tick-label" x="63" y="104" text-anchor="end">$12M</text>
-      <line class="tick" x1="66" y1="47" x2="70" y2="47"/>
-      <text class="tick-label" x="63" y="51" text-anchor="end">$16M</text>
-
-      <!-- Spending line (solid FY06-FY25) -->
-      <polyline class="data-line s-cost"
-                points="70,154 97,147 124,136 151,117 178,126 205,120 232,103 260,116 287,106 314,99 341,91 368,86 395,85 422,80 476,76 503,67 530,57 557,75 584,78"/>
-      <!-- Dashed FY25-FY27 -->
-      <polyline class="data-line data-line--thin data-line--dashed s-cost"
-                points="584,78 611,59 640,37"/>
-
-      <text class="end-label s-cost" x="646" y="40">$16.8M</text>
-
-      <!-- GIC marker -->
-      <line class="annotation-line" x1="232" y1="20" x2="232" y2="180"/>
-      <text class="annotation annotation--hide-sm" x="236" y="28">Joined state insurance pool</text>
-
-      <!-- Panel separator -->
-      <line class="grid-minor" x1="70" y1="195" x2="640" y2="195"/>
-
-      <!-- === BOTTOM PANEL === -->
-      <line class="axis-base" x1="70" y1="320" x2="640" y2="320"/>
-
-      <line class="tick" x1="66" y1="254" x2="70" y2="254"/>
-      <text class="tick-label" x="63" y="258" text-anchor="end">700</text>
-      <line class="tick" x1="66" y1="298" x2="70" y2="298"/>
-      <text class="tick-label" x="63" y="302" text-anchor="end">600</text>
-
-      <!-- FTE line -->
-      <polyline class="data-line data-line--thin s-neutral"
-                points="70,274 97,268 124,266 151,263 179,262 206,262 233,265 260,260 287,260 314,260 341,265 369,265 396,258 423,267 450,268 477,269 504,268 531,250 559,251"/>
-
-      <text class="annotation" x="565" y="254">706 full-time equivalent</text>
-
-      <!-- Shared X axis -->
-      <text class="tick-label tick-label--major" x="70"  y="342" text-anchor="middle">FY06</text>
-      <text class="tick-label tick-label--minor" x="151" y="342" text-anchor="middle">FY09</text>
-      <text class="tick-label tick-label--major" x="232" y="342" text-anchor="middle">FY12</text>
-      <text class="tick-label tick-label--minor" x="314" y="342" text-anchor="middle">FY15</text>
-      <text class="tick-label tick-label--minor" x="395" y="342" text-anchor="middle">FY18</text>
-      <text class="tick-label tick-label--minor" x="476" y="342" text-anchor="middle">FY21</text>
-      <text class="tick-label tick-label--major" x="557" y="342" text-anchor="middle">FY24</text>
-      <text class="tick-label tick-label--major" x="640" y="342" text-anchor="middle">FY27</text>
-    </svg>
-  </div>
-
-  <p class="caption">
-    Top: health insurance spending by fiscal year (19 data points from annual budgets). Bottom: full-time equivalent employees (annual from audited financial reports). FTE counts part-time employees as fractions. Total headcount is higher (1,185 in FY25) but historical headcount data is not publicly available.
-  </p>
-
-  <div class="notes">
-    <p><strong>Why is this rising so fast?</strong> Hill Group consultants, reporting to Marblehead's Public Employee Committee, put Marblehead's "loss ratio" (claims paid out by the GIC on Marblehead's behalf divided by the premiums Marblehead paid in) at <strong>114% in FY2024</strong>, rising to <strong>119% through April of FY2025</strong>. A ratio above 100% means the town draws more in claims than it contributes, which is a major reason Marblehead's GIC rates keep climbing even as it shares a pool with dozens of other municipalities. The consultants identified GLP-1 weight-loss drugs as a notable cost driver. <a href="https://www.marbleheadindependent.com/possible-insurance-break-gives-marblehead-budget-outlook-a-lift/" target="_blank" rel="noopener">Source: Marblehead Independent</a>.</p>
-    <p>Spending: "Group Insurance" from Annual Comprehensive Financial Report budget schedules (FY06&ndash;FY13) and Finance Committee reports (FY14&ndash;FY25). FY20 not available. FY26&ndash;FY27 proposed (dashed). Includes active employee health insurance, Medicare supplement, and Medicare reimbursement.</p>
-    <p>Employees: full-time equivalent from audited financial report statistical sections (FY06&ndash;FY24). FTE counts a 20 hr/wk employee as 0.5. Total headcount (1,185 in FY25 per Marblehead Independent) is higher because many employees are part-time. Historical headcount data is not publicly available.</p>
-  </div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="0; url=/charts/healthcare_costs.html">
+<link rel="canonical" href="https://marbleheaddata.org/charts/healthcare_costs.html">
+<title>Moved to healthcare costs</title>
+<meta name="robots" content="noindex">
+</head>
+<body>
+<p>This chart has moved to <a href="/charts/healthcare_costs.html">/charts/healthcare_costs.html</a>, where the spending-vs-staffing view is part of a fuller article about Marblehead's health insurance cost growth.</p>
+</body>
+</html>

--- a/charts/premium_per_employee.html
+++ b/charts/premium_per_employee.html
@@ -1,52 +1,18 @@
 ---
-title: "GIC Family Plan Cost"
+title: "Moved to healthcare costs"
+permalink: /charts/premium_per_employee.html
+sitemap: false
 ---
-<h1>Annual Cost of One Family Health Insurance Plan</h1>
-  <p class="subtitle">Full premium cost for one family plan before the 83/17 employer-employee split. The town pays 83% of these figures. Harvard Pilgrim plan through the state Group Insurance Commission, FY2019&ndash;FY2026.</p>
-
-  <div class="chart-wrapper">
-    <svg class="chart" viewBox="0 0 760 310" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart: annual Harvard Pilgrim family plan premium rose from $24,107 in FY19 to $38,562 in FY26.">
-      <line class="axis-base" x1="80" y1="270" x2="620" y2="270"/>
-
-      <line class="tick" x1="76" y1="215" x2="80" y2="215"/>
-      <text class="tick-label" x="73" y="219" text-anchor="end">$25K</text>
-      <line class="tick" x1="76" y1="161" x2="80" y2="161"/>
-      <text class="tick-label" x="73" y="165" text-anchor="end">$30K</text>
-      <line class="tick" x1="76" y1="106" x2="80" y2="106"/>
-      <text class="tick-label" x="73" y="110" text-anchor="end">$35K</text>
-      <line class="tick" x1="76" y1="52" x2="80" y2="52"/>
-      <text class="tick-label" x="73" y="56" text-anchor="end">$40K</text>
-
-      <text class="tick-label tick-label--major" x="80"  y="290" text-anchor="middle">FY19</text>
-      <text class="tick-label tick-label--minor" x="157" y="290" text-anchor="middle">FY20</text>
-      <text class="tick-label tick-label--minor" x="389" y="290" text-anchor="middle">FY23</text>
-      <text class="tick-label tick-label--minor" x="466" y="290" text-anchor="middle">FY24</text>
-      <text class="tick-label tick-label--minor" x="543" y="290" text-anchor="middle">FY25</text>
-      <text class="tick-label tick-label--major" x="620" y="290" text-anchor="middle">FY26</text>
-
-      <polyline class="data-line s-cost"
-                points="80,225 157,204 389,180 466,144 543,121 620,68"/>
-
-      <circle class="data-dot s-cost" cx="80" cy="225" r="4"/>
-      <circle class="data-dot s-cost" cx="157" cy="204" r="4"/>
-      <circle class="data-dot s-cost" cx="389" cy="180" r="4"/>
-      <circle class="data-dot s-cost" cx="466" cy="144" r="4"/>
-      <circle class="data-dot s-cost" cx="543" cy="121" r="4"/>
-      <circle class="data-dot s-cost" cx="620" cy="68" r="4"/>
-
-      <text class="value-label" x="80" y="243" text-anchor="middle">$24,107</text>
-      <text class="end-label s-cost" x="620" y="58" text-anchor="middle">$38,562</text>
-
-      <text class="end-label s-cost" x="640" y="140">+60%</text>
-      <text class="annotation" x="640" y="153">in 7 years</text>
-    </svg>
-  </div>
-
-  <p class="caption">
-    Full annual premium for one Harvard Pilgrim family plan through the state Group Insurance Commission. Rose from $24,107 (FY19) to $38,562 (FY26), +60% in seven years. The town pays 83% of this premium; employees pay 17%. FY20 data point is derived from state employee rates, not directly from municipal rate sheet. FY21&ndash;FY22 rate sheets were not publicly available. Plan name changed from Independence Plan to Access America in FY24.
-  </p>
-
-  <div class="notes">
-    <p>Rates from GIC published rate charts: FY19 from Wayback Machine archive, FY20 derived from state employee rate sheet, FY23&ndash;FY26 from current mass.gov. Plan is Harvard Pilgrim Independence Plan (FY19&ndash;FY23) / Access America (FY24&ndash;FY26), the most common broad-network option. FY21&ndash;FY22 rate sheets not publicly available.</p>
-    <p>Marblehead pays 83% of the full premium; employees pay 17%. This split is set by agreement with the Public Employee Committee and cannot be changed unilaterally.</p>
-  </div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="0; url=/charts/healthcare_costs.html">
+<link rel="canonical" href="https://marbleheaddata.org/charts/healthcare_costs.html">
+<title>Moved to healthcare costs</title>
+<meta name="robots" content="noindex">
+</head>
+<body>
+<p>This chart has moved to <a href="/charts/healthcare_costs.html">/charts/healthcare_costs.html</a>, where the GIC family plan premium is part of a fuller article about Marblehead's health insurance cost growth.</p>
+</body>
+</html>

--- a/charts/real_cost_comparison.html
+++ b/charts/real_cost_comparison.html
@@ -1,97 +1,18 @@
 ---
-title: "Tax Levy vs. Health Insurance"
+title: "Moved to healthcare costs"
+permalink: /charts/real_cost_comparison.html
+sitemap: false
 ---
-<h1 class="h-center">Tax Levy vs. Health Insurance Spending</h1>
-  <p class="subtitle h-center">Both lines start at 100 in FY2006 so you can compare how fast each grew. Marblehead, FY2006&ndash;FY2027.</p>
-
-  <div class="legend">
-    <div class="legend-item s-revenue"><span class="legend-swatch"></span><span class="legend-text">Total tax levy</span></div>
-    <div class="legend-item s-neutral"><span class="legend-swatch"></span><span class="legend-text">Health insurance spending</span></div>
-  </div>
-
-  <div class="chart-wrapper">
-    <svg class="chart" viewBox="0 0 760 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart comparing tax levy growth and health insurance spending growth from FY2006 to FY2027, both indexed to FY2006 equals 100. Health insurance grew faster for most of the period, with both converging near 200 by FY2027.">
-      <!--
-        Y axis: y = 246 - (index - 100) * 1.72
-        X axis: x = 60 + (FY - 2006) * 26.67
-        Scale: y=246 = index 100, y=160 = index 150, y=74 = index 200
-        All y-positions calculated from actual dollar values / FY06 base * 100.
-      -->
-
-      <!-- Baseline at 100 -->
-      <line class="axis-base" x1="60" y1="246" x2="620" y2="246"/>
-
-      <!-- Y ticks -->
-      <line class="tick" x1="56" y1="246" x2="60" y2="246"/>
-      <text class="tick-label" x="53" y="250" text-anchor="end">100</text>
-      <line class="tick" x1="56" y1="160" x2="60" y2="160"/>
-      <text class="tick-label" x="53" y="164" text-anchor="end">150</text>
-      <line class="tick" x1="56" y1="74" x2="60" y2="74"/>
-      <text class="tick-label" x="53" y="78" text-anchor="end">200</text>
-
-      <!-- X labels -->
-      <text class="tick-label tick-label--major" x="60"  y="292" text-anchor="middle">FY06</text>
-      <text class="tick-label tick-label--minor" x="140" y="292" text-anchor="middle">FY09</text>
-      <text class="tick-label tick-label--major" x="220" y="292" text-anchor="middle">FY12</text>
-      <text class="tick-label tick-label--minor" x="300" y="292" text-anchor="middle">FY15</text>
-      <text class="tick-label tick-label--minor" x="380" y="292" text-anchor="middle">FY18</text>
-      <text class="tick-label tick-label--minor" x="460" y="292" text-anchor="middle">FY21</text>
-      <text class="tick-label tick-label--major" x="540" y="292" text-anchor="middle">FY24</text>
-      <text class="tick-label tick-label--major" x="620" y="292" text-anchor="middle">FY27</text>
-
-      <!-- Verified / projected boundary -->
-      <line class="annotation-line" x1="540" y1="42" x2="540" y2="260" style="stroke-dasharray:2 4"/>
-      <text class="annotation annotation--hide-sm" x="500" y="50" text-anchor="end">actual</text>
-      <text class="annotation annotation--hide-sm" x="548" y="50">projected</text>
-
-      <!-- GIC marker -->
-      <line class="annotation-line" x1="220" y1="60" x2="220" y2="260"/>
-      <text class="annotation annotation--hide-sm" x="224" y="68">Joined GIC (state insurance pool)</text>
-
-      <!-- === TAX LEVY === -->
-      <!-- Actual FY06-FY24 (DOR data, includes debt exclusions) -->
-      <polyline class="data-line s-revenue"
-                points="60,246 87,242 113,236 140,231 167,223 193,218 220,209 247,205 273,197 300,188 327,179 353,169 380,160 407,154 433,146 460,137 487,121 513,110 540,98"/>
-      <!-- Projected FY24-FY27 (3%/yr, Finance Committee rate) -->
-      <polyline class="data-line data-line--thin data-line--dashed s-revenue"
-                points="540,98 567,89 593,79 620,69"/>
-
-      <!-- === HEALTH INSURANCE === -->
-      <!-- Actual FY06-FY19 (ACFR + FinCom) -->
-      <polyline class="data-line s-neutral"
-                points="60,246 87,234 113,216 140,187 167,201 193,191 220,164 247,184 273,168 300,156 327,145 353,136 380,135 407,127"/>
-      <!-- Dashed FY19-FY21 (FY20 data not available) -->
-      <polyline class="data-line data-line--thin data-line--dashed s-neutral"
-                points="407,127 460,120"/>
-      <!-- Actual FY21-FY24 (FinCom) -->
-      <polyline class="data-line s-neutral"
-                points="460,120 487,105 513,89 540,117"/>
-      <!-- Proposed FY24-FY27 (budget documents) -->
-      <polyline class="data-line data-line--thin data-line--dashed s-neutral"
-                points="540,117 567,122 593,92 620,56"/>
-
-      <!-- End labels at FY27 -->
-      <text class="end-label s-neutral" x="628" y="53">+110% health ins.</text>
-      <text class="end-label s-revenue" x="628" y="78">+103% levy</text>
-    </svg>
-  </div>
-
-  <p class="caption">
-    Health insurance spending grew faster than the tax levy for most of FY2006&ndash;FY2023.
-  </p>
-  <p class="caption">
-    <strong>The FY24 dip:</strong> The GIC replaced the Harvard Pilgrim Independence Plan with Access America. Per-employee premiums rose 11.6%, but total town spending fell 8.7% under the new plan. Staffing was flat.
-  </p>
-  <p class="caption">
-    <strong>The FY26&ndash;FY27 spike:</strong> GIC rate increases driven by Marblehead's 119% loss ratio (claims exceeding premiums), attributed in part to GLP-1 drug costs. The FY27 budget projects a 15% increase. The GIC voted in February 2026 to drop GLP-1 weight-loss drug coverage starting July 2026, which may slow future growth, but FY27 rates were already set.
-  </p>
-  <p class="caption">
-    Through FY24 (actual): levy +86%, health insurance +75%. Through FY27 (projected): levy +103%, health insurance +110%. Solid lines are actual data. Dashed lines after FY24 are projected.
-  </p>
-
-  <div class="notes">
-    <p>Tax levy from MA Department of Revenue, FY06&ndash;FY24 (includes debt exclusions). FY25&ndash;FY27 projected at 3% annual growth (Finance Committee rate for levy + new growth).</p>
-    <p>Health insurance ("Group Insurance") from ACFR budget schedules (FY06&ndash;FY13), Finance Committee reports (FY14&ndash;FY25), and proposed budgets (FY26&ndash;FY27). FY20 not publicly available (dashed connector). Includes active employee health insurance, Medicare supplement, and Medicare reimbursement for all town and school employees.</p>
-    <p>Rates are set by the state Group Insurance Commission (GIC). The town joined the GIC in FY2012. The GIC sets plan designs and premium rates; the town has no control over either. The GIC voted 10&ndash;7 in February 2026 to drop GLP-1 weight-loss drug coverage effective July 2026, but FY27 rates were already set before that decision.</p>
-    <p>Loss ratio and GLP-1 attribution from Sue Shillue of Hill Group (town insurance consultant), reporting to the Public Employee Committee. Quoted in Marblehead Independent, "Possible insurance break gives Marblehead budget outlook a lift." Plan names from GIC published rate sheets (mass.gov). GLP-1 coverage decision from GIC board vote, February 2026.</p>
-  </div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="0; url=/charts/healthcare_costs.html">
+<link rel="canonical" href="https://marbleheaddata.org/charts/healthcare_costs.html">
+<title>Moved to healthcare costs</title>
+<meta name="robots" content="noindex">
+</head>
+<body>
+<p>This chart has moved to <a href="/charts/healthcare_costs.html">/charts/healthcare_costs.html</a>, where the tax-levy-vs-health-insurance comparison is part of a fuller article that also covers spending-vs-staffing and the GIC family plan premium.</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -72,21 +72,9 @@ og_url: https://marbleheaddata.org/
 
   <p class="section-label">Cost drivers</p>
   <div class="question-list">
-    <a class="question" href="charts/real_cost_comparison.html">
-      <h2>Why is there a deficit?</h2>
-      <p>Tax levy vs health insurance spending, indexed to FY2006. Two lines diverging over 21 years.</p>
-      <span class="tag tag-charts">Chart</span>
-    </a>
-
-    <a class="question" href="charts/premium_per_employee.html">
-      <h2>How fast are insurance costs rising?</h2>
-      <p>Annual cost of one GIC family plan from published rate sheets. $24K to $39K in 7 years.</p>
-      <span class="tag tag-charts">Chart</span>
-    </a>
-
-    <a class="question" href="charts/healthcare_indexed.html">
-      <h2>Did hiring drive health insurance growth?</h2>
-      <p>Health insurance spending vs employee headcount. Spending doubled; staffing data is flat.</p>
+    <a class="question" href="charts/healthcare_costs.html">
+      <h2>Why is health insurance outpacing the levy?</h2>
+      <p>Three charts and one loss ratio. Tax levy vs health insurance, spending vs headcount, and the actual annual price of one GIC family plan. $24K to $39K in 7 years, not driven by hiring.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
 


### PR DESCRIPTION
## Summary
The three healthcare-related chart pages each told one-third of the same argument. Merging them into a single article lets a reader see the full case in one scroll.

| Old page | Old homepage card | What it showed |
|---|---|---|
| `real_cost_comparison.html` | "Why is there a deficit?" | Tax levy vs health insurance, indexed — health insurance grew faster |
| `healthcare_indexed.html` | "Did hiring drive health insurance growth?" | Spending vs FTE — spending doubled, staffing flat |
| `premium_per_employee.html` | "How fast are insurance costs rising?" | GIC family plan price — $24K → $38K in 7 years |

Each was a supporting data point for "Marblehead's health insurance costs are growing because of per-employee unit cost set by the GIC," but the point only came together if you navigated all three pages and stitched the narrative yourself.

## New structure — `/charts/healthcare_costs.html`

**Title**: "Why Health Insurance Is Outpacing the Tax Levy"

**Lead**: one paragraph establishing the thesis — "Health insurance is the single line growing faster than the tax levy. It is not headcount. It is not any particular plan year."

**Section 1 — Health insurance vs. the tax levy, indexed**: the two-line indexed chart from `real_cost_comparison`, with the growth-comparison caption.

**Section 2 — It is not headcount**: the dual-panel spending-vs-FTE chart from `healthcare_indexed`. Transitional prose: "If the spending line went up because the town hired more people, you would see FTE headcount rise alongside it. It did not."

**Section 3 — One family plan, published premiums**: the GIC family plan chart from `premium_per_employee`. Transitional prose: "If it is not headcount, it is price per employee. Here is the actual price..."

**Section 4 — Why it is rising this fast**: consolidated prose pulling from all three sources:
- Hill Group loss ratio (114% FY24, 119% through April FY25)
- FY24 Access America plan swap (the dip in the first chart)
- FY26–FY27 spike (119% loss ratio working through GIC rate-setting, 15% FY27 increase)
- GIC February 2026 vote to drop GLP-1 weight-loss coverage starting July 2026
- GIC vs town authority note (MGL c. 32B s. 19, PEC agreement, 83/17 split)

**Notes**: five consolidated source blocks (tax levy, insurance spending, FTE, premiums, loss ratio/GLP-1, employer-employee split).

## What happens to the old URLs

All three old pages become meta-refresh redirect stubs pointing at `/charts/healthcare_costs.html`, with `robots: noindex` so they drop out of search but preserve any existing bookmarks or shared links. This matches the pattern used in #88 (`avg_tax_bill.html` → `four_town_rates.html`).

## Homepage changes — `index.html`

Three cards in the "Cost drivers" section collapse to one:

- **Removed**: "Why is there a deficit?" → `real_cost_comparison.html`
- **Removed**: "How fast are insurance costs rising?" → `premium_per_employee.html`
- **Removed**: "Did hiring drive health insurance growth?" → `healthcare_indexed.html`
- **New**: "Why is health insurance outpacing the levy?" → `/charts/healthcare_costs.html` with a description that names all three views ("Three charts and one loss ratio. Tax levy vs health insurance, spending vs headcount, and the actual annual price of one GIC family plan. $24K to $39K in 7 years, not driven by hiring.")

Cost drivers section drops from 4 cards to 2. The remaining card in that section is "Did enrollment drive the budget?" (the schools chart).

Chart pages under `charts/` drop from 8 active to 6 active (plus 3 redirect stubs).

## Test plan
- [x] Desktop 1100px: all three charts render stacked, h2s number the sections 1/2/3, narrative flows as argument → rule-out → proof → explanation
- [x] Mobile 390px: chart-page container with nav + fade, h1 wraps, each chart scales down
- [x] All three old URLs are meta-refresh redirects with `robots: noindex` and preserved shared-link paths
- [x] Homepage Cost drivers section has 2 cards (was 4)
- [x] No internal references to the old URLs except the homepage cards I removed (verified with grep inside the worktree)
- [x] STYLE_GUIDE followed: chart page uses Title Case h1 ("Why Health Insurance Is Outpacing the Tax Levy")