### PR TITLE
Gitignore Jekyll's _site/ build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ __pycache__/
 community-pulse/node_modules/
 community-pulse/.wrangler/
 community-pulse/dist/
+
+# Jekyll build output (local dev only; site is built by GitHub Pages)
+_site/


### PR DESCRIPTION
## Summary

Adds `_site/` to `.gitignore` so the Jekyll local-dev build directory stops showing up as untracked content.

## Why

Any session that runs `jekyll serve` leaves `_site/` behind as untracked. Without an ignore rule, that directory could be accidentally staged with `git add .` (the structure and flag-button PRs both flagged it as a hazard during commit). The deployed site is built by GitHub Pages from source, not from a checked-in `_site/`, so this only affects local dev.

## What changed

`.gitignore` gains:

```
# Jekyll build output (local dev only; site is built by GitHub Pages)
_site/
```

Placed alongside the other build-output sections at the bottom of the file.

## Test plan

- [x] `git check-ignore -v _site/` matches `.gitignore:39:_site/`
- [x] No other tracked file is affected (single-line addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)