### PR TITLE
Remove dead .tag-text CSS and unused color tokens

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -62,8 +62,6 @@
   /* Tag colors (category pills) */
   --tag-chart-bg:   #E6F0EE;
   --tag-chart-fg:   #2F6356;
-  --tag-text-bg:    #E3ECF4;
-  --tag-text-fg:    #1B3A57;
   --tag-data-bg:    #F4EBD6;
   --tag-data-fg:    #7A5A15;
 
@@ -111,8 +109,6 @@
 
     --tag-chart-bg: #132B27;
     --tag-chart-fg: #8FC6B7;
-    --tag-text-bg:  #13202E;
-    --tag-text-fg:  #8AB0C4;
     --tag-data-bg:  #2A220F;
     --tag-data-fg:  #E4B363;
 
@@ -599,7 +595,6 @@ p a:hover { text-decoration: underline; }
   align-self: flex-start;
 }
 .tag-charts { background: var(--tag-chart-bg); color: var(--tag-chart-fg); }
-.tag-text   { background: var(--tag-text-bg);  color: var(--tag-text-fg); }
 .tag-data   { background: var(--tag-data-bg);  color: var(--tag-data-fg); }
 
 @media (max-width: 600px) {
@@ -2208,16 +2203,6 @@ blockquote.quote--mixed p {
   color: var(--text-subtle);
   line-height: 1.55;
   margin-bottom: 12px;
-}
-.featured-card .tag {
-  display: inline-block;
-  font-size: 10px;
-  font-weight: 700;
-  padding: 3px 9px;
-  border-radius: 100px;
-  letter-spacing: 0.3px;
-  background: var(--tag-text-bg);
-  color: var(--tag-text-fg);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
Housekeeping. After PR #67 removed the featured-card tag and PR #79 collapsed homepage text-card tags to no tag, `.tag-text` and `.featured-card .tag` are unreachable CSS. Dropped both rules plus the `--tag-text-bg` and `--tag-text-fg` custom properties from both light and dark themes.

## Changes
- `assets/site.css:62-68` — removed `--tag-text-bg: #E3ECF4;` and `--tag-text-fg: #1B3A57;` from the light-theme `:root` block
- `assets/site.css:112-113` — removed the same tokens from the dark-theme `@media` block
- `assets/site.css:598` — removed the `.tag-text { background: var(--tag-text-bg); color: var(--tag-text-fg); }` rule
- `assets/site.css:2207-2216` — removed the `.featured-card .tag { ... }` rule

## Kept
- `.tag-charts` (Chart, Calculator pills on the homepage)
- `.tag-data` (data-links badges in the homepage Data & Sources section)
- The base `.question .tag` rule

## Verification
- `grep -n 'tag-text' assets/site.css` → 0 hits
- `grep -rn 'tag-text' --include='*.html'` → 0 hits on live HTML
- Only remaining references are in `docs/superpowers/plans/` which is Jekyll-excluded per `_config.yml:4` and archival historical plan documents. Not touching those.

Net: 15 lines removed, no behavior change.