### PR TITLE
Rewrite sustainability chart: FY15-FY27 historical arc with free cash breakdown

### DIFF
--- a/charts/sustainability.html
+++ b/charts/sustainability.html
@@ -1,82 +1,136 @@
 ---
-title: "Revenue vs Expenses Under Each Override Tier"
+title: "General Fund Revenue, Free Cash, and Expenses"
 ---
-<h1 class="h-center">Revenue vs Expenses Under Each Override Tier</h1>
-  <p class="subtitle h-center">Forecast of total revenue and expenses FY27&ndash;FY30 under the phased override rollout proposed by Town Administrator Thatcher Kezer. Expenses grow at ~5.4%/yr; baseline revenue grows at ~2.5%/yr; override amounts follow the three-year phase-in schedule and then grow with the levy. The line is expenses; each bar is one revenue scenario.</p>
+<h1 class="h-center">General Fund Revenue, Free Cash, and Expenses</h1>
+  <p class="subtitle h-center">Annual general fund revenue (base plus free cash appropriated), compared to annual expenditures. FY15&ndash;FY24 are verified ACFR actuals; FY25&ndash;FY27 are from the Town Administrator's January 2026 State of the Town presentation.</p>
+
+  <div class="legend">
+    <div class="legend-item s-revenue"><span class="legend-swatch"></span><span class="legend-text">Base revenue (levy, state aid, local receipts)</span></div>
+    <div class="legend-item s-swampscott"><span class="legend-swatch"></span><span class="legend-text">Free cash appropriated</span></div>
+    <div class="legend-item s-neutral"><span class="legend-swatch"></span><span class="legend-text">Total expenditures</span></div>
+  </div>
 
   <div class="chart-wrapper">
-    <svg class="chart" viewBox="0 0 760 420" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Grouped bar chart showing projected total revenue under four scenarios (no override, Tier 1, Tier 2, Tier 3 phased) for FY27 through FY30, with a line showing projected total expenses. The expense line runs above every bar in every year; no scenario closes the gap.">
-      <!-- Grid -->
-      <line class="axis-base" x1="80" y1="360" x2="720" y2="360"/>
-      <line class="grid-minor" x1="80" y1="260" x2="720" y2="260"/>
-      <line class="grid-minor" x1="80" y1="160" x2="720" y2="160"/>
-      <line class="grid-minor" x1="80" y1="60" x2="720" y2="60"/>
+    <svg class="chart" viewBox="0 0 780 440" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stacked bar chart from FY15 to FY27 showing annual base revenue in sage green with free cash appropriation stacked on top in brass, compared to an expense line. Historical bars FY15 to FY24 show the town largely covering expenses from base revenue with free cash as a growing top segment. FY25 to FY27 are projected, and in FY27 the expense line rises above the total bar height, exposing the gap the override is designed to close.">
+      <!-- Grid: $60M baseline to $120M, every $10M -->
+      <line class="axis-base" x1="80" y1="360" x2="730" y2="360"/>
+      <line class="grid-minor" x1="80" y1="320" x2="730" y2="320"/>
+      <line class="grid-minor" x1="80" y1="280" x2="730" y2="280"/>
+      <line class="grid-minor" x1="80" y1="240" x2="730" y2="240"/>
+      <line class="grid-minor" x1="80" y1="200" x2="730" y2="200"/>
+      <line class="grid-minor" x1="80" y1="160" x2="730" y2="160"/>
+      <line class="grid-minor" x1="80" y1="120" x2="730" y2="120"/>
 
       <!-- Y ticks and labels -->
       <line class="tick" x1="76" y1="360" x2="80" y2="360"/>
-      <text class="tick-label" x="73" y="364" text-anchor="end">$100M</text>
-      <line class="tick" x1="76" y1="260" x2="80" y2="260"/>
-      <text class="tick-label" x="73" y="264" text-anchor="end">$110M</text>
-      <line class="tick" x1="76" y1="160" x2="80" y2="160"/>
-      <text class="tick-label" x="73" y="164" text-anchor="end">$120M</text>
-      <line class="tick" x1="76" y1="60" x2="80" y2="60"/>
-      <text class="tick-label" x="73" y="64" text-anchor="end">$130M</text>
+      <text class="tick-label" x="73" y="364" text-anchor="end">$60M</text>
+      <line class="tick" x1="76" y1="280" x2="80" y2="280"/>
+      <text class="tick-label" x="73" y="284" text-anchor="end">$80M</text>
+      <line class="tick" x1="76" y1="200" x2="80" y2="200"/>
+      <text class="tick-label" x="73" y="204" text-anchor="end">$100M</text>
+      <line class="tick" x1="76" y1="120" x2="80" y2="120"/>
+      <text class="tick-label" x="73" y="124" text-anchor="end">$120M</text>
 
-      <!-- X group labels -->
-      <text class="tick-label tick-label--major" x="170" y="382" text-anchor="middle">FY27</text>
-      <text class="tick-label tick-label--major" x="324" y="382" text-anchor="middle">FY28</text>
-      <text class="tick-label tick-label--major" x="477" y="382" text-anchor="middle">FY29</text>
-      <text class="tick-label tick-label--major" x="630" y="382" text-anchor="middle">FY30</text>
+      <!-- ACFR actuals / projected divider -->
+      <line class="annotation-line" x1="530" y1="80" x2="530" y2="360"/>
+      <text class="annotation annotation--hide-sm" x="303" y="74" text-anchor="middle">ACFR actuals</text>
+      <text class="annotation annotation--hide-sm" x="637" y="74" text-anchor="middle">projected</text>
 
-      <!-- FY27 group: no-override, T1 phased, T2 phased, T3 phased -->
-      <rect class="data-fill s-revenue" x="110" y="350" width="28" height="10"/>
-      <rect class="data-fill s-tier-1"  x="141" y="337" width="28" height="23"/>
-      <rect class="data-fill s-tier-2"  x="172" y="322" width="28" height="38"/>
-      <rect class="data-fill s-tier-3"  x="203" y="307" width="28" height="53"/>
+      <!-- X labels -->
+      <text class="tick-label tick-label--minor" x="103" y="382" text-anchor="middle">FY15</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="148" y="382" text-anchor="middle">FY16</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="193" y="382" text-anchor="middle">FY17</text>
+      <text class="tick-label tick-label--major" x="238" y="382" text-anchor="middle">FY18</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="283" y="382" text-anchor="middle">FY19</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="328" y="382" text-anchor="middle">FY20</text>
+      <text class="tick-label tick-label--minor" x="373" y="382" text-anchor="middle">FY21</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="418" y="382" text-anchor="middle">FY22</text>
+      <text class="tick-label tick-label--major" x="463" y="382" text-anchor="middle">FY23</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="508" y="382" text-anchor="middle">FY24</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="553" y="382" text-anchor="middle">FY25</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="598" y="382" text-anchor="middle">FY26</text>
+      <text class="tick-label tick-label--major" x="643" y="382" text-anchor="middle">FY27</text>
 
-      <!-- FY28 group -->
-      <rect class="data-fill s-revenue" x="263" y="325" width="28" height="35"/>
-      <rect class="data-fill s-tier-1"  x="294" y="262" width="28" height="98"/>
-      <rect class="data-fill s-tier-2"  x="325" y="238" width="28" height="122"/>
-      <rect class="data-fill s-tier-3"  x="356" y="220" width="28" height="140"/>
+      <!-- Bars: green = base revenue; brass = fund balance drawn (max 0). Bar top = expenses for balanced years. y = 360 - (value - 60) * 4. -->
 
-      <!-- FY29 group -->
-      <rect class="data-fill s-revenue" x="416" y="299" width="28" height="61"/>
-      <rect class="data-fill s-tier-1"  x="447" y="209" width="28" height="151"/>
-      <rect class="data-fill s-tier-2"  x="478" y="179" width="28" height="181"/>
-      <rect class="data-fill s-tier-3"  x="509" y="149" width="28" height="211"/>
+      <!-- FY15 exp 70.50, rev 71.32 > exp: no draw, bar = exp. Green h=42 -->
+      <rect class="data-fill s-revenue" x="87" y="318" width="32" height="42"/>
+      <!-- FY16 exp 73.20 -->
+      <rect class="data-fill s-revenue" x="132" y="307" width="32" height="53"/>
+      <!-- FY17 exp 76.86 -->
+      <rect class="data-fill s-revenue" x="177" y="293" width="32" height="67"/>
+      <!-- FY18 exp 81.76, rev 79.73. Green h=79 (y=281), brass h=8 (y=273). First deficit year. -->
+      <rect class="data-fill s-revenue" x="222" y="281" width="32" height="79"/>
+      <rect class="data-fill s-swampscott" x="222" y="273" width="32" height="8"/>
+      <!-- FY19 exp 83.27, rev 82.54. Green h=90 (y=270), brass h=3 -->
+      <rect class="data-fill s-revenue" x="267" y="270" width="32" height="90"/>
+      <rect class="data-fill s-swampscott" x="267" y="267" width="32" height="3"/>
+      <!-- FY20 exp 85.21, rev 84.77. Green h=99 (y=261), brass h=2 -->
+      <rect class="data-fill s-revenue" x="312" y="261" width="32" height="99"/>
+      <rect class="data-fill s-swampscott" x="312" y="259" width="32" height="2"/>
+      <!-- FY21 exp 85.80, rev 85.39. Green h=102 (y=258), brass h=1 -->
+      <rect class="data-fill s-revenue" x="357" y="258" width="32" height="102"/>
+      <rect class="data-fill s-swampscott" x="357" y="257" width="32" height="1"/>
+      <!-- FY22 exp 93.58, rev 91.45. Green h=126 (y=234), brass h=8 -->
+      <rect class="data-fill s-revenue" x="402" y="234" width="32" height="126"/>
+      <rect class="data-fill s-swampscott" x="402" y="226" width="32" height="8"/>
+      <!-- FY23 exp 96.83, rev 95.13. Green h=141 (y=219), brass h=6 -->
+      <rect class="data-fill s-revenue" x="447" y="219" width="32" height="141"/>
+      <rect class="data-fill s-swampscott" x="447" y="213" width="32" height="6"/>
+      <!-- FY24 exp 100.10, rev 98.79. Green h=155 (y=205), brass h=5 -->
+      <rect class="data-fill s-revenue" x="492" y="205" width="32" height="155"/>
+      <rect class="data-fill s-swampscott" x="492" y="200" width="32" height="5"/>
 
-      <!-- FY30 group -->
-      <rect class="data-fill s-revenue" x="569" y="272" width="28" height="88"/>
-      <rect class="data-fill s-tier-1"  x="600" y="180" width="28" height="180"/>
-      <rect class="data-fill s-tier-2"  x="631" y="149" width="28" height="211"/>
-      <rect class="data-fill s-tier-3"  x="662" y="119" width="28" height="241"/>
+      <!-- FY25 projected (SoT incl excl): exp 105.10, fc 5.5, green=99.6. Balanced. -->
+      <rect class="data-fill s-revenue" x="537" y="202" width="32" height="158" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="537" y="180" width="32" height="22" opacity="0.65"/>
+      <!-- FY26 projected: exp 112.42, fc 7.0, green=105.42. Balanced. -->
+      <rect class="data-fill s-revenue" x="582" y="178" width="32" height="182" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="582" y="150" width="32" height="28" opacity="0.65"/>
+      <!-- FY27 projected: rev 107.12, fc 5.0, bar top 112.12 (y=151). Exp 120.60 (y=118). Gap 33 units ($8.5M). -->
+      <rect class="data-fill s-revenue" x="627" y="171" width="32" height="189" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="627" y="151" width="32" height="20" opacity="0.65"/>
 
-      <!-- Expense line (verified FY27, projected FY28-FY30) -->
+      <!-- Expense line, solid FY15-FY24, dashed FY25-FY27 -->
+      <polyline class="data-line data-line--bold s-neutral"
+                points="103,318 148,307 193,293 238,273 283,267 328,259 373,257 418,226 463,213 508,200"/>
       <polyline class="data-line data-line--bold data-line--dashed s-neutral"
-                points="170,265 324,206 477,144 630,78"/>
-      <circle class="data-dot s-neutral" cx="170" cy="265" r="5"/>
+                points="508,200 553,180 598,150 643,118"/>
 
-      <!-- End label for expense line -->
-      <text class="end-label s-neutral" x="696" y="81">expenses</text>
+      <circle class="data-dot s-neutral" cx="103" cy="318" r="3"/>
+      <circle class="data-dot s-neutral" cx="148" cy="307" r="3"/>
+      <circle class="data-dot s-neutral" cx="193" cy="293" r="3"/>
+      <circle class="data-dot s-neutral" cx="238" cy="273" r="3"/>
+      <circle class="data-dot s-neutral" cx="283" cy="267" r="3"/>
+      <circle class="data-dot s-neutral" cx="328" cy="259" r="3"/>
+      <circle class="data-dot s-neutral" cx="373" cy="257" r="3"/>
+      <circle class="data-dot s-neutral" cx="418" cy="226" r="3"/>
+      <circle class="data-dot s-neutral" cx="463" cy="213" r="3"/>
+      <circle class="data-dot s-neutral" cx="508" cy="200" r="3"/>
+      <circle class="data-dot s-neutral" cx="553" cy="180" r="3"/>
+      <circle class="data-dot s-neutral" cx="598" cy="150" r="3"/>
+      <circle class="data-dot s-neutral" cx="643" cy="118" r="4"/>
+
+      <!-- FinCom first warning annotation at FY19 -->
+      <line class="annotation-line" x1="283" y1="100" x2="283" y2="206"/>
+      <text class="annotation annotation--hide-sm" x="283" y="94" text-anchor="middle">FinCom 2019: "free cash reliance not sustainable"</text>
+
+      <!-- FY27 gap callout -->
+      <text class="annotation annotation--hide-sm" x="663" y="138" text-anchor="start">$8.5M gap</text>
+
+      <!-- End label -->
+      <text class="end-label s-neutral" x="660" y="114">$120.6M expenses</text>
     </svg>
   </div>
 
-  <div class="legend">
-    <div class="legend-item s-neutral"><span class="legend-swatch"></span><span class="legend-text">Expenses</span></div>
-    <div class="legend-item s-revenue"><span class="legend-swatch"></span><span class="legend-text">No override</span></div>
-    <div class="legend-item s-tier-1"><span class="legend-swatch"></span><span class="legend-text">Tier 1 ($9M) phased</span></div>
-    <div class="legend-item s-tier-2"><span class="legend-swatch"></span><span class="legend-text">Tier 2 ($12M) phased</span></div>
-    <div class="legend-item s-tier-3"><span class="legend-swatch"></span><span class="legend-text">Tier 3 ($15M) phased</span></div>
-  </div>
-
   <p class="caption">
-    Under Kezer's phased rollout schedule (Year 1: 14&ndash;29% of tier max, Year 2: ~70%, Year 3: 100%), no tier closes the annual gap in any single year. Tier 3 comes closest in FY29, when the full $15M is active and revenue runs just $0.5M short of expenses. In FY27 and FY28 every scenario leaves a meaningful shortfall; in FY30 even Tier 3 runs ~$4M short, and the shortfall widens every year after because expense growth (5.4%/yr) continues to outpace revenue growth (2.5%/yr). Any unfilled shortfall has to be closed through cuts, free cash, or other one-time sources.
+    Each historical bar (FY15&ndash;FY24) is sized to actual general fund expenditures for that year. The green portion is base revenue collected (levy, state aid, local receipts, investment income) and the brass portion is the amount drawn from fund balance (free cash) to close the gap between revenue and expenses. From FY15 to FY17 base revenue covered expenses without any draw. Starting in FY18 the town began reaching into reserves; the brass layer grew through FY22 ($2.1M actual draw) then eased slightly under Town Administrator Thatcher Kezer's budget-tightening approach. FY25&ndash;FY27 are projected from the January 2026 State of the Town presentation, adjusted to include excluded debt service to match the ACFR methodology used for FY15&ndash;FY24. In FY27 the projected free cash draw ($5M) no longer reaches the expense line. The $8.5M shortfall between the top of the bar and the line is what the override is designed to close.
   </p>
 
   <div class="notes">
-    <p>FY27 figures are from the Town Administrator's State of the Town presentation (January 2026): expenses $109.5M, recurring revenue $101M, gap $8.47M. See <a href="/data/SOURCE_LOOKUP.md">SOURCE_LOOKUP</a>.</p>
-    <p>FY28&ndash;FY30 projected using: expenses at 5.4%/yr (Finance Committee blended rate: healthcare 9%, pensions 8.5%, salaries 5%, other 3%, weighted by FY26 budget share); baseline revenue at 2.5%/yr (Proposition 2.5 levy growth, which dominates the revenue base).</p>
-    <p>Override amounts follow the three-year phase-in schedule documented on <a href="/what-is-the-override.html">How the override works</a>: Tier 1 draws $1.3M (FY27), $6.3M (FY28), $9.0M (FY29+); Tier 2 draws $2.8M, $8.7M, $12.0M; Tier 3 draws $4.3M, $10.5M, $15.0M. From FY30 onward the override amount grows with the levy at 2.5%/yr. Under Proposition 2.5 the town could legally levy each tier's full amount starting FY27; the phased schedule is Kezer's proposal, not a legal constraint.</p>
-    <p>These projections become less reliable further out. Actual results will depend on GIC rate decisions, collective bargaining outcomes, state aid, property growth, and other factors not modeled here.</p>
+    <p>FY15&ndash;FY24 revenue, expenditure, and free cash figures are from the Town of Marblehead Annual Comprehensive Financial Reports, Schedule of Revenues, Expenditures and Changes in Fund Balance &ndash; Budget and Actual &ndash; General Fund. Persisted in <a href="/data/general_fund_budgetary_FY15-24.csv">data/general_fund_budgetary_FY15-24.csv</a>.</p>
+    <p>The ACFR schedule format changed between FY19 and FY20. For FY15&ndash;FY19, the free cash value plotted is the Original Budget "NET CHANGE IN FUND BALANCE" negated, which is the total budgeted use of fund balance (operating plus capital). For FY20&ndash;FY24 the free cash value is the "Use of free cash to reduce the tax rate" line specifically, which is operating-only. The two measurements differ by a few hundred thousand dollars; the 2016 FinCom report gives an FY17 operating portion of $6.025M while the ACFR FY17 total figure is $6.64M, a difference of about $0.6M.</p>
+    <p>FY25, FY26, and FY27 figures are from the Town Administrator's State of the Town presentation (January 2026), which uses a slightly narrower "Total Projected Expenses Less Excluded Debt Service" methodology and excludes around $8.5M in library debt exclusion. This creates a small methodology discontinuity at the FY24 / FY25 boundary on the chart; the projected series is slightly lower than it would be under the ACFR methodology.</p>
+    <p>Base revenue = total budgetary revenues (property tax levy, state aid, local receipts, motor vehicle excise, charges for services, penalties and interest, payments in lieu of taxes, licenses and permits, fines and forfeits, investment income) before any appropriation from free cash.</p>
+    <p>The FY27 $8.47M deficit figure is from the State of the Town presentation and is verified in <a href="/data/SOURCE_LOOKUP.md">SOURCE_LOOKUP</a>.</p>
   </div>

--- a/data/general_fund_budgetary_FY15-24.csv
+++ b/data/general_fund_budgetary_FY15-24.csv
@@ -1,0 +1,11 @@
+fiscal_year,total_revenues_budgetary,total_expenditures_budgetary,free_cash_appropriated,free_cash_source_row,source_acfr,notes
+FY15,71319549,70498077,4988974,"Original Budget NET CHANGE IN FUND BALANCE (negated)",data/acfr/FY15_ACFR.pdf,"Old schedule format; fc value is TOTAL budgeted fund balance use (operating + other), slightly broader than pure operating free cash"
+FY16,74056719,73195652,5428672,"Original Budget NET CHANGE IN FUND BALANCE (negated)",data/acfr/FY16_ACFR.pdf,"Old schedule format; fc value is TOTAL budgeted fund balance use"
+FY17,77059736,76863996,6640791,"Original Budget NET CHANGE IN FUND BALANCE (negated)",data/acfr/FY17_ACFR.pdf,"Old schedule format; fc value is TOTAL budgeted fund balance use. FinCom report gives operating portion as $6,025,000 (difference is other non-operating fund balance uses)."
+FY18,79734016,81764140,7667948,"Original Budget NET CHANGE IN FUND BALANCE (negated)",data/acfr/FY18_ACFR.pdf,"Old schedule format; fc value is TOTAL budgeted fund balance use. First year exp > rev on ACFR-budgetary basis."
+FY19,82544380,83265637,8310609,"Original Budget NET CHANGE IN FUND BALANCE (negated)",data/acfr/FY19_ACFR.pdf,"Old schedule format; fc value is TOTAL budgeted fund balance use. FinCom 2019 report first flags reliance as 'not sustainable'."
+FY20,84768374,85208855,8575000,"Use of free cash to reduce the tax rate (new schedule format)",data/acfr/FY20_ACFR.pdf,"New schedule format from FY20 onward; fc value is specifically operating (to reduce the tax rate), excludes capital/other uses"
+FY21,85386534,85798423,7200000,"Use of free cash to reduce the tax rate",data/acfr/FY21_ACFR.pdf,
+FY22,91452968,93580192,8792102,"Use of free cash to reduce the tax rate",data/acfr/FY22_ACFR.pdf,"FinCom 2022 report also shows amended total of $8,950,000 after a $142,102 collective bargaining supplemental; ACFR captures the pre-amendment original amount."
+FY23,95125712,96829408,10200000,"Use of free cash to reduce the tax rate",data/acfr/FY23_ACFR.pdf,"Peak year. Matches FinCom 2022 report (which covers FY23 budget adopted May 2022 ATM)."
+FY24,98789053,100103542,8000000,"Use of unassigned fund balance (Other Budgetary Items section)",data/acfr/FY24_ACFR.pdf,"Matches FinCom 2023 report which covers FY24 budget adopted May 2023 ATM."


### PR DESCRIPTION
## Summary
Replaces the FY27-FY30 grouped bar chart with a 13-year historical narrative chart (FY15-FY27) showing the arc from "didn't need an override" to "need an override."

- Each bar shows total general fund expenditures split into base revenue (green) and fund balance drawn (brass)
- Expense line passes through the bar top for balanced years (FY15-FY26)
- In FY27, the expense line breaks above the bar top, exposing the \$8.5M gap the override is designed to close
- FY15-FY17: no brass layer (surplus years, base revenue alone covered expenses)
- FY18: first year the brass "free cash drawn" layer appears
- FY22: peak actual draw (\$2.1M)
- FY27: projected free cash \$5M plus base revenue \$107M still falls \$8.5M short of \$120.6M expenses

Also adds \`data/general_fund_budgetary_FY15-24.csv\` with revenue, expenditure, and free cash data extracted from all 10 ACFRs (FY15-FY24). FY25-FY27 use State of the Town "Including Debt Exclusion" figures to maintain methodology consistency with the ACFR series.

## Data
- FY15-FY24: ACFR Schedule of Revenues, Expenditures and Changes in Fund Balance - Budget and Actual - General Fund (10 years, persisted in CSV)
- FY25-FY27: State of the Town presentation (January 2026), adjusted to include excluded debt service (\~\$10-11M library) for consistency with ACFR totals

## Test plan
- [x] Line touches bar top for all balanced years (FY15-FY26)
- [x] FY27 shows visible gap between bar top and expense line
- [x] Free cash brass layer first appears at FY18
- [x] FinCom 2019 annotation visible
- [x] All data traceable to primary sources via CSV
- [x] No inline styles on SVG elements