### PR TITLE
Fix reading-time undercount from adjacent-tag word gluing

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -9,17 +9,21 @@ layout: default
   {%- comment -%}
   Reading-time label. Word count uses strip_html first so inline <style>
   and <script> blocks don't inflate the count (Jekyll's strip_html drops
-  those blocks AND their content, not just the tags). Chart count is
-  computed on the raw content before stripping, since strip_html would
-  remove the <svg> and <iframe> tokens we're counting.
-  Heuristic: 230 wpm + 30s per chart. Bands: <3min unlabeled, 3–7 "~5 min",
-  8–12 "~10 min", 13+ "deep dive".
+  those blocks AND their content, not just the tags). The replace before
+  strip_html inserts a space after every `>` so adjacent tags like
+  `<p>foo</p><p>bar</p>` don't glue into `foobar` after stripping —
+  without it, pages with dense tag nesting undercount words by ~5% and
+  can land in the wrong reading-time band. Chart count is computed on
+  the raw content before stripping, since strip_html would remove the
+  <svg> and <iframe> tokens we're counting.
+  Heuristic: 230 wpm + 30s per chart. Bands: <3min unlabeled, 3&ndash;7 "~5 min",
+  8&ndash;12 "~10 min", 13+ "deep dive".
   {%- endcomment -%}
   {%- assign _rt_svgs = content | split: "<svg" | size | minus: 1 -%}
   {%- assign _rt_iframe_charts = content | split: 'src="charts/' | size | minus: 1 -%}
   {%- assign _rt_chart_count = _rt_svgs | plus: _rt_iframe_charts -%}
   {%- assign _rt_chart_min = _rt_chart_count | divided_by: 2 -%}
-  {%- assign _rt_words = content | strip_html | number_of_words -%}
+  {%- assign _rt_words = content | replace: '>', '> ' | strip_html | number_of_words -%}
   {%- assign _rt_minutes = _rt_words | divided_by: 230 | plus: _rt_chart_min -%}
   {%- if _rt_minutes >= 13 -%}
     <p class="read-time">Deep dive</p>


### PR DESCRIPTION
## Summary

Reading-time word counts were undercounting by ~5% on pages with dense tag nesting, because Liquid's `strip_html` replaces each tag with the empty string — so `<p>foo</p><p>bar</p>` becomes `foobar` (one word) instead of `foo bar` (two words).

On `why-not-elsewhere.html` that undercount was enough to push it from "Deep dive" (~14 min actual) down to "~10 min read" (12 min computed) — a user-visible wrong band for a page that's clearly in the deep-dive tier.

## Fix

One-filter prepend: `| replace: '>', '> '` before `strip_html`. Inserts a space after every closing angle bracket so tag boundaries survive the strip as word boundaries. Costs nothing at build time.

## Verification (simulated against current content)

| Page | Before fix | After fix | Change |
|---|---|---|---|
| about.html | (no label) | (no label) | — |
| privacy.html | (no label) | (no label) | — |
| how-we-got-here.html | ~5 min read | ~5 min read | — |
| no-override-budget.html | ~5 min read | ~5 min read | — |
| what-you-can-do.html | ~10 min read | ~10 min read | — |
| senior-tax-relief.html | ~10 min read | ~10 min read | — |
| **why-not-elsewhere.html** | **~10 min read** | **Deep dive** | **fixed** |
| question-2-trash.html | Deep dive | Deep dive | — |
| where-has-the-money-gone.html | Deep dive | Deep dive | — |
| the-debate.html | Deep dive | Deep dive | — |
| what-is-the-override.html | Deep dive | Deep dive | — |

Only one page changes band; everything else is stable.

## Test plan
- [ ] After Pages rebuilds, load `/why-not-elsewhere.html` and confirm the label above the h1 now reads "Deep dive" instead of "~10 min read"
- [ ] Spot-check `/the-debate.html` (should still say "Deep dive") and `/how-we-got-here.html` (should still say "~5 min read") to confirm no regressions