### PR TITLE
Rename debate page tensions to dividing lines and wordsmith intro

### DIFF
--- a/the-debate.html
+++ b/the-debate.html
@@ -1,12 +1,12 @@
 ---
 title: "Both sides of the override debate"
 og_title: "Both sides of the override debate"
-og_description: The six tensions in the FY27 override debate, presented as the strongest version of each side's case. A map of where the real disagreements are, for readers still working through their vote.
+og_description: The six dividing lines in the FY27 override debate, presented as the strongest version of each side's case. A map of where the real disagreements are, for readers still working through their vote.
 og_url: https://marbleheaddata.org/the-debate.html
 community_pulse: off-sections
 ---
 <style>
-  /* Perspective blocks: one per side per tension */
+  /* Perspective blocks: one per side per dividing line */
   .perspective {
     border-radius: 0 10px 10px 0;
     padding: 18px 22px 16px;
@@ -41,7 +41,7 @@ community_pulse: off-sections
     margin-bottom: 0;
   }
 
-  /* Mini-synthesis: the quieter block between tensions */
+  /* Mini-synthesis: the quieter block between dividing lines */
   .mini-synthesis {
     margin: 20px 0 28px;
     padding: 14px 0 0;
@@ -62,7 +62,7 @@ community_pulse: off-sections
     font-weight: 700;
   }
 
-  /* Tension headings */
+  /* Dividing line headings (class kept as .tension-heading) */
   .tension-heading {
     margin-top: 40px;
     font-size: 20px;
@@ -74,7 +74,7 @@ community_pulse: off-sections
     font-style: italic;
   }
 
-  /* Meta-note: the "these tensions aren't all the same kind" callout above the TL;DR */
+  /* Meta-note: the "these dividing lines aren't all the same kind" callout above the TL;DR */
   .meta-note {
     font-size: 14px;
     color: var(--text-muted);
@@ -115,7 +115,7 @@ community_pulse: off-sections
     line-height: 1.55;
   }
 
-  /* TL;DR section: visually promote the summary above the five tensions */
+  /* TL;DR section: visually promote the summary above the six dividing lines */
   .tldr {
     background: color-mix(in srgb, var(--c-navy) 3%, var(--surface));
     border: 1px solid var(--border);
@@ -261,10 +261,10 @@ community_pulse: off-sections
 </style>
 
 <h1>Both sides of the override debate</h1>
-  <p>Marblehead's override is on the June ballot. If you're working through how to vote, this page is for you. It maps the six tensions in the debate, with the strongest version of each side of each one.</p>
+  <p>Marblehead's override is on the June ballot. If you're working through how to vote, this page is for you. It maps the six dividing lines in the debate, with the strongest version of each side of each one.</p>
 
   <div class="meta-note">
-    <p>The override debate isn't one argument. It's four kinds, mixed together:</p>
+    <p>The override debate isn't one argument. It's four questions, tangled together:</p>
     <dl class="meta-note-list">
       <dt>Facts</dt>
       <dd>Are costs rising from things we can't control, or from choices we made?</dd>
@@ -275,7 +275,7 @@ community_pulse: off-sections
       <dt>Governance</dt>
       <dd>Do you trust the town to spend more money wisely?</dd>
     </dl>
-    <p>Most real disagreements blend all four. Helping you answer them for yourself is the whole point of this site. Notice which one feels loudest as you read the tensions below.</p>
+    <p>Real disagreements rarely stay in one lane. Helping you answer these questions for yourself is the whole point of this site. As you read the dividing lines below, notice which of the four matter most to you, and decide which should weigh most in how you vote.</p>
   </div>
 
   <div class="tldr">
@@ -293,7 +293,7 @@ community_pulse: off-sections
     </div>
   </div>
 
-  <h2 class="tension-heading">Tension 1. Where does the cost pressure come from?</h2>
+  <h2 class="tension-heading">1. Where does the cost pressure come from?</h2>
   <p class="tension-framing">Both sides agree costs are rising faster than revenue. They disagree on whether the town chose those costs or they happened to it.</p>
 
   <div class="perspective perspective--for">
@@ -310,7 +310,7 @@ community_pulse: off-sections
     <p><strong>Where they actually disagree:</strong> whether a cost the town could in principle renegotiate counts as "external" depends on whether you are looking at a 12-week budget cycle or a 5-year planning horizon. Both sides are answering different versions of the question. Most of the items the against side names (the 83/17 split, the 20-hour benefits threshold, contract provisions) are subject to collective bargaining under MGL c. 150E and can only be renegotiated at contract renewal, typically every 2&ndash;3 years. Long-horizon controllable; short-horizon fixed.</p>
   </div>
 
-  <h2 class="tension-heading">Tension 2. Are the proposed reductions damage or discipline?</h2>
+  <h2 class="tension-heading">2. Are the proposed reductions damage or discipline?</h2>
   <p class="tension-framing">The no-override budget is published. Both sides have read it and reached opposite conclusions. See <a href="no-override-budget.html">what's in the no-override budget</a>.</p>
 
   <div class="perspective perspective--for">
@@ -327,7 +327,7 @@ community_pulse: off-sections
     <p><strong>Where they actually disagree:</strong> whether FY26 is the correct baseline against which to measure cuts. Those for the override treat FY26 as the level of service residents have chosen and should maintain. Those against the override treat FY26 as the peak of a trajectory that should have been corrected earlier.</p>
   </div>
 
-  <h2 class="tension-heading">Tension 3. Is this a one-time reset or the start of annual asks?</h2>
+  <h2 class="tension-heading">3. Is this a one-time reset or the start of annual asks?</h2>
   <p class="tension-framing">If the override passes, does the problem go away for years, or does the same pressure rebuild immediately?</p>
 
   <div class="perspective perspective--for">
@@ -344,8 +344,8 @@ community_pulse: off-sections
     <p><strong>Where they actually disagree:</strong> whether "one-time reset" means "no override next year" or "no override for the foreseeable future." Both sides agree costs will keep rising; they disagree on whether the override's capacity absorbs that rise or just delays its arrival.</p>
   </div>
 
-  <h2 class="tension-heading">Tension 4. Do meaningful alternatives exist?</h2>
-  <p class="tension-framing">The debate turns on whether the town has real options other than override versus reductions. See <a href="why-not-elsewhere.html">why some MA towns run overrides and others don't</a> for the structural data underneath this tension.</p>
+  <h2 class="tension-heading">4. Do meaningful alternatives exist?</h2>
+  <p class="tension-framing">The debate turns on whether the town has real options other than override versus reductions. See <a href="why-not-elsewhere.html">why some MA towns run overrides and others don't</a> for the structural data underneath this question.</p>
 
   <div class="perspective perspective--for">
     <div class="perspective-label">For the override</div>
@@ -361,8 +361,8 @@ community_pulse: off-sections
     <p><strong>Where they actually disagree:</strong> whether "meaningful alternatives" is measured over a 12-week budget cycle or a 5-year planning horizon. Both sides are answering different versions of the same question. The same time-horizon asymmetry applies in specifics: benefits reform is possible at contract renewal, zoning changes require Town Meeting votes and face historic-district and neighborhood constraints, and state aid reform requires state-level advocacy. None of these is impossible; none is fast.</p>
   </div>
 
-  <h2 class="tension-heading">Tension 5. Can we trust the people asking?</h2>
-  <p class="tension-framing">Most Prop 2&frac12; debates are about money. In Marblehead this tension is also about who decides, what they tell residents, and whether residents believe them.</p>
+  <h2 class="tension-heading">5. Can we trust the people asking?</h2>
+  <p class="tension-framing">Most Prop 2&frac12; debates are about money. In Marblehead this question is also about who decides, what they tell residents, and whether residents believe them.</p>
 
   <div class="perspective perspective--for">
     <div class="perspective-label">For the override</div>
@@ -378,7 +378,7 @@ community_pulse: off-sections
     <p><strong>Where they actually disagree:</strong> whether past behavior plus transparent process is sufficient evidence that future spending will be responsible. Those for the override read the FinCom arc as evidence of disciplined governance. Those against the override read the same arc as the pattern the override perpetuates rather than interrupts.</p>
   </div>
 
-  <h2 class="tension-heading">Tension 6. Has school staffing kept pace with enrollment?</h2>
+  <h2 class="tension-heading">6. Has school staffing kept pace with enrollment?</h2>
   <p class="tension-framing">Enrollment has fallen substantially. Classroom teacher staffing has fallen more slowly. Total school headcount has grown. Both sides draw on the same data and reach different conclusions about what it means.</p>
 
   <div class="perspective perspective--for">
@@ -396,10 +396,10 @@ community_pulse: off-sections
   </div>
 
   <h2 class="tension-heading">The cruxes, side by side</h2>
-  <p>The six tensions above are not about different facts. Both sides read the same facts: the same FY27 deficit, the same health insurance trajectory, the same Finance Committee letters, the same no-override budget, the same enrollment charts. They reach different conclusions because they apply different frames. Each tension's crux compressed into a phrase:</p>
+  <p>The six dividing lines above are not about different facts. Both sides read the same facts: the same FY27 deficit, the same health insurance trajectory, the same Finance Committee letters, the same no-override budget, the same enrollment charts. They reach different conclusions because they apply different frames. Each one's crux, compressed into a phrase:</p>
 
   <div class="crux-map">
-    <div class="crux-map-header crux-map-header--tension">Tension</div>
+    <div class="crux-map-header crux-map-header--tension">Dividing line</div>
     <div class="crux-map-header crux-map-header--for">For the override reads it as</div>
     <div class="crux-map-header crux-map-header--against">Against the override reads it as</div>
 
@@ -431,7 +431,7 @@ community_pulse: off-sections
   <p class="closing-statement">Both readings are honest. The choice between them depends on how you weight external pressure versus local discretion, documented warnings versus the absence of attempted reform, and whether past FinCom discipline is sufficient evidence of future spending discipline. Nothing on this site resolves those weightings for you. They are values questions dressed in budget numbers.</p>
 
   <div class="notes">
-    <p><strong>Sources and methodology.</strong> Each tension's factual claims are sourced on the linked pages: FY27 budget numbers and the no-override cut list on <a href="no-override-budget.html">what's in the no-override budget</a>; the Finance Committee transmittal letter arc on <a href="how-we-got-here.html">how we got here</a>; the ten-year spending walkthrough (which lines grew, by how much, and under which reviewers) on <a href="where-has-the-money-gone.html">where has Marblehead's money gone</a>; the peer-town structural data on <a href="why-not-elsewhere.html">why some MA towns run overrides and others don't</a>; the three-tier override structure and the ballot mechanics on <a href="what-is-the-override.html">what is the override</a>; the enrollment and staffing data on the <a href="charts/enrollment_vs_staffing.html">enrollment vs. staffing chart</a>. Statewide fiscal context: MMA, <a href="https://www.mma.org/wp-content/uploads/2025/10/MMA-APerfectStorm-HistoricFiscalPressures-report-10.9.25.pdf"><em>A Perfect Storm: Cities and Towns Face Historic Fiscal Pressures</em> (October 2025)</a>.</p>
+    <p><strong>Sources and methodology.</strong> Each dividing line's factual claims are sourced on the linked pages: FY27 budget numbers and the no-override cut list on <a href="no-override-budget.html">what's in the no-override budget</a>; the Finance Committee transmittal letter arc on <a href="how-we-got-here.html">how we got here</a>; the ten-year spending walkthrough (which lines grew, by how much, and under which reviewers) on <a href="where-has-the-money-gone.html">where has Marblehead's money gone</a>; the peer-town structural data on <a href="why-not-elsewhere.html">why some MA towns run overrides and others don't</a>; the three-tier override structure and the ballot mechanics on <a href="what-is-the-override.html">what is the override</a>; the enrollment and staffing data on the <a href="charts/enrollment_vs_staffing.html">enrollment vs. staffing chart</a>. Statewide fiscal context: MMA, <a href="https://www.mma.org/wp-content/uploads/2025/10/MMA-APerfectStorm-HistoricFiscalPressures-report-10.9.25.pdf"><em>A Perfect Storm: Cities and Towns Face Historic Fiscal Pressures</em> (October 2025)</a>.</p>
     <p><strong>Quotes.</strong> Direct quotes on this page come from local news reporting of public meetings, budget hearings, and Select Board deliberations (Marblehead Independent, Marblehead Beacon, Marblehead Current). Named officials and school administrators appear more often on the record than resident opponents of the override, who more often speak at Town Meeting, in letters to the editor, or in informal public discussion. Where the against side is represented by named officials on this page (Moses Grader, Alec Goolsby, Tom Mathers), this reflects accountability voices inside the process rather than organized opposition outside it.</p>
     <p><strong>What this page doesn't do.</strong> It does not argue for or against the override, does not summarize "the" debate, and does not engage with the minority of voters who would reject any override regardless of the specifics. Each side here is the persuadable version of its position, not the version that treats the debate as already decided.</p>
     <p><strong>Author disclosure.</strong> See <a href="about.html">about this site</a>. The author is a Marblehead homeowner who is genuinely undecided and uses this page as a tool to work through both sides.</p>


### PR DESCRIPTION
## Summary
- Replaces "tensions" with "dividing lines" across the-debate.html — plainer, more honest, and better matches the site's calm you-decide register. The old word carried a faint tectonic-drama tail.
- Drops the redundant "Tension N." heading prefix; headings are now just numbered questions (e.g. `1. Where does the cost pressure come from?`). The number preserves list rhythm without the label.
- Rewrites the meta-note block above TL;DR: "four questions, tangled together" / "Real disagreements rarely stay in one lane" / closing now asks the reader to **decide which of the four matter most to you, and which should weigh most in how you vote** (instead of "notice which feels loudest").
- Updates `og_description`, the crux-map column header, the notes paragraph, and internal CSS comments for consistency.
- Fixes a pre-existing bug: a TL;DR-section comment said "five tensions" when there are six.

CSS class names (`.tension-heading`, `.tension-framing`, `.crux-map-header--tension`) are intentionally left alone — they're stable identifiers, not copy, and a rename would risk breakage for no reader-visible benefit. Comment at line 65 flags the class-name/copy mismatch for future editors.

20 insertions, 20 deletions — every "tension" reference replaced 1-for-1.

## Test plan
- [ ] View https://marbleheaddata.org/the-debate.html after merge; confirm headings read `1.`–`6.` with no "Tension" prefix
- [ ] Confirm meta-note above TL;DR reads as rewritten
- [ ] Confirm crux-map table column header reads "Dividing line"
- [ ] Confirm no visual regressions (CSS class names unchanged, so styling should be identical)
- [ ] Confirm og_description on social shares says "six dividing lines"

🤖 Generated with [Claude Code](https://claude.com/claude-code)