### PR TITLE
Shorten nav brand to "MHD Data"

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,6 +1,6 @@
 <nav class="site-nav">
   <div class="nav-inner">
-    <a class="nav-brand" href="{{ '/' | relative_url }}">Marblehead Data</a>
+    <a class="nav-brand" href="{{ '/' | relative_url }}">MHD Data</a>
     <a href="{{ '/' | relative_url }}the-debate.html">Debate</a>
     <a href="{{ '/' | relative_url }}what-is-the-override.html">Override</a>
     <a href="{{ '/' | relative_url }}question-2-trash.html">Trash</a>


### PR DESCRIPTION
## Summary

The horizontally-scrolling mobile nav has a fixed brand slot on the left that pushes the actual page links off-screen. Shortening "Marblehead Data" → "MHD Data" saves ~7 characters in that slot so more of the page links are visible in the initial viewport before the reader has to scroll horizontally.

- **Scope:** `_includes/nav.html` only (the nav brand anchor).
- **Not touched:** page titles, OG metadata, README, homepage copy, site.css — all continue to use "Marblehead Data" as the full brand. Only the recurring top-left nav label is shortened.

## Test plan

- [ ] On a narrow viewport, confirm the nav now shows "MHD Data" plus more of the actual page links (Debate, Override, Trash, ...) visible before horizontal scroll
- [ ] On desktop, confirm the shorter brand still reads cleanly at the left edge
- [ ] `<title>` tags on pages continue to say "Marblehead Data" (they are not affected by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)