### PR TITLE
Citation markers across the remaining six content pages

### DIFF
--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -9,7 +9,7 @@ title: "How did we get here?"
   </div>
 
   <h2 data-stance-section="balanced-budgets-era">2005 to 2021: Sixteen years of balanced budgets</h2>
-  <p>Marblehead's last successful operating override was the June 2005 vote that funded a $2.73M supplemental override for the FY2006 budget. For the sixteen fiscal years that followed, the Finance Committee reported balanced budgets and explicitly celebrated the absence of overrides as evidence of disciplined management.</p>
+  <p>Marblehead's last successful operating override was the June 2005 vote that funded a $2.73M supplemental override for the FY2006 budget.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride" data-source="MA DOR, Proposition 2½ Override & Underride Votes (Marblehead FY2006 supplemental override, June 2005)"></sup> For the sixteen fiscal years that followed, the Finance Committee reported balanced budgets and explicitly celebrated the absence of overrides as evidence of disciplined management.<sup class="cite" data-href="data/2021_FinCom_Report.pdf" data-source="2021 Finance Committee Annual Report, transmittal letter (&quot;sixteenth consecutive year... without proposing a general override&quot;)"></sup></p>
   <p>The 2016 transmittal letter (for the FY17 budget) is typical of the period:</p>
 
   <blockquote class="quote">
@@ -54,7 +54,7 @@ title: "How did we get here?"
     <footer>2023 Finance Committee Annual Report, transmittal letter to the 2023 Annual Town Meeting (for the FY24 budget). <a href="data/2023_FinCom_Report.pdf">PDF</a>.</footer>
   </blockquote>
 
-  <p>Town Meeting approved the override 534 to 230. It failed at the ballot, 2,992 to 3,399, by a margin of roughly 400 votes. The FY24 budget was delivered as a "reduced services" version instead.</p>
+  <p>Town Meeting approved the override 534 to 230. It failed at the ballot, 2,992 to 3,399, by a margin of roughly 400 votes.<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2025/03/town_meeting_minutes_2023__0.pdf" data-source="2023 Annual Town Meeting minutes (Article 31 paper ballot 534-230); Marblehead Current coverage for the June 2023 ballot result 2,992-3,399"></sup> The FY24 budget was delivered as a "reduced services" version instead.</p>
 
   <h2 data-stance-section="deficit-continues">2024 and 2025: The structural deficit continues</h2>
   <p>With the FY24 override defeated at the ballot, the next two transmittal letters continued the warning, each time with more specificity. From the 2024 letter (for the FY25 budget):</p>
@@ -72,7 +72,7 @@ title: "How did we get here?"
   </blockquote>
 
   <h2 data-stance-section="vote-2026">2026: The vote before us</h2>
-  <p>Here we are. The deficit the Finance Committee first signaled in 2019, explicitly predicted in 2022, partially delivered in 2023 (and defeated at the ballot), continued warning about in 2024, and specifically named for FY27 in 2025 is now on the June 2026 ballot as a three-tier override ranging from $9 million to $15 million. Residents have had roughly seven years of warning, four years of explicit deficit predictions, and three years since the first override attempt was defeated.</p>
+  <p>Here we are. The deficit the Finance Committee first signaled in 2019, explicitly predicted in 2022, partially delivered in 2023 (and defeated at the ballot), continued warning about in 2024, and specifically named for FY27 in 2025 is now on the June 2026 ballot as a three-tier override ranging from $9 million to $15 million.<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2026/02/2026-State-of-the-Town-Presenation-Final.pdf" data-source="2026 State of the Town presentation, three-tier override framework ($9M / $12M / $15M)"></sup> Residents have had roughly seven years of warning, four years of explicit deficit predictions, and three years since the first override attempt was defeated.</p>
 
   <p>This page is FinCom's own warning arc, told in their own transmittal letters. For the complementary question &ndash; what the town actually spent during those same years, and which lines grew fastest &ndash; see <a href="where-has-the-money-gone.html">where has Marblehead's money gone</a>.</p>
 

--- a/no-override-budget.html
+++ b/no-override-budget.html
@@ -78,7 +78,7 @@ og_url: https://marbleheaddata.org/no-override-budget.html
     <p class="source">Source: <a href="https://marbleheadma.gov/wp-content/uploads/2026/04/PROPOSED-FY27-BALANCED-BUDGET-WITH-NO-OVERRIDE.pdf">FY27 Proposed Budget</a>, pages 1-4. Bars are proportional to dollar amount. Dollar amounts are FY26 budget minus FY27 proposed.</p>
   </div>
 
-  <p>The library reduction (-43%) would "significantly reduce services in terms of days that the library can be open," per the <a href="https://www.marbleheadindependent.com/marblehead-advances-122-8m-budget-built-on-cuts-defers-override-decisions/">Marblehead Independent</a>. The library was recently renovated with a separate $8.5M debt exclusion approved by voters in 2021.</p>
+  <p>The library reduction (-43%) would "significantly reduce services in terms of days that the library can be open," per the <a href="https://www.marbleheadindependent.com/marblehead-advances-122-8m-budget-built-on-cuts-defers-override-decisions/">Marblehead Independent</a>.<sup class="cite" data-href="https://www.marbleheadindependent.com/marblehead-advances-122-8m-budget-built-on-cuts-defers-override-decisions/" data-source="Marblehead Independent, &quot;Marblehead advances $122.8M budget built on cuts&quot;"></sup> The library was recently renovated with a separate $8.5M debt exclusion approved by voters in 2021.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.debtexclusionvotes" data-source="MA DOR, Proposition 2½ Debt Exclusion Votes (Marblehead 2021 Abbot Library debt exclusion, $8.5M)"></sup></p>
 
   <h2 data-stance-section="school-side-reductions">School-side reductions</h2>
 
@@ -123,9 +123,9 @@ og_url: https://marbleheaddata.org/no-override-budget.html
 
   <h2 data-stance-section="what-other-towns-did">What other MA towns did after similar votes</h2>
 
-  <p>Melrose (population ~28,000) rejected a $7.7M override in June 2024 and reduced 61.4 FTEs over two years across teachers, library hours, senior van drivers, and other departments. Elementary class sizes were proposed up to 32 students. The middle and high school shared one principal. Melrose returned to the ballot in November 2025 and passed a $13.5M override, 75% larger than the original ask.</p>
+  <p>Melrose (population ~28,000) rejected a $7.7M override in June 2024 and reduced 61.4 FTEs over two years across teachers, library hours, senior van drivers, and other departments. Elementary class sizes were proposed up to 32 students. The middle and high school shared one principal. Melrose returned to the ballot in November 2025 and passed a $13.5M override, 75% larger than the original ask.<sup class="cite" data-href="data/case_studies.md" data-source="case_studies.md: Melrose $7.7M failed June 2024, staffing and service cuts, $13.5M passed November 2025 (+75%)"></sup></p>
 
-  <p>Stoneham rejected a $14.6M override in April 2025. Staff departed for higher-paying districts, leaving 28 vacant positions at the start of the school year. Teachers earned 30% below market rate. The library lost weekend and evening hours. Stoneham passed a $9.3M override in December 2025; the larger $12.5M option failed by 43 votes.</p>
+  <p>Stoneham rejected a $14.6M override in April 2025. Staff departed for higher-paying districts, leaving 28 vacant positions at the start of the school year. Teachers earned 30% below market rate. The library lost weekend and evening hours. Stoneham passed a $9.3M override in December 2025; the larger $12.5M option failed by 43 votes.<sup class="cite" data-href="data/case_studies.md" data-source="case_studies.md: Stoneham $14.6M failed April 2025, staffing departures and service cuts, $9.3M passed December 2025"></sup></p>
 
   <p>See the full <a href="data/case_studies">case studies</a> for details and sources. For a broader look at how 21 Massachusetts peer towns compare on residential tax share, new growth, and override history, see <a href="why-not-elsewhere.html">why do some MA towns run overrides and others don't</a>.</p>
 

--- a/senior-tax-relief.html
+++ b/senior-tax-relief.html
@@ -147,7 +147,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
   }
 </style>
 <h1>What relief can seniors claim?</h1>
-  <p>Two programs can reduce what a Marblehead senior pays in property tax. The state Senior Circuit Breaker refunds up to <strong>$2,820</strong> per year and is available today. A local exemption approved by Marblehead Town Meeting in May 2025 (Article 28, now H.4225) would stack on top of it; the bill passed the Massachusetts House on March 30, 2026 and is awaiting Senate action. This page explains both programs, who qualifies, how to apply, and how each interacts with the override math.</p>
+  <p>Two programs can reduce what a Marblehead senior pays in property tax. The state Senior Circuit Breaker refunds up to <strong>$2,820</strong> per year and is available today.<sup class="cite" data-href="https://www.mass.gov/technical-information-release/tir-25-7-annual-update-of-real-estate-tax-credit-for-certain-persons-age-65-and-older" data-source="MA DOR TIR 25-7, annual update of the Senior Circuit Breaker credit cap for TY2025"></sup> A local exemption approved by Marblehead Town Meeting in May 2025 (Article 28, now H.4225) would stack on top of it; the bill passed the Massachusetts House on March 30, 2026 and is awaiting Senate action.<sup class="cite" data-href="https://malegislature.gov/Bills/194/H4225" data-source="MA House Bill H.4225 (means-tested senior property tax exemption for Marblehead), bill history page"></sup> This page explains both programs, who qualifies, how to apply, and how each interacts with the override math.</p>
 
   <div class="tldr">
     <p class="tldr-label">TL;DR</p>
@@ -287,7 +287,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
   </div>
 
   <h2 data-stance-section="local-exemption">2. The local exemption Marblehead voted for</h2>
-  <p>At the May 5, 2025 Annual Town Meeting, voters approved <strong>Article 28</strong> by a reported 93% margin. Article 28 is a home rule petition asking the state legislature to authorize Marblehead to create a local means-tested senior exemption on top of the Circuit Breaker. It was filed at the State House as <strong>House Bill H.4225</strong>.</p>
+  <p>At the May 5, 2025 Annual Town Meeting, voters approved <strong>Article 28</strong> by a reported 93% margin.<sup class="cite" data-href="https://itemlive.com/2025/05/11/marblehead-town-meeting-passes-key-articles/" data-source="Itemlive, &quot;Marblehead Town Meeting passes key articles&quot; (May 11 2025), confirms Article 28 passage with ~93% support"></sup> Article 28 is a home rule petition asking the state legislature to authorize Marblehead to create a local means-tested senior exemption on top of the Circuit Breaker. It was filed at the State House as <strong>House Bill H.4225</strong>.<sup class="cite" data-href="https://malegislature.gov/Bills/194/H4225" data-source="MA House Bill H.4225 (Marblehead home rule petition for means-tested senior exemption)"></sup></p>
 
   <div class="card">
     <h3>What H.4225 would do</h3>

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -256,7 +256,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
   <p>See the <a href="charts/override_calculator.html">override cost calculator</a> for year-by-year costs at different home values.</p>
 
   <h2 data-stance-section="history">History</h2>
-  <p>Marblehead's last successful operating override was the June 2005 vote that authorized a $2.73M supplemental override for the FY2006 budget, 21 years ago. Every operating override attempt since has failed. In the full Massachusetts Department of Revenue ballot record, Marblehead voters have approved 4 of 13 operating override attempts since 1990, but 28 of 29 debt exclusion attempts since 1982. They will reliably borrow to build things; they almost never vote to raise taxes for operating costs.</p>
+  <p>Marblehead's last successful operating override was the June 2005 vote that authorized a $2.73M supplemental override for the FY2006 budget, 21 years ago.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride" data-source="MA DOR, Proposition 2½ Override & Underride Votes (Marblehead record)"></sup> Every operating override attempt since has failed. In the full Massachusetts Department of Revenue ballot record, Marblehead voters have approved 4 of 13 operating override attempts since 1990, but 28 of 29 debt exclusion attempts since 1982.<sup class="cite" data-href="data/marblehead_prop25_votes.csv" data-source="marblehead_prop25_votes.csv (compiled from MA DOR Proposition 2½ Override &amp; Underride Votes and Debt Exclusion Votes reports)"></sup> They will reliably borrow to build things; they almost never vote to raise taxes for operating costs.</p>
 
   <div class="stat-compare">
     <div class="stat-row">

--- a/where-has-the-money-gone.html
+++ b/where-has-the-money-gone.html
@@ -69,12 +69,12 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
     </div>
   </div>
 
-  <p>The property tax levy doubled from $39M in 2005 to $82M in 2024. Here is where every additional dollar went, who has been checking the books, and what grew faster than it probably should have.</p>
+  <p>The property tax levy doubled from $39M in 2005 to $82M in 2024.<sup class="cite" data-href="data/SOURCE_LOOKUP.md" data-source="Marblehead ACFR schedules of Property Tax Levies and Collections (FY05 ACFR p.121, FY14 ACFR p.117, FY24 ACFR p.129)"></sup> Here is where every additional dollar went, who has been checking the books, and what grew faster than it probably should have.</p>
 
   <!-- Act 1: Where it went. Filled by Task 5 (prose and department table) and Task 6 (stacked spending chart). -->
   <h2 data-stance-section="where-it-went">Where it went</h2>
 
-  <p>Marblehead's General Fund spending grew from $70.5 million in 2015 to $106.2 million in 2026, an increase of $35.7 million. These are the town's budgetary-basis General Fund numbers: the money the Finance Committee builds the annual budget around and Town Meeting votes on. They exclude grants, school food service and athletics fees, and state on-behalf payments into the teachers pension fund, which together total roughly $26 million a year in additional money the town does not directly control.</p>
+  <p>Marblehead's General Fund spending grew from $70.5 million in 2015 to $106.2 million in 2026, an increase of $35.7 million.<sup class="cite" data-href="data/SOURCES.md" data-source="Marblehead ACFR &quot;Schedule of Revenues, Expenditures and Changes in Fund Balance, Budget and Actual, General Fund&quot; (FY2015-FY2024); FY2025/FY2026 columns from the FY2027 Proposed Budget"></sup> These are the town's budgetary-basis General Fund numbers: the money the Finance Committee builds the annual budget around and Town Meeting votes on. They exclude grants, school food service and athletics fees, and state on-behalf payments into the teachers pension fund, which together total roughly $26 million a year in additional money the town does not directly control.</p>
 
   <p>Six categories account for all of that $35.7 million in growth.</p>
 
@@ -196,7 +196,7 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
 
   <p>Schools drove nearly half of the $35.7 million in growth, adding $17.0 million (a 53 percent increase). Health insurance added $4.7 million (45 percent). Public safety added $3.9 million (54 percent). Debt payments added $3.8 million (70 percent). Pensions, measured on a budgetary basis, added $3.1 million (136 percent). The remaining $3.1 million came from "everything else", the catch-all bucket that includes public works, the library, the Council on Aging, state and county charges, and every other general fund line.</p>
 
-  <p>Schools is the biggest dollar pull, so it is worth unpacking. From 2015 to 2024, the most recent year with closed-book actuals, the schools line grew from $32.1 million to $46.2 million in nominal dollars. After inflation (the consumer price index rose about 31 percent over the same window), the picture changes:</p>
+  <p>Schools is the biggest dollar pull, so it is worth unpacking. From 2015 to 2024, the most recent year with closed-book actuals, the schools line grew from $32.1 million to $46.2 million in nominal dollars. After inflation (the consumer price index rose about 31 percent over the same window), the picture changes:<sup class="cite" data-href="data/cpi_us.csv" data-source="BLS Consumer Price Index for All Urban Consumers, U.S. City Average, annual averages (CUUR0000SA0); schools line from Marblehead ACFR schedules"></sup></p>
 
   <div class="stat-compare stat-compare--diverge">
     <div class="stat-row">

--- a/why-not-elsewhere.html
+++ b/why-not-elsewhere.html
@@ -135,7 +135,7 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
   </div>
 
   <h2 data-stance-section="residential-share">Residential share of the tax levy, FY2026</h2>
-  <p>When a homeowner in Marblehead pays their tax bill, 95.5&cent; of every dollar the town collects in property tax comes from residential property. In Cambridge, that figure is 33.8&cent;. The rest comes from commercial, industrial, and personal property taxes. Towns with a large commercial base can spread cost increases across office parks, labs, and retail instead of concentrating them on homeowners; towns without one can't. This isn't a statement about which model is better. It's a statement about what each town's tax revenue depends on.</p>
+  <p>When a homeowner in Marblehead pays their tax bill, 95.5&cent; of every dollar the town collects in property tax comes from residential property. In Cambridge, that figure is 33.8&cent;.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=propertytaxinformation.taxlevies.leviesbyclass" data-source="MA DOR, Tax Levies by Class FY2026 (Marblehead 95.5% residential, Cambridge 33.8% residential)"></sup> The rest comes from commercial, industrial, and personal property taxes. Towns with a large commercial base can spread cost increases across office parks, labs, and retail instead of concentrating them on homeowners; towns without one can't. This isn't a statement about which model is better. It's a statement about what each town's tax revenue depends on.</p>
 
   <div class="peer-chart">
     <h3>% of Total Property Tax Levy Paid by Residential</h3>
@@ -174,7 +174,7 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
   <h2 data-stance-section="new-growth">New growth: the other lever</h2>
   <p>Proposition 2&frac12; caps annual levy growth at 2.5%, but new construction (new homes, new office buildings, additions and renovations) adds to the levy ceiling outside that cap. DOR calls this "new growth." In towns with active development, the levy limit expands every year from new construction alone, without an override vote.</p>
 
-  <p>Marblehead's 5-year average new growth is 0.54% of prior-year levy, which works out to roughly $460,000 per year added to the levy ceiling. Needham, the top residential-adjacent suburb in the peer set by this metric, averages 2.83%, about $4.1 million per year. Cambridge averages 2.74% on a levy five times larger than Marblehead's: around $18 million per year. Whether this difference is a structural advantage for the commercial towns or a price paid by their residents (in traffic, scale, or lost small-town character) depends on what you value.</p>
+  <p>Marblehead's 5-year average new growth is 0.54% of prior-year levy, which works out to roughly $460,000 per year added to the levy ceiling. Needham, the top residential-adjacent suburb in the peer set by this metric, averages 2.83%, about $4.1 million per year. Cambridge averages 2.74% on a levy five times larger than Marblehead's: around $18 million per year.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdPage.aspx?rdReport=NewGrowth.NewGrowth_dash_v2_test" data-source="MA DOR, New Growth Analysis (5-year averages FY2022-FY2026 for Marblehead, Needham, and Cambridge)"></sup> Whether this difference is a structural advantage for the commercial towns or a price paid by their residents (in traffic, scale, or lost small-town character) depends on what you value.</p>
 
   <div class="peer-chart">
     <h3>5-yr Avg New Growth as % of Prior-Year Levy Limit</h3>


### PR DESCRIPTION
## Summary

Completes the comprehensive citation rollout that started with the debate page (PR #81). Adds \`<sup class=\"cite\">\` markers to the main prose of the remaining six content pages.

Each page got its markers in a separate commit so they're individually reviewable.

## Per-page changes

- **how-we-got-here.html** — 4 markers: 2005 supplemental override (DOR), sixteen-year streak (2021 FinCom Report), 2023 ballot vote totals (Town Meeting minutes), three-tier structure (2026 State of the Town presentation).
- **no-override-budget.html** — 3 markers: Marblehead Independent library quote, 2021 Abbot Library debt exclusion (DOR), and the Melrose/Stoneham case studies.
- **where-has-the-money-gone.html** — 3 markers on top-line prose stats: property tax levy doubling (ACFR schedules), \$70.5M→\$106.2M General Fund growth (ACFR), and CPI inflation adjustment (BLS CPI-U).
- **why-not-elsewhere.html** — 2 markers: the 95.5% residential claim (DOR Tax Levies by Class) and the new growth comparison (DOR New Growth Analysis).
- **what-is-the-override.html** — 2 markers: the 2005 override history (DOR) and the 4-of-13 / 28-of-29 ballot summary statistic (marblehead_prop25_votes.csv).
- **senior-tax-relief.html** — 4 markers: the \$2,820 Circuit Breaker cap (MA DOR TIR 25-7), H.4225 status, Article 28 Town Meeting passage (Itemlive), and the H.4225 bill page.

Total: ~18 new citation markers across 6 pages.

## Why the density is lower than the debate page

The debate page had 29 markers because its argument lives entirely in prose — no cards, no chart footers. The other pages are much more card- and chart-heavy, and those components already use the \`<p class=\"source\">\` footer pattern. Adding \`sup.cite\` markers to claims that are already cited 5 lines below in a card footer is double-counting. I added markers only where prose makes factual claims that are not otherwise attributed inline.

## Test plan

- [ ] Each of the six pages renders a Sources section at the bottom, before any \`.notes\` block
- [ ] All superscript markers are navy-colored and unobtrusive
- [ ] Clicking a marker scrolls below the sticky nav to the matching source entry
- [ ] Back-links scroll back to the in-text marker below the sticky nav
- [ ] No JS console errors on any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)