### PR TITLE
Fix dangling "four" reference on the-debate.html intro

### DIFF
--- a/the-debate.html
+++ b/the-debate.html
@@ -275,7 +275,7 @@ community_pulse: off-sections
       <dt>Governance</dt>
       <dd>Do you trust the town to spend more money wisely?</dd>
     </dl>
-    <p>Real disagreements rarely stay in one lane. Helping you answer these questions for yourself is the whole point of this site. As you read the dividing lines below, notice which of the four matter most to you, and decide which should weigh most in how you vote.</p>
+    <p>Real disagreements rarely stay in one lane. Helping you answer these questions for yourself is the whole point of this site. As you read the dividing lines below, notice which of these four questions matters most to you, and decide which should weigh most in how you vote.</p>
   </div>
 
   <div class="tldr">


### PR DESCRIPTION
## Summary
- The meta-note lists **four** question types (facts, interpretation, values, governance) but the closing sentence said "notice which of the four matter most to you" right after referencing the **six** dividing lines below, so "the four" read as if it were counting dividing lines.
- Rewritten to "these four questions" so the antecedent is unambiguous.

## Test plan
- [x] Eyeball the paragraph in context
- [ ] Confirm on the live site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)