### PR TITLE
Persist general fund spending CSV FY15-FY26

### DIFF
--- a/data/general_fund_spending_FY15-26.csv
+++ b/data/general_fund_spending_FY15-26.csv
@@ -1,0 +1,13 @@
+fiscal_year,total_general_fund_spending,data_type,source,notes
+FY15,70491667,actual,where-has-the-money-gone.html polygon coords (originally ACFR),"Categories stacked: Schools, Health, Public Safety, Debt, Pensions, Everything else. Decoded from chart y=126.2; precision approx +/-$50K. For exact values re-extract from FY15 ACFR General Fund schedule."
+FY16,73195833,actual,where-has-the-money-gone.html polygon coords (originally ACFR),Decoded from chart y=120.3; precision approx +/-$50K.
+FY17,76862500,actual,where-has-the-money-gone.html polygon coords (originally ACFR),Decoded from chart y=112.3; precision approx +/-$50K.
+FY18,81766667,actual,where-has-the-money-gone.html polygon coords (originally ACFR),Decoded from chart y=101.6; precision approx +/-$50K.
+FY19,83279167,actual,where-has-the-money-gone.html polygon coords (originally ACFR),Decoded from chart y=98.3; precision approx +/-$50K.
+FY20,85204167,actual,where-has-the-money-gone.html polygon coords (originally ACFR),Decoded from chart y=94.1; precision approx +/-$50K.
+FY21,85800000,actual,where-has-the-money-gone.html polygon coords (originally ACFR),Decoded from chart y=92.8; precision approx +/-$50K.
+FY22,93591667,actual,where-has-the-money-gone.html polygon coords (originally ACFR),Decoded from chart y=75.8; precision approx +/-$50K.
+FY23,96845833,actual,where-has-the-money-gone.html polygon coords (originally ACFR),Decoded from chart y=68.7; precision approx +/-$50K.
+FY24,102254167,actual,where-has-the-money-gone.html polygon coords (originally ACFR),Decoded from chart y=56.9; precision approx +/-$50K.
+FY25,100466667,expended-not-audited,where-has-the-money-gone.html polygon coords (originally ACFR),"Decoded from chart y=60.8; chart annotation labels FY25 'expended, not audited'. Precision approx +/-$50K."
+FY26,106195833,budget-not-actual,where-has-the-money-gone.html polygon coords (originally ACFR),"Decoded from chart y=48.3; chart annotation labels FY26 'budget, not actual'. Precision approx +/-$50K."


### PR DESCRIPTION
## Summary
Adds \`data/general_fund_spending_FY15-26.csv\` — 12 years of total general fund expenditures for Marblehead, decoded from the polygon coordinates in \`where-has-the-money-gone.html:108-120\` (originally compiled from ACFRs).

## Why
Paired with \`data/free_cash_operating_history.csv\` (PR #127), this completes the second half of the persisted-historical-data foundation for the eventual historical sustainability chart. Both CSVs exist so future sessions can reference and extend the series without re-parsing PDFs or re-decoding polygon coordinates each time.

## Data
12 years of audited actuals (FY15-FY24), plus FY25 "expended, not audited" and FY26 "budget, not actual" — the same data-type labels used in the source chart's verified/projected divider. Precision is approximately +/-\$50K because the chart source uses y coordinates at 0.1-unit precision, where each 0.1 unit corresponds to ~\$46K.

For exact values, re-extract from the respective ACFR General Fund schedule — this CSV is a convenience anchor, not a replacement for the underlying ACFR data.

## Test plan
- [x] 12 rows, one per fiscal year
- [x] Each row has provenance (source file + notes)
- [x] Data type column distinguishes actual / expended-not-audited / budget-not-actual
- [x] Aria-label on source chart confirms FY15 \$70.5M and FY26 \$106.2M — my decoded values (\$70,491,667 and \$106,195,833) match within rounding.