### PR TITLE
Add scroll-locked ballot nesting explainer

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1711,6 +1711,158 @@ button.ballot-box[aria-pressed="true"] .ballot-box-x-stroke:nth-child(2) {
 }
 
 /* ==========================================================================
+   Scroll-locked ballot nesting explainer (.scrolly-nesting)
+   Sticky visual that updates as the reader scrolls past text steps.
+   Used on what-is-the-override.html to illustrate which Q1 tier wins
+   for each combination of Yes/No votes.
+   ========================================================================== */
+
+.scrolly-nesting {
+  margin: 28px 0 40px;
+}
+.scrolly-nesting-sticky {
+  position: sticky;
+  top: 60px;
+  z-index: 1;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 16px 18px 14px;
+  box-shadow: var(--shadow-sm);
+  margin-bottom: 18px;
+}
+.sn-viz-title {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-subtle);
+  margin: 0 0 10px;
+}
+.sn-row {
+  display: grid;
+  grid-template-columns: 28px 72px 1fr 48px;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px;
+  margin-bottom: 4px;
+  border-radius: 6px;
+  background: var(--divider);
+  border: 2px solid transparent;
+  opacity: 0.45;
+  transition: opacity 0.45s ease, background 0.45s ease, border-color 0.45s ease, transform 0.45s ease;
+}
+.sn-row.is-active {
+  opacity: 1;
+  border-color: var(--c-navy);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+.sn-row.is-nested {
+  opacity: 0.6;
+}
+.sn-row.is-out {
+  opacity: 0.2;
+}
+.sn-row-label {
+  font-weight: 700;
+  font-size: 12px;
+  color: var(--c-navy);
+  font-variant-numeric: tabular-nums;
+}
+.sn-row-name {
+  font-size: 12px;
+  color: var(--text-mid);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+.sn-row-bar {
+  height: 8px;
+  background: var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.sn-row-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+}
+.sn-row--1a .sn-row-bar-fill { width: 100%; background: var(--series-tier-3); }
+.sn-row--1b .sn-row-bar-fill { width: 80%;  background: var(--series-tier-2); }
+.sn-row--1c .sn-row-bar-fill { width: 60%;  background: var(--series-tier-1); }
+.sn-row--q2 .sn-row-bar-fill { width: 24%;  background: var(--text-subtle); }
+.sn-row-amt {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  font-size: 13px;
+  text-align: right;
+  color: var(--text);
+}
+.sn-divider {
+  height: 1px;
+  background: var(--divider);
+  margin: 8px 0 6px;
+}
+.sn-result {
+  margin-top: 12px;
+  padding: 9px 12px;
+  background: var(--divider);
+  border-radius: 6px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-mid);
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1.35;
+}
+.sn-result strong {
+  color: var(--c-navy);
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+}
+
+.scrolly-nesting-steps { margin: 0; }
+.scrolly-step {
+  min-height: 46vh;
+  padding: 18px 20px;
+  margin-bottom: 10px;
+  border-left: 3px solid var(--divider);
+  transition: border-color 0.3s ease, background 0.3s ease;
+}
+.scrolly-step.is-active {
+  border-left-color: var(--c-navy);
+  background: var(--divider);
+}
+.scrolly-step h3 {
+  margin: 0 0 6px;
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.3;
+}
+.scrolly-step p {
+  margin: 0;
+  font-size: 15px;
+  color: var(--text-mid);
+  line-height: 1.55;
+}
+
+@media (max-width: 600px) {
+  .scrolly-nesting-sticky { padding: 14px 14px 12px; top: 56px; }
+  .sn-row { grid-template-columns: 24px 60px 1fr 44px; gap: 8px; padding: 6px 8px; }
+  .sn-row-name { font-size: 11px; }
+  .scrolly-step { min-height: 52vh; padding: 16px; }
+  .scrolly-step h3 { font-size: 16px; }
+  .scrolly-step p { font-size: 14px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sn-row,
+  .scrolly-step { transition: none; }
+}
+
+/* ==========================================================================
    Vote split chart (yes/no split bars for ballot/TM counts)
    ========================================================================== */
 

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -140,6 +140,61 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
 
   <p>That reading is arithmetically understandable (9+12+15=36) but the ballot does not work that way. Because the tiers are nested, a yes vote on all three still caps the override at the highest tier that passes, $15 million, not $36 million. If the nested structure tripped up a careful attendee at the meeting where it was first presented, it is likely to confuse voters at the polls.</p>
 
+  <section class="scrolly-nesting" aria-label="How the nested ballot produces an override amount">
+    <div class="scrolly-nesting-sticky">
+      <p class="sn-viz-title">Question 1 ballot outcome</p>
+      <div class="sn-row sn-row--1a" data-row="1a">
+        <span class="sn-row-label">1A</span>
+        <span class="sn-row-name">Invest</span>
+        <span class="sn-row-bar"><span class="sn-row-bar-fill"></span></span>
+        <span class="sn-row-amt">$15M</span>
+      </div>
+      <div class="sn-row sn-row--1b" data-row="1b">
+        <span class="sn-row-label">1B</span>
+        <span class="sn-row-name">Stabilize</span>
+        <span class="sn-row-bar"><span class="sn-row-bar-fill"></span></span>
+        <span class="sn-row-amt">$12M</span>
+      </div>
+      <div class="sn-row sn-row--1c" data-row="1c">
+        <span class="sn-row-label">1C</span>
+        <span class="sn-row-name">Restore</span>
+        <span class="sn-row-bar"><span class="sn-row-bar-fill"></span></span>
+        <span class="sn-row-amt">$9M</span>
+      </div>
+      <div class="sn-divider"></div>
+      <div class="sn-row sn-row--q2" data-row="q2">
+        <span class="sn-row-label">Q2</span>
+        <span class="sn-row-name">Trash</span>
+        <span class="sn-row-bar"><span class="sn-row-bar-fill"></span></span>
+        <span class="sn-row-amt">$2.3M</span>
+      </div>
+      <div class="sn-result" id="sn-result">Scroll down to walk through each outcome.</div>
+    </div>
+
+    <div class="scrolly-nesting-steps">
+      <div class="scrolly-step" data-step="0" data-result="Scroll down to walk through each outcome.">
+        <h3>Four questions, one nested structure</h3>
+        <p>Question 1 has three parts (1A, 1B, 1C). Question 2 stands alone. The three Q1 parts do not add together. The highest one that gets a majority is the override amount.</p>
+      </div>
+      <div class="scrolly-step" data-step="1" data-result="Override: <strong>$9 million</strong> &middot; Restore">
+        <h3>If only 1C passes</h3>
+        <p>A yes on the lowest tier only. The override is $9&nbsp;million. It restores services that were cut from the no-override budget and nothing more.</p>
+      </div>
+      <div class="scrolly-step" data-step="2" data-result="Override: <strong>$12 million</strong> &middot; Stabilize">
+        <h3>If 1C and 1B pass, but not 1A</h3>
+        <p>The middle tier's $12&nbsp;million is everything in the lowest tier plus more maintenance and staffing. It is the higher of the two that passed, so it is the amount. Not $21 million.</p>
+      </div>
+      <div class="scrolly-step" data-step="3" data-result="Override: <strong>$15 million</strong> &middot; Invest">
+        <h3>If all three pass</h3>
+        <p>The top tier wins. $15&nbsp;million, not $36&nbsp;million. The lower tiers are already contained in the top tier's scope, so approving them as well does not add anything on top.</p>
+      </div>
+      <div class="scrolly-step" data-step="4" data-result="Q2 settles trash funding on its own.">
+        <h3>Question 2 is independent</h3>
+        <p>Question 2 sits outside the tier. It passes or fails on its own. If it passes, a $2.3&nbsp;million trash levy is added to whatever Q1 produces. If it fails, the Board of Health implements a flat fee of roughly $262 per household instead.</p>
+      </div>
+    </div>
+  </section>
+
   <h2 data-stance-section="how-youll-vote">How You'll Vote</h2>
   <p>Two ballot questions at the Annual Town Election on June 9, 2026.</p>
 
@@ -507,3 +562,60 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
     <p>Override structure from the <a href="data/2026-04-08_Override_Presentation.pdf">Town Administrator's override presentation</a> (April 8, 2026) and <a href="https://marbleheadcurrent.org/2026/03/25/select-board-backs-tiered-multi-year-override-framework-combining-school-town-requests/">Marblehead Current</a> / <a href="https://www.marbleheadindependent.com/select-board-locks-in-three-tier-override-structure-votes-to-unite-town-and-school-ask/">Marblehead Independent</a> reporting on the March 25, 2026 Select Board meeting. The $8.47M deficit from the <a href="https://marbleheadma.gov/wp-content/uploads/2026/02/2026-State-of-the-Town-Presenation-Final.pdf">2026 State of the Town presentation</a>, page 29. Ballot format from Town Clerk. Statutory references: <a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter59/Section21C">MGL c. 59 s. 21C</a> (Prop 2.5), <a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIV/Chapter32B/Section19">MGL c. 32B s. 19</a> (PEC).</p>
     <p>Quoted material is cited inline with each quotation. Finance Committee transmittal letters from the 2019, 2022, 2025, and 2026 Annual Town Meeting reports are archived locally in the <code>/data/</code> folder and are primary sources signed by the named FinCom chairs. 2023 override opposition voices are drawn from the Marblehead Current archives (signed letter from Jack Buba, February 18, 2023; and direct quotes from Jim Nye, May 24, 2023, and Sue MacInnis, June 14, 2023). April 8, 2026 Select Board meeting quotes as reported by Will Dowd in the <a href="https://www.marbleheadindependent.com/kezer-presents-9m-to-15m-tiered-override-plan-and-separate-2-2m-trash-tax-option/">Marblehead Independent</a>; the town's own meeting minutes for April 8, 2026 had not been posted at time of publication and are expected at <a href="https://marbleheadma.gov/category/select-board/">marbleheadma.gov/category/select-board/</a>. The 2023 Town Meeting vote record (Article 31 paper ballot, 534-230) is in the <a href="https://marbleheadma.gov/wp-content/uploads/2025/03/town_meeting_minutes_2023__0.pdf">2023 Annual Town Meeting minutes</a>; the June 20, 2023 ballot result (2,992-3,399) is from contemporaneous Marblehead Current coverage. Override history from Marblehead Current, "Overriding Considerations" series.</p>
   </div>
+
+<script>
+(function () {
+  var section = document.querySelector('.scrolly-nesting');
+  if (!section || !('IntersectionObserver' in window)) return;
+
+  var steps = section.querySelectorAll('.scrolly-step');
+  var rows = {
+    '1a': section.querySelector('.sn-row--1a'),
+    '1b': section.querySelector('.sn-row--1b'),
+    '1c': section.querySelector('.sn-row--1c'),
+    'q2': section.querySelector('.sn-row--q2')
+  };
+  var resultEl = section.querySelector('#sn-result');
+
+  // Per step: active rows, nested rows (passed but overridden), out rows (failed).
+  var states = {
+    '0': { active: [],               nested: [],           out: [] },
+    '1': { active: ['1c'],           nested: [],           out: ['1a', '1b'] },
+    '2': { active: ['1b'],           nested: ['1c'],       out: ['1a'] },
+    '3': { active: ['1a'],           nested: ['1b', '1c'], out: [] },
+    '4': { active: ['q2'],           nested: [],           out: [] }
+  };
+
+  function clearRowClasses() {
+    Object.keys(rows).forEach(function (k) {
+      if (!rows[k]) return;
+      rows[k].classList.remove('is-active', 'is-nested', 'is-out');
+    });
+  }
+
+  function applyStep(stepIndex) {
+    var state = states[String(stepIndex)];
+    if (!state) return;
+    clearRowClasses();
+    state.active.forEach(function (k) { if (rows[k]) rows[k].classList.add('is-active'); });
+    state.nested.forEach(function (k) { if (rows[k]) rows[k].classList.add('is-nested'); });
+    state.out.forEach(function (k)    { if (rows[k]) rows[k].classList.add('is-out');    });
+    var step = section.querySelector('.scrolly-step[data-step="' + stepIndex + '"]');
+    if (step && resultEl) resultEl.innerHTML = step.getAttribute('data-result') || '&nbsp;';
+  }
+
+  var observer = new IntersectionObserver(function (entries) {
+    entries.forEach(function (entry) {
+      if (!entry.isIntersecting) return;
+      steps.forEach(function (s) { s.classList.remove('is-active'); });
+      entry.target.classList.add('is-active');
+      applyStep(entry.target.getAttribute('data-step'));
+    });
+  }, {
+    rootMargin: '-45% 0px -45% 0px',
+    threshold: 0
+  });
+
+  steps.forEach(function (s) { observer.observe(s); });
+})();
+</script>


### PR DESCRIPTION
## Summary

- New `.scrolly-nesting` section on `what-is-the-override.html` between the Ginny O'Brien $36M quote and the "How You'll Vote" h2
- Sticky visual pins the four-row ballot diagram (1A Invest $15M, 1B Stabilize $12M, 1C Restore $9M, Q2 Trash $2.3M) while the reader scrolls through five text steps
- Each text step drives a different viz state: intro &rarr; only 1C ($9M) &rarr; 1C+1B ($12M) &rarr; all three ($15M) &rarr; Q2 independent

## Why here, in this form

The `.tier-chart` at the top of the page already shows *what's in* each tier statically. The scrolly answers a different question: *given a yes/no vote on each of the three nested Q1 questions, what amount actually wins?* That's the confusion the Ginny quote captures ("you're voting for \$36 million"), and a static chart doesn't really refute it — the reader needs to see the mechanism applied to each vote combination. Scrollytelling earns its weight here because the reader is being asked to hold multiple states (which passed, which is the winner, what gets nested under what).

## Label convention

Rows use the **ballot numbering** (1A = $15M Invest at top, 1C = $9M Restore at bottom) not the tier-card numbering (Tier 1 = $9M). Rationale: voters encounter 1A/1B/1C on the sample ballot immediately below, so the scrolly primes them on the ballot they'll see, not the tier-card order.

## Row states

Per step:
- **active** — the winning tier (full opacity, navy border, shadow)
- **nested** — passed but overridden by a higher tier that also passed (60% opacity)
- **out** — failed (20% opacity)

This makes the nesting logic visually explicit: when all three pass, 1A is active and 1B/1C are shown as *nested inside* 1A's scope rather than disappearing.

## Technical

- Driven by `IntersectionObserver` with `rootMargin: '-45% 0px -45% 0px'` so steps trigger when they cross the middle ~10% of the viewport
- Inline `<script>` at the bottom of the page, scoped to this section only (no new JS file)
- No-ops in browsers without `IntersectionObserver`
- `@media (prefers-reduced-motion: reduce)` disables transitions
- Sticky `top: 60px` clears the sticky site nav on desktop, `56px` on mobile

## Test plan

- [x] Visually verified scroll choreography on a local server with the production `site.css` — five states transition correctly as each text block enters the middle viewport band
- [x] Tested on narrow viewport (long step headings wrap, sticky positioning clears nav)
- [x] CSS braces balanced (545/545), HTML section tags balanced (1/1)
- [x] Row state classes transition cleanly (`active` / `nested` / `out`)
- [ ] Spot-check dark mode after GitHub Pages builds the preview
- [ ] Spot-check the transition at the join — first step should be in view when the reader first scrolls into the section, not already past

🤖 Generated with [Claude Code](https://claude.com/claude-code)