### PR TITLE
Split rate card: add specific math and revenue-neutral clarification

### DIFF
--- a/why-not-elsewhere.html
+++ b/why-not-elsewhere.html
@@ -320,7 +320,7 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
   <div class="card">
     <h3>Split tax rates (CIP shift)</h3>
     <p>Massachusetts allows municipalities to tax commercial, industrial, and personal property at up to 175% of the residential rate, shifting some of the burden off homeowners. Boston, Cambridge, Waltham, and most gateway cities use this aggressively. It's the primary reason Cambridge residents have a low effective tax rate despite the city's overall wealth.</p>
-    <p><strong>Marblehead context:</strong> Marblehead already uses a single tax rate (no split) and the CIP class is only 4.5% of the levy. Even the maximum allowable shift would reduce residential taxes by a small single-digit percentage. Whether that's a meaningful amount depends on the size of the underlying budget gap and what else is on the table.</p>
+    <p><strong>Marblehead context:</strong> Marblehead already uses a single tax rate (no split) and the CIP class is only 4.5% of the levy. If Marblehead shifted to the maximum 175% CIP rate allowed under state law, residential bills would fall by approximately 3.3% (roughly $2.4M shifted from residential to commercial on the FY26 $75.6M levy) and commercial bills would rise by the same amount. But the total levy would be unchanged. A split tax rate redistributes who pays, not how much is raised. It can reduce the residential share of the tax burden, but it cannot raise additional revenue under Proposition 2&frac12;, so it is not a substitute for an override when the town needs more total revenue.</p>
   </div>
 
   <div class="card">


### PR DESCRIPTION
## Summary

Enhances the "Split tax rates (CIP shift)" card on `why-not-elsewhere.html` with two additions:

1. **Specific math:** *"If Marblehead shifted to the maximum 175% CIP rate allowed under state law, residential bills would fall by approximately 3.3% (roughly $2.4M shifted from residential to commercial on the FY26 $75.6M levy) and commercial bills would rise by the same amount."*

2. **Revenue-neutral clarification:** *"A split tax rate redistributes who pays, not how much is raised. It can reduce the residential share of the tax burden, but it cannot raise additional revenue under Proposition 2&frac12;, so it is not a substitute for an override when the town needs more total revenue."*

## Why

The existing card said *"even the maximum allowable shift would reduce residential taxes by a small single-digit percentage"* without a number and without addressing the common misconception that a split rate would raise more revenue. This question comes up regularly in the Facebook override debate ("Why hasn't the issue of taxing residential and commercial property at the same mill rate come up? Would it be fair to raise the commercial mill rate a little to raise more revenue?"). The answer is that under Proposition 2&frac12;, split rates are revenue-neutral: the total levy is capped regardless of how it's distributed.

## Derivation

Under MGL c.59 s.56, the maximum CIP shift is 175% of the residential rate. With CIP at 4.5% of the levy:

`0.955 × R + 0.045 × 1.75R = L`
`1.03375R = L`
`R = L / 1.03375`

Residential rate drops to 96.7% of the unshifted rate = 3.3% reduction. On the FY26 $75.6M levy, that's roughly $2.4M shifted from residential to commercial.

## Test plan

- [x] One file changed: `why-not-elsewhere.html`
- [x] Existing card structure preserved (same `<div class="card">`, same `<h3>`)
- [x] No em-dashes, no inline styles, no advocacy framing
- [x] Math derivation traceable (shown in this PR body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)