### PR TITLE
Improve private note: side margin on desktop, full-width on mobile

### DIFF
--- a/assets/community-pulse/widget.css
+++ b/assets/community-pulse/widget.css
@@ -4,10 +4,12 @@
 
 /* Right-aligned end-of-section container. Holds the widget on its own
    row after the last paragraph of the section, so readers see the
-   reaction affordance after they finish reading the claim, not before. */
+   reaction affordance after they finish reading the claim, not before.
+   position:relative anchors the side-note on desktop. */
 .cp-section-end {
   display: flex;
   justify-content: flex-end;
+  position: relative;
   margin: 1rem 0 2rem 0;
 }
 
@@ -37,6 +39,7 @@
 @media (max-width: 640px) {
   .cp-section-end {
     justify-content: flex-start;
+    flex-wrap: wrap;
     margin: 0.75rem 0 1.5rem 0;
   }
   .cp-widget {
@@ -136,21 +139,51 @@
 
 .cp-widget__note {
   display: block;
-  width: 100%;
-  margin-top: 0.4rem;
-  padding: 0.4rem;
+  padding: 0.5rem 0.6rem;
   font-family: inherit;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
+  line-height: 1.45;
   color: var(--text, #222);
   background: var(--surface, rgba(0,0,0,0.03));
   border: 1px solid var(--border, rgba(0,0,0,0.1));
   border-radius: 0.35rem;
   resize: vertical;
-  min-height: 3.5rem;
+  min-height: 4.5rem;
+}
+
+/* Desktop (enough viewport for a side panel): absolutely position
+   the note to the right of the content column. */
+@media (min-width: 960px) {
+  .cp-widget__note {
+    position: absolute;
+    right: 0;
+    top: 0;
+    transform: translateX(calc(100% + 1.25rem));
+    width: 240px;
+  }
+}
+
+/* Tablet / narrow desktop: inline below the widget, full content width */
+@media (max-width: 959px) {
+  .cp-widget__note {
+    width: 100%;
+    margin-top: 0.5rem;
+  }
 }
 
 .cp-widget__note[hidden] {
   display: none;
+}
+
+/* Placeholder styling */
+.cp-widget__note::placeholder {
+  color: var(--text-muted, #888);
+  font-size: 0.8rem;
+}
+
+/* Highlight the note toggle when a note has content */
+.cp-widget__note-toggle[data-has-note="true"] {
+  color: var(--c-teal, #2F7D8E);
 }
 
 .cp-widget__toast {

--- a/assets/community-pulse/widget.js
+++ b/assets/community-pulse/widget.js
@@ -260,15 +260,17 @@ function buildWidget(sectionId, sectionTitle, sectionUrl, initialReactions, init
 
   root.appendChild(meta);
 
-  // Note textarea (hidden initially).
+  // Note textarea is appended to the section-end container (not the
+  // widget itself) so it can break out into the right margin on desktop.
+  // Store a reference on the root so wireWidget can find it.
   const note = document.createElement('textarea');
   note.id = `${widgetId}-note`;
   note.className = 'cp-widget__note';
-  note.placeholder = 'Write a private note. Saved locally in your browser.';
+  note.placeholder = 'Private note -- saved in your browser, never sent anywhere.';
   note.setAttribute('aria-label', 'Private note, saved locally in your browser');
   note.hidden = true;
   note.rows = 3;
-  root.appendChild(note);
+  root._noteElement = note;
 
   return root;
 }
@@ -301,7 +303,10 @@ function debounce(fn, ms) {
 function wireWidget(root, db, sectionId, sectionUrl, sectionTitle, initialRecord) {
   const buttons = root.querySelectorAll('.cp-widget__button');
   const noteToggle = root.querySelector('.cp-widget__note-toggle');
-  const noteField = root.querySelector('.cp-widget__note');
+  // Note textarea lives in the parent .cp-section-end, not inside the widget.
+  const noteField = root.parentElement
+    ? root.parentElement.querySelector('.cp-widget__note')
+    : root.querySelector('.cp-widget__note');
   const shareBtn = root.querySelector('.cp-widget__share');
   const countNum = root.querySelector('.cp-widget__count-num');
   const countDelta = root.querySelector('.cp-widget__delta');
@@ -316,6 +321,7 @@ function wireWidget(root, db, sectionId, sectionUrl, sectionTitle, initialRecord
     noteField.value = currentNote;
     noteField.hidden = false;
     noteToggle.setAttribute('aria-expanded', 'true');
+    noteToggle.dataset.hasNote = 'true';
   }
 
   /** Persist the current stance, note, and reacted state to IndexedDB. */
@@ -377,6 +383,7 @@ function wireWidget(root, db, sectionId, sectionUrl, sectionTitle, initialRecord
   // time the note contains non-empty text.
   const saveNote = debounce(async () => {
     currentNote = noteField.value;
+    noteToggle.dataset.hasNote = currentNote.trim().length > 0 ? 'true' : 'false';
     await persist();
     if (currentNote.trim().length > 0) await ensureCounted();
   }, 1000);
@@ -482,6 +489,11 @@ export async function hydrateWidgets() {
     const endRow = document.createElement('div');
     endRow.className = 'cp-section-end';
     endRow.appendChild(widget);
+    // Append the note textarea to the section-end container (not the
+    // widget) so CSS can position it in the right margin on desktop.
+    if (widget._noteElement) {
+      endRow.appendChild(widget._noteElement);
+    }
     if (cursor) {
       parent.insertBefore(endRow, cursor);
     } else {


### PR DESCRIPTION
## Summary
- Move the note `<textarea>` from inside the inline-flex `.cp-widget` to the `.cp-section-end` container so it can break out of the 720px content column
- **Desktop (960px+):** Note appears as a 240px margin note to the right of the content, anchored to the widget row
- **Tablet/mobile (<960px):** Note expands full-width below the widget, stacking cleanly via flex-wrap
- Note toggle icon highlights teal when a note has content (visual indicator)
- Updated placeholder copy to be friendlier

## Test plan
- [ ] Open a long page (e.g. the-debate.html) on a wide desktop viewport, click the note toggle, verify the textarea floats in the right margin
- [ ] Resize below 960px, verify it stacks full-width below the widget
- [ ] Type in a note, verify the toggle icon turns teal; clear the note, verify it returns to default
- [ ] Reload the page, verify persisted notes still display correctly and the toggle state is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)