### PR TITLE
Default community pulse widget to every h2 with opt-out attribute

### DIFF
--- a/assets/community-pulse/widget.js
+++ b/assets/community-pulse/widget.js
@@ -1,7 +1,10 @@
 // Community pulse widget module.
 // Loaded by each content page as a <script defer> tag.
 // Hydrates every <h2> on the page with a stance widget, unless the page
-// opts out via <body data-community-pulse="off-sections">.
+// opts out via <body data-community-pulse="off-sections"> or the
+// individual <h2> opts out via data-stance-section="off". An <h2> with
+// an explicit data-stance-section="<slug>" uses that slug as a stable
+// override; otherwise the slug is auto-derived from the heading text.
 
 /**
  * Convert a heading text into an anchor ID slug.
@@ -362,23 +365,30 @@ function wireWidget(root, db, sectionId, sectionUrl, sectionTitle, initialRecord
 }
 
 /**
- * Walk every element with a data-stance-section attribute and inject a
- * widget next to it. Widgets are opt-in only: authors add the attribute
- * to the specific headings or blocks they want to capture.
+ * Walk every <h2> on the page and inject a widget next to it, unless
+ * the page is opted out via <body data-community-pulse="off-sections">
+ * or the individual <h2> is opted out via data-stance-section="off".
+ * The slug for each section is taken from data-stance-section if
+ * present (acting as a stable override that survives heading edits),
+ * otherwise auto-derived from the heading text via slugify().
  */
 export async function hydrateWidgets() {
-  // Opt-out check (also used as a performance short-circuit via conditional script inclusion in the layout).
+  // Page-level opt-out (also used as a performance short-circuit via conditional script inclusion in the layout).
   if (document.body.dataset.communityPulse === 'off-sections') return;
 
   const pagePath = location.pathname.replace(/^\//, '') || 'index.html';
   const collectedTargets = [];
   const seenSlugs = new Set();
 
-  // Opt-in: elements with an explicit data-stance-section attribute.
-  document.querySelectorAll('[data-stance-section]').forEach(el => {
-    const slug = el.dataset.stanceSection.trim();
+  // Auto-attach: every <h2> unless explicitly opted out at the section level.
+  // Per-h2 slug override: data-stance-section="<slug>" pins a stable slug;
+  // otherwise the slug is auto-derived from the heading text.
+  document.querySelectorAll('h2:not([data-stance-section="off"])').forEach(el => {
+    const explicitSlug = el.dataset.stanceSection?.trim();
+    const slug = explicitSlug || slugify(el.textContent.trim());
     if (!slug) return;
-    // If this slug is already in use on the page, skip (author should pick a unique slug).
+    // If this slug is already in use on the page, skip. Disambiguate by adding
+    // an explicit data-stance-section="<unique-slug>" to one of the colliding h2s.
     if (seenSlugs.has(slug)) return;
     seenSlugs.add(slug);
     if (!el.id) el.id = slug;

--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -98,7 +98,7 @@ title: "How did we get here?"
     </a>
   </div>
 
-  <h2>Key terms and context</h2>
+  <h2 data-stance-section="off">Key terms and context</h2>
 
   <div class="term">
     <p><strong>Finance Committee transmittal letter</strong> -- The signed introduction to the Finance Committee's annual report, addressed "To the Residents of Marblehead," presented in the book distributed to every Town Meeting attendee. The content is the FinCom's official recommendation and context for the coming fiscal year's budget, signed by the Chair and Vice Chairs.</p>

--- a/question-2-trash.html
+++ b/question-2-trash.html
@@ -562,7 +562,7 @@ og_url: https://marbleheaddata.org/question-2-trash.html
 
 <p>The counter to that concern is that the new Republic Services contract did add genuine new cost (~$900K&ndash;$1 million) and that cost has to come from somewhere. The carve-out decision is a policy choice about whether to let that cost land in the general fund (reducing the town's ability to fund other things) or keep the general fund capacity for other needs while raising the trash cost separately. Neither direction escapes the underlying math: contracts got more expensive and someone pays.</p>
 
-<h2>What this page does not cover</h2>
+<h2 data-stance-section="off">What this page does not cover</h2>
 
 <ul>
   <li>Whether the Select Board publicly debated the carve-out decision before drafting Question 2, or how that debate went if it occurred</li>

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -477,7 +477,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
     </a>
   </div>
 
-  <h2>Key Terms</h2>
+  <h2 data-stance-section="off">Key Terms</h2>
 
   <div class="term">
     <p><strong>Prop 2.5</strong> -- State law capping annual property tax growth at 2.5%. Overrides are the only way to exceed this cap permanently.</p>

--- a/why-not-elsewhere.html
+++ b/why-not-elsewhere.html
@@ -344,7 +344,7 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
     <p><strong>Marblehead context:</strong> Marblehead is a high-wealth community by state measures and receives near the minimum per-capita state aid. The MMA's October 2025 <em>Perfect Storm</em> report documents that statewide UGGA is 25% below its 2002 level after inflation. Residential-heavy suburbs with little commercial base have fewer alternative revenue options to offset that reduction, which is part of the structural story this page describes.</p>
   </div>
 
-  <h2>What this page does and doesn't say</h2>
+  <h2 data-stance-section="off">What this page does and doesn't say</h2>
   <p>The data on this page shows that <strong>Massachusetts towns face different fiscal pressures because of different underlying structures</strong>, and that Marblehead sits at the residential-dominant, low-new-growth end of the spectrum. Several things this page does not claim, and should not be read to claim:</p>
   <ul style="font-size: 14px; color: var(--text-muted); line-height: 1.7; margin: 10px 0 10px 24px;">
     <li>It does not claim that structural factors are the <em>only</em> reason for Marblehead's FY27 deficit. Spending decisions, benefit costs, enrollment changes, and management choices also matter. Other pages on this site examine those factors in detail.</li>


### PR DESCRIPTION
## Summary

- Flips the community pulse widget from opt-in (manual `data-stance-section` per h2) to default-on (every h2 unless explicitly opted out). Reverts to the original spec's `every <h2>` model.
- Adds a per-section opt-out via `data-stance-section="off"` for legitimately meta headings.
- Leaves all 21 existing `data-stance-section="<slug>"` attributes in place as stable slug overrides, so existing reaction counts in the worker DB remain anchored to the same `section_ids`.

## Why

Hand-curating which h2s got widgets produced uneven coverage: only 21 marked h2s across 6 of 12 content pages, with `question-2-trash.html` having zero widgets despite being substantive content. From the design spec at `docs/superpowers/specs/2026-04-10-community-pulse-design.md:56`:

> Automatic: one section per `<h2>` heading. At page load... every `<h2>` element on every content page is assigned an anchor ID derived from its heading text and hydrated with a stance widget.

That's the model this PR restores. The top-of-file comment in `widget.js` already described this behavior; only the implementation had drifted to opt-in.

## What changed

- **`assets/community-pulse/widget.js`** — `hydrateWidgets()` now walks `h2:not([data-stance-section="off"])` and falls back to `slugify(textContent)` when no explicit slug is set. JSDoc and top-of-file comment updated to match.
- **`how-we-got-here.html`** — opt-out on "Key terms and context" (glossary)
- **`what-is-the-override.html`** — opt-out on "Key Terms" (glossary)
- **`why-not-elsewhere.html`** — opt-out on "What this page does and doesn't say" (page meta)
- **`question-2-trash.html`** — opt-out on "What this page does not cover" (page meta). The other 8 h2s on this page gain widgets via auto-on.

## What stays unchanged

- All page-level `community_pulse: off-sections` switches (`about.html`, `privacy.html`, `index.html`, `the-debate.html`, `what-you-can-do.html`). Notably `the-debate.html` stays off per the spec's brigading-resistance principle: "A comment thread or a public for-and-against tally would undermine the site's neutrality positioning and attract brigading from both sides of the override debate."
- All 21 existing `data-stance-section="<slug>"` attributes — they preserve the slugs that anchor existing reaction counts in the worker DB.
- The widget UI itself (stance buttons, share, note, count display).

## Coverage diff

| Page | Before | After |
|------|-------:|------:|
| `how-we-got-here.html` | 4 widgets | 6 widgets (adds 2019 + 2022 waypoint h2s; opts out "Key terms") |
| `no-override-budget.html` | 5 widgets | 5 widgets (unchanged) |
| `senior-tax-relief.html` | 4 widgets | 5 widgets (adds "5. How to actually get this") |
| `what-is-the-override.html` | 4 widgets | 4 widgets (opts out "Key Terms") |
| `where-has-the-money-gone.html` | 4 widgets | 4 widgets (unchanged) |
| `why-not-elsewhere.html` | 5 widgets | 5 widgets (opts out "What this page does and doesn't say") |
| `question-2-trash.html` | **0 widgets** | **8 widgets** (opts out "What this page does not cover") |

## Test plan

- [x] All 30 existing tests pass (`npm test` in `community-pulse/`)
- [x] Static HTML rendering verified via curl on every changed page: widget script tags present where expected, opt-out attributes serialized correctly
- [x] `the-debate.html` confirmed widget-free in rendered output (no widget script tag at all)
- [ ] Browser hydration spot-check on `question-2-trash.html` (the biggest behavior change) and `the-debate.html` (the most important non-change)

## Follow-ups (NOT in this PR)

- Flag-button reaction (`⚑ Suggest a correction` opening a pre-filled GitHub issue) — separate PR
- `_site/` is not gitignored — separate cleanup
- Decision on whether `what-you-can-do.html` should stay page-level off or get widgets
- Decision on whether the 2019 / 2022 waypoint h2s on `how-we-got-here.html` should stay as h2s with widgets or be demoted to h3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)