### PR TITLE
Reading-time bands + copy button on audit snippet

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,6 +6,29 @@ layout: default
 <div class="page">
   <a class="back" href="{{ '/' | relative_url }}">&larr;</a>
 
+  {%- comment -%}
+  Reading-time label. Word count uses strip_html first so inline <style>
+  and <script> blocks don't inflate the count (Jekyll's strip_html drops
+  those blocks AND their content, not just the tags). Chart count is
+  computed on the raw content before stripping, since strip_html would
+  remove the <svg> and <iframe> tokens we're counting.
+  Heuristic: 230 wpm + 30s per chart. Bands: <3min unlabeled, 3–7 "~5 min",
+  8–12 "~10 min", 13+ "deep dive".
+  {%- endcomment -%}
+  {%- assign _rt_svgs = content | split: "<svg" | size | minus: 1 -%}
+  {%- assign _rt_iframe_charts = content | split: 'src="charts/' | size | minus: 1 -%}
+  {%- assign _rt_chart_count = _rt_svgs | plus: _rt_iframe_charts -%}
+  {%- assign _rt_chart_min = _rt_chart_count | divided_by: 2 -%}
+  {%- assign _rt_words = content | strip_html | number_of_words -%}
+  {%- assign _rt_minutes = _rt_words | divided_by: 230 | plus: _rt_chart_min -%}
+  {%- if _rt_minutes >= 13 -%}
+    <p class="read-time">Deep dive</p>
+  {%- elsif _rt_minutes >= 8 -%}
+    <p class="read-time">~10 min read</p>
+  {%- elsif _rt_minutes >= 3 -%}
+    <p class="read-time">~5 min read</p>
+  {%- endif -%}
+
   {{ content }}
 
   {% include footer.html %}

--- a/about.html
+++ b/about.html
@@ -64,17 +64,21 @@ og_title: "Who made this?"
   @media (max-width: 600px) {
     .meta-pill { padding: 6px 12px; font-size: 12px; }
   }
+  .audit-snippet-wrap {
+    position: relative;
+    margin: 0 0 24px;
+  }
   .audit-snippet {
     font-family: var(--font-mono);
     font-size: 13px;
     line-height: 1.6;
-    padding: 14px 18px;
+    padding: 14px 60px 14px 18px;
     background: color-mix(in srgb, var(--c-navy) 6%, var(--surface));
     border-left: 3px solid var(--c-navy);
     border-radius: 0 10px 10px 0;
     color: var(--text);
     overflow-x: auto;
-    margin: 0 0 24px;
+    margin: 0;
   }
   .audit-snippet code {
     font-family: inherit;
@@ -90,6 +94,32 @@ og_title: "Who made this?"
     padding: 1px 6px;
     background: var(--divider);
     border-radius: 4px;
+  }
+  .audit-copy {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    padding: 5px 10px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-subtle);
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+  }
+  .audit-copy:hover {
+    background: var(--divider);
+    border-color: var(--text-faint);
+    color: var(--text);
+  }
+  .audit-copy.is-copied {
+    background: color-mix(in srgb, var(--c-navy) 10%, var(--surface));
+    border-color: var(--c-navy);
+    color: var(--c-navy);
   }
 </style>
 
@@ -107,9 +137,32 @@ og_title: "Who made this?"
 
   <h2 data-stance-section="off">Audit it yourself</h2>
   <p class="audit-note">If you have <code>git</code> and <a href="https://claude.com/claude-code">Claude Code</a> installed, you can check the work from your terminal. The repo's <code>CLAUDE.md</code> and <code>STYLE_GUIDE.md</code> will orient Claude automatically.</p>
-  <pre class="audit-snippet"><code>git clone https://github.com/agbaber/marblehead
+  <div class="audit-snippet-wrap">
+    <pre class="audit-snippet"><code>git clone https://github.com/agbaber/marblehead
 cd marblehead
 claude "audit this site. find the bias. follow the money. be skeptical."</code></pre>
+    <button type="button" class="audit-copy" aria-label="Copy the audit command to clipboard">Copy</button>
+  </div>
+  <script>
+  (function () {
+    var btn = document.querySelector('.audit-copy');
+    var target = document.querySelector('.audit-snippet code');
+    if (!btn || !target || !navigator.clipboard) {
+      if (btn) btn.hidden = true;
+      return;
+    }
+    btn.addEventListener('click', function () {
+      navigator.clipboard.writeText(target.textContent).then(function () {
+        btn.classList.add('is-copied');
+        btn.textContent = 'Copied';
+        setTimeout(function () {
+          btn.classList.remove('is-copied');
+          btn.textContent = 'Copy';
+        }, 1500);
+      });
+    });
+  })();
+  </script>
 
   <h2>Reactions</h2>
   <p>Some sections let you react as you read. Your reactions stay in this browser, and no one else can see which one you picked. The number next to each section is a rough measure of interest, not a poll.</p>

--- a/assets/site.css
+++ b/assets/site.css
@@ -518,6 +518,17 @@ p a:hover { text-decoration: underline; }
 }
 .back:hover { color: var(--text); background: var(--border); text-decoration: none; }
 
+.page > .read-time {
+  display: inline-block;
+  margin: 0 0 10px;
+  padding: 0;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.4px;
+  color: var(--text-subtle);
+}
+
 @media (max-width: 600px) {
   h1 { font-size: 20px; }
   h2 { font-size: 17px; margin-top: 24px; }


### PR DESCRIPTION
## Summary

Two small UX affordances in one PR.

**Reading-time bands** — small uppercase label above the h1 on every page using the `page` layout:
- Under 3 min: no label (short pages like about, privacy, index stay clean)
- 3–7 min: "~5 min read"
- 8–12 min: "~10 min read"
- 13+ min: "Deep dive"

Heuristic: ~230 words per minute + ~30s per chart (`<svg>` + `src="charts/"`). `strip_html` runs before `number_of_words` so inline `<style>` and `<script>` blocks don't inflate the count. Label styling matches the existing `.featured-card-eyebrow` pattern.

**Copy button on the audit snippet** — a small "Copy" button in the top-right of the `.audit-snippet` block on `about.html`. Uses `navigator.clipboard.writeText`; hides itself if the clipboard API isn't available. After click, flips to "Copied" with a navy tint for 1.5s, then resets.

## Expected read-time labels

Based on my local word/chart count script (Python, not Liquid, so actual Liquid numbers may drift by a minute or two):

| Page | ~Min | Label |
|---|---:|---|
| about.html | 1 | (no label) |
| privacy.html | 2 | (no label) |
| how-we-got-here.html | 7 | ~5 min read |
| no-override-budget.html | 7 | ~5 min read |
| what-you-can-do.html | 9 | ~10 min read |
| senior-tax-relief.html | 11 | ~10 min read |
| question-2-trash.html | 13 | Deep dive |
| why-not-elsewhere.html | 14 | Deep dive |
| the-debate.html | 15 | Deep dive |
| where-has-the-money-gone.html | 15 | Deep dive |
| what-is-the-override.html | 18 | Deep dive |

## Test plan
- [ ] After GitHub Pages builds, load `/about.html` and confirm the read-time label does NOT appear (page is ~1 min, under the 3-min threshold)
- [ ] Load `/the-debate.html` and confirm "Deep dive" appears above the h1, in subtle uppercase styling matching other eyebrow labels
- [ ] Load `/how-we-got-here.html` and confirm "~5 min read" appears
- [ ] Load `/what-you-can-do.html` and confirm "~10 min read" appears
- [ ] Load `/index.html` — index uses `layout: home` so no label should appear
- [ ] On `/about.html`, click the Copy button next to the audit snippet — confirm clipboard actually contains the three-line snippet. Paste into a terminal to verify.
- [ ] Click again and confirm the button flips to "Copied" then back to "Copy" after ~1.5s
- [ ] On a narrow viewport (~380px wide), confirm the button doesn't overlap the `claude "..."` line in the snippet (right padding on `.audit-snippet` was bumped from 18px to 60px to reserve space)
- [ ] Mobile keyboard nav: tab to the Copy button, confirm it's keyboard-focusable and activates on Enter