### PR TITLE
Add ⚑ section flag link that opens a pre-filled GitHub issue

### DIFF
--- a/assets/community-pulse/widget.css
+++ b/assets/community-pulse/widget.css
@@ -61,6 +61,7 @@
   font-weight: 500;
   line-height: 1;
   color: var(--text-muted, #666);
+  text-decoration: none;
   background: transparent;
   border: 1px solid var(--border, rgba(0,0,0,0.15));
   border-radius: 0.3rem;

--- a/assets/community-pulse/widget.js
+++ b/assets/community-pulse/widget.js
@@ -144,12 +144,32 @@ export async function incrementReaction(sectionId) {
   }
 }
 
+// ---- Section flag link --------------------------------------------------
+
+// GitHub repo for the section flag's pre-filled issue link. Hardcoded
+// to the production deployment because this widget ships only to
+// marbleheaddata.org. The flag is structurally an <a> opening the
+// issue compose page in a new tab; nothing is sent until the reader
+// hits "Submit" on GitHub, so this is opt-in by construction.
+const ISSUE_REPO = 'agbaber/marblehead';
+
+/**
+ * Build a pre-filled GitHub issue URL for flagging a possible error
+ * in a section. The reader sees the body before submitting on GitHub,
+ * so this is fully opt-in and safe to construct client-side.
+ */
+export function buildIssueUrl(sectionTitle, sectionUrl) {
+  const title = `Possible error: ${sectionTitle}`;
+  const body = `**Section:** [${sectionTitle}](${sectionUrl})\n\nDescribe the issue:\n`;
+  const params = new URLSearchParams({ title, body });
+  return `https://github.com/${ISSUE_REPO}/issues/new?${params.toString()}`;
+}
+
 // ---- Widget rendering and hydration -------------------------------------
 
 const STANCE_BUTTONS = [
   { key: 'agree',    glyph: '+', label: 'Agree' },
-  { key: 'disagree', glyph: '−', label: 'Disagree' },
-  { key: 'alert',    glyph: '!', label: 'Alert: something here caught my eye' }
+  { key: 'disagree', glyph: '−', label: 'Disagree' }
 ];
 
 let widgetCounter = 0;
@@ -158,13 +178,16 @@ let widgetCounter = 0;
  * Build the widget DOM for one section and attach it to the given parent
  * element. Returns the widget root element.
  */
-function buildWidget(sectionId, sectionTitle, initialReactions, initialStance) {
+function buildWidget(sectionId, sectionTitle, sectionUrl, initialReactions, initialStance) {
   const root = document.createElement('div');
   root.className = 'cp-widget';
   root.dataset.sectionId = sectionId;
   const widgetId = `cp-widget-${++widgetCounter}`;
 
-  // Stance buttons.
+  // Stance row: two stance buttons (agree, disagree) plus a third element
+  // that is structurally an <a> link, not a button. The flag opens a
+  // pre-filled GitHub issue in a new tab so corrections land in the
+  // issue tracker rather than in a per-stance counter on the worker.
   const buttons = document.createElement('div');
   buttons.className = 'cp-widget__buttons';
   STANCE_BUTTONS.forEach(({ key, glyph, label }) => {
@@ -177,6 +200,18 @@ function buildWidget(sectionId, sectionTitle, initialReactions, initialStance) {
     btn.setAttribute('aria-pressed', initialStance === key ? 'true' : 'false');
     buttons.appendChild(btn);
   });
+
+  // Flag link. Visually identical to a stance button (same class) but
+  // has no aria-pressed state and triggers no IndexedDB write.
+  const flag = document.createElement('a');
+  flag.className = 'cp-widget__button cp-widget__flag';
+  flag.href = buildIssueUrl(sectionTitle, sectionUrl);
+  flag.target = '_blank';
+  flag.rel = 'noopener';
+  flag.setAttribute('aria-label', 'Suggest a correction');
+  flag.textContent = '⚑';
+  buttons.appendChild(flag);
+
   root.appendChild(buttons);
 
   // Meta group: reaction count + secondary action icons. Kept as a single
@@ -424,9 +459,11 @@ export async function hydrateWidgets() {
   for (const target of collectedTargets) {
     const initialReactions = reactionsMap[target.sectionId];
     const initialRecord = stanceMap.get(target.sectionId) || null;
+    const sectionUrl = `${location.origin}${location.pathname}#${target.element.id}`;
     const widget = buildWidget(
       target.sectionId,
       target.title,
+      sectionUrl,
       initialReactions,
       initialRecord?.stance
     );
@@ -455,7 +492,7 @@ export async function hydrateWidgets() {
       widget,
       db,
       target.sectionId,
-      `${location.origin}${location.pathname}#${target.element.id}`,
+      sectionUrl,
       target.title,
       initialRecord
     );

--- a/community-pulse/tests/issue-url.test.js
+++ b/community-pulse/tests/issue-url.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { buildIssueUrl } from '../../assets/community-pulse/widget.js';
+
+describe('buildIssueUrl', () => {
+  it('returns a github.com/agbaber/marblehead/issues/new URL', () => {
+    const url = buildIssueUrl('Test section', 'https://example.com/page.html#test');
+    expect(url).toMatch(/^https:\/\/github\.com\/agbaber\/marblehead\/issues\/new\?/);
+  });
+
+  it('puts the section title in the issue title parameter', () => {
+    const url = buildIssueUrl('How the $8.47M FY27 gap is calculated', 'https://example.com/p#g');
+    const params = new URL(url).searchParams;
+    expect(params.get('title')).toBe('Possible error: How the $8.47M FY27 gap is calculated');
+  });
+
+  it('includes the section URL as a markdown link in the body', () => {
+    const url = buildIssueUrl('Test', 'https://example.com/page.html#anchor');
+    const body = new URL(url).searchParams.get('body');
+    expect(body).toContain('[Test](https://example.com/page.html#anchor)');
+  });
+
+  it('includes the writing prompt in the body', () => {
+    const url = buildIssueUrl('Test', 'https://example.com/p#a');
+    const body = new URL(url).searchParams.get('body');
+    expect(body).toContain('Describe the issue:');
+  });
+
+  it('preserves section titles with colons and dollar signs unchanged', () => {
+    const title = 'Health insurance: the $1.5M employer share';
+    const url = buildIssueUrl(title, 'https://example.com/p#a');
+    const params = new URL(url).searchParams;
+    expect(params.get('title')).toBe(`Possible error: ${title}`);
+  });
+});

--- a/community-pulse/vitest.config.js
+++ b/community-pulse/vitest.config.js
@@ -7,7 +7,7 @@ export default defineWorkersConfig({
         extends: true,
         test: {
           name: 'widget',
-          include: ['tests/slug.test.js', 'tests/store.test.js', 'tests/api.test.js'],
+          include: ['tests/slug.test.js', 'tests/store.test.js', 'tests/api.test.js', 'tests/issue-url.test.js'],
           environment: 'node',
           setupFiles: ['./tests/setup-widget.js']
         }


### PR DESCRIPTION
## Summary

Adds a "Suggest a correction" flag link as the third element in the community pulse widget's stance row, replacing the old `!` self-alert button. Clicking it opens GitHub's issue compose page in a new tab with title and body pre-filled to identify the section the reader was looking at.

## What changed

**`assets/community-pulse/widget.js`**

- New exported helper `buildIssueUrl(sectionTitle, sectionUrl)` builds a `https://github.com/agbaber/marblehead/issues/new?title=…&body=…` URL.
- `STANCE_BUTTONS` no longer contains the `alert` entry (the old `!` button).
- `buildWidget()` now appends an `<a>` element after the two stance `<button>`s, sharing the `cp-widget__button` class so it's pixel-identical to its siblings. The anchor has `target="_blank"`, `rel="noopener"`, `aria-label="Suggest a correction"`, and renders the `⚑` glyph.
- `buildWidget()` signature gains a `sectionUrl` parameter; `hydrateWidgets()` constructs the URL once and passes it to both `buildWidget()` and `wireWidget()` (replacing duplicate construction at the wireWidget call site).

**`assets/community-pulse/widget.css`**

- `.cp-widget__button` gains `text-decoration: none` so the new `<a>` rendering of that class doesn't show the default link underline.

**`community-pulse/tests/issue-url.test.js`** (new file, 5 tests)

- Validates the URL shape, the issue title, the markdown body, the writing prompt, and titles containing colons / dollar signs.

**`community-pulse/vitest.config.js`**

- Adds `tests/issue-url.test.js` to the widget project's `include` allowlist.

## Why this design

We discussed routing the flag two ways:

1. **Per-stance counter on the worker** — adds a column to the `reactions` table and surfaces a flag count. Pro: low friction. Con: builds a private analytics surface that the privacy page doesn't currently describe; can't tell *why* something was flagged, only *that* it was.
2. **Pre-filled GitHub issue** ✓ — no schema change, no migration, no analytics surface. Reader sees the body in GitHub's UI before submitting (opt-in by construction). Lands signal in the issue tracker where it's actually actionable, alongside the existing "Found a mistake?" affordance on `about.html` and in the footer.

The light friction of needing a GitHub account is intentional and on-brand: it self-selects for serious flaggers and avoids creating a polling surface on a site that's deliberately not a polling site.

Why the flag stays in the stance row (not in the meta row with share/note): readers see "three reaction options" exactly like before — the fact that one is structurally an anchor opening GitHub instead of a button writing to IndexedDB is invisible to them. Same shape, same hover, same position. The stance/action distinction is internal taxonomy.

## Existing reaction data

Server-side counts in the worker DB are unaffected: the `reactions` table is keyed by `section_id` and has no concept of stance type. Removing the `alert` button orphans any locally-stored "alert" stances in readers' IndexedDB, but that's per-browser private state — nobody loses anything visible, the old key just sits unused.

## Test plan

- [x] All 35 tests pass (`npm test` — 30 existing + 5 new)
- [x] Browser-verified on `question-2-trash.html`: 8 widgets, 8 flags, all `<a target="_blank" rel="noopener">` with valid GitHub URLs containing the section anchor and a markdown link to the section
- [x] Browser-verified on `no-override-budget.html`: 6 widgets, 6 flags, 12 stance buttons (2 per widget), all three elements pixel-identical (28.8 × 24.4)
- [x] Browser-verified on `the-debate.html`: 0 widgets, no widget script tag (page-level off-sections still respected)
- [ ] After deploy, click a flag in production to confirm GitHub renders the pre-filled issue body correctly with the markdown link

## Follow-ups (NOT in this PR)

- The "Sources" h2 on `no-override-budget.html` got auto-instrumented after the structure PR — may want a `data-stance-section="off"` opt-out depending on whether you consider it a substantive section or just primary-source footnotes.
- `_site/` is still not gitignored — separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)