### PR TITLE
Tune post-restructure widget coverage across four pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,7 +1,6 @@
 ---
 title: "Who made this?"
 og_title: "Who made this?"
-community_pulse: off-sections
 ---
 <style>
 /* Page-scoped: profile disclosure callout and meta pills */
@@ -76,13 +75,13 @@ community_pulse: off-sections
 
   <p>This vote matters. So before voting, I wanted to understand two things: how we got here, and what each possible outcome would actually mean. Is this about cuts we could make, or costs rising faster than revenue? I honestly don't know. The site is where I'm working that out.</p>
 
-  <h2>How I use AI</h2>
+  <h2 data-stance-section="off">How I use AI</h2>
   <p>An AI assistant (Claude) handles the research, analysis, and digital infrastructure behind this site. Reading 39 primary-source PDFs totaling over 3,000 pages of ACFRs, DLS reports, PERAC valuations, and budget documents and turning them into charts is a good fit for what current AI tools are actually useful for. That said, they can and do make mistakes, and I don't re-verify every number against the original document myself. I try to keep it as neutral as I can. If you catch an error, the "Report an issue" link in the footer of any page opens a new GitHub issue.</p>
 
   <h2>Reactions</h2>
   <p>Some sections let you react as you read. Your reactions stay in this browser, and no one else can see which one you picked. The number next to each section is a rough measure of interest, not a poll.</p>
 
-  <h2>Costs</h2>
+  <h2 data-stance-section="off">Costs</h2>
   <div class="card">
     <div class="cut-item">
       <span class="cut-item-name">Claude AI subscription<span class="cut-item-note">Not exclusive to this site.</span></span>

--- a/assets/citations.js
+++ b/assets/citations.js
@@ -70,6 +70,9 @@
     var heading = document.createElement('h2');
     heading.className = 'sources-list-heading';
     heading.textContent = 'Sources';
+    // Auto-generated footnotes list; not a substantive section, so opt out
+    // of the community pulse widget's auto-h2 hydration.
+    heading.setAttribute('data-stance-section', 'off');
     section.appendChild(heading);
 
     var list = document.createElement('ol');

--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -26,7 +26,7 @@ title: "How did we get here?"
 
   <p>This matters because it rebuts the reasonable skepticism that FinCom always wants more money. For sixteen consecutive years, they actively did not. They reported balanced budgets, celebrated the no-override streak, and told residents the town was well-managed.</p>
 
-  <h2>2019: The first signal</h2>
+  <h3>2019: The first signal</h3>
   <p>The tone began to shift in the 2019 transmittal letter (for the FY20 budget), which introduced a phrase that had not appeared in earlier letters:</p>
 
   <blockquote class="quote">
@@ -36,7 +36,7 @@ title: "How did we get here?"
 
   <p>No mention of "override" yet. No specific future year named. But "unsustainable" was doing real work. Something had changed in the underlying math.</p>
 
-  <h2>2022: The first explicit warning</h2>
+  <h3>2022: The first explicit warning</h3>
   <p>Three years later, the 2022 transmittal letter (for the FY23 budget) broke the sixteen-year streak of reassuring language and told residents in writing that an override was coming:</p>
 
   <blockquote class="quote">

--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -1,6 +1,5 @@
 ---
 title: "What can you do?"
-community_pulse: off-sections
 og_title: "What can you do?"
 og_description: "How to engage with Marblehead budget decisions beyond voting yes or no on the override: who decides what, when residents can input, and what longer-term oversight looks like."
 og_url: https://marbleheaddata.org/what-you-can-do.html


### PR DESCRIPTION
## Summary

Four related fixes to the community pulse widget's coverage, all follow-ups from the restructure (#117) and flag-link (#120) PRs.

## Changes

### 1. `about.html` becomes a self-demo for the Reactions widget

The page that explains the feature now actually shows it. Removes the page-level `community_pulse: off-sections` switch and opts out the other two h2s (How I use AI, Costs), so exactly one widget renders — on the "Reactions" h2 itself. A reader who scrolls to that section sees the widget they just read about, right where the explanation ends.

### 2. `what-you-can-do.html` is no longer page-level off

All six h2s are procedural "how to engage" content: pick a goal, understand which body decides what, how to reach each body, what to expect at Town Meeting, how to petition a warrant article. None of these are contested-question framing in the sense that protects `the-debate.html` — reactions here measure usefulness, not position. No per-section opt-outs needed. Removes the `community_pulse: off-sections` line from the frontmatter.

### 3. Demote the 2019 and 2022 waypoint h2s on `how-we-got-here.html` to h3

The page's real story structure is four major eras:
- **2005-2021:** Sixteen years of balanced budgets
- **2023:** The failed override
- **2024-2025:** The structural deficit continues
- **2026:** The vote before us

The 2019 "first signal" and 2022 "first explicit warning" were sitting as h2s but function as sub-points within those eras (2019 within the balanced-budgets era, 2022 as the transition between eras). Demoting both to h3 collapses the widget set from 6 back to 4 — one per major story-beat, matching the original curation rule.

### 4. `assets/citations.js` now opts out the auto-generated Sources h2

This was a silent bug from #117. The `citations.js` runtime scans every page for `<sup class="cite">` markers and, when it finds any, injects a `<h2>Sources</h2>` section into the DOM at load time. Both `citations.js` and `widget.js` are deferred, so by the time `hydrateWidgets()` walks `h2:not([data-stance-section="off"])`, the injected Sources h2 is already there — and under auto-on it was getting picked up as a widget target.

One-line fix at the element creation site in `citations.js`:

```js
heading.setAttribute('data-stance-section', 'off');
```

The Sources h2 is auto-generated footnotes, not a substantive section. This keeps it out of the widget set across every page that uses citation markers, not just `no-override-budget.html` where I first noticed the symptom.

## Test plan

- [x] Browser-verified `about.html`: 1 widget, section_id `about.html#reactions`. How I use AI and Costs opted out.
- [x] Browser-verified `no-override-budget.html`: 5 widgets (was 6). Sources h2 still gets injected by `citations.js` but has `data-stance-section="off"` and the widget hydrator skips it.
- [x] Browser-verified `what-you-can-do.html`: 6 widgets across all 6 procedural h2s. Widget script loaded (page no longer page-level off).
- [x] Browser-verified `how-we-got-here.html`: 4 widgets on the 4 major era h2s. 2019 and 2022 present as h3s with no widgets.
- [x] All other pages unchanged — `the-debate.html` still widget-free (page-level off preserved), all existing instrumented pages' explicit slug overrides preserved.

## Why this is one PR instead of four

The four changes share a theme: "complete the post-restructure tuning of widget coverage." Each one is small (1-3 line edits), the logical grouping is coherent, and splitting them into four PRs would be ceremony without benefit.

The Sources h2 fix in `citations.js` could arguably be its own PR since it's the only one touching non-HTML. Grouping it here because it's the same conceptual category (where widgets do and don't belong) and because it's the root cause of a symptom the other changes would otherwise obscure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)