### PR TITLE
Add AI bias audit report and remediation plan

### DIFF
--- a/about.html
+++ b/about.html
@@ -64,22 +64,37 @@ og_title: "Who made this?"
   @media (max-width: 600px) {
     .meta-pill { padding: 6px 12px; font-size: 12px; }
   }
-  .audit-snippet-wrap {
-    position: relative;
-    margin: 0 0 24px;
-  }
   .audit-snippet {
+    position: relative;
     font-family: var(--font-mono);
     font-size: 13px;
     line-height: 1.6;
-    padding: 14px 60px 14px 18px;
+    padding: 14px 18px;
     background: color-mix(in srgb, var(--c-navy) 6%, var(--surface));
     border-left: 3px solid var(--c-navy);
     border-radius: 0 10px 10px 0;
     color: var(--text);
     overflow-x: auto;
-    margin: 0;
+    margin: 0 0 24px;
   }
+  .audit-copy-btn {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 5px 6px;
+    cursor: pointer;
+    color: var(--text-subtle);
+    line-height: 1;
+    transition: color 0.15s, border-color 0.15s;
+  }
+  .audit-copy-btn:hover {
+    color: var(--text);
+    border-color: var(--text-faint);
+  }
+  .audit-copy-btn svg { display: block; }
   .audit-snippet code {
     font-family: inherit;
     font-size: inherit;
@@ -95,29 +110,6 @@ og_title: "Who made this?"
     background: var(--divider);
     border-radius: 4px;
   }
-  .audit-copy {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    padding: 5px 6px;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    color: var(--text-subtle);
-    cursor: pointer;
-    line-height: 1;
-    transition: background 0.15s, border-color 0.15s, color 0.15s;
-  }
-  .audit-copy:hover {
-    background: var(--divider);
-    border-color: var(--text-faint);
-    color: var(--text);
-  }
-  .audit-copy.is-copied {
-    color: var(--c-navy);
-    border-color: var(--c-navy);
-  }
-  .audit-copy svg { display: block; }
 </style>
 
   <h1>Who made this?</h1>
@@ -134,34 +126,21 @@ og_title: "Who made this?"
 
   <h2 data-stance-section="off">Audit it yourself</h2>
   <p class="audit-note">If you have <code>git</code> and <a href="https://claude.com/claude-code">Claude Code</a> installed, you can check the work from your terminal. The repo's <code>CLAUDE.md</code> and <code>STYLE_GUIDE.md</code> will orient Claude automatically.</p>
-  <div class="audit-snippet-wrap">
-    <pre class="audit-snippet"><code>git clone https://github.com/agbaber/marblehead
+  <pre class="audit-snippet"><button class="audit-copy-btn" aria-label="Copy to clipboard"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><rect x="5.5" y="5.5" width="8" height="8" rx="1.5"/><path d="M3.5 10.5h-1a1.5 1.5 0 0 1-1.5-1.5v-6a1.5 1.5 0 0 1 1.5-1.5h6a1.5 1.5 0 0 1 1.5 1.5v1"/></svg></button><code>git clone https://github.com/agbaber/marblehead
 cd marblehead
 claude "audit this site. find the bias. follow the money. be skeptical."</code></pre>
-    <button type="button" class="audit-copy" aria-label="Copy to clipboard"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><rect x="5.5" y="5.5" width="8" height="8" rx="1.5"/><path d="M3.5 10.5h-1a1.5 1.5 0 0 1-1.5-1.5v-6a1.5 1.5 0 0 1 1.5-1.5h6a1.5 1.5 0 0 1 1.5 1.5v1"/></svg></button>
-  </div>
+
   <script>
-  (function () {
-    var btn = document.querySelector('.audit-copy');
-    var target = document.querySelector('.audit-snippet code');
-    if (!btn || !target || !navigator.clipboard) {
-      if (btn) btn.hidden = true;
-      return;
-    }
-    var copyIcon = btn.innerHTML;
-    var checkIcon = '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 8.5l3 3 6-6.5"/></svg>';
-    btn.addEventListener('click', function () {
-      navigator.clipboard.writeText(target.textContent).then(function () {
-        btn.classList.add('is-copied');
-        btn.innerHTML = checkIcon;
-        setTimeout(function () {
-          btn.classList.remove('is-copied');
-          btn.innerHTML = copyIcon;
-        }, 1500);
-      });
-    });
-  })();
+  document.querySelector('.audit-copy-btn').addEventListener('click', function() {
+    var text = this.closest('pre').querySelector('code').textContent;
+    navigator.clipboard.writeText(text);
+    var svg = this.innerHTML;
+    this.innerHTML = '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 8.5l3 3 6-6.5"/></svg>';
+    var btn = this;
+    setTimeout(function() { btn.innerHTML = svg; }, 1500);
+  });
   </script>
+  <p>The first audit has already been run. Read the <a href="bias-audit.html">full bias audit</a> and the <a href="bias-remediation-plan">remediation plan</a> for every finding.</p>
 
   <h2>Reactions</h2>
   <p>Some sections let you react as you read. Your reactions stay in this browser, and no one else can see which one you picked. The number next to each section is a rough measure of interest, not a poll.</p>

--- a/bias-audit.html
+++ b/bias-audit.html
@@ -1,0 +1,208 @@
+---
+title: "Bias audit"
+og_title: "Bias audit"
+og_description: An independent AI audit of marbleheaddata.org for bias, selective framing, and editorial tilt. Run on April 11, 2026 using Claude Code against the full codebase.
+og_url: https://marbleheaddata.org/bias-audit.html
+---
+<style>
+  .audit-meta {
+    font-size: 13px;
+    color: var(--text-muted);
+    line-height: 1.55;
+    padding: 14px 18px;
+    background: color-mix(in srgb, var(--c-navy) 4%, var(--surface));
+    border-left: 3px solid var(--c-navy);
+    border-radius: 0 10px 10px 0;
+    margin: 0 0 28px;
+  }
+  .audit-meta p { margin: 0 0 6px; }
+  .audit-meta p:last-child { margin-bottom: 0; }
+  .finding {
+    padding: 16px 20px;
+    margin: 14px 0;
+    border-radius: 0 10px 10px 0;
+    border-left: 4px solid var(--border);
+    background: var(--surface);
+    box-shadow: var(--shadow-sm);
+  }
+  .finding--pass {
+    border-left-color: var(--c-sage);
+  }
+  .finding--concern {
+    border-left-color: var(--c-brass);
+  }
+  .finding-label {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.4px;
+    margin-bottom: 6px;
+  }
+  .finding--pass .finding-label { color: var(--c-sage); }
+  .finding--concern .finding-label { color: var(--c-brass); }
+  .finding h3 { margin-top: 0; }
+  .finding p { font-size: 15px; line-height: 1.65; }
+  .finding p:last-child { margin-bottom: 0; }
+  .finding blockquote {
+    margin: 10px 0;
+    padding: 8px 14px;
+    border-left: 2px solid var(--border);
+    font-style: italic;
+    font-size: 14px;
+    color: var(--text-muted);
+  }
+  .severity {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    margin-left: 8px;
+    vertical-align: middle;
+  }
+  .severity--low {
+    background: color-mix(in srgb, var(--c-sage) 12%, var(--surface));
+    color: var(--c-sage);
+  }
+  .severity--moderate {
+    background: color-mix(in srgb, var(--c-brass) 12%, var(--surface));
+    color: var(--c-brass);
+  }
+  .severity--structural {
+    background: color-mix(in srgb, var(--c-navy) 10%, var(--surface));
+    color: var(--c-navy);
+  }
+  @media (max-width: 600px) {
+    .finding { padding: 14px 16px; }
+    .finding p { font-size: 14px; }
+  }
+</style>
+
+<h1>Bias audit</h1>
+
+  <div class="audit-meta">
+    <p><strong>Auditor:</strong> Claude Code (claude-opus-4-6), run against the full codebase on April 11, 2026.</p>
+    <p><strong>Scope:</strong> All HTML pages, all CSV/JSON data files, all chart source code, all editorial copy, STYLE_GUIDE.md, README.md, CLAUDE.md, case studies, and the debate page.</p>
+    <p><strong>Method:</strong> Systematic review of time-range selection, axis scaling, annotation choices, caption language, case-study selection, page architecture, and narrative framing. No external data was fetched; the audit is based entirely on what ships in the repository.</p>
+    <p><strong>Prompt used:</strong> <code>claude "audit this site. find the bias. follow the money. be skeptical."</code></p>
+  </div>
+
+  <p>This page is the unedited output of an AI bias audit of this site. The site's author invited it on the <a href="about.html">about page</a>. The remediation plan for every finding is published separately: <a href="bias-remediation-plan">bias remediation plan</a>.</p>
+
+  <h2>Where the bias controls are genuinely strong</h2>
+
+  <div class="finding finding--pass">
+    <div class="finding-label">Pass</div>
+    <h3>Sourcing discipline</h3>
+    <p>Every number checked traces to a named primary document with a page number (ACFRs, DOR reports, PERAC valuations, GIC rate sheets, FinCom transmittal letters). The <a href="data/SOURCE_LOOKUP">SOURCE_LOOKUP</a> and <a href="data/DATA_CATALOG">DATA_CATALOG</a> files are detailed and auditable. This is not a site making up numbers.</p>
+  </div>
+
+  <div class="finding finding--pass">
+    <div class="finding-label">Pass</div>
+    <h3>Time ranges are not cherry-picked</h3>
+    <p>Tax levy data spans FY01 to FY24 (23 years). Health insurance spans FY06 to FY27 (21 years). Enrollment and staffing span FY01 to FY24 (23 years). No suspiciously convenient start dates were found.</p>
+  </div>
+
+  <div class="finding finding--pass">
+    <div class="finding-label">Pass</div>
+    <h3>Chart axes are honest</h3>
+    <p>No truncated Y-axes to exaggerate trends. Indexed charts start at 100 (appropriate). Actual vs. projected data uses solid vs. dashed lines with clear labels.</p>
+  </div>
+
+  <div class="finding finding--pass">
+    <div class="finding-label">Pass</div>
+    <h3>Data caveats are surfaced, not hidden</h3>
+    <p>The FY23 FTE jump (+54 education positions in one year) is flagged as unexplained. The FY24 OPEB member spike is noted as likely a methodology change. Missing GIC rate sheets are disclosed. Derived data is labeled with precision estimates.</p>
+  </div>
+
+  <div class="finding finding--pass">
+    <div class="finding-label">Pass</div>
+    <h3>The debate page is structurally fair</h3>
+    <p>Six dividing lines, each with a "for" and "against" block of roughly equal length and rhetorical quality. The "against" arguments are not strawmen. They cite named officials (Select Board member Moses Grader, FinCom Chair Alec Goolsby, School Committee member Tom Mathers) and link to the same underlying data. The mini-synthesis blocks between each tension are genuinely clarifying, not secretly pro-override.</p>
+  </div>
+
+  <div class="finding finding--pass">
+    <div class="finding-label">Pass</div>
+    <h3>No fabrication, no selective data</h3>
+    <p>Health insurance growing 60% over seven years is real (GIC sets the rates). Enrollment declining 21% while staffing stayed flat is real data from DESE and ACFRs. The $8.47M gap calculation is sourced to the State of the Town presentation and proposed budget and the waterfall chart components add up. Peer-town comparisons are normalized correctly.</p>
+  </div>
+
+  <div class="finding finding--pass">
+    <div class="finding-label">Pass</div>
+    <h3>Follow the money: there is very little to follow</h3>
+    <p>The site costs approximately $108 per year in domain fees plus a Claude AI subscription the author was already paying. No ads, no donations, no PAC, no campaign affiliation. The author's financial interest is as a homeowner (property tax goes up if the override passes) and parent (school services decline if it does not). Both are disclosed on the <a href="about.html">about page</a>. The community-pulse widget counts interest, not opinions. No email capture. No fundraising.</p>
+  </div>
+
+  <h2>Where the bias is</h2>
+
+  <div class="finding finding--concern">
+    <div class="finding-label">Concern</div>
+    <h3>1. The case studies are advocacy wearing a footnote <span class="severity severity--moderate">Moderate</span></h3>
+    <p>The <a href="data/case_studies">case studies page</a> presents Melrose and Stoneham, two towns that rejected overrides, suffered cuts, and then passed <em>larger</em> overrides. The "key lesson" boxes are editorial:</p>
+    <blockquote>Key lesson. Voted no on $7.7M. Lived through the cuts. Came back and voted yes on $13.5M &ndash; 75% more. The cost of delay: one year of deep cuts that had to be reversed, plus a bigger eventual bill.</blockquote>
+    <p>This is not a neutral observation. It is a cautionary tale with a clear moral: "if you vote no, you will end up paying more later." The site does not present case studies of towns that voted no and successfully restructured without a larger override. There may not be many such cases, but the absence is not acknowledged. The selection of comparison towns does argumentative work.</p>
+    <p>The statewide statistics reinforce this: "of towns that put a failed override back to voters, 590 passed within one year." This frames rejection as delay, not as a viable outcome.</p>
+  </div>
+
+  <div class="finding finding--concern">
+    <div class="finding-label">Concern</div>
+    <h3>2. The no-override page is more vivid than the override-cost page <span class="severity severity--moderate">Moderate</span></h3>
+    <p>The <a href="no-override-budget.html">no-override budget page</a> is the most visually detailed page on the site: a headcount bar showing 22 positions cut, a department-by-department waterfall with colored bars, named services (library &minus;43%, Community Development &minus;59%), and a link to case studies of towns that lived through cuts.</p>
+    <p>The override <em>cost</em> to taxpayers is presented on the <a href="charts/override_calculator.html">calculator page</a>, which is functional but clinical: type in your home value, see a monthly dollar amount. There is no equivalent emotional weight. No visualization of what $400 per month means to a median household, no case studies of towns where overrides strained fixed-income residents, no "what $15M in new taxes looks like over 10 years."</p>
+    <p>Both pages are factually accurate. But the asymmetry in vividness &ndash; detailed harm from no-override, abstract cost from yes-override &ndash; creates an emotional tilt toward approval.</p>
+  </div>
+
+  <div class="finding finding--concern">
+    <div class="finding-label">Concern</div>
+    <h3>3. The "how we got here" narrative favors the institutional account <span class="severity severity--low">Low-moderate</span></h3>
+    <p>The <a href="how-we-got-here.html">how we got here</a> page constructs a narrative of responsible governance: FinCom balanced budgets for 16 years, warned about unsustainability starting in 2019, predicted the override in 2022. The page concludes that "the 'board always wants more' skepticism does not fit the record."</p>
+    <p>This is an editorial conclusion presented as historical finding. It forecloses a legitimate counter-reading: that the same boards presided over the spending growth that created the deficit, and their warnings were about a problem of their own making. The debate page does present this counter-argument (tension #5), but the standalone history page does not. It reads as a defense of institutional credibility.</p>
+  </div>
+
+  <div class="finding finding--concern">
+    <div class="finding-label">Concern</div>
+    <h3>4. The "against" side has fewer named advocates <span class="severity severity--low">Low</span></h3>
+    <p>The debate page's notes section acknowledges this directly: "Named officials and school administrators appear more often on the record than resident opponents of the override." The practical effect is that the "for" side is represented by the Town Administrator, Finance Director, Superintendent, and parent advocates with names and quotes, while the "against" side draws more on a single Select Board dissenter and on structural arguments.</p>
+    <p>This is partly a function of who speaks on the record in public meetings. The site acknowledges it. But the resulting asymmetry in human voices matters for how persuasive each side feels.</p>
+  </div>
+
+  <div class="finding finding--concern">
+    <div class="finding-label">Concern</div>
+    <h3>5. The author's "undecided" framing is unverifiable <span class="severity severity--structural">Structural</span></h3>
+    <p>The <a href="about.html">about page</a> states: "The author is a Marblehead homeowner who is genuinely undecided." The site's construction &ndash; 3,000+ pages of primary sources processed, 41 CSVs, 15+ HTML pages, a peer-town structural analysis, a debate page with six tensions &ndash; is an enormous amount of work. The question is whether someone genuinely undecided would build a site this comprehensive, or whether the site is the product of someone who has already decided and is building the case with enough balance to be credible.</p>
+    <p>This cannot be resolved from the code. The "audit it yourself" invitation is itself a rhetorical move: it signals confidence that the audit will come back clean, which it mostly does. That confidence is itself a tell.</p>
+  </div>
+
+  <div class="finding finding--concern">
+    <div class="finding-label">Concern</div>
+    <h3>6. The site's existence is itself pro-override <span class="severity severity--structural">Structural</span></h3>
+    <p>The deepest bias is structural. The site exists because there is a vote. If the default outcome (no override, service cuts) were not on the table, no one would build this site. The homepage question hierarchy starts with "What is the override?" and "What's in the no-override budget?" &ndash; framing the override as the central question and the cuts as the thing that needs explaining.</p>
+    <p>A site framed from the skeptic's perspective might equally lead with "What would the override cost over 10 years?" or "What alternatives to an override exist?" or "How did spending reach this level?" The site does cover these questions, but they are secondary to the override/no-override binary.</p>
+    <p>This is partly inherent to the occasion: any site built for a vote will center the vote. But it is worth naming.</p>
+  </div>
+
+  <h2>Bottom line</h2>
+
+  <p>This is a genuinely high-integrity civic data project with real bias controls that work. The sourcing is verifiable, the data is not fabricated, the debate page is structurally fair, and the editorial rules are followed with discipline.</p>
+
+  <p>The bias that exists is <strong>bias of emphasis</strong>, not bias of fabrication:</p>
+  <ol>
+    <li>Case studies only show towns where "no" led to a bigger "yes" later</li>
+    <li>The cost of rejection is visualized more vividly than the cost of approval</li>
+    <li>The institutional narrative is sympathetic to the boards that created the deficit</li>
+    <li>The "against" side has fewer named human voices</li>
+    <li>The author's neutrality claim is unverifiable</li>
+    <li>The site's architecture inherently centers the override question</li>
+  </ol>
+
+  <p>A skeptical no-override voter would find their arguments represented on the debate page, but would notice that the rest of the site's architecture &ndash; the case studies, the no-override budget detail, the "how we got here" timeline &ndash; builds a stronger gravitational pull toward "yes." The site is neutral <em>on the debate page</em> but slightly pro-override <em>in its architecture</em>.</p>
+
+  <p>Whether that is intentional advocacy or the natural shape of following the data honestly is the question the author is asking you to decide for yourself.</p>
+
+  <p>The remediation plan for every finding on this page is published at <a href="bias-remediation-plan">bias remediation plan</a>.</p>
+
+  <div class="notes">
+    <p><strong>Methodology note.</strong> This audit was run by Claude Code (claude-opus-4-6) against the full repository on April 11, 2026. The AI was given the prompt shown at the top of this page and no other instructions beyond the project's own CLAUDE.md and STYLE_GUIDE.md. The output was written directly to this file by the author without substantive edits to the findings. The AI auditor has its own biases: it tends toward measured, both-sides framing, and it cannot verify claims against external documents not in the repository. A human auditor reviewing the same material might reach different conclusions.</p>
+  </div>

--- a/bias-remediation-plan.md
+++ b/bias-remediation-plan.md
@@ -1,0 +1,104 @@
+---
+layout: page
+body_class: doc-page
+title: Bias remediation plan
+---
+
+# Bias remediation plan
+
+Remediation actions for every finding in the [April 11, 2026 bias audit](bias-audit.html). Each item maps to a numbered concern from that report.
+
+---
+
+## 1. Case studies show only one direction (Moderate)
+
+**Finding:** The case studies page presents Melrose and Stoneham, both towns where a failed override led to cuts and then a larger override. No counter-examples are presented. The "key lesson" boxes use editorial language ("cost of delay," "bigger eventual bill").
+
+**Remediation:**
+
+- **1a. Add counter-examples or acknowledge their absence.** Research Massachusetts towns that rejected overrides and sustained the resulting budget without returning to the ballot at a larger amount within three years. If such towns exist, add them as case studies with equal depth. If the research finds that the pattern genuinely runs one direction (failed overrides nearly always return larger), state that finding explicitly and cite the DOR dataset that supports it, so the reader knows the selection is not cherry-picked but representative.
+- **1b. Remove editorial language from "key lesson" boxes.** Replace "cost of delay" and "bigger eventual bill" with factual summaries. Example: "Melrose rejected $7.7M in June 2024 and passed $13.5M in November 2025. The intervening 17 months included 61.4 FTE reductions." Let the reader draw the conclusion.
+- **1c. Add a framing note at the top of the case studies page.** State what the case studies show (towns that rejected and later passed) and what they do not show (towns that rejected and did not return, or towns that restructured successfully after rejection). Cite the source for the selection criteria.
+
+---
+
+## 2. Asymmetric vividness between no-override and override-cost pages (Moderate)
+
+**Finding:** The no-override budget page is the most visually detailed page on the site (headcount bars, department-by-department cut charts, named services). The override cost page is a clinical calculator. The emotional weight is asymmetric.
+
+**Remediation:**
+
+- **2a. Add a "what the override costs" visualization to the calculator page.** Show cumulative cost over 5 and 10 years for a median-value home at each tier, not just monthly. Include annual totals. Use the same visual language (bars, labeled amounts) as the no-override page.
+- **2b. Add fixed-income context to the calculator.** Note the median household income in Marblehead (from Census ACS data), and show the override cost as a percentage of median income at each tier. Note the number of households below a relevant income threshold. This gives the cost side the same human specificity that the cuts side has.
+- **2c. Add a "read next" link from the no-override page to the calculator.** The no-override page currently links to the debate page and case studies. Add an equally prominent link to the calculator so that readers who just saw the cuts immediately see the cost.
+
+---
+
+## 3. "How we got here" favors the institutional account (Low-moderate)
+
+**Finding:** The history page reads as a defense of institutional credibility. It quotes FinCom transmittal letters showing 16 years of balanced budgets and advance warnings, and concludes that "the 'board always wants more' skepticism does not fit the record." This forecloses the counter-reading that the same boards presided over the spending growth.
+
+**Remediation:**
+
+- **3a. Add the counter-reading to the history page.** After the FinCom timeline, add a section (or a callout block in the style of the debate page's mini-synthesis) that names the alternative interpretation: "A different reading of the same timeline: the Finance Committee presided over the spending growth that produced the deficit, and their warnings were about a problem of their own making. The debate page explores this tension in full." Link to tension #5 on the debate page.
+- **3b. Remove or qualify the editorial conclusion.** The sentence "the 'board always wants more' skepticism does not fit the record" is an editorial judgment. Either remove it or reframe it: "the record shows the board did not request overrides for 16 years. Whether that history is evidence of fiscal discipline or of deferred structural reform is one of the central tensions in the debate."
+
+---
+
+## 4. The "against" side has fewer named advocates (Low)
+
+**Finding:** The "for" side is represented by the Town Administrator, Finance Director, Superintendent, and named parent advocates. The "against" side draws primarily on a single Select Board dissenter and on structural arguments. This is partly a function of who speaks on the public record.
+
+**Remediation:**
+
+- **4a. Actively seek on-the-record quotes from override opponents.** Review Town Meeting transcripts, letters to the editor in the Marblehead Independent/Beacon/Current, and any public statements from the For Marblehead group (the organized opposition). Add named quotes where they strengthen the "against" perspective blocks on the debate page.
+- **4b. If quotes remain scarce, strengthen the disclosure.** Expand the existing notes-section acknowledgment into a more prominent callout that explains why the asymmetry exists and invites override opponents to contribute on-the-record statements via GitHub issue or pull request.
+
+---
+
+## 5. The author's "undecided" framing is unverifiable (Structural)
+
+**Finding:** The about page claims the author is "genuinely undecided." The scale of the project raises the question of whether this is credible. This cannot be resolved from the code.
+
+**Remediation:**
+
+- **5a. Replace the undecided claim with a process commitment.** Instead of claiming a state of mind that readers cannot verify, commit to a verifiable process: "I apply the same editorial rules to both sides of the debate. The STYLE_GUIDE.md enforces them. The bias audit tests them. If you find a violation, report it." This shifts the trust basis from intent (unverifiable) to process (auditable).
+- **5b. Publish the bias audit and this remediation plan.** (Done. The audit is at [bias-audit.html](bias-audit.html) and you are reading the remediation plan.) The act of publishing criticism of the site and committing to fix it is stronger evidence of good faith than a neutrality claim.
+
+---
+
+## 6. The site's architecture inherently centers the override (Structural)
+
+**Finding:** The homepage leads with "What is the override?" and "What's in the no-override budget?" A skeptic's version of the site might lead with "How did spending reach this level?" or "What alternatives to an override exist?"
+
+**Remediation:**
+
+- **6a. Elevate the spending and alternatives questions on the homepage.** Move "Where has Marblehead's money gone?" and the peer-town structural analysis higher in the homepage card order, so the spending-growth context appears before the override mechanics. The current order is: override, spending, cost drivers, peer comparison. Consider reordering to: spending, cost drivers, the override, peer comparison. This frames the override as one response to a spending situation rather than the central question.
+- **6b. Add a homepage card for the civic guide.** The "What can you do?" page is currently only in the nav bar. Give it a homepage card in the override section, positioned alongside the override and no-override cards, so that "engage beyond the vote" is as visible as the binary choice.
+- **6c. Acknowledge the structural framing in the about page or bias audit.** (Done. Finding #6 in the bias audit names this directly.)
+
+---
+
+## Implementation priority
+
+| Priority | Item | Effort |
+|----------|------|--------|
+| 1 | 1b. Remove editorial language from case study "key lesson" boxes | Small (text edit) |
+| 2 | 3b. Remove or qualify the editorial conclusion on the history page | Small (text edit) |
+| 3 | 5a. Replace "undecided" claim with process commitment | Small (text edit) |
+| 4 | 2c. Add "read next" link from no-override page to calculator | Small (HTML) |
+| 5 | 6b. Add civic guide homepage card | Small (HTML) |
+| 6 | 1c. Add framing note to case studies page | Small (text) |
+| 7 | 3a. Add counter-reading to history page | Medium (new section) |
+| 8 | 6a. Reorder homepage sections | Medium (HTML restructure) |
+| 9 | 2a. Add cumulative cost visualization to calculator | Medium (chart work) |
+| 10 | 2b. Add fixed-income context to calculator | Medium (data + text) |
+| 11 | 4a. Seek on-the-record quotes from override opponents | Large (research) |
+| 12 | 1a. Research and add counter-example towns | Large (research) |
+| 13 | 4b. Strengthen voice-asymmetry disclosure | Small (text, fallback if 4a is insufficient) |
+
+---
+
+## Status
+
+This plan was generated on April 11, 2026 alongside the bias audit. Items will be checked off as they are completed. Progress is tracked in the [GitHub repository](https://github.com/agbaber/marblehead).

--- a/question-2-trash.html
+++ b/question-2-trash.html
@@ -375,7 +375,19 @@ og_url: https://marbleheaddata.org/question-2-trash.html
   <p><strong>Already decided, not on the ballot:</strong> the choice to move curbside trash out of the general property tax budget was made by the Select Board before Question 2 was drafted. Whether voters approve Question 2 or reject it, the FY27 general fund Waste Collection line is still reduced by $1.15&nbsp;million, and that capacity is still available for other general fund spending. Question 2 is only about how to fund the carved-out curbside line.</p>
 </div>
 
-<h2>What is on the ballot</h2>
+<nav class="page-toc" aria-label="On this page">
+  <span class="page-toc-label">On this page</span>
+  <a href="#on-the-ballot">What is on the ballot</a>
+  <a href="#how-funded">How trash has been funded</a>
+  <a href="#why-changed">Why this changed</a>
+  <a href="#cost-by-home-value">Cost by home value</a>
+  <a href="#peer-towns">How other towns do it</a>
+  <a href="#long-term-alternatives">Long-term alternatives</a>
+  <a href="#trickiness-concern">The trickiness concern</a>
+  <a href="#not-covered">What this page does not cover</a>
+</nav>
+
+<h2 id="on-the-ballot">What is on the ballot</h2>
 
 <div class="ballot">
   <div class="ballot-header">
@@ -401,7 +413,7 @@ og_url: https://marbleheaddata.org/question-2-trash.html
 
 <p>Question 2's shape differs from Question 1. The operating override ramps over three years. At Tier 2, for example, the draw goes from $2.81M in FY27 to $8.71M in FY28 to the full $12M in FY29, because restored positions, maintenance work, and capital projects phase in over time. Question 2 hits full cost in FY27 because the new Republic Services contract starts immediately. In a Year 1 tax-bill comparison between the two questions, Q1 is still warming up while Q2 is already at steady state.</p>
 
-<h2>How trash has been funded</h2>
+<h2 id="how-funded">How trash has been funded</h2>
 
 <p>Before FY27, curbside trash and recycling was a line in the town's Waste Collection department, funded like any other general fund department: through property taxes, state aid, and local receipts.</p>
 
@@ -415,7 +427,7 @@ og_url: https://marbleheaddata.org/question-2-trash.html
 
 <p>Residents did not see a separate trash charge on their bills because the cost was embedded inside property tax revenue flowing to the general fund. The Waste Collection department spent the money; the property tax base funded the department.</p>
 
-<h2>Why this changed for FY27</h2>
+<h2 id="why-changed">Why this changed for FY27</h2>
 
 <p>The change has one specific trigger: a new contract with Republic Services that increased annual collection and processing costs by roughly $900,000 to $1 million. Recycling processing costs alone jumped from what the town had previously been paying (close to nothing for more than a decade) to roughly $125 per ton under the new contract terms. The earlier contract had locked in favorable terms that are no longer available on renewal.</p>
 
@@ -461,7 +473,7 @@ og_url: https://marbleheaddata.org/question-2-trash.html
 
 <p>The net effect: $1.15 million of what used to be general-fund trash spending is now available for other general fund needs. The remaining $2.19 million of trash costs needs to be funded through some new mechanism, because it is no longer in the general fund budget. That is where Question 2 (or the Board of Health's fallback fee) comes in.</p>
 
-<h2>What each outcome costs residents, by home value</h2>
+<h2 id="cost-by-home-value">What each outcome costs residents, by home value</h2>
 
 <p>Marblehead's total residential assessed value is approximately $9.9 billion, and the override of $2,298,575 translates to roughly $0.23 per $1,000 of assessed value added to the tax rate. The Board of Health's fallback fee is a flat $281 per household. Both options are designed to raise approximately the same total revenue; they differ in who pays.</p>
 
@@ -579,7 +591,7 @@ og_url: https://marbleheaddata.org/question-2-trash.html
 
 <p>A note on the shape of the choice: the flat fee is regressive compared to the levy. A household in a $500,000 home pays the same $281 as a household in a $3 million home. Under the levy, the $3 million home pays $698 (about 2.5 times the flat fee) while the $500,000 home pays $116 (less than half the flat fee). Whether that progressive distribution is better or worse depends on who you think should bear the cost.</p>
 
-<h2>How other Massachusetts towns fund curbside trash</h2>
+<h2 id="peer-towns">How other Massachusetts towns fund curbside trash</h2>
 
 <p>There is no single Massachusetts approach to funding curbside residential trash. Towns use a mix of property tax, flat fees, pay-as-you-throw (PAYT) systems, and hybrids. Three of Marblehead's closest comparison towns illustrate the range:</p>
 


### PR DESCRIPTION
## Summary
- Publishes the full output of a Claude Code bias audit run against the codebase on April 11, 2026
- Adds a remediation plan with 13 prioritized actions mapped to the 6 identified concerns
- Links both from the about page under "Audit it yourself"

### Audit findings
**7 passes:** sourcing discipline, time ranges, axis honesty, data caveats, debate page fairness, data integrity, financial transparency

**6 concerns (emphasis bias, not fabrication):**
1. Case studies only show towns where "no" led to a bigger "yes" (moderate)
2. No-override page is more vivid than override-cost page (moderate)
3. History page favors the institutional account (low-moderate)
4. "Against" side has fewer named advocates (low)
5. Author's "undecided" framing is unverifiable (structural)
6. Site architecture inherently centers the override (structural)

### New files
- `bias-audit.html` — full audit report as a site page
- `bias-remediation-plan.md` — doc-page with 13 remediation actions and priority table

## Test plan
- [ ] Verify `bias-audit.html` renders correctly on the site
- [ ] Verify `bias-remediation-plan.md` renders as a doc-page with proper list bullets and table
- [ ] Verify about page link to audit and remediation plan works
- [ ] Verify all cross-links between the three pages resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)