### PR TITLE
Stack civic-decide table into cards on mobile

### DIFF
--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -107,6 +107,63 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
     .body-card dl { grid-template-columns: 80px 1fr; font-size: 12px; }
     .tldr { padding: 16px 18px 14px; }
     .tldr li { font-size: 13px; }
+
+    /* Stack the "Who decides what" table into cards on mobile so
+       the 3-column text content doesn't wrap cell-by-cell at 390px.
+       Keeps the normal peer-table rendering on desktop. */
+    table.civic-decide-table { display: block; }
+    table.civic-decide-table thead {
+      position: absolute;
+      width: 1px; height: 1px;
+      padding: 0; margin: -1px; overflow: hidden;
+      clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+    }
+    table.civic-decide-table tbody { display: block; }
+    table.civic-decide-table tbody tr {
+      display: block;
+      background: var(--surface);
+      border-radius: var(--radius-sm);
+      box-shadow: var(--shadow-sm);
+      padding: 14px 16px 12px;
+      margin-bottom: 10px;
+    }
+    table.civic-decide-table tbody tr:last-child { margin-bottom: 0; }
+    table.civic-decide-table tbody td {
+      display: block;
+      padding: 0;
+      text-align: left;
+      border-bottom: none;
+      font-size: 13px;
+      line-height: 1.5;
+      color: var(--text-muted);
+    }
+    table.civic-decide-table tbody td:first-child {
+      font-size: 14px;
+      color: var(--text);
+      padding-bottom: 6px;
+      margin-bottom: 8px;
+      border-bottom: 1px solid var(--divider);
+    }
+    table.civic-decide-table tbody td:nth-child(2),
+    table.civic-decide-table tbody td:nth-child(3) {
+      padding-top: 6px;
+    }
+    table.civic-decide-table tbody td:nth-child(2)::before {
+      content: "Who decides";
+      display: block;
+      font-size: 10px; font-weight: 700;
+      text-transform: uppercase; letter-spacing: 0.6px;
+      color: var(--text-subtle);
+      margin-bottom: 2px;
+    }
+    table.civic-decide-table tbody td:nth-child(3)::before {
+      content: "How residents engage";
+      display: block;
+      font-size: 10px; font-weight: 700;
+      text-transform: uppercase; letter-spacing: 0.6px;
+      color: var(--text-subtle);
+      margin-bottom: 2px;
+    }
   }
 </style>
 
@@ -176,7 +233,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
 <h2>Who decides what</h2>
 <p>Most civic decisions in Marblehead are distributed across several bodies, each with different authority. Knowing which body handles which decision is the difference between writing the right email and writing to no one.</p>
 
-<table class="peer-table">
+<table class="peer-table civic-decide-table">
   <thead>
     <tr>
       <th>Decision</th>


### PR DESCRIPTION
## Summary
The "Who decides what" table on `what-you-can-do.html` has three columns of text (decision / who decides / how to engage) and renders with browser-default HTML table styling — there is no shared `.peer-table` CSS on that page, so the existing desktop appearance is whatever the browser does by default. At 390px viewport width, the three columns squish badly.

This change adds a page-scoped mobile treatment that:
- Tags the table `class="peer-table civic-decide-table"`
- Hides `<thead>` via the visually-hidden clip pattern
- Turns each `<tbody> tr` into a card with the decision name as a header and `::before` labels ("Who decides" / "How residents engage") on the other two cells

Scoped via `table.civic-decide-table` inside the existing `@media (max-width: 600px)` block, so desktop rendering is unchanged.

## Test plan
- [ ] Visit what-you-can-do.html in a desktop browser — table renders unchanged (plain HTML table)
- [ ] Resize to 390px or check in mobile devtools — table stacks into cards with labels
- [ ] No regressions on `why-not-elsewhere.html` (which has its own page-scoped `.peer-table` styles)

## Context
This branch was created earlier today (base: commit 09e7a4c after PR #92) and sat unpushed in a worktree until now. No conflicting commits touch `what-you-can-do.html` in the interim; rebased cleanly onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
