### PR TITLE
Persist free cash operating history CSV (FY17-FY27 with gaps)

### DIFF
--- a/data/free_cash_operating_history.csv
+++ b/data/free_cash_operating_history.csv
@@ -1,0 +1,13 @@
+fiscal_year,operating_free_cash_dollars,source,source_article,notes
+FY16,,,,Not yet extracted
+FY17,6025000,data/2016_FinCom_Report.pdf,Article 28 Available Funds Appropriate to Reduce Tax Rate,Recommendation approved at May 2016 ATM for FY17 budget
+FY18,,,,Not in repo (no 2017 FinCom report on hand)
+FY19,,,,Not in repo (no 2018 FinCom report on hand)
+FY20,,data/2019_FinCom_Report.pdf,Article 21 Available Funds Appropriate to Reduce Tax Rate,FinCom report explicitly says 'Recommendation to be made at Town Meeting' so number is in May 2019 ATM minutes not the report
+FY21,,,,Not in repo (no 2020 FinCom report on hand)
+FY22,8950000,data/2021_FinCom_Report.pdf,Article 30 Available Funds Appropriate to Reduce Tax Rate,Approved May 2021 ATM for FY22 budget
+FY23,10200000,data/2022_FinCom_Report.pdf,Article 29 Available Funds Appropriate to Reduce Tax Rate,Approved May 2022 ATM for FY23 budget. Peak year; FinCom's 'unsustainable' language intensifies.
+FY24,8000000,data/2023_FinCom_Report.pdf,Available Funds Appropriate to Reduce Tax Rate,Approved May 2023 ATM for FY24 budget
+FY25,5500000,data/2025_FinCom_Report.pdf + data/2026_State_of_the_Town.pdf,Article 19 (approved amount),Approved May 2024 ATM for FY25 budget
+FY26,7000000,data/2026_FinCom_Report.pdf + data/2026_State_of_the_Town.pdf,Article 18 (approved amount),Approved May 2025 ATM for FY26 budget
+FY27,5000000,data/2026_State_of_the_Town.pdf,Proposed FY27 budget,"Projected draw in FY27 proposed budget; not yet adopted. Separately, the town may also draw Free Cash for capital/stabilization ($0 projected in FY27)."


### PR DESCRIPTION
## Summary
Adds \`data/free_cash_operating_history.csv\` with the free cash operating appropriations for FY17-FY27, extracted from FinCom annual reports already in \`data/\` and from the 2026 State of the Town presentation.

## Why
Every research session so far has re-extracted these numbers from the PDFs and then thrown away the results at session end. That was the motivating complaint: \"how are we not storing these results?\" This PR starts the persistence habit with the one series we've confirmed.

## Data coverage

| FY | Amount | Source |
|---|---|---|
| FY16 | — | gap (no 2015 FinCom report in repo) |
| FY17 | \$6,025,000 | 2016 FinCom report |
| FY18 | — | gap (no 2017 FinCom report in repo) |
| FY19 | — | gap (no 2018 FinCom report in repo) |
| FY20 | — | known to exist in 2019 ATM minutes; FinCom report defers to live vote |
| FY21 | — | gap (no 2020 FinCom report in repo) |
| FY22 | \$8,950,000 | 2021 FinCom report |
| FY23 | \$10,200,000 | 2022 FinCom report |
| FY24 | \$8,000,000 | 2023 FinCom report |
| FY25 | \$5,500,000 | 2025 FinCom report + State of the Town |
| FY26 | \$7,000,000 | 2026 FinCom report + State of the Town |
| FY27 | \$5,000,000 (projected) | State of the Town |

## Correction
During this research pass I flagged an error in \`what-is-the-override.html:495\` that doesn't exist — the site says "\$10.2M in FY2023" and that's correct. My earlier skepticism was based on a wrong year-mapping for FinCom report filenames. The mapping is: filename year = year of Town Meeting that adopted the budget; the **fiscal year** covered starts July 1 of the same year (so 2022 filename = May 2022 ATM = FY23 budget).

## Known follow-up
- Fetch the 2015, 2017, 2018, 2020, 2024 FinCom reports from marbleheadma.gov to fill FY16/FY18/FY19/FY21/FY25.
- Fetch the May 2019 Town Meeting minutes to extract the FY20 free cash adoption.
- Extract historical operating revenue/expenses (consistent methodology) to complete the foundation for the historical version of the sustainability chart.

## Test plan
- [x] CSV is valid UTF-8, one row per fiscal year, header row present
- [x] Each populated row has a source reference to a PDF in \`data/\`
- [x] Gap rows are explicit (empty amount, notes explaining why)