### PR TITLE
Add .takeaway--neutral variant for descriptive takeaways

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -741,6 +741,10 @@ p a:hover { text-decoration: underline; }
   background: color-mix(in srgb, var(--c-sage) 10%, var(--surface));
   border-left-color: var(--c-sage);
 }
+.takeaway.takeaway--neutral {
+  background: color-mix(in srgb, var(--text-subtle) 8%, var(--surface));
+  border-left-color: var(--text-subtle);
+}
 
 .footnotes {
   background: var(--divider);

--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -74,7 +74,7 @@ title: "How did we get here?"
   <h2 data-stance-section="vote-2026">2026: The vote before us</h2>
   <p>Here we are. The deficit the Finance Committee first signaled in 2019, explicitly predicted in 2022, partially delivered in 2023 (and defeated at the ballot), continued warning about in 2024, and specifically named for FY27 in 2025 is now on the June 2026 ballot as a three-tier override ranging from $9 million to $15 million.<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2026/02/2026-State-of-the-Town-Presenation-Final.pdf" data-source="2026 State of the Town presentation, three-tier override framework ($9M / $12M / $15M)"></sup> Residents have had roughly seven years of warning, four years of explicit deficit predictions, and three years since the first override attempt was defeated.</p>
 
-  <div class="takeaway">
+  <div class="takeaway takeaway--neutral">
     The $8.47M FY27 gap breaks into two pieces. Roughly three-quarters is specific costs going up &ndash; health insurance, pension contributions, the new curbside trash contract, and regular salary and contract increases. The remaining quarter is one-time reserves &ndash; Free Cash, interest income, motor vehicle excise &ndash; that balanced the FY26 budget but aren't available at the same level again in FY27.
   </div>
 


### PR DESCRIPTION
## Summary

Adds a third `.takeaway` variant for descriptive (non-warning, non-reassuring) content and switches the closing takeaway on `how-we-got-here.html` (shipped in #107) to use it.

## Why

The existing `.takeaway` CSS at `assets/site.css:732-743` defines only two variants:

- **Base** `.takeaway` — subtle `var(--c-buoy)` (buoy red) tint at 8%. Used for "warning / concern" framing.
- **`.takeaway--pos`** — subtle `var(--c-sage)` (salt marsh green) tint at 10%. Used for "positive / reassuring" framing.

The closing takeaway on `how-we-got-here.html` that shipped in #107 uses the base variant because neither existing option fit its content, which is a neutral factual summary of the FY27 gap composition ("$8.47M gap breaks into two pieces..."). The base variant's buoy tint reads as mild advocacy against the site's non-advocacy editorial stance from CLAUDE.md. The PR's final code review flagged this as an important editorial concern and suggested adding a neutral variant as the cleanest fix.

## What this changes

1. **`assets/site.css`** — adds `.takeaway.takeaway--neutral` using `color-mix(in srgb, var(--text-subtle) 8%, var(--surface))` for the background and `var(--text-subtle)` for the border-left. Uses only existing palette variables, both of which have dark-mode counterparts.

2. **`how-we-got-here.html`** — adds `takeaway--neutral` to the class list of the closing takeaway div at line 77.

The opening `.takeaway--pos` at `how-we-got-here.html:7` is unchanged. Sage green there intentionally signals the reassuring framing (that FinCom restraint over 16 years rebuts the "board always wants more" skepticism).

## Test plan

- [x] CSS change uses only existing variables (both have dark-mode counterparts in `assets/site.css:89-103`)
- [x] Only the closing takeaway switches variants; the opening stays as `--pos`
- [ ] Visual check on how-we-got-here.html after merge — confirm the closing takeaway now reads as descriptive rather than cautionary
- [ ] Dark mode spot check

🤖 Generated with [Claude Code](https://claude.com/claude-code)