### PR TITLE
Add primary source archive page

### DIFF
--- a/data/archive.md
+++ b/data/archive.md
@@ -1,0 +1,89 @@
+---
+body_class: doc-page
+title: Primary source archive
+---
+
+# Primary source archive
+
+Local copies of the primary documents cited across this site. These files are identical to the versions published by the Town of Marblehead and by Massachusetts state agencies (DOR, PERAC). They are hosted here, as a GitHub release on the site's repository, so that citations remain reachable if upstream URLs change.
+
+Nothing in this archive is under third-party license. Everything is a public record.
+
+For trace-by-trace source lookup of every number in the charts and tables, see [Source Lookup]({{ '/data/SOURCE_LOOKUP.html' | relative_url }}). For dataset-level methodology and caveats, see [Data Catalog]({{ '/data/DATA_CATALOG.html' | relative_url }}).
+
+## Annual Comprehensive Financial Reports (ACFRs)
+
+Audited annual financial statements from the Town of Marblehead. The Statistical Section (roughly the last 30 pages of each report) contains 10-year trend tables for tax levy, FTE, pension, and demographic data.
+
+- [FY04 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY04_ACFR.pdf)
+- [FY05 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY05_ACFR.pdf)
+- [FY06 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY06_ACFR.pdf)
+- [FY07 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY07_ACFR.pdf)
+- [FY08 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY08_ACFR.pdf)
+- [FY09 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY09_ACFR.pdf)
+- [FY10 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY10_ACFR.pdf)
+- [FY11 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY11_ACFR.pdf)
+- [FY12 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY12_ACFR.pdf)
+- [FY13 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY13_ACFR.pdf)
+- [FY14 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY14_ACFR.pdf)
+- [FY15 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY15_ACFR.pdf)
+- [FY16 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY16_ACFR.pdf)
+- [FY17 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY17_ACFR.pdf)
+- [FY18 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY18_ACFR.pdf)
+- [FY19 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY19_ACFR.pdf)
+- [FY20 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY20_ACFR.pdf)
+- [FY21 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY21_ACFR.pdf)
+- [FY22 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY22_ACFR.pdf)
+- [FY23 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY23_ACFR.pdf)
+- [FY24 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY24_ACFR.pdf)
+
+## Town budgets
+
+- [FY27 Proposed Budget (No Override)](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY27_Proposed_Budget_No_Override.pdf) &ndash; line-item budget with FY25 actual, FY26, and FY27 side by side for every department. Source document for the FY27 deficit framing and for the Question 2 Waste Collection / Curbside Collection split.
+- [FY26 General Fund Budget (Excel)](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY26_General_Fund_Budget.xlsx) &ndash; adopted FY26 budget as a spreadsheet.
+
+## Finance Committee annual reports
+
+Annual reports from the Marblehead Finance Committee, transmitted ahead of each year's Annual Town Meeting. The signed transmittal letter at the front of each is the usable source for named individual positions; the body is committee voice.
+
+- [2016 FinCom Report](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2016_FinCom_Report.pdf)
+- [2019 FinCom Report](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2019_FinCom_Report.pdf)
+- [2021 FinCom Report](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2021_FinCom_Report.pdf)
+- [2022 FinCom Report](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2022_FinCom_Report.pdf)
+- [2023 FinCom Report](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2023_FinCom_Report.pdf)
+- [2025 FinCom Report](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2025_FinCom_Report.pdf) &ndash; covers FY25 / May 2024 Annual Town Meeting.
+- [2026 FinCom Report](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026_FinCom_Report.pdf) &ndash; covers FY26 / May 2025 Annual Town Meeting. Also published by the town as the FY26 Annual Report.
+
+## Town presentations and audit letters
+
+- [2026 State of the Town](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026_State_of_the_Town.pdf) &ndash; Town Administrator's January 2026 presentation with revenue and expense projections and the FY27 deficit framing.
+- [April 8, 2026 Override Presentation](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-08_Override_Presentation.pdf) &ndash; town slide deck on the three-tier override and Question 2.
+- [Financial Policies (2023)](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/Financial_Policies_2023.pdf) &ndash; adopted town financial policies.
+- [FY22 Management Letter](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY22_Management_Letter.pdf) &ndash; audit management letter to the Select Board.
+- [FY23 Management Letter](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY23_Management_Letter.pdf)
+
+## PERAC actuarial valuations
+
+Pension actuarial valuation reports from the Massachusetts Public Employee Retirement Administration Commission. Biennial reports on the funded status and actuarial assumptions of the Marblehead Contributory Retirement System.
+
+- [PERAC Marblehead 2018](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/PERAC_Marblehead_2018.pdf)
+- [PERAC Marblehead 2020](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/PERAC_Marblehead_2020.pdf)
+- [PERAC Marblehead 2022](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/PERAC_Marblehead_2022.pdf)
+- [PERAC Marblehead 2024 Valuation](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/PERAC_Marblehead_Valuation_2024.pdf)
+
+## MA DOR tax data
+
+Spreadsheets downloaded from the Massachusetts Department of Revenue, Division of Local Services (DLS) reporting portal.
+
+- [DOR Marblehead tax rates, FY03-FY26](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/DOR_Marblehead_tax_rates_FY03-26.xlsx) &ndash; residential and commercial tax rates by year, Tax Rates by Class report.
+- [DOR Swampscott tax rates, FY03-FY26](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/DOR_Swampscott_tax_rates_FY03-26.xlsx)
+- [DOR Melrose and Stoneham tax rates, FY03-FY26](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/DOR_Melrose_Stoneham_tax_rates_FY03-26.xlsx)
+- [DOR Average Single Family Tax Bill, four towns](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/DOR_AvgSingleFamTaxBill_4towns.xlsx) &ndash; Marblehead, Swampscott, Melrose, Stoneham, from the Average Single Family Tax Bill report.
+
+## Datasets (CSV)
+
+Verified time-series data compiled from the documents above and from state agencies. The CSV files live in the site repository itself (not this archive), and are visible at [data/](https://github.com/agbaber/marblehead/tree/main/data) on GitHub. File-by-file methodology, field definitions, and confidence notes are in the [Data Catalog]({{ '/data/DATA_CATALOG.html' | relative_url }}).
+
+## Notes
+
+This archive is a GitHub release on [agbaber/marblehead](https://github.com/agbaber/marblehead/releases). It contains only files that are already publicly available through marbleheadma.gov and mass.gov. These copies exist to protect against upstream link rot, not to publish anything new.


### PR DESCRIPTION
## Summary

- New `data/archive.md` landing page at `marbleheaddata.org/data/archive.html` indexing every primary source document the site cites: 21 ACFRs (FY04-FY24), 7 FinCom annual reports, the FY27 proposed budget and FY26 general fund budget, 4 PERAC actuarial valuations, 4 DOR tax rate spreadsheets, and 5 town presentations / management letters / financial policies (43 files total).
- Files are hosted as assets on a new GitHub release, `source-archive-v1`, rather than committed to the repo. This keeps `git clone` fast and keeps binary blobs out of git history, while giving every citation a stable download URL independent of marbleheadma.gov.
- No changes to any existing page, layout, CSS, or `_config.yml`. New file only.

## Why

Every primary-source citation on the site currently links to `marbleheadma.gov/wp-content/uploads/...`, and those URLs have been shifting during the town's WordPress migration (per memory and `SOURCE_LOOKUP.md`). When a URL dies, the citation dies. Hosting a local mirror of the same public records fixes that and costs nothing.

## Before merging

**The release is currently a draft.** Download links in `archive.md` will 404 until the release is published. After you review the asset list and release notes at https://github.com/agbaber/marblehead/releases, hit Publish. At that moment the tag `source-archive-v1` gets created on `main` and every link resolves.

You can publish the release and merge this PR in either order — the page renders fine either way, links just don't resolve until publish.

## Not in this PR (deliberate)

- Rewriting the external `marbleheadma.gov/...` links in `data/SOURCE_LOOKUP.md` to point at the new release URLs. That's a larger mechanical rewrite that deserves its own reviewable PR and its own before/after diff.
- Linking to `archive.html` from the main nav or home page. Discoverability is a separate decision.
- Touching the `.gitignore` entries for `data/acfr/`, `data/budgets/`, `data/*.pdf`, `data/*.xlsx`. The original "local-only data" stance is preserved. PDFs stay out of the repo; they live on the release.

## Test plan

- [ ] Review the draft release at https://github.com/agbaber/marblehead/releases and confirm the 43 assets and release notes look right
- [ ] Publish the draft release
- [ ] Click through to `marbleheaddata.org/data/archive.html` after merge and spot-check a few download links (e.g., FY24 ACFR, FY27 Proposed Budget, a PERAC report, a DOR xlsx)
- [ ] Confirm the page renders as a `doc-page` (bulleted list, readable on mobile)