### PR TITLE
Promote end-of-section cross-page links to .btn-link buttons

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -287,6 +287,40 @@ nav.site-nav a[aria-current="page"] {
 }
 
 /* ==========================================================================
+   .btn-link - outlined CTA for end-of-section cross-page links
+   Used when a trailing "see X for Y" sentence deserves its own line.
+   ========================================================================== */
+
+.btn-link {
+  display: inline-block;
+  max-width: 100%;
+  margin: 10px 0 4px;
+  padding: 10px 18px;
+  background: transparent;
+  color: var(--c-navy);
+  border: 1.5px solid var(--c-navy);
+  border-radius: var(--radius-sm);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.35;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+}
+.btn-link::after {
+  content: " \2192";
+  display: inline-block;
+  transition: transform 0.2s;
+}
+.btn-link:hover {
+  background: var(--c-navy);
+  color: var(--bg);
+  text-decoration: none;
+}
+.btn-link:hover::after {
+  transform: translateX(3px);
+}
+
+/* ==========================================================================
    Headcount ratio bar (what-fails 22-of-185 visual)
    ========================================================================== */
 

--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -78,9 +78,11 @@ title: "How did we get here?"
     The $8.47M FY27 gap breaks into two pieces. Roughly three-quarters is specific costs going up &ndash; health insurance, pension contributions, the new curbside trash contract, and regular salary and contract increases. The remaining quarter is one-time reserves &ndash; Free Cash, interest income, motor vehicle excise &ndash; that balanced the FY26 budget but aren't available at the same level again in FY27.
   </div>
 
-  <p>For the full calculation, see <a href="no-override-budget.html#fy27-gap-calculated">how the $8.47M FY27 gap is calculated</a>.</p>
+  <p>For the full calculation:</p>
+  <a class="btn-link" href="no-override-budget.html#fy27-gap-calculated">How the $8.47M FY27 gap is calculated</a>
 
-  <p>This page is FinCom's own warning arc, told in their own transmittal letters. For the complementary question &ndash; what the town actually spent during those same years, and which lines grew fastest &ndash; see <a href="where-has-the-money-gone.html">where has Marblehead's money gone</a>.</p>
+  <p>This page is FinCom's own warning arc, told in their own transmittal letters. The complementary question &ndash; what the town actually spent during those same years, and which lines grew fastest &ndash; is covered separately.</p>
+  <a class="btn-link" href="where-has-the-money-gone.html">Where has Marblehead's money gone</a>
 
   <div class="read-next">
     <div class="read-next-label">Read next</div>

--- a/no-override-budget.html
+++ b/no-override-budget.html
@@ -209,7 +209,10 @@ og_url: https://marbleheaddata.org/no-override-budget.html
 
   <p>Stoneham rejected a $14.6M override in April 2025. Staff departed for higher-paying districts, leaving 28 vacant positions at the start of the school year. Teachers earned 30% below market rate. The library lost weekend and evening hours. Stoneham passed a $9.3M override in December 2025; the larger $12.5M option failed by 43 votes.<sup class="cite" data-href="data/case_studies.md" data-source="case_studies.md: Stoneham $14.6M failed April 2025, staffing departures and service cuts, $9.3M passed December 2025"></sup></p>
 
-  <p>See the full <a href="data/case_studies">case studies</a> for details and sources. For a broader look at how 21 Massachusetts peer towns compare on residential tax share, new growth, and override history, see <a href="why-not-elsewhere.html">why do some MA towns run overrides and others don't</a>.</p>
+  <p>Full details and sources for each town:</p>
+  <a class="btn-link" href="data/case_studies">Override case studies</a>
+
+  <p>For a broader look at how 21 Massachusetts peer towns compare on residential tax share, new growth, and override history, see <a href="why-not-elsewhere.html">why do some MA towns run overrides and others don't</a>.</p>
 
   <div class="read-next">
     <div class="read-next-label">Read next</div>

--- a/the-debate.html
+++ b/the-debate.html
@@ -311,7 +311,8 @@ community_pulse: off-sections
   </div>
 
   <h2 class="tension-heading">2. Are the proposed reductions damage or discipline?</h2>
-  <p class="tension-framing">The no-override budget is published. Both sides have read it and reached opposite conclusions. See <a href="no-override-budget.html">what's in the no-override budget</a>.</p>
+  <p class="tension-framing">The no-override budget is published. Both sides have read it and reached opposite conclusions.</p>
+  <a class="btn-link" href="no-override-budget.html">What's in the no-override budget</a>
 
   <div class="perspective perspective--for">
     <div class="perspective-label">For the override</div>
@@ -345,7 +346,8 @@ community_pulse: off-sections
   </div>
 
   <h2 class="tension-heading">4. Do meaningful alternatives exist?</h2>
-  <p class="tension-framing">The debate turns on whether the town has real options other than override versus reductions. See <a href="why-not-elsewhere.html">why some MA towns run overrides and others don't</a> for the structural data underneath this question.</p>
+  <p class="tension-framing">The debate turns on whether the town has real options other than override versus reductions. The structural data underneath this question is covered separately.</p>
+  <a class="btn-link" href="why-not-elsewhere.html">Why some MA towns run overrides and others don't</a>
 
   <div class="perspective perspective--for">
     <div class="perspective-label">For the override</div>

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -127,7 +127,8 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
     <p class="tier-label">Separate Question: Trash ($2.3 million)</p>
     <h3>Fund curbside trash/recycling through the levy instead of a flat fee</h3>
     <p>Independent of the tiers. Curbside trash and recycling are already paid for through general property taxes via the Waste Collection department (FY26 budget: $2.94 million). The FY27 budget restructures this by carving curbside service out into a new dedicated line item and reducing the existing Waste Collection budget by roughly the same amount. Question 2 asks voters to fund that new line via a $2.3 million levy addition. If it fails, the Board of Health will implement a flat fee of roughly $262 per household instead.</p>
-    <p>Either way, residents pay for trash. The difference is the distribution: the levy scales with assessed home value (a $500K home pays less than a $3M home), while the flat fee is the same for everyone. For the full walkthrough (history, distributional analysis by home value, peer town comparison, and long-term alternatives), see <a href="question-2-trash.html">Question 2: trash funding</a>.</p>
+    <p>Either way, residents pay for trash. The difference is the distribution: the levy scales with assessed home value (a $500K home pays less than a $3M home), while the flat fee is the same for everyone. The full walkthrough covers history, distributional analysis by home value, peer town comparison, and long-term alternatives.</p>
+    <a class="btn-link" href="question-2-trash.html">Question 2: trash funding</a>
   </div>
 
   <p>The nesting matters more than it looks. At the April 8, 2026 Select Board meeting where the tiered structure was first presented, one resident added the three dollar amounts together and described the ballot as a $36 million ask.</p>
@@ -197,7 +198,8 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
       </div>
     </div>
   </div>
-  <p>Question 2 is independent of Question 1. Either way, residents pay for trash: the override spreads the cost by home value, while the Board of Health's fallback is a flat fee of roughly $262 per household. See <a href="question-2-trash.html">Trash: levy or fee?</a> for the full walkthrough.</p>
+  <p>Question 2 is independent of Question 1. Either way, residents pay for trash: the override spreads the cost by home value, while the Board of Health's fallback is a flat fee of roughly $262 per household.</p>
+  <a class="btn-link" href="question-2-trash.html">Trash: levy or fee?</a>
 
   <h2 data-stance-section="what-it-costs">What It Costs</h2>
   <p>The override phases in over three years (FY27 to FY29). Year 1 draws only a fraction of the full amount; the full override is active only in Year 3:</p>


### PR DESCRIPTION
Rebase + re-open of #123 after prior branch manipulation closed it.

## Summary

- Adds a new `.btn-link` class to `assets/site.css`: outlined navy pill, arrow affordance, hover-fill transition, dark-mode aware
- Converts 7 trailing "see X for Y" cross-page links into `.btn-link` buttons on their own line across 4 pages
- Keeps inline references inside sentences, author disclosures, and footnote links as text

## Test plan

- [x] Visually verified `.btn-link` on the actual trash card
- [x] Hover-fill transition works, long labels wrap cleanly on narrow viewports
- [x] CSS braces balanced
- [x] Rebased onto main after PRs #124 and #122 landed; no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)