### PR TITLE
Wire current-page highlight and scroll-into-view on mobile nav

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,15 +1,26 @@
 <nav class="site-nav">
   <div class="nav-inner">
     <a class="nav-brand" href="{{ '/' | relative_url }}">MHD Data</a>
-    <a href="{{ '/' | relative_url }}the-debate.html">Debate</a>
-    <a href="{{ '/' | relative_url }}what-is-the-override.html">Override</a>
-    <a href="{{ '/' | relative_url }}question-2-trash.html">Trash</a>
-    <a href="{{ '/' | relative_url }}how-we-got-here.html">History</a>
-    <a href="{{ '/' | relative_url }}where-has-the-money-gone.html">Spending</a>
-    <a href="{{ '/' | relative_url }}no-override-budget.html">No-Override</a>
-    <a href="{{ '/' | relative_url }}why-not-elsewhere.html">Peer Towns</a>
-    <a href="{{ '/' | relative_url }}senior-tax-relief.html">Senior Relief</a>
-    <a href="{{ '/' | relative_url }}what-you-can-do.html">Civic Guide</a>
-    <a href="{{ '/' | relative_url }}about.html">About</a>
+    <a href="{{ '/' | relative_url }}the-debate.html"{% if page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Debate</a>
+    <a href="{{ '/' | relative_url }}what-is-the-override.html"{% if page.url == '/what-is-the-override.html' %} aria-current="page"{% endif %}>Override</a>
+    <a href="{{ '/' | relative_url }}question-2-trash.html"{% if page.url == '/question-2-trash.html' %} aria-current="page"{% endif %}>Trash</a>
+    <a href="{{ '/' | relative_url }}how-we-got-here.html"{% if page.url == '/how-we-got-here.html' %} aria-current="page"{% endif %}>History</a>
+    <a href="{{ '/' | relative_url }}where-has-the-money-gone.html"{% if page.url == '/where-has-the-money-gone.html' %} aria-current="page"{% endif %}>Spending</a>
+    <a href="{{ '/' | relative_url }}no-override-budget.html"{% if page.url == '/no-override-budget.html' %} aria-current="page"{% endif %}>No-Override</a>
+    <a href="{{ '/' | relative_url }}why-not-elsewhere.html"{% if page.url == '/why-not-elsewhere.html' %} aria-current="page"{% endif %}>Peer Towns</a>
+    <a href="{{ '/' | relative_url }}senior-tax-relief.html"{% if page.url == '/senior-tax-relief.html' %} aria-current="page"{% endif %}>Senior Relief</a>
+    <a href="{{ '/' | relative_url }}what-you-can-do.html"{% if page.url == '/what-you-can-do.html' %} aria-current="page"{% endif %}>Civic Guide</a>
+    <a href="{{ '/' | relative_url }}about.html"{% if page.url == '/about.html' %} aria-current="page"{% endif %}>About</a>
   </div>
 </nav>
+<script>
+  (function () {
+    if (!window.matchMedia || !window.matchMedia('(max-width: 799px)').matches) return;
+    var navInner = document.querySelector('nav.site-nav .nav-inner');
+    if (!navInner) return;
+    var current = navInner.querySelector('a[aria-current="page"]');
+    if (!current) return;
+    var target = current.offsetLeft - (navInner.clientWidth - current.offsetWidth) / 2;
+    navInner.scrollLeft = Math.max(0, target);
+  })();
+</script>


### PR DESCRIPTION
## Summary

`assets/site.css:232-235` already had styling for `nav.site-nav a[aria-current="page"]` (darker color, bold weight) but nothing in the repo ever set the `aria-current` attribute, so the rule was dead code. On a mobile viewport the nav is horizontally scrollable and most page links sit off-screen — which meant even first-time visitors couldn't see where in the nav the current page lives.

Two small changes to `_includes/nav.html`:

1. **Static highlight.** `aria-current="page"` is set at build time via a Liquid `page.url` comparison on each link. No JS cost; the highlight lights up before the browser parses anything.
2. **Scroll-into-view on mobile.** Inline script runs only on viewports under 800px (matching the existing media query in site.css that disables the fade mask on desktop). It centers the current link inside the `.nav-inner` scroll container by setting `scrollLeft` directly. Window scroll is never affected.

## Verification

Tested against the live site with Playwright at a 390×844 iPhone viewport, injecting the same logic via devtools:

- **Senior Relief** (off-screen right at offsetLeft 657 in a 358px-wide scroll container): scrolled the nav so Senior Relief is visually centered; `window.scrollY` stayed at 0.
- **Debate** (already visible at offsetLeft ~155): no over-scroll, nav stays at scrollLeft 0.
- **Homepage** (no matching link): script is a clean no-op with no error.

## Test plan

- [ ] On mobile, navigate to /senior-tax-relief.html and confirm "Senior Relief" is visible in the nav with bold weight
- [ ] On mobile, navigate to /the-debate.html and confirm "Debate" is visible and highlighted, no horizontal over-scroll
- [ ] On desktop, confirm the nav behavior is unchanged (no fade mask, no scroll, current page still bolded)
- [ ] On the homepage, confirm no element gets aria-current and no JS error appears in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)