### PR TITLE
Widen Master Dataset page on desktop

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -2047,6 +2047,18 @@ blockquote.quote--mixed p {
 
 /* --- Wide table (default, desktop) --- */
 .master-wide { display: block; margin: 16px 0 24px; }
+
+/* On the Master Dataset page only, widen the whole .page container on
+   desktop so the heading, subtitle, and wide data table all share the
+   same left and right edges. Scoped via body.doc-page--wide (set in the
+   master-data frontmatter) so other doc pages keep the narrow 720px
+   container that's sized for readable prose. Capped at 1400px so it
+   doesn't sprawl on very wide monitors. */
+@media (min-width: 900px) {
+  body.doc-page--wide .page {
+    max-width: min(1400px, calc(100vw - 40px));
+  }
+}
 .master-scroll {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;

--- a/data/master-data.html
+++ b/data/master-data.html
@@ -1,6 +1,6 @@
 ---
 layout: page
-body_class: doc-page
+body_class: doc-page doc-page--wide
 title: Master Dataset
 ---
 


### PR DESCRIPTION
The Master Dataset page is a 17-column data table that was squeezed into the default `.page` container (`--page-max: 720px`), which is sized for prose readability. On desktop most of the columns were hidden behind horizontal scroll even though the viewport had room to show them.

## Fix

Opt-in modifier: `body.doc-page--wide` widens the whole `.page` container to `min(1400px, calc(100vw - 40px))` at viewports ≥ 900px. The heading, subtitle, instruction note, and data table all share the same left and right edges, so the layout reads as one coherent block rather than T-shaped.

Applied only to `data/master-data.html` via `body_class: doc-page doc-page--wide` in the frontmatter. No other page uses the modifier, so the rest of the site keeps its narrow prose-optimized container.

## Tested

Verified visually at 1440, 1200, and 800 viewport widths via a local test harness:

- **1440px:** wide container at 1400px, all 17 columns visible in the table without horizontal scroll, heading and table aligned on both edges
- **1200px:** container shrinks to (1200 - 40) = 1160px, table fits with the `.master-scroll` handling any overflow, heading and table still share edges
- **800px:** media query doesn't apply (breakpoint is 900px), default 720px narrow container stays in effect
- **≤720px:** no change; mobile card view still active per the existing `max-width: 720px` media query

## Test plan

- [ ] Load /data/master-data on desktop — container fills more of the viewport than before
- [ ] Heading, subtitle, buttons, instruction note, and table all start and end at the same horizontal positions
- [ ] All other pages with `body_class: doc-page` (DATA_CATALOG, SOURCES, SOURCE_LOOKUP, case_studies) still use the narrow 720px container
- [ ] Mobile card view at ≤720px still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)