### PR TITLE
Right-align read-time labels

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -598,9 +598,10 @@ details.notes[open] > summary {
 .back:hover { color: var(--text); background: var(--border); text-decoration: none; }
 
 .page > .read-time {
-  display: inline-block;
+  display: block;
   margin: 0 0 10px;
   padding: 0;
+  text-align: right;
   font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
- Right-aligns the "Deep dive", "~10 min read", and "~5 min read" labels that appear at the top of pages
- Changes `display: inline-block` to `display: block` and adds `text-align: right`

## Test plan
- [ ] Verify labels appear right-aligned on a "Deep dive" page (e.g. where-has-the-money-gone)
- [ ] Verify labels appear right-aligned on shorter pages (~5 min, ~10 min)
- [ ] Check mobile layout still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)