### PR TITLE
Add PostHog analytics for session replay and user paths

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,12 @@
 <!-- Cloudflare Web Analytics -->
 <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "e8f616ce3f5948ce91ae0dd6058282a8"}'></script>
 <!-- End Cloudflare Web Analytics -->
+<!-- PostHog Analytics -->
+<script>
+  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+  posthog.init('phc_nzM4bbctKEJDaM8WftemRWiSXhRmk7X3hNuasyGA2jxg',{api_host:'https://us.i.posthog.com',person_profiles:'identified_only'});
+</script>
+<!-- End PostHog Analytics -->
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="color-scheme" content="light dark">
 <meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">


### PR DESCRIPTION
## Summary
- Adds PostHog JS snippet to `head.html` alongside existing Cloudflare Web Analytics
- Enables session replay, funnels, user path tracking, and event tracking
- Uses `person_profiles: 'identified_only'` for privacy (anonymous users stay anonymous)

## Test plan
- [ ] Verify PostHog script loads (check Network tab for `array.js`)
- [ ] Confirm events appear in PostHog dashboard
- [ ] Verify Cloudflare beacon still works alongside PostHog

🤖 Generated with [Claude Code](https://claude.com/claude-code)