### PR TITLE
Add "Audit it yourself" block to about.html

### DIFF
--- a/about.html
+++ b/about.html
@@ -64,6 +64,33 @@ og_title: "Who made this?"
   @media (max-width: 600px) {
     .meta-pill { padding: 6px 12px; font-size: 12px; }
   }
+  .audit-snippet {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    line-height: 1.6;
+    padding: 14px 18px;
+    background: color-mix(in srgb, var(--c-navy) 6%, var(--surface));
+    border-left: 3px solid var(--c-navy);
+    border-radius: 0 10px 10px 0;
+    color: var(--text);
+    overflow-x: auto;
+    margin: 0 0 24px;
+  }
+  .audit-snippet code {
+    font-family: inherit;
+    font-size: inherit;
+    background: none;
+    color: inherit;
+    padding: 0;
+    white-space: pre;
+  }
+  .audit-note code {
+    font-family: var(--font-mono);
+    font-size: 0.88em;
+    padding: 1px 6px;
+    background: var(--divider);
+    border-radius: 4px;
+  }
 </style>
 
   <h1>Who made this?</h1>
@@ -77,6 +104,12 @@ og_title: "Who made this?"
 
   <h2 data-stance-section="off">How I use AI</h2>
   <p>An AI assistant (Claude) handles the research, analysis, and digital infrastructure behind this site. Reading 39 primary-source PDFs totaling over 3,000 pages of ACFRs, DLS reports, PERAC valuations, and budget documents and turning them into charts is a good fit for what current AI tools are actually useful for. That said, they can and do make mistakes, and I don't re-verify every number against the original document myself. I try to keep it as neutral as I can. If you catch an error, the "Report an issue" link in the footer of any page opens a new GitHub issue.</p>
+
+  <h2 data-stance-section="off">Audit it yourself</h2>
+  <p class="audit-note">If you have <code>git</code> and <a href="https://claude.com/claude-code">Claude Code</a> installed, you can check the work from your terminal. The repo's <code>CLAUDE.md</code> and <code>STYLE_GUIDE.md</code> will orient Claude automatically.</p>
+  <pre class="audit-snippet"><code>git clone https://github.com/agbaber/marblehead
+cd marblehead
+claude "audit this site. find the bias. follow the money. be skeptical."</code></pre>
 
   <h2>Reactions</h2>
   <p>Some sections let you react as you read. Your reactions stay in this browser, and no one else can see which one you picked. The number next to each section is a rough measure of interest, not a poll.</p>


### PR DESCRIPTION
## Summary
- Adds a new "Audit it yourself" section to `about.html`, positioned right after "How I use AI"
- Short copy-paste shell snippet: `git clone` + `cd` + `claude "audit this site. find the bias. follow the money. be skeptical."`
- Scoped CSS matches the existing `.profile-disclosure` aesthetic (navy-tinted background, left border) so the transparency blocks on the page visually rhyme
- `<pre>` uses `white-space: pre` + `overflow-x: auto` for horizontal scroll on narrow screens
- Section heading gets `data-stance-section="off"` because it's meta-transparency, not reaction-worthy content

## Test plan
- [ ] Load `/about.html` on desktop and confirm the snippet block appears between "How I use AI" and "Reactions"
- [ ] Confirm `<code>` in the intro line renders with scoped background (navy-divider), matching the nearby disclosure callout
- [ ] Confirm the `<pre>` block is monospace, navy-tinted, and the three shell lines stay on their own lines (no wrap)
- [ ] On a narrow viewport (< 400px), confirm the snippet horizontally scrolls rather than wrapping the `claude "..."` line
- [ ] Confirm no community-pulse reaction widget appears next to the new h2 (it should be off because of `data-stance-section="off"`)
- [ ] Copy the snippet from the page, paste into a real terminal, and run it. Verify the `claude "..."` invocation lands cleanly as one argument (quoting survives clipboard round-trip)