### PR TITLE
Replace Google Analytics with Cloudflare Web Analytics

### DIFF
--- a/_includes/gtm-noscript.html
+++ b/_includes/gtm-noscript.html
@@ -1,4 +1,0 @@
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5PQG62BJ"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,19 +1,7 @@
 <meta charset="utf-8">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5PQG62BJ');</script>
-<!-- End Google Tag Manager -->
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZK1KEJT3KX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-ZK1KEJT3KX');
-</script>
+<!-- Cloudflare Web Analytics -->
+<script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "e8f616ce3f5948ce91ae0dd6058282a8"}'></script>
+<!-- End Cloudflare Web Analytics -->
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="color-scheme" content="light dark">
 <meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,8 +4,6 @@
 {% include head.html %}
 </head>
 <body{% if page.body_class %} class="{{ page.body_class }}"{% elsif layout.body_class %} class="{{ layout.body_class }}"{% endif %}{% if page.community_pulse == "off-sections" %} data-community-pulse="off-sections"{% endif %}>
-{% include gtm-noscript.html %}
-
 {{ content }}
 
 </body>

--- a/privacy.html
+++ b/privacy.html
@@ -23,9 +23,9 @@ og_url: https://marbleheaddata.org/privacy.html
 <p>The community pulse feature does not collect your name, email, address, phone number, device identifier, user agent, cookies beyond what your browser sends automatically, or any other information about you as a person. There is no login, no account, no profile. The only identifier tying any activity to anyone is the IP rate-limit bucket, which is hashed and ephemeral.</p>
 
 <h2>What is on the rest of the site</h2>
-<p>Note that the rest of the Marblehead Budget Data site uses Google Analytics via Google Tag Manager, like most modern websites. That is a separate matter from the community pulse feature and is disclosed here for completeness. Google Analytics collects the usual page-view and referrer information for every visitor to the site as a whole.</p>
+<p>The rest of the Marblehead Budget Data site uses Cloudflare Web Analytics for basic, privacy-friendly traffic measurement. Cloudflare Web Analytics does not use cookies, does not track individual users across sites, and does not collect personal data. It records aggregate page views and referrer information only.</p>
 
 <h2>Questions</h2>
 <p>If something on this page is unclear or you want to verify any claim above, the full source code for the community pulse feature (front-end widget and server-side Worker) is published at <a href="https://github.com/agbaber/marblehead">github.com/agbaber/marblehead</a> under the <code>community-pulse/</code> and <code>assets/community-pulse/</code> directories. You can read the code and confirm these claims for yourself.</p>
 
-<p class="notes">Last updated: April 11, 2026.</p>
+<p class="notes">Last updated: April 12, 2026.</p>


### PR DESCRIPTION
## Summary
- Removes Google Tag Manager and GA4 scripts from `head.html` and the GTM noscript fallback from `default.html`
- Adds the Cloudflare Web Analytics beacon (cookie-free, privacy-friendly)
- Updates privacy page to reflect the new analytics provider

## Test plan
- [ ] Verify beacon loads on deployed site (check Network tab for `beacon.min.js`)
- [ ] Confirm Cloudflare dashboard starts showing pageview data
- [ ] Check privacy page reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)