### PR TITLE
Responsive sustainability chart: unified FY15-FY30 on desktop, historical on mobile

### DIFF
--- a/charts/sustainability.html
+++ b/charts/sustainability.html
@@ -1,18 +1,151 @@
 ---
 title: "General Fund Revenue, Free Cash, and Expenses"
 ---
+<style>
+  .chart-desktop { display: block; }
+  .chart-mobile  { display: none; }
+  @media (max-width: 880px) {
+    .chart-desktop { display: none; }
+    .chart-mobile  { display: block; }
+  }
+</style>
+
 <h1 class="h-center">General Fund Revenue, Free Cash, and Expenses</h1>
-  <p class="subtitle h-center">Annual general fund revenue (base plus free cash appropriated), compared to annual expenditures. FY15&ndash;FY24 are verified ACFR actuals; FY25&ndash;FY27 are from the Town Administrator's January 2026 State of the Town presentation.</p>
+  <p class="subtitle h-center">Annual general fund revenue (base plus free cash) compared to expenditures, FY15&ndash;FY30. FY15&ndash;FY24 are ACFR actuals. FY25&ndash;FY30 are projected, with FY28&ndash;FY30 showing each override tier under the phased rollout.</p>
 
   <div class="legend">
-    <div class="legend-item s-revenue"><span class="legend-swatch"></span><span class="legend-text">Base revenue (levy, state aid, local receipts)</span></div>
-    <div class="legend-item s-swampscott"><span class="legend-swatch"></span><span class="legend-text">Free cash appropriated</span></div>
+    <div class="legend-item s-revenue"><span class="legend-swatch"></span><span class="legend-text">Base revenue</span></div>
+    <div class="legend-item s-swampscott"><span class="legend-swatch"></span><span class="legend-text">Free cash drawn</span></div>
+    <div class="legend-item s-tier-1"><span class="legend-swatch"></span><span class="legend-text">Tier 1 ($9M)</span></div>
+    <div class="legend-item s-tier-2"><span class="legend-swatch"></span><span class="legend-text">Tier 2 ($12M)</span></div>
+    <div class="legend-item s-tier-3"><span class="legend-swatch"></span><span class="legend-text">Tier 3 ($15M)</span></div>
     <div class="legend-item s-neutral"><span class="legend-swatch"></span><span class="legend-text">Total expenditures</span></div>
   </div>
 
-  <div class="chart-wrapper">
-    <svg class="chart" viewBox="0 0 780 440" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stacked bar chart from FY15 to FY27 showing annual base revenue in sage green with free cash appropriation stacked on top in brass, compared to an expense line. Historical bars FY15 to FY24 show the town largely covering expenses from base revenue with free cash as a growing top segment. FY25 to FY27 are projected, and in FY27 the expense line rises above the total bar height, exposing the gap the override is designed to close.">
-      <!-- Grid: $60M baseline to $120M, every $10M -->
+  <!-- ====== DESKTOP: unified FY15-FY30 chart ====== -->
+  <div class="chart-wrapper chart-desktop">
+    <svg class="chart" viewBox="0 0 1050 440" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Wide chart combining the FY15 to FY27 historical arc with FY28 to FY30 override tier comparison. Historical bars show base revenue plus free cash drawn. From FY28 onward, grouped bars compare no override, Tier 1, Tier 2, and Tier 3 phased scenarios. The expense line runs above all bars at FY27 and above the no-override bar through FY30, showing the growing gap.">
+      <!-- Grid: $60M to $140M, 3.5 units/$M -->
+      <line class="axis-base" x1="80" y1="360" x2="920" y2="360"/>
+      <line class="grid-minor" x1="80" y1="290" x2="920" y2="290"/>
+      <line class="grid-minor" x1="80" y1="220" x2="920" y2="220"/>
+      <line class="grid-minor" x1="80" y1="150" x2="920" y2="150"/>
+      <line class="grid-minor" x1="80" y1="80" x2="920" y2="80"/>
+
+      <!-- Y labels -->
+      <text class="tick-label" x="73" y="364" text-anchor="end">$60M</text>
+      <text class="tick-label" x="73" y="294" text-anchor="end">$80M</text>
+      <text class="tick-label" x="73" y="224" text-anchor="end">$100M</text>
+      <text class="tick-label" x="73" y="154" text-anchor="end">$120M</text>
+      <text class="tick-label" x="73" y="84" text-anchor="end">$140M</text>
+
+      <!-- Dividers -->
+      <line class="annotation-line" x1="430" y1="60" x2="430" y2="360"/>
+      <line class="annotation-line" x1="545" y1="60" x2="545" y2="360"/>
+      <text class="annotation" x="255" y="54" text-anchor="middle">ACFR actuals</text>
+      <text class="annotation" x="488" y="54" text-anchor="middle">projected</text>
+      <text class="annotation" x="740" y="54" text-anchor="middle">override scenarios (phased)</text>
+
+      <!-- X labels: historical -->
+      <text class="tick-label tick-label--minor" x="98" y="382" text-anchor="middle">FY15</text>
+      <text class="tick-label tick-label--major" x="203" y="382" text-anchor="middle">FY18</text>
+      <text class="tick-label tick-label--minor" x="308" y="382" text-anchor="middle">FY21</text>
+      <text class="tick-label tick-label--major" x="378" y="382" text-anchor="middle">FY23</text>
+      <text class="tick-label tick-label--major" x="518" y="382" text-anchor="middle">FY27</text>
+      <!-- X labels: grouped -->
+      <text class="tick-label tick-label--major" x="608" y="382" text-anchor="middle">FY28</text>
+      <text class="tick-label tick-label--major" x="728" y="382" text-anchor="middle">FY29</text>
+      <text class="tick-label tick-label--major" x="848" y="382" text-anchor="middle">FY30</text>
+
+      <!-- Historical single bars FY15-FY27 -->
+      <rect class="data-fill s-revenue" x="85" y="323" width="26" height="37"/>
+      <rect class="data-fill s-revenue" x="120" y="314" width="26" height="46"/>
+      <rect class="data-fill s-revenue" x="155" y="301" width="26" height="59"/>
+      <rect class="data-fill s-revenue" x="190" y="291" width="26" height="69"/>
+      <rect class="data-fill s-swampscott" x="190" y="284" width="26" height="7"/>
+      <rect class="data-fill s-revenue" x="225" y="281" width="26" height="79"/>
+      <rect class="data-fill s-swampscott" x="225" y="279" width="26" height="2"/>
+      <rect class="data-fill s-revenue" x="260" y="273" width="26" height="87"/>
+      <rect class="data-fill s-swampscott" x="260" y="272" width="26" height="1"/>
+      <rect class="data-fill s-revenue" x="295" y="271" width="26" height="89"/>
+      <rect class="data-fill s-swampscott" x="295" y="270" width="26" height="1"/>
+      <rect class="data-fill s-revenue" x="330" y="250" width="26" height="110"/>
+      <rect class="data-fill s-swampscott" x="330" y="242" width="26" height="8"/>
+      <rect class="data-fill s-revenue" x="365" y="237" width="26" height="123"/>
+      <rect class="data-fill s-swampscott" x="365" y="231" width="26" height="6"/>
+      <rect class="data-fill s-revenue" x="400" y="224" width="26" height="136"/>
+      <rect class="data-fill s-swampscott" x="400" y="220" width="26" height="4"/>
+      <!-- FY25-FY26 projected balanced -->
+      <rect class="data-fill s-revenue" x="435" y="221" width="26" height="139" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="435" y="202" width="26" height="19" opacity="0.65"/>
+      <rect class="data-fill s-revenue" x="470" y="201" width="26" height="159" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="470" y="177" width="26" height="24" opacity="0.65"/>
+      <!-- FY27 deficit -->
+      <rect class="data-fill s-revenue" x="505" y="195" width="26" height="165" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="505" y="178" width="26" height="17" opacity="0.65"/>
+
+      <!-- FY28 grouped bars -->
+      <rect class="data-fill s-revenue" x="561" y="169" width="22" height="191" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="561" y="152" width="22" height="17" opacity="0.65"/>
+      <rect class="data-fill s-tier-1" x="585" y="147" width="22" height="213" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="585" y="130" width="22" height="17" opacity="0.65"/>
+      <rect class="data-fill s-tier-2" x="609" y="139" width="22" height="221" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="609" y="121" width="22" height="18" opacity="0.65"/>
+      <rect class="data-fill s-tier-3" x="633" y="132" width="22" height="228" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="633" y="115" width="22" height="17" opacity="0.65"/>
+
+      <!-- FY29 grouped bars -->
+      <rect class="data-fill s-revenue" x="681" y="160" width="22" height="200" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="681" y="143" width="22" height="17" opacity="0.65"/>
+      <rect class="data-fill s-tier-1" x="705" y="129" width="22" height="231" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="705" y="111" width="22" height="18" opacity="0.65"/>
+      <rect class="data-fill s-tier-2" x="729" y="118" width="22" height="242" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="729" y="101" width="22" height="17" opacity="0.65"/>
+      <rect class="data-fill s-tier-3" x="753" y="108" width="22" height="252" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="753" y="90" width="22" height="18" opacity="0.65"/>
+
+      <!-- FY30 grouped bars -->
+      <rect class="data-fill s-revenue" x="801" y="151" width="22" height="209" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="801" y="133" width="22" height="18" opacity="0.65"/>
+      <rect class="data-fill s-tier-1" x="825" y="119" width="22" height="241" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="825" y="101" width="22" height="18" opacity="0.65"/>
+      <rect class="data-fill s-tier-2" x="849" y="108" width="22" height="252" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="849" y="90" width="22" height="18" opacity="0.65"/>
+      <rect class="data-fill s-tier-3" x="873" y="97" width="22" height="263" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="873" y="79" width="22" height="18" opacity="0.65"/>
+
+      <!-- Expense line: solid FY15-FY24, dashed FY25-FY30 -->
+      <polyline class="data-line data-line--bold s-neutral"
+                points="98,323 133,314 168,301 203,284 238,279 273,272 308,270 343,242 378,231 413,220"/>
+      <polyline class="data-line data-line--bold data-line--dashed s-neutral"
+                points="413,220 448,202 483,177 518,148 608,128 728,106 848,83"/>
+
+      <!-- Data dots -->
+      <circle class="data-dot s-neutral" cx="98" cy="323" r="2"/>
+      <circle class="data-dot s-neutral" cx="203" cy="284" r="2"/>
+      <circle class="data-dot s-neutral" cx="308" cy="270" r="2"/>
+      <circle class="data-dot s-neutral" cx="413" cy="220" r="2"/>
+      <circle class="data-dot s-neutral" cx="518" cy="148" r="3"/>
+      <circle class="data-dot s-neutral" cx="608" cy="128" r="3"/>
+      <circle class="data-dot s-neutral" cx="728" cy="106" r="3"/>
+      <circle class="data-dot s-neutral" cx="848" cy="83" r="3"/>
+
+      <!-- Annotations -->
+      <line class="annotation-line" x1="238" y1="100" x2="238" y2="279"/>
+      <text class="annotation" x="238" y="95" text-anchor="middle">FinCom 2019: "unsustainable"</text>
+
+      <text class="annotation" x="525" y="166" text-anchor="start">$8.5M gap</text>
+
+      <!-- End labels -->
+      <text class="end-label s-neutral" x="860" y="78">$139M expenses</text>
+      <text class="end-label s-tier-3" x="893" y="76">T3</text>
+      <text class="end-label s-revenue" x="815" y="128">no override</text>
+    </svg>
+  </div>
+
+  <!-- ====== MOBILE: historical FY15-FY27 only ====== -->
+  <div class="chart-wrapper chart-mobile">
+    <svg class="chart" viewBox="0 0 780 440" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stacked bar chart FY15 to FY27 showing base revenue plus free cash drawn, compared to an expense line.">
       <line class="axis-base" x1="80" y1="360" x2="730" y2="360"/>
       <line class="grid-minor" x1="80" y1="320" x2="730" y2="320"/>
       <line class="grid-minor" x1="80" y1="280" x2="730" y2="280"/>
@@ -21,116 +154,63 @@ title: "General Fund Revenue, Free Cash, and Expenses"
       <line class="grid-minor" x1="80" y1="160" x2="730" y2="160"/>
       <line class="grid-minor" x1="80" y1="120" x2="730" y2="120"/>
 
-      <!-- Y ticks and labels -->
-      <line class="tick" x1="76" y1="360" x2="80" y2="360"/>
       <text class="tick-label" x="73" y="364" text-anchor="end">$60M</text>
-      <line class="tick" x1="76" y1="280" x2="80" y2="280"/>
       <text class="tick-label" x="73" y="284" text-anchor="end">$80M</text>
-      <line class="tick" x1="76" y1="200" x2="80" y2="200"/>
       <text class="tick-label" x="73" y="204" text-anchor="end">$100M</text>
-      <line class="tick" x1="76" y1="120" x2="80" y2="120"/>
       <text class="tick-label" x="73" y="124" text-anchor="end">$120M</text>
 
-      <!-- ACFR actuals / projected divider -->
-      <line class="annotation-line" x1="530" y1="80" x2="530" y2="360"/>
-      <text class="annotation annotation--hide-sm" x="303" y="74" text-anchor="middle">ACFR actuals</text>
-      <text class="annotation annotation--hide-sm" x="637" y="74" text-anchor="middle">projected</text>
-
-      <!-- X labels -->
       <text class="tick-label tick-label--minor" x="103" y="382" text-anchor="middle">FY15</text>
-      <text class="tick-label tick-label--minor annotation--hide-sm" x="148" y="382" text-anchor="middle">FY16</text>
-      <text class="tick-label tick-label--minor annotation--hide-sm" x="193" y="382" text-anchor="middle">FY17</text>
       <text class="tick-label tick-label--major" x="238" y="382" text-anchor="middle">FY18</text>
-      <text class="tick-label tick-label--minor annotation--hide-sm" x="283" y="382" text-anchor="middle">FY19</text>
-      <text class="tick-label tick-label--minor annotation--hide-sm" x="328" y="382" text-anchor="middle">FY20</text>
       <text class="tick-label tick-label--minor" x="373" y="382" text-anchor="middle">FY21</text>
-      <text class="tick-label tick-label--minor annotation--hide-sm" x="418" y="382" text-anchor="middle">FY22</text>
       <text class="tick-label tick-label--major" x="463" y="382" text-anchor="middle">FY23</text>
-      <text class="tick-label tick-label--minor annotation--hide-sm" x="508" y="382" text-anchor="middle">FY24</text>
-      <text class="tick-label tick-label--minor annotation--hide-sm" x="553" y="382" text-anchor="middle">FY25</text>
-      <text class="tick-label tick-label--minor annotation--hide-sm" x="598" y="382" text-anchor="middle">FY26</text>
       <text class="tick-label tick-label--major" x="643" y="382" text-anchor="middle">FY27</text>
 
-      <!-- Bars: green = base revenue; brass = fund balance drawn (max 0). Bar top = expenses for balanced years. y = 360 - (value - 60) * 4. -->
-
-      <!-- FY15 exp 70.50, rev 71.32 > exp: no draw, bar = exp. Green h=42 -->
+      <!-- Bars: same as PR #140 -->
       <rect class="data-fill s-revenue" x="87" y="318" width="32" height="42"/>
-      <!-- FY16 exp 73.20 -->
       <rect class="data-fill s-revenue" x="132" y="307" width="32" height="53"/>
-      <!-- FY17 exp 76.86 -->
       <rect class="data-fill s-revenue" x="177" y="293" width="32" height="67"/>
-      <!-- FY18 exp 81.76, rev 79.73. Green h=79 (y=281), brass h=8 (y=273). First deficit year. -->
       <rect class="data-fill s-revenue" x="222" y="281" width="32" height="79"/>
       <rect class="data-fill s-swampscott" x="222" y="273" width="32" height="8"/>
-      <!-- FY19 exp 83.27, rev 82.54. Green h=90 (y=270), brass h=3 -->
       <rect class="data-fill s-revenue" x="267" y="270" width="32" height="90"/>
       <rect class="data-fill s-swampscott" x="267" y="267" width="32" height="3"/>
-      <!-- FY20 exp 85.21, rev 84.77. Green h=99 (y=261), brass h=2 -->
       <rect class="data-fill s-revenue" x="312" y="261" width="32" height="99"/>
       <rect class="data-fill s-swampscott" x="312" y="259" width="32" height="2"/>
-      <!-- FY21 exp 85.80, rev 85.39. Green h=102 (y=258), brass h=1 -->
       <rect class="data-fill s-revenue" x="357" y="258" width="32" height="102"/>
       <rect class="data-fill s-swampscott" x="357" y="257" width="32" height="1"/>
-      <!-- FY22 exp 93.58, rev 91.45. Green h=126 (y=234), brass h=8 -->
       <rect class="data-fill s-revenue" x="402" y="234" width="32" height="126"/>
       <rect class="data-fill s-swampscott" x="402" y="226" width="32" height="8"/>
-      <!-- FY23 exp 96.83, rev 95.13. Green h=141 (y=219), brass h=6 -->
       <rect class="data-fill s-revenue" x="447" y="219" width="32" height="141"/>
       <rect class="data-fill s-swampscott" x="447" y="213" width="32" height="6"/>
-      <!-- FY24 exp 100.10, rev 98.79. Green h=155 (y=205), brass h=5 -->
       <rect class="data-fill s-revenue" x="492" y="205" width="32" height="155"/>
       <rect class="data-fill s-swampscott" x="492" y="200" width="32" height="5"/>
-
-      <!-- FY25 projected (SoT incl excl): exp 105.10, fc 5.5, green=99.6. Balanced. -->
       <rect class="data-fill s-revenue" x="537" y="202" width="32" height="158" opacity="0.65"/>
       <rect class="data-fill s-swampscott" x="537" y="180" width="32" height="22" opacity="0.65"/>
-      <!-- FY26 projected: exp 112.42, fc 7.0, green=105.42. Balanced. -->
       <rect class="data-fill s-revenue" x="582" y="178" width="32" height="182" opacity="0.65"/>
       <rect class="data-fill s-swampscott" x="582" y="150" width="32" height="28" opacity="0.65"/>
-      <!-- FY27 projected: rev 107.12, fc 5.0, bar top 112.12 (y=151). Exp 120.60 (y=118). Gap 33 units ($8.5M). -->
       <rect class="data-fill s-revenue" x="627" y="171" width="32" height="189" opacity="0.65"/>
       <rect class="data-fill s-swampscott" x="627" y="151" width="32" height="20" opacity="0.65"/>
 
-      <!-- Expense line, solid FY15-FY24, dashed FY25-FY27 -->
-      <polyline class="data-line data-line--bold s-neutral"
-                points="103,318 148,307 193,293 238,273 283,267 328,259 373,257 418,226 463,213 508,200"/>
-      <polyline class="data-line data-line--bold data-line--dashed s-neutral"
-                points="508,200 553,180 598,150 643,118"/>
+      <polyline class="data-line data-line--bold s-neutral" points="103,318 148,307 193,293 238,273 283,267 328,259 373,257 418,226 463,213 508,200"/>
+      <polyline class="data-line data-line--bold data-line--dashed s-neutral" points="508,200 553,180 598,150 643,118"/>
 
       <circle class="data-dot s-neutral" cx="103" cy="318" r="3"/>
-      <circle class="data-dot s-neutral" cx="148" cy="307" r="3"/>
-      <circle class="data-dot s-neutral" cx="193" cy="293" r="3"/>
       <circle class="data-dot s-neutral" cx="238" cy="273" r="3"/>
-      <circle class="data-dot s-neutral" cx="283" cy="267" r="3"/>
-      <circle class="data-dot s-neutral" cx="328" cy="259" r="3"/>
       <circle class="data-dot s-neutral" cx="373" cy="257" r="3"/>
-      <circle class="data-dot s-neutral" cx="418" cy="226" r="3"/>
-      <circle class="data-dot s-neutral" cx="463" cy="213" r="3"/>
       <circle class="data-dot s-neutral" cx="508" cy="200" r="3"/>
-      <circle class="data-dot s-neutral" cx="553" cy="180" r="3"/>
-      <circle class="data-dot s-neutral" cx="598" cy="150" r="3"/>
       <circle class="data-dot s-neutral" cx="643" cy="118" r="4"/>
 
-      <!-- FinCom first warning annotation at FY19 -->
-      <line class="annotation-line" x1="283" y1="100" x2="283" y2="206"/>
-      <text class="annotation annotation--hide-sm" x="283" y="94" text-anchor="middle">FinCom 2019: "free cash reliance not sustainable"</text>
-
-      <!-- FY27 gap callout -->
-      <text class="annotation annotation--hide-sm" x="663" y="138" text-anchor="start">$8.5M gap</text>
-
-      <!-- End label -->
       <text class="end-label s-neutral" x="660" y="114">$120.6M expenses</text>
+      <text class="annotation" x="660" y="138" text-anchor="start">$8.5M gap</text>
     </svg>
+    <p class="caption" aria-hidden="true">View on a wider screen to see the FY28&ndash;FY30 override tier comparison.</p>
   </div>
 
   <p class="caption">
-    Each historical bar (FY15&ndash;FY24) is sized to actual general fund expenditures for that year. The green portion is base revenue collected (levy, state aid, local receipts, investment income) and the brass portion is the amount drawn from fund balance (free cash) to close the gap between revenue and expenses. From FY15 to FY17 base revenue covered expenses without any draw. Starting in FY18 the town began reaching into reserves; the brass layer grew through FY22 ($2.1M actual draw) then eased slightly under Town Administrator Thatcher Kezer's budget-tightening approach. FY25&ndash;FY27 are projected from the January 2026 State of the Town presentation, adjusted to include excluded debt service to match the ACFR methodology used for FY15&ndash;FY24. In FY27 the projected free cash draw ($5M) no longer reaches the expense line. The $8.5M shortfall between the top of the bar and the line is what the override is designed to close.
+    Each historical bar (FY15&ndash;FY24) is sized to actual general fund expenditures. The green portion is base revenue collected and the brass portion is fund balance drawn. From FY15 to FY17 no draw was needed. Starting in FY18 the brass layer appears and grows through FY22. In FY27, the expense line breaks above the bar: even $5M of free cash leaves an $8.5M shortfall. FY28&ndash;FY30 show each override tier under Kezer's phased rollout alongside the no-override scenario. At FY30, only Tier 3 reaches the expense line.
   </p>
 
   <div class="notes">
-    <p>FY15&ndash;FY24 revenue, expenditure, and free cash figures are from the Town of Marblehead Annual Comprehensive Financial Reports, Schedule of Revenues, Expenditures and Changes in Fund Balance &ndash; Budget and Actual &ndash; General Fund. Persisted in <a href="/data/general_fund_budgetary_FY15-24.csv">data/general_fund_budgetary_FY15-24.csv</a>.</p>
-    <p>The ACFR schedule format changed between FY19 and FY20. For FY15&ndash;FY19, the free cash value plotted is the Original Budget "NET CHANGE IN FUND BALANCE" negated, which is the total budgeted use of fund balance (operating plus capital). For FY20&ndash;FY24 the free cash value is the "Use of free cash to reduce the tax rate" line specifically, which is operating-only. The two measurements differ by a few hundred thousand dollars; the 2016 FinCom report gives an FY17 operating portion of $6.025M while the ACFR FY17 total figure is $6.64M, a difference of about $0.6M.</p>
-    <p>FY25, FY26, and FY27 figures are from the Town Administrator's State of the Town presentation (January 2026), which uses a slightly narrower "Total Projected Expenses Less Excluded Debt Service" methodology and excludes around $8.5M in library debt exclusion. This creates a small methodology discontinuity at the FY24 / FY25 boundary on the chart; the projected series is slightly lower than it would be under the ACFR methodology.</p>
-    <p>Base revenue = total budgetary revenues (property tax levy, state aid, local receipts, motor vehicle excise, charges for services, penalties and interest, payments in lieu of taxes, licenses and permits, fines and forfeits, investment income) before any appropriation from free cash.</p>
-    <p>The FY27 $8.47M deficit figure is from the State of the Town presentation and is verified in <a href="/data/SOURCE_LOOKUP.md">SOURCE_LOOKUP</a>.</p>
+    <p>FY15&ndash;FY24: ACFR Schedule of Revenues, Expenditures and Changes in Fund Balance &ndash; Budget and Actual &ndash; General Fund. Persisted in <a href="/data/general_fund_budgetary_FY15-24.csv">data/general_fund_budgetary_FY15-24.csv</a>.</p>
+    <p>FY25&ndash;FY27: Town Administrator's State of the Town presentation (January 2026), adjusted to include excluded debt service (~$11M) for consistency with ACFR totals.</p>
+    <p>FY28&ndash;FY30: expenses projected at 5.4%/yr (Finance Committee blended rate); baseline revenue at 2.5%/yr; override draws per the three-year phase-in schedule on <a href="/what-is-the-override.html">How the override works</a>; from FY30 onward override grows with the levy at 2.5%/yr. Free cash held at $5M/yr projected.</p>
   </div>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ og_url: https://marbleheaddata.org/
 
     <a class="question" href="charts/sustainability.html">
       <h2>Is this a one-time reset?</h2>
-      <p>Forecast of revenue vs expenses FY27 through FY30 under each override tier, using the phased rollout. The expense line runs above every scenario in every year. Under the proposed plan, no tier fully closes the annual gap.</p>
+      <p>Ten years of general fund revenue and expenses, from balanced budgets through growing free cash reliance to the FY27 gap. Shows how each override tier compares to projected expenses through FY30.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
 


### PR DESCRIPTION
## Summary
- **Desktop** (>880px): single wide chart showing FY15-FY30 as one continuous narrative. Historical single bars (FY15-FY27) flow into grouped override bars (FY28-FY30). The expense line runs the full width.
- **Mobile** (<=880px): the FY15-FY27 historical chart, with a note to view wider for the override comparison.
- CSS toggle via `.chart-desktop` / `.chart-mobile` display classes in a page-scoped `<style>` block.

## The story it tells (left to right on desktop)
1. **FY15-FY17**: All green bars, no free cash drawn. Base revenue covers expenses.
2. **FY18+**: Brass "free cash drawn" layer appears and grows. Town starts reaching into reserves.
3. **FY27**: Expense line breaks above bar top. $8.5M gap visible.
4. **FY28-FY30**: Grouped bars show each override tier (phased rollout). No-override bar falls further behind. Tier 3 barely keeps up through FY30.

## Test plan
- [x] Desktop renders unified wide chart
- [x] Mobile renders historical-only chart
- [x] CSS breakpoint at 880px toggles correctly
- [x] All numbers consistent with ACFR data and State of the Town
- [x] Home card blurb updated