### PR TITLE
Link trash blurb after Q2 sample ballot to dedicated trash page

### DIFF
--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -197,7 +197,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
       </div>
     </div>
   </div>
-  <p>Question 2 is independent of Question 1. Either way, residents pay for trash: the override spreads the cost by home value, while the Board of Health's fallback is a flat fee of roughly $262 per household.</p>
+  <p>Question 2 is independent of Question 1. Either way, residents pay for trash: the override spreads the cost by home value, while the Board of Health's fallback is a flat fee of roughly $262 per household. See <a href="question-2-trash.html">Trash: levy or fee?</a> for the full walkthrough.</p>
 
   <h2 data-stance-section="what-it-costs">What It Costs</h2>
   <p>The override phases in over three years (FY27 to FY29). Year 1 draws only a fraction of the full amount; the full override is active only in Year 3:</p>


### PR DESCRIPTION
## Summary
The `tier-card--trash` block in the three-tier section of `what-is-the-override.html` already linked to `question-2-trash.html`, but the paragraph immediately after the Q2 sample ballot did not. That's the most natural point for a reader to want to dig into the trash question (they just read the ballot text), so it should link to the dedicated walkthrough.

One-line change: appends `See <a href="question-2-trash.html">Trash: levy or fee?</a> for the full walkthrough.` to the existing sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
