### PR TITLE
Replace copy button text with clipboard icon

### DIFF
--- a/about.html
+++ b/about.html
@@ -99,16 +99,13 @@ og_title: "Who made this?"
     position: absolute;
     top: 8px;
     right: 8px;
-    font-size: 10px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.8px;
-    padding: 5px 10px;
+    padding: 5px 6px;
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: 6px;
     color: var(--text-subtle);
     cursor: pointer;
+    line-height: 1;
     transition: background 0.15s, border-color 0.15s, color 0.15s;
   }
   .audit-copy:hover {
@@ -117,10 +114,10 @@ og_title: "Who made this?"
     color: var(--text);
   }
   .audit-copy.is-copied {
-    background: color-mix(in srgb, var(--c-navy) 10%, var(--surface));
-    border-color: var(--c-navy);
     color: var(--c-navy);
+    border-color: var(--c-navy);
   }
+  .audit-copy svg { display: block; }
 </style>
 
   <h1>Who made this?</h1>
@@ -141,7 +138,7 @@ og_title: "Who made this?"
     <pre class="audit-snippet"><code>git clone https://github.com/agbaber/marblehead
 cd marblehead
 claude "audit this site. find the bias. follow the money. be skeptical."</code></pre>
-    <button type="button" class="audit-copy" aria-label="Copy the audit command to clipboard">Copy</button>
+    <button type="button" class="audit-copy" aria-label="Copy to clipboard"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><rect x="5.5" y="5.5" width="8" height="8" rx="1.5"/><path d="M3.5 10.5h-1a1.5 1.5 0 0 1-1.5-1.5v-6a1.5 1.5 0 0 1 1.5-1.5h6a1.5 1.5 0 0 1 1.5 1.5v1"/></svg></button>
   </div>
   <script>
   (function () {
@@ -151,13 +148,15 @@ claude "audit this site. find the bias. follow the money. be skeptical."</code><
       if (btn) btn.hidden = true;
       return;
     }
+    var copyIcon = btn.innerHTML;
+    var checkIcon = '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 8.5l3 3 6-6.5"/></svg>';
     btn.addEventListener('click', function () {
       navigator.clipboard.writeText(target.textContent).then(function () {
         btn.classList.add('is-copied');
-        btn.textContent = 'Copied';
+        btn.innerHTML = checkIcon;
         setTimeout(function () {
           btn.classList.remove('is-copied');
-          btn.textContent = 'Copy';
+          btn.innerHTML = copyIcon;
         }, 1500);
       });
     });


### PR DESCRIPTION
## Summary
- Replaces the text "Copy" / "Copied" button on the audit snippet with a clipboard SVG icon
- Shows a checkmark icon briefly after copying, then reverts to the clipboard icon
- Removes font-size/weight/letter-spacing styles that were only needed for the text label

## Test plan
- [ ] Verify the clipboard icon renders in the top-right of the code snippet
- [ ] Click the icon and confirm it copies the commands to clipboard
- [ ] Confirm the icon briefly changes to a checkmark, then reverts

🤖 Generated with [Claude Code](https://claude.com/claude-code)