### PR TITLE
Remove dead .tag-text CSS and --tag-text-* tokens

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -62,8 +62,6 @@
   /* Tag colors (category pills) */
   --tag-chart-bg:   #E6F0EE;
   --tag-chart-fg:   #2F6356;
-  --tag-text-bg:    #E3ECF4;
-  --tag-text-fg:    #1B3A57;
   --tag-data-bg:    #F4EBD6;
   --tag-data-fg:    #7A5A15;
 
@@ -111,8 +109,6 @@
 
     --tag-chart-bg: #132B27;
     --tag-chart-fg: #8FC6B7;
-    --tag-text-bg:  #13202E;
-    --tag-text-fg:  #8AB0C4;
     --tag-data-bg:  #2A220F;
     --tag-data-fg:  #E4B363;
 
@@ -599,7 +595,6 @@ p a:hover { text-decoration: underline; }
   align-self: flex-start;
 }
 .tag-charts { background: var(--tag-chart-bg); color: var(--tag-chart-fg); }
-.tag-text   { background: var(--tag-text-bg);  color: var(--tag-text-fg); }
 .tag-data   { background: var(--tag-data-bg);  color: var(--tag-data-fg); }
 
 @media (max-width: 600px) {
@@ -2220,16 +2215,6 @@ blockquote.quote--mixed p {
   color: var(--text-subtle);
   line-height: 1.55;
   margin-bottom: 12px;
-}
-.featured-card .tag {
-  display: inline-block;
-  font-size: 10px;
-  font-weight: 700;
-  padding: 3px 9px;
-  border-radius: 100px;
-  letter-spacing: 0.3px;
-  background: var(--tag-text-bg);
-  color: var(--tag-text-fg);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
Removes dead CSS from `assets/site.css`:

- `.tag-text` class declaration (line 602) — no HTML in the repo uses `class="tag-text"`
- `--tag-text-bg` / `--tag-text-fg` custom properties (lines 65-66 light, 114-115 dark)
- `.featured-card .tag` rule (lines 2224-2233) — the only consumer of those tokens, but the single `.featured-card` element on `index.html:14` has no `.tag` child, so the rule matches nothing

All four pieces are interdependent dead code. Removing them together leaves no dangling `var()` references.

## Verification
Grep across all HTML/CSS/JS for `tag-text` (excluding archived plan docs in `docs/superpowers/`) returns zero matches after this change.

## Test plan
- [ ] Homepage `.featured-card` still renders correctly (only affected by the `.tag` child rule, which matched nothing before)
- [ ] No visual regressions on any page that uses `.tag-charts` or `.tag-data` (those tokens are untouched)

## Context
This branch was created earlier today (base: commit 09e7a4c after PR #92) and sat unpushed in a worktree until now. Rebased cleanly onto current main — the only site.css commit since (PR #96 adding `.master-wide` desktop styles at line ~2047) does not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
