### PR TITLE
Rework ambiguous "schools after inflation" hero tile

### DIFF
--- a/where-has-the-money-gone.html
+++ b/where-has-the-money-gone.html
@@ -60,8 +60,8 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
       <div class="key-stat-label">Schools share of growth</div>
     </div>
     <div class="key-stat">
-      <div class="key-stat-value">+10%</div>
-      <div class="key-stat-label">Schools, after inflation</div>
+      <div class="key-stat-value">$32M&rarr;$46M</div>
+      <div class="key-stat-label">School spending, FY15&ndash;24</div>
     </div>
     <div class="key-stat">
       <div class="key-stat-value">$7.0M</div>


### PR DESCRIPTION
## Summary

The hero tile on `where-has-the-money-gone.html` that read `+10% / SCHOOLS, AFTER INFLATION` was hard to parse at a glance:

- Label didn't say *spending* &mdash; could be read as enrollment, staffing, or anything else.
- "After inflation" required the reader to already know real-vs-nominal.
- The window (FY15&ndash;FY24) silently differed from the neighboring FY15&ndash;FY26 tile, because FY24 is the latest closed-book schools actual.
- Headlining schools against CPI alone, with no other yardstick in the tile row, is in tension with the STYLE_GUIDE rule against standalone CPI comparisons as the sole benchmark for a municipal cost category.

This PR replaces it with `$32M->$46M / SCHOOL SPENDING, FY15-24`, which mirrors tile #1's `$70M->$106M / FY15 TO FY26` nominal-range pattern. "Spending" is now explicit, the window is visible in the label, and the value is self-evidently dollars.

The real-growth figure and the CPI comparison are unchanged in the body prose a few paragraphs down (`where-has-the-money-gone.html:199` onward), where the caveat and the source citation already live.

## Test plan

- [ ] Build the Jekyll site locally and load `/where-has-the-money-gone.html`
- [ ] Verify the new tile label fits the box without awkward wrapping on desktop (>= 900px)
- [ ] Verify the mobile 2-column layout still looks right
- [ ] Confirm the body paragraph below the hero still explains the real/nominal comparison so nothing is lost

https://claude.ai/code/session_01VSZ7XbwjLW84vctgD5BiYG