### PR TITLE
Fix scrolly bar fill, tighten step boxes, relabel 2 not Q2

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1777,12 +1777,14 @@ button.ballot-box[aria-pressed="true"] .ballot-box-x-stroke:nth-child(2) {
   letter-spacing: 0.4px;
 }
 .sn-row-bar {
+  display: block;
   height: 8px;
   background: var(--border);
   border-radius: 4px;
   overflow: hidden;
 }
 .sn-row-bar-fill {
+  display: block;
   height: 100%;
   border-radius: 4px;
 }
@@ -1824,13 +1826,18 @@ button.ballot-box[aria-pressed="true"] .ballot-box-x-stroke:nth-child(2) {
 
 .scrolly-nesting-steps { margin: 0; }
 .scrolly-step {
-  min-height: 46vh;
-  padding: 18px 20px;
-  margin-bottom: 10px;
+  min-height: 38vh;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+}
+.scrolly-step-inner {
+  width: 100%;
+  padding: 14px 18px;
   border-left: 3px solid var(--divider);
   transition: border-color 0.3s ease, background 0.3s ease;
 }
-.scrolly-step.is-active {
+.scrolly-step.is-active .scrolly-step-inner {
   border-left-color: var(--c-navy);
   background: var(--divider);
 }
@@ -1852,14 +1859,15 @@ button.ballot-box[aria-pressed="true"] .ballot-box-x-stroke:nth-child(2) {
   .scrolly-nesting-sticky { padding: 14px 14px 12px; top: 56px; }
   .sn-row { grid-template-columns: 24px 60px 1fr 44px; gap: 8px; padding: 6px 8px; }
   .sn-row-name { font-size: 11px; }
-  .scrolly-step { min-height: 52vh; padding: 16px; }
+  .scrolly-step { min-height: 44vh; }
+  .scrolly-step-inner { padding: 12px 14px; }
   .scrolly-step h3 { font-size: 16px; }
   .scrolly-step p { font-size: 14px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .sn-row,
-  .scrolly-step { transition: none; }
+  .scrolly-step-inner { transition: none; }
 }
 
 /* ==========================================================================

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -142,7 +142,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
 
   <section class="scrolly-nesting" aria-label="How the nested ballot produces an override amount">
     <div class="scrolly-nesting-sticky">
-      <p class="sn-viz-title">Question 1 ballot outcome</p>
+      <p class="sn-viz-title">Ballot outcome</p>
       <div class="sn-row sn-row--1a" data-row="1a">
         <span class="sn-row-label">1A</span>
         <span class="sn-row-name">Invest</span>
@@ -163,7 +163,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
       </div>
       <div class="sn-divider"></div>
       <div class="sn-row sn-row--q2" data-row="q2">
-        <span class="sn-row-label">Q2</span>
+        <span class="sn-row-label">2</span>
         <span class="sn-row-name">Trash</span>
         <span class="sn-row-bar"><span class="sn-row-bar-fill"></span></span>
         <span class="sn-row-amt">$2.3M</span>
@@ -173,24 +173,34 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
 
     <div class="scrolly-nesting-steps">
       <div class="scrolly-step" data-step="0" data-result="Scroll down to walk through each outcome.">
-        <h3>Four questions, one nested structure</h3>
-        <p>Question 1 has three parts (1A, 1B, 1C). Question 2 stands alone. The three Q1 parts do not add together. The highest one that gets a majority is the override amount.</p>
+        <div class="scrolly-step-inner">
+          <h3>Four questions, one nested structure</h3>
+          <p>Question 1 has three parts (1A, 1B, 1C). Question 2 stands alone. The three Q1 parts do not add together. The highest one that gets a majority is the override amount.</p>
+        </div>
       </div>
       <div class="scrolly-step" data-step="1" data-result="Override: <strong>$9 million</strong> &middot; Restore">
-        <h3>If only 1C passes</h3>
-        <p>A yes on the lowest tier only. The override is $9&nbsp;million. It restores services that were cut from the no-override budget and nothing more.</p>
+        <div class="scrolly-step-inner">
+          <h3>If only 1C passes</h3>
+          <p>A yes on the lowest tier only. The override is $9&nbsp;million. It restores services that were cut from the no-override budget and nothing more.</p>
+        </div>
       </div>
       <div class="scrolly-step" data-step="2" data-result="Override: <strong>$12 million</strong> &middot; Stabilize">
-        <h3>If 1C and 1B pass, but not 1A</h3>
-        <p>The middle tier's $12&nbsp;million is everything in the lowest tier plus more maintenance and staffing. It is the higher of the two that passed, so it is the amount. Not $21 million.</p>
+        <div class="scrolly-step-inner">
+          <h3>If 1C and 1B pass, but not 1A</h3>
+          <p>The middle tier's $12&nbsp;million is everything in the lowest tier plus more maintenance and staffing. It is the higher of the two that passed, so it is the amount. Not $21 million.</p>
+        </div>
       </div>
       <div class="scrolly-step" data-step="3" data-result="Override: <strong>$15 million</strong> &middot; Invest">
-        <h3>If all three pass</h3>
-        <p>The top tier wins. $15&nbsp;million, not $36&nbsp;million. The lower tiers are already contained in the top tier's scope, so approving them as well does not add anything on top.</p>
+        <div class="scrolly-step-inner">
+          <h3>If all three pass</h3>
+          <p>The top tier wins. $15&nbsp;million, not $36&nbsp;million. The lower tiers are already contained in the top tier's scope, so approving them as well does not add anything on top.</p>
+        </div>
       </div>
-      <div class="scrolly-step" data-step="4" data-result="Q2 settles trash funding on its own.">
-        <h3>Question 2 is independent</h3>
-        <p>Question 2 sits outside the tier. It passes or fails on its own. If it passes, a $2.3&nbsp;million trash levy is added to whatever Q1 produces. If it fails, the Board of Health implements a flat fee of roughly $262 per household instead.</p>
+      <div class="scrolly-step" data-step="4" data-result="Question 2 settles trash funding on its own.">
+        <div class="scrolly-step-inner">
+          <h3>Question 2 is independent</h3>
+          <p>Question 2 sits outside the tier. It passes or fails on its own. If it passes, a $2.3&nbsp;million trash levy is added to whatever Q1 produces. If it fails, the Board of Health implements a flat fee of roughly $262 per household instead.</p>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

Polish pass on the ballot-nesting scrolly from #126. Three issues found during first read:

### 1. Bar fills were invisible
`.sn-row-bar` and `.sn-row-bar-fill` were `<span>` elements with implicit `display: inline`, so the CSS `width` / `height` rules had no effect and the bar tracks rendered empty. Added `display: block` to both so the proportional fills render as intended (1A 100% buoy red, 1B 80% navy, 1C 60% teal, Q2 24% subtle).

### 2. Step boxes were too tall
Each step was `min-height: 46vh` with the colored background applied to the whole element, so a short text paragraph sat inside a nearly half-screen-tall filled block. Wrapped each step's `h3` + `p` in a new `.scrolly-step-inner` div and moved the background/border to the inner. The outer `.scrolly-step` is now a flex container (`min-height: 38vh` desktop, `44vh` mobile) that vertically centers the inner box around the text. Preserves the scroll distance needed for the IntersectionObserver trigger band without the visual bulk.

### 3. Q2 label mismatch
The sample ballot mockup on the same page uses `<div class="ballot-q-num">2</div>` (just the digit) for Question 2. The scrolly row was labeled `Q2`. Relabeled to `2` so the scrolly row numbering matches what voters see on the ballot (`1A / 1B / 1C / 2`). Also changed the viz heading from "Question 1 ballot outcome" to "Ballot outcome" since the viz includes the Q2 row.

## Test plan

- [x] Bar fills render with the expected proportional widths
- [x] Step boxes are a reasonable visual size and hug the text
- [x] IntersectionObserver still triggers cleanly as steps enter the middle viewport band (min-height is still tall enough)
- [x] Mobile media query updated to match (44vh outer, 12px 14px inner padding)
- [x] CSS braces balanced (551/551)
- [ ] Spot-check after GitHub Pages builds the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)