### PR TITLE
Add read-next block to the-debate.html

### DIFF
--- a/the-debate.html
+++ b/the-debate.html
@@ -430,6 +430,22 @@ community_pulse: off-sections
 
   <p class="closing-statement">Both readings are honest. The choice between them depends on how you weight external pressure versus local discretion, documented warnings versus the absence of attempted reform, and whether past FinCom discipline is sufficient evidence of future spending discipline. Nothing on this site resolves those weightings for you. They are values questions dressed in budget numbers.</p>
 
+  <div class="read-next">
+    <div class="read-next-label">Read next</div>
+    <a class="read-next-link" href="what-you-can-do.html">
+      <div class="read-next-title">What can you do? &rarr;</div>
+      <div class="read-next-desc">Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight.</div>
+    </a>
+    <a class="read-next-link" href="what-is-the-override.html">
+      <div class="read-next-title">What is the override? &rarr;</div>
+      <div class="read-next-desc">The three-tier structure, what each tier funds, key terms, and history.</div>
+    </a>
+    <a class="read-next-link" href="how-we-got-here.html">
+      <div class="read-next-title">How did we get here? &rarr;</div>
+      <div class="read-next-desc">Seven years of Finance Committee warnings, in their own words. The FY27 override was predicted, in writing, as far back as 2019.</div>
+    </a>
+  </div>
+
   <div class="notes">
     <p><strong>Sources and methodology.</strong> Each dividing line's factual claims are sourced on the linked pages: FY27 budget numbers and the no-override cut list on <a href="no-override-budget.html">what's in the no-override budget</a>; the Finance Committee transmittal letter arc on <a href="how-we-got-here.html">how we got here</a>; the ten-year spending walkthrough (which lines grew, by how much, and under which reviewers) on <a href="where-has-the-money-gone.html">where has Marblehead's money gone</a>; the peer-town structural data on <a href="why-not-elsewhere.html">why some MA towns run overrides and others don't</a>; the three-tier override structure and the ballot mechanics on <a href="what-is-the-override.html">what is the override</a>; the enrollment and staffing data on the <a href="charts/enrollment_vs_staffing.html">enrollment vs. staffing chart</a>. Statewide fiscal context: MMA, <a href="https://www.mma.org/wp-content/uploads/2025/10/MMA-APerfectStorm-HistoricFiscalPressures-report-10.9.25.pdf"><em>A Perfect Storm: Cities and Towns Face Historic Fiscal Pressures</em> (October 2025)</a>.</p>
     <p><strong>Quotes.</strong> Direct quotes on this page come from local news reporting of public meetings, budget hearings, and Select Board deliberations (Marblehead Independent, Marblehead Beacon, Marblehead Current). Named officials and school administrators appear more often on the record than resident opponents of the override, who more often speak at Town Meeting, in letters to the editor, or in informal public discussion. Where the against side is represented by named officials on this page (Moses Grader, Alec Goolsby, Tom Mathers), this reflects accountability voices inside the process rather than organized opposition outside it.</p>

--- a/the-debate.html
+++ b/the-debate.html
@@ -432,10 +432,6 @@ community_pulse: off-sections
 
   <div class="read-next">
     <div class="read-next-label">Read next</div>
-    <a class="read-next-link" href="what-you-can-do.html">
-      <div class="read-next-title">What can you do? &rarr;</div>
-      <div class="read-next-desc">Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight.</div>
-    </a>
     <a class="read-next-link" href="what-is-the-override.html">
       <div class="read-next-title">What is the override? &rarr;</div>
       <div class="read-next-desc">The three-tier structure, what each tier funds, key terms, and history.</div>
@@ -443,6 +439,10 @@ community_pulse: off-sections
     <a class="read-next-link" href="how-we-got-here.html">
       <div class="read-next-title">How did we get here? &rarr;</div>
       <div class="read-next-desc">Seven years of Finance Committee warnings, in their own words. The FY27 override was predicted, in writing, as far back as 2019.</div>
+    </a>
+    <a class="read-next-link" href="what-you-can-do.html">
+      <div class="read-next-title">What can you do? &rarr;</div>
+      <div class="read-next-desc">Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight.</div>
     </a>
   </div>
 


### PR DESCRIPTION
The debate page was the only main content page without a read-next
block. Its closing paragraph pivots from facts to values ("they are
values questions dressed in budget numbers"), so the natural next step
is civic engagement: what can you do, how does the ballot work, and
the long-horizon FinCom warning arc.

Links: what-you-can-do, what-is-the-override, how-we-got-here. Copy is
reused verbatim from the same targets' descriptions on other pages for
site-wide consistency.