### PR TITLE
Point SOURCE_LOOKUP.md document links at source-archive-v1

### DIFF
--- a/data/SOURCE_LOOKUP.md
+++ b/data/SOURCE_LOOKUP.md
@@ -8,10 +8,12 @@ title: Source Lookup
 
 Use this to trace any chart number back to its original document and page. For per-CSV methodology notes (why KFF for health insurance, why national vs Boston-metro CPI, why per-pupil data starts at FY2008, the Prop 2&frac12; ballot history row counts and caveats), see [Data File Methodology](SOURCES).
 
+Document links below point at the [primary source archive](archive), a GitHub release of this repository that mirrors every town document cited. State-agency links (MA DOR, mass.gov, PERAC) remain on their live upstream URLs.
+
 ## Tax Levy ($30.2M in FY01 to $82.2M in FY24)
-- FY01-FY10: [FY10 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY10-Town-of-Marblehead-ACFR.pdf) page 121, "Property Tax Levies and Collections"
-- FY05-FY14: [FY14 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY14-Town-of-Marblehead-ACFR.pdf) page 117, same table
-- FY15-FY24: [FY24 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY24-Town-of-Marblehead-ACFR.pdf) page 129, same table
+- FY01-FY10: [FY10 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY10_ACFR.pdf) page 121, "Property Tax Levies and Collections"
+- FY05-FY14: [FY14 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY14_ACFR.pdf) page 117, same table
+- FY15-FY24: [FY24 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY24_ACFR.pdf) page 129, same table
 
 ## Tax Rate ($8.42 in FY03 to $8.56 in FY26)
 - All years: [MA DOR Tax Rates by Class](https://dls-gw.dor.state.ma.us/reports/rdPage.aspx?rdReport=PropertyTaxInformation.taxratesbyclass.taxratesbyclass_main) (select Marblehead, All Years)
@@ -20,52 +22,52 @@ Use this to trace any chart number back to its original document and page. For p
 - All years, all four towns: [MA DOR Average Single Family Tax Bill](https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=averagesingletaxbill.singlefamtaxbill_wrange)
 
 ## Total FTE (599.6 in FY01 to 706.0 in FY24)
-- FY01-FY10: [FY10 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY10-Town-of-Marblehead-ACFR.pdf) page 127, "Full-time Equivalent Town Employees by Function"
-- FY05-FY14: [FY14 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY14-Town-of-Marblehead-ACFR.pdf) page 123, same table
-- FY15-FY24: [FY24 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY24-Town-of-Marblehead-ACFR.pdf) page 136, same table
+- FY01-FY10: [FY10 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY10_ACFR.pdf) page 127, "Full-time Equivalent Town Employees by Function"
+- FY05-FY14: [FY14 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY14_ACFR.pdf) page 123, same table
+- FY15-FY24: [FY24 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY24_ACFR.pdf) page 136, same table
 
 ## Education FTE (400.1 in FY01 to 537.0 in FY24)
 - Same ACFR pages as Total FTE, "Education" row
 
 ## Population and School Enrollment
-- FY01-FY10: [FY10 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY10-Town-of-Marblehead-ACFR.pdf) page 125, "Demographic and Economic Statistics"
-- FY05-FY14: [FY14 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY14-Town-of-Marblehead-ACFR.pdf) page 121, same table
-- FY15-FY24: [FY24 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY24-Town-of-Marblehead-ACFR.pdf) page 134, same table
+- FY01-FY10: [FY10 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY10_ACFR.pdf) page 125, "Demographic and Economic Statistics"
+- FY05-FY14: [FY14 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY14_ACFR.pdf) page 121, same table
+- FY15-FY24: [FY24 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY24_ACFR.pdf) page 134, same table
 
 ## Group Insurance Spending ($8.0M in FY06 to $16.8M in FY27)
-- FY06: [FY06 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY06-Town-of-Marblehead-ACFR.pdf) page 82, budget schedule, "Group Insurance" line
-- FY07: [FY07 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY07-Town-of-Marblehead-ACFR.pdf) page 84
-- FY08: [FY08 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY08-Town-of-Marblehead-ACFR.pdf) page 83
-- FY09: [FY09 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY09-Town-of-Marblehead-ACFR.pdf) page 85
-- FY10: [FY10 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY10-Town-of-Marblehead-ACFR.pdf) page 83
-- FY11: [FY11 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY11-Town-of-Marblehead-ACFR.pdf) page 83
-- FY12: [FY12 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY12-Town-of-Marblehead-ACFR.pdf) page 85
-- FY13: [FY13 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY13-Town-of-Marblehead-ACFR.pdf) page 85
-- FY14-FY16: [2016 FinCom Report](https://marbleheadma.gov/wp-content/uploads/2026/02/2016-Annual-Town-Meeting-Finance-Committee-Report.pdf) page 17, Line 221
-- FY17-FY19: [2019 FinCom Report](https://marbleheadma.gov/wp-content/uploads/2026/02/2019-Annual-Town-Meeting-Finance-Committee-Report.pdf) page 14, Line 221
-- FY21-FY23: [2022 FinCom Report](https://marbleheadma.gov/wp-content/uploads/2025/05/fincom_report_final_print_2022.pdf) page 17, Line 221
-- FY24-FY25: [2025 FinCom Report](https://marbleheadma.gov/wp-content/uploads/2025/05/2025-Annual-Town-Meeting-Finance-Committee-Report.pdf) page 23, Line 221
-- FY26-FY27: [FY27 Proposed Budget](https://marbleheadma.gov/wp-content/uploads/2026/04/PROPOSED-FY27-BALANCED-BUDGET-WITH-NO-OVERRIDE.pdf) page 4, Line 221
+- FY06: [FY06 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY06_ACFR.pdf) page 82, budget schedule, "Group Insurance" line
+- FY07: [FY07 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY07_ACFR.pdf) page 84
+- FY08: [FY08 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY08_ACFR.pdf) page 83
+- FY09: [FY09 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY09_ACFR.pdf) page 85
+- FY10: [FY10 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY10_ACFR.pdf) page 83
+- FY11: [FY11 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY11_ACFR.pdf) page 83
+- FY12: [FY12 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY12_ACFR.pdf) page 85
+- FY13: [FY13 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY13_ACFR.pdf) page 85
+- FY14-FY16: [2016 FinCom Report](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2016_FinCom_Report.pdf) page 17, Line 221
+- FY17-FY19: [2019 FinCom Report](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2019_FinCom_Report.pdf) page 14, Line 221
+- FY21-FY23: [2022 FinCom Report](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2022_FinCom_Report.pdf) page 17, Line 221
+- FY24-FY25: [2025 FinCom Report](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2025_FinCom_Report.pdf) page 23, Line 221
+- FY26-FY27: [FY27 Proposed Budget](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY27_Proposed_Budget_No_Override.pdf) page 4, Line 221
 
 ## Pension Expenditure ($5.1M in FY01 to $12.5M in FY24)
-- FY01-FY10: [FY10 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY10-Town-of-Marblehead-ACFR.pdf) page 118, "Changes in Fund Balances," "Pension benefits" row
-- FY05-FY14: [FY14 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY14-Town-of-Marblehead-ACFR.pdf) page 114, same table
-- FY15-FY24: [FY24 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY24-Town-of-Marblehead-ACFR.pdf) page 126, same table
+- FY01-FY10: [FY10 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY10_ACFR.pdf) page 118, "Changes in Fund Balances," "Pension benefits" row
+- FY05-FY14: [FY14 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY14_ACFR.pdf) page 114, same table
+- FY15-FY24: [FY24 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY24_ACFR.pdf) page 126, same table
 - CAUTION: This line is volatile due to GASB accounting changes. Not a clean trend.
 
 ## Pension Assessment - Budget Line ($5,380,625 in FY26)
-- FY26-FY27: [FY27 Proposed Budget](https://marbleheadma.gov/wp-content/uploads/2026/04/PROPOSED-FY27-BALANCED-BUDGET-WITH-NO-OVERRIDE.pdf) page 4, Line 217 "Contributory Retirement Fund"
+- FY26-FY27: [FY27 Proposed Budget](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY27_Proposed_Budget_No_Override.pdf) page 4, Line 217 "Contributory Retirement Fund"
 - FY27: $5,843,360 (same document)
 
 ## OPEB Insurance Membership (642-748 active, FY11-FY24)
-- FY11: [FY11 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY11-Town-of-Marblehead-ACFR.pdf) page 93
-- FY12: [FY12 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY12-Town-of-Marblehead-ACFR.pdf) page 95
-- FY13: [FY13 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY13-Town-of-Marblehead-ACFR.pdf) page 72 (also [FY14 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY14-Town-of-Marblehead-ACFR.pdf) page 73)
-- FY15: [FY15 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY15-Town-of-Marblehead-ACFR.pdf) page 74 (also [FY16 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY16-Town-of-Marblehead-ACFR.pdf) page 76)
-- FY17: [FY17 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY17-Town-of-Marblehead-ACFR.pdf) page 80 (also [FY18 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY18-Town-of-Marblehead-ACFR.pdf) page 81)
-- FY20: [FY20 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY20-Town-of-Marblehead-ACFR.pdf) page 82
-- FY22: [FY22 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY22-Town-of-Marblehead-ACFR.pdf) page 81
-- FY24: [FY24 ACFR](https://marbleheadma.gov/wp-content/uploads/2025/03/FY24-Town-of-Marblehead-ACFR.pdf) page 78
+- FY11: [FY11 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY11_ACFR.pdf) page 93
+- FY12: [FY12 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY12_ACFR.pdf) page 95
+- FY13: [FY13 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY13_ACFR.pdf) page 72 (also [FY14 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY14_ACFR.pdf) page 73)
+- FY15: [FY15 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY15_ACFR.pdf) page 74 (also [FY16 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY16_ACFR.pdf) page 76)
+- FY17: [FY17 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY17_ACFR.pdf) page 80 (also [FY18 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY18_ACFR.pdf) page 81)
+- FY20: [FY20 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY20_ACFR.pdf) page 82
+- FY22: [FY22 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY22_ACFR.pdf) page 81
+- FY24: [FY24 ACFR](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY24_ACFR.pdf) page 78
 
 ## GIC Premium Rates ($24,107 in FY19 to $38,562 in FY26)
 - FY19: [Wayback Machine archive](https://web.archive.org/web/20181127081902/https://www.mass.gov/doc/rate-chart-1-2018-active-employee-basic-life-health-insurance-coverage-non-medicare-plans-and/download) of mass.gov GIC rate chart 1
@@ -81,7 +83,7 @@ Use this to trace any chart number back to its original document and page. For p
 - Funding schedule: same document, page 13
 
 ## FY26 Budget Line Items (every position and salary)
-- [FY26 General Fund Budget](https://marbleheadma.gov/wp-content/uploads/2025/09/FY26-GENERAL-FUND-BUDGET-MUNIS-SYSTEM-1.xlsx) (Excel)
+- [FY26 General Fund Budget](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY26_General_Fund_Budget.xlsx) (Excel)
 - Four sheets: TOWN BUDGET, SCHOOL BUDGET, TOWN PIVOT TABLE, SCHOOL PIVOT TABLE
 - Key lookups:
   - Town Administrator salary: TOWN BUDGET, "SB-DEPT HEAD" = $207,732
@@ -91,11 +93,11 @@ Use this to trace any chart number back to its original document and page. For p
   - Pension: TOWN PIVOT TABLE, "CONTRIB RETIRE" = $5,380,625
 
 ## FY27 Deficit ($8,471,823)
-- [2026 State of the Town](https://marbleheadma.gov/wp-content/uploads/2026/02/2026-State-of-the-Town-Presenation-Final.pdf), page 29
+- [2026 State of the Town](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026_State_of_the_Town.pdf), page 29
 - Revenue $101,024,029 minus Expenses $109,495,852 = -$8,471,823
 
 ## Revenue and Expense Projections
-- [2026 State of the Town](https://marbleheadma.gov/wp-content/uploads/2026/02/2026-State-of-the-Town-Presenation-Final.pdf), pages 13-29
+- [2026 State of the Town](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026_State_of_the_Town.pdf), pages 13-29
 - FY25 actual, FY26 projected, FY27 projected with line-by-line detail
 
 ## Melrose/Stoneham Case Studies
@@ -103,7 +105,7 @@ Use this to trace any chart number back to its original document and page. For p
 - Sources listed within the document
 
 ## Override Tier Amounts and Tax Impact
-- Primary: [Town Administrator's Override Presentation, April 8, 2026](2026-04-08_Override_Presentation.pdf) (local copy in `data/`)
+- Primary: [Town Administrator's Override Presentation, April 8, 2026](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-08_Override_Presentation.pdf)
 - Summary: Marblehead Independent, ["Kezer presents $9M-to-$15M tiered override plan"](https://www.marbleheadindependent.com/kezer-presents-9m-to-15m-tiered-override-plan-and-separate-2-2m-trash-tax-option/)
 
 Extracted into:


### PR DESCRIPTION
## Summary

- Rewrites 37 `marbleheadma.gov/wp-content/uploads/...` document URLs in `data/SOURCE_LOOKUP.md` to their stable counterparts on the `source-archive-v1` GitHub release (landed in #132).
- Fixes one pre-existing dead relative link to `2026-04-08_Override_Presentation.pdf`, which was 404 on the live site because that file is gitignored.
- Adds one intro line documenting the convention: document links go through the archive, state-agency links stay on live upstream URLs.

## Why

The town's WordPress migration has been shifting `marbleheadma.gov/wp-content/uploads/...` URLs, and the paths in `SOURCE_LOOKUP.md` were already showing signs of that churn (e.g. `fincom_report_final_print_2022.pdf` under `/2025/05/`, vs. other years under `/2026/02/`). When a citation URL dies, the corresponding number on the site can no longer be traced to its primary source, which is the central promise of this project. Pointing those links at a release we own gives every citation a stable path.

## Scope

**Rewritten (37 occurrences, 24 distinct URLs):**
- 16 ACFRs (FY06-FY18 every year, plus FY20, FY22, FY24)
- 4 FinCom reports (2016, 2019, 2022, 2025)
- FY27 Proposed Budget (twice)
- FY26 General Fund Budget (xlsx)
- 2026 State of the Town (twice)
- April 8 2026 Override Presentation (was a broken relative link)

**Deliberately NOT rewritten:**
- MA DOR DLS data portals (\`dls-gw.dor.state.ma.us\`) — live query URLs, not brittle uploads
- mass.gov GIC rate sheets and the PERAC 2024 valuation — stable state URLs
- Wayback Machine archives
- All Marblehead Independent, Current, Itemlive, and Boston Globe article links

## Verification

- 0 remaining \`marbleheadma.gov\` references in \`SOURCE_LOOKUP.md\`
- 24 unique release URLs, all cross-checked against the 43 assets in the published \`source-archive-v1\` release (empty set-difference)
- 0 em-dashes introduced (per STYLE_GUIDE)
- \`+40/-38\` diff, confined to URL swaps and one new intro paragraph
- Unchanged content (news article links, Boston Globe link, CAUTION notes, extracted-CSV list, override tier breakdown) preserved verbatim

## Test plan

- [ ] Click through to \`marbleheaddata.org/data/SOURCE_LOOKUP.html\` after merge
- [ ] Spot-check a few document links: FY24 ACFR, FY10 ACFR (hit from 5 different tables), 2022 FinCom Report, FY27 Proposed Budget, 2026 State of the Town, and the previously-broken Override Presentation link
- [ ] Confirm state-agency links (DOR portal, PERAC, mass.gov GIC sheets) still point at their live upstream URLs