### PR TITLE
Switch scrolly components to sticky-step scroll pattern

### DIFF
--- a/question-2-trash.html
+++ b/question-2-trash.html
@@ -866,19 +866,36 @@ function update() {
     winnerEl.innerHTML = winnerHtml || '&nbsp;';
   }
 
-  const observer = new IntersectionObserver(function (entries) {
-    entries.forEach(function (entry) {
-      if (!entry.isIntersecting) return;
-      steps.forEach(function (s) { s.classList.remove('is-active'); });
-      entry.target.classList.add('is-active');
-      applyStep(entry.target);
-    });
-  }, {
-    rootMargin: '-45% 0px -45% 0px',
-    threshold: 0
-  });
+  // "Sticky step" pattern: each step activates when its top crosses a
+  // trigger line 40% from the top of the viewport and stays active until
+  // the *next* step's top crosses that same line.
+  const triggerRatio = 0.4;
+  let activeIndex = 0;
 
-  steps.forEach(function (s) { observer.observe(s); });
+  function updateActiveStep() {
+    const triggerY = window.innerHeight * triggerRatio;
+    let best = 0;
+    steps.forEach(function (s, i) {
+      const rect = s.getBoundingClientRect();
+      if (rect.top <= triggerY) best = i;
+    });
+    if (best !== activeIndex) {
+      activeIndex = best;
+      steps.forEach(function (s) { s.classList.remove('is-active'); });
+      steps[activeIndex].classList.add('is-active');
+      applyStep(steps[activeIndex]);
+    }
+  }
+
+  // Throttle scroll handler for performance.
+  let ticking = false;
+  window.addEventListener('scroll', function () {
+    if (!ticking) {
+      requestAnimationFrame(function () { updateActiveStep(); ticking = false; });
+      ticking = true;
+    }
+  }, { passive: true });
+  updateActiveStep();
 })();
 </script>
 

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -621,18 +621,35 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
     if (step && resultEl) resultEl.innerHTML = step.getAttribute('data-result') || '&nbsp;';
   }
 
-  var observer = new IntersectionObserver(function (entries) {
-    entries.forEach(function (entry) {
-      if (!entry.isIntersecting) return;
-      steps.forEach(function (s) { s.classList.remove('is-active'); });
-      entry.target.classList.add('is-active');
-      applyStep(entry.target.getAttribute('data-step'));
-    });
-  }, {
-    rootMargin: '-45% 0px -45% 0px',
-    threshold: 0
-  });
+  // "Sticky step" pattern: each step activates when its top crosses a
+  // trigger line 40% from the top of the viewport and stays active until
+  // the *next* step's top crosses that same line.
+  var triggerRatio = 0.4;
+  var activeIndex = 0;
 
-  steps.forEach(function (s) { observer.observe(s); });
+  function updateActiveStep() {
+    var triggerY = window.innerHeight * triggerRatio;
+    var best = 0;
+    steps.forEach(function (s, i) {
+      var rect = s.getBoundingClientRect();
+      if (rect.top <= triggerY) best = i;
+    });
+    if (best !== activeIndex) {
+      activeIndex = best;
+      steps.forEach(function (s) { s.classList.remove('is-active'); });
+      steps[activeIndex].classList.add('is-active');
+      applyStep(steps[activeIndex].getAttribute('data-step'));
+    }
+  }
+
+  // Throttle scroll handler for performance.
+  var ticking = false;
+  window.addEventListener('scroll', function () {
+    if (!ticking) {
+      requestAnimationFrame(function () { updateActiveStep(); ticking = false; });
+      ticking = true;
+    }
+  }, { passive: true });
+  updateActiveStep();
 })();
 </script>


### PR DESCRIPTION
## Summary
- Replace center-band IntersectionObserver with scroll-driven sticky-step pattern on both scrolly components
- Steps now lock in place when their top crosses a trigger line (40% from viewport top) and stay active until the next step pushes them out
- Applies to ballot nesting explainer (what-is-the-override) and trash distributional scrolly (question-2-trash)
- Uses `requestAnimationFrame`-throttled scroll listener with `{ passive: true }`

## Test plan
- [ ] Scroll through ballot nesting explainer on what-is-the-override.html — steps should stick and transition cleanly
- [ ] Scroll through trash distributional scrolly on question-2-trash.html — same sticky behavior
- [ ] Test on mobile viewport
- [ ] Verify `prefers-reduced-motion` still disables CSS transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)