### PR TITLE
Contrast Q2 full-cost with Q1 three-year phase-in

### DIFF
--- a/question-2-trash.html
+++ b/question-2-trash.html
@@ -360,6 +360,8 @@ og_url: https://marbleheaddata.org/question-2-trash.html
 
 <p>The $2,298,575 figure covers the FY27 contract cost plus a 2.5% annual buffer for FY28 and FY29 growth, in a phased draw ($2,186,516 in FY27, +$54,663 in FY28, +$57,396 in FY29). A yes vote authorizes the town to add that amount to the property tax levy beyond the Proposition 2&frac12; cap. A no vote leaves the levy at its existing cap and triggers a Board of Health curbside fee instead.</p>
 
+<p>Question 2's shape differs from Question 1. The operating override ramps over three years. At Tier 2, for example, the draw goes from $2.81M in FY27 to $8.71M in FY28 to the full $12M in FY29, because restored positions, maintenance work, and capital projects phase in over time. Question 2 hits full cost in FY27 because the new Republic Services contract starts immediately. In a Year 1 tax-bill comparison between the two questions, Q1 is still warming up while Q2 is already at steady state.</p>
+
 <h2>How trash has been funded</h2>
 
 <p>Before FY27, curbside trash and recycling was a line in the town's Waste Collection department, funded like any other general fund department: through property taxes, state aid, and local receipts.</p>


### PR DESCRIPTION
## Summary
- Adds a paragraph to `question-2-trash.html` explaining that Q1 ramps over FY27-FY29 (Tier 2: $2.81M → $8.71M → $12M) while Q2 hits full cost in FY27 because the Republic Services contract starts immediately.
- Voter-comprehension framing: in a Year 1 tax-bill comparison, Q1 is still warming up while Q2 is already at steady state.

## Test plan
- [ ] Visually confirm the new paragraph renders between the phased-draw explanation and the "How trash has been funded" heading
- [ ] Confirm no em-dashes in the new copy (per STYLE_GUIDE.md)