### PR TITLE
Add rate, value, and schools comparison page

### DIFF
--- a/charts/rate_value_schools.html
+++ b/charts/rate_value_schools.html
@@ -1,0 +1,319 @@
+---
+title: "Rate, Value, and What You Get"
+---
+<style>
+/* Page-specific: tradeoff table, scatter plot, school staffing bars */
+  .tradeoff-intro {
+    font-size: 14px; line-height: 1.6; color: var(--text-mid);
+    max-width: 680px; margin: 0 auto 24px;
+  }
+
+  .section-divider {
+    display: flex; align-items: center; gap: 10px;
+    margin: 28px 0 16px;
+  }
+  .section-divider .label {
+    font-size: 11px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 1.1px; color: var(--text-subtle); white-space: nowrap;
+  }
+  .section-divider .rule {
+    flex: 1; height: 1px; background: var(--divider);
+  }
+
+  /* Tradeoff table */
+  table.tradeoff { width: 100%; border-collapse: collapse; margin: 0 0 8px; }
+  table.tradeoff th {
+    font-size: 10px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.8px; color: var(--text-subtle);
+    text-align: right; padding: 8px 8px; border-bottom: 1px solid var(--border);
+  }
+  table.tradeoff th:first-child { text-align: left; }
+  table.tradeoff td {
+    font-size: 13px; padding: 10px 8px; text-align: right;
+    border-bottom: 1px solid var(--divider);
+    font-variant-numeric: tabular-nums;
+  }
+  table.tradeoff td:first-child {
+    text-align: left; font-weight: 600; color: var(--text);
+  }
+  table.tradeoff tr.mh td:first-child { color: var(--series-marblehead); }
+  table.tradeoff tr.sw td:first-child { color: var(--series-swampscott); }
+  table.tradeoff tr.me td:first-child { color: var(--series-melrose); }
+  table.tradeoff tr.st td:first-child { color: var(--series-stoneham); }
+
+  /* School bars */
+  .school-bars { margin: 8px 0 20px; }
+  .school-bar-group { margin-bottom: 20px; }
+  .school-bar-group-title {
+    font-size: 11px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 1.1px; color: var(--text-subtle); margin-bottom: 10px;
+  }
+  .school-row {
+    display: grid; grid-template-columns: 92px 1fr 64px;
+    align-items: center; gap: 10px; margin-bottom: 5px; font-size: 12px;
+  }
+  .school-row .t {
+    color: var(--text); text-align: right; font-weight: 500;
+    white-space: nowrap;
+  }
+  .school-row .track {
+    height: 22px; background: var(--divider); border-radius: 4px;
+    overflow: hidden;
+  }
+  .school-row .fill { height: 100%; border-radius: 4px; }
+  .school-row .v {
+    color: var(--text-muted); font-variant-numeric: tabular-nums;
+    text-align: left; font-weight: 600;
+  }
+  .school-row.s-marblehead .t { font-weight: 700; }
+  .school-row.s-marblehead .fill { background: var(--series-marblehead); }
+  .school-row.s-swampscott .fill { background: var(--series-swampscott); }
+  .school-row.s-melrose .fill { background: var(--series-melrose); }
+  .school-row.s-stoneham .fill { background: var(--series-stoneham); }
+
+  /* Employer contribution highlight */
+  .contrib-cards {
+    display: grid; grid-template-columns: repeat(4, 1fr);
+    gap: 10px; margin: 8px 0 20px;
+  }
+  .contrib-card {
+    border-radius: 10px; padding: 14px 12px; text-align: center;
+    border: 1px solid var(--border); background: var(--surface);
+  }
+  .contrib-card .town-name {
+    font-size: 10px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.8px; margin-bottom: 6px;
+  }
+  .contrib-card.s-marblehead .town-name { color: var(--series-marblehead); }
+  .contrib-card.s-swampscott .town-name { color: var(--series-swampscott); }
+  .contrib-card.s-melrose .town-name { color: var(--series-melrose); }
+  .contrib-card.s-stoneham .town-name { color: var(--series-stoneham); }
+  .contrib-card .pct {
+    font-size: 28px; font-weight: 800; color: var(--text);
+    letter-spacing: -0.5px; line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+  .contrib-card .pct-label {
+    font-size: 11px; color: var(--text-subtle); margin-top: 4px;
+  }
+
+  @media (max-width: 560px) {
+    table.tradeoff { font-size: 12px; }
+    table.tradeoff th, table.tradeoff td { padding: 8px 4px; }
+    .contrib-cards { grid-template-columns: repeat(2, 1fr); }
+    .school-row { grid-template-columns: 78px 1fr 56px; font-size: 11px; }
+  }
+</style>
+
+<h1 class="h-center">Rate, Value, and What You Get</h1>
+<p class="subtitle h-center">Tax rates, home values, school staffing, and employer health contributions for four North Shore towns.</p>
+
+<p class="tradeoff-intro">A town's tax rate and its home values tend to move in opposite directions. Towns with lower assessed values need higher rates to raise the same revenue. The result: the sticker price on the house is different, but the annual carrying cost can be similar. This page puts the tax tradeoff and school staffing data side by side for four towns.</p>
+
+<div class="section-divider">
+  <span class="label">The tax tradeoff</span>
+  <span class="rule"></span>
+</div>
+
+<div class="table-wrap">
+  <table class="data tradeoff">
+    <thead>
+      <tr>
+        <th>Town</th>
+        <th>FY26 Rate</th>
+        <th>Median Home</th>
+        <th>Avg SF Bill</th>
+        <th>Res. Share</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="mh">
+        <td>Marblehead</td>
+        <td>$8.56</td>
+        <td>$1,010,100</td>
+        <td>$11,055</td>
+        <td>95.6%</td>
+      </tr>
+      <tr class="sw">
+        <td>Swampscott</td>
+        <td>$12.00</td>
+        <td>~$643,000</td>
+        <td>$11,478</td>
+        <td>88.6%</td>
+      </tr>
+      <tr class="me">
+        <td>Melrose</td>
+        <td>$11.47</td>
+        <td>$853,264</td>
+        <td>$9,787</td>
+        <td>91.4%</td>
+      </tr>
+      <tr class="st">
+        <td>Stoneham</td>
+        <td>$10.06</td>
+        <td>~$601,000</td>
+        <td>$8,059</td>
+        <td>83.0%</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<p class="caption">
+  Marblehead has the lowest rate and the second-highest bill. Swampscott has the highest rate and the highest bill. The rate and the bill answer different questions: the rate reflects how much revenue the town needs per dollar of property value, while the bill reflects what a homeowner actually pays. Residential share shows how much of the total levy falls on homeowners vs. commercial and industrial property.
+</p>
+
+<div class="section-divider">
+  <span class="label">Rate vs. value</span>
+  <span class="rule"></span>
+</div>
+
+<div class="chart-wrapper">
+  <svg class="chart" viewBox="0 0 880 380" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Scatter plot: FY2026 tax rate vs median assessed home value for four North Shore towns. Higher home values correlate with lower tax rates.">
+    <!-- Grid -->
+    <line class="axis-base" x1="80" y1="300" x2="780" y2="300"/>
+    <line class="axis-base" x1="80" y1="40" x2="80" y2="300"/>
+    <line class="grid-minor" x1="80" y1="235" x2="780" y2="235"/>
+    <line class="grid-minor" x1="80" y1="170" x2="780" y2="170"/>
+    <line class="grid-minor" x1="80" y1="105" x2="780" y2="105"/>
+
+    <!-- Y-axis: Tax rate -->
+    <text class="tick-label" x="73" y="304" text-anchor="end">$8</text>
+    <text class="tick-label" x="73" y="239" text-anchor="end">$9</text>
+    <text class="tick-label" x="73" y="174" text-anchor="end">$10</text>
+    <text class="tick-label" x="73" y="109" text-anchor="end">$11</text>
+    <text class="tick-label" x="73" y="44" text-anchor="end">$12</text>
+    <text class="annotation" x="20" y="170" transform="rotate(-90 20 170)" text-anchor="middle">Tax rate per $1K</text>
+
+    <!-- X-axis: Median home value -->
+    <text class="tick-label" x="80" y="325" text-anchor="middle">$550K</text>
+    <text class="tick-label" x="267" y="325" text-anchor="middle">$700K</text>
+    <text class="tick-label" x="453" y="325" text-anchor="middle">$850K</text>
+    <text class="tick-label" x="640" y="325" text-anchor="middle">$1.0M</text>
+    <text class="tick-label" x="780" y="325" text-anchor="middle">$1.1M</text>
+    <text class="annotation" x="430" y="350" text-anchor="middle">Median assessed home value</text>
+
+    <!-- Plot area: X maps $550K-$1.1M to 80-780, Y maps $8-$12 to 300-40 -->
+    <!-- Stoneham: $601K, $10.06 => x=144, y=162 -->
+    <circle class="data-dot s-stoneham" cx="144" cy="162" r="7"/>
+    <text class="end-label s-stoneham" x="160" y="152">Stoneham $10.06</text>
+
+    <!-- Swampscott: $643K, $12.00 => x=197, y=40 -->
+    <circle class="data-dot s-swampscott" cx="197" cy="40" r="7"/>
+    <text class="end-label s-swampscott" x="213" y="35">Swampscott $12.00</text>
+
+    <!-- Melrose: $853K, $11.47 => x="461" y="75" -->
+    <circle class="data-dot s-melrose" cx="461" cy="75" r="7"/>
+    <text class="end-label s-melrose" x="477" y="70">Melrose $11.47</text>
+
+    <!-- Marblehead: $1,010K, $8.56 => x=658, y=264 -->
+    <circle class="data-dot s-marblehead" cx="658" cy="264" r="8"/>
+    <text class="end-label s-marblehead" x="674" y="258">Marblehead $8.56</text>
+  </svg>
+</div>
+
+<p class="caption">
+  FY2026 residential tax rate plotted against median assessed home value. Higher home values allow a lower rate to raise comparable revenue. The Melrose FY26 rate reflects a $13.5M override passed November 2025. Stoneham's $9.3M override (December 2025) is not yet reflected in this rate.
+</p>
+
+<div class="section-divider">
+  <span class="label">School staffing</span>
+  <span class="rule"></span>
+</div>
+
+<div class="school-bars">
+  <p class="school-bar-group-title">Students per teacher, SY2024</p>
+  <!-- Marblehead 10.65, Swampscott 11.05, Stoneham 10.79, Melrose 13.72 -->
+  <!-- Scale: 0-16, so width% = value/16*100 -->
+  <div class="school-row s-marblehead">
+    <span class="t">Marblehead</span>
+    <div class="track"><div class="fill" style="width:66.6%"></div></div>
+    <span class="v">10.65</span>
+  </div>
+  <div class="school-row s-stoneham">
+    <span class="t">Stoneham</span>
+    <div class="track"><div class="fill" style="width:67.4%"></div></div>
+    <span class="v">10.79</span>
+  </div>
+  <div class="school-row s-swampscott">
+    <span class="t">Swampscott</span>
+    <div class="track"><div class="fill" style="width:69.1%"></div></div>
+    <span class="v">11.05</span>
+  </div>
+  <div class="school-row s-melrose">
+    <span class="t">Melrose</span>
+    <div class="track"><div class="fill" style="width:85.8%"></div></div>
+    <span class="v">13.72</span>
+  </div>
+
+  <p class="school-bar-group-title" style="margin-top:24px">Total school FTE per 100 students, SY2025&ndash;26</p>
+  <!-- Marblehead 430.2/2389=18.0, Stoneham 395.9/2296=17.2, Swampscott 316.6/2083=15.2, Melrose 480.3/3730=12.9 -->
+  <!-- Scale: 0-22, so width% = value/22*100 -->
+  <div class="school-row s-marblehead">
+    <span class="t">Marblehead</span>
+    <div class="track"><div class="fill" style="width:81.8%"></div></div>
+    <span class="v">18.0</span>
+  </div>
+  <div class="school-row s-stoneham">
+    <span class="t">Stoneham</span>
+    <div class="track"><div class="fill" style="width:78.2%"></div></div>
+    <span class="v">17.2</span>
+  </div>
+  <div class="school-row s-swampscott">
+    <span class="t">Swampscott</span>
+    <div class="track"><div class="fill" style="width:69.1%"></div></div>
+    <span class="v">15.2</span>
+  </div>
+  <div class="school-row s-melrose">
+    <span class="t">Melrose</span>
+    <div class="track"><div class="fill" style="width:58.6%"></div></div>
+    <span class="v">12.9</span>
+  </div>
+</div>
+
+<p class="caption">
+  Students-per-teacher uses DESE teacher FTE and enrollment for SY2023&ndash;24. Total school FTE per 100 students includes all staff reported to DESE EPIMS for SY2025&ndash;26 (administrators, teachers, paraprofessionals, counselors, special education, office and clerical, medical, and support). Higher values mean more staff per student. These ratios reflect district staffing models and special education caseloads, not quality or efficiency.
+</p>
+
+<div class="section-divider">
+  <span class="label">Employer health insurance contribution</span>
+  <span class="rule"></span>
+</div>
+
+<div class="contrib-cards">
+  <div class="contrib-card s-marblehead">
+    <p class="town-name">Marblehead</p>
+    <p class="pct">83%</p>
+    <p class="pct-label">employer share</p>
+  </div>
+  <div class="contrib-card s-melrose">
+    <p class="town-name">Melrose</p>
+    <p class="pct">80%+</p>
+    <p class="pct-label">employer share</p>
+  </div>
+  <div class="contrib-card s-stoneham">
+    <p class="town-name">Stoneham</p>
+    <p class="pct">80%</p>
+    <p class="pct-label">employer share</p>
+  </div>
+  <div class="contrib-card s-swampscott">
+    <p class="town-name">Swampscott</p>
+    <p class="pct">83%</p>
+    <p class="pct-label">employer share</p>
+  </div>
+</div>
+
+<p class="caption">
+  Modal employer premium contribution share for health insurance, FY2026. These are the most common split across each town's plan options. Stoneham has a tiered structure: 80% for post-2009 hires, 90% legacy for pre-2009 hires. Melrose is reported as "over 80%" per PEC agreement. Swampscott's rate is set by GIC. All four towns participate in the GIC.
+</p>
+
+<div class="notes">
+  <p><span class="footnote-marker"></span>Tax rate source: MA DOR Division of Local Services, Tax Rates by Class, FY2026.</p>
+  <p><span class="footnote-marker"></span>Average single-family tax bill source: MA DOR DLS, "Average Single Family Tax Bill" report, FY2026.</p>
+  <p><span class="footnote-marker"></span>Residential share source: MA DOR DLS, Tax Levy by Class, FY2026.</p>
+  <p><span class="footnote-marker"></span>Median assessed home value: Marblehead and Melrose from DOR; Swampscott from Assessor's Office; Stoneham estimated from DOR average bill / rate.</p>
+  <p><span class="footnote-marker"></span>Students per teacher: DESE, SY2023&ndash;24 staffing and enrollment data.</p>
+  <p><span class="footnote-marker"></span>Total school FTE: DESE EPIMS, SY2025&ndash;26.</p>
+  <p><span class="footnote-marker"></span>Employer premium share: Town GIC rate sheets and PEC agreements, FY2026. See <a href="/data/SOURCE_LOOKUP">Source Lookup</a> for document links.</p>
+  <p><span class="footnote-marker"></span>Melrose FY26 tax rate reflects a $13.5M override passed November 2025. Stoneham's $9.3M override (December 2025) is not yet reflected in FY26 data.</p>
+</div>

--- a/index.html
+++ b/index.html
@@ -113,6 +113,12 @@ og_url: https://marbleheaddata.org/
       <p>Tax rates, home values, median bills, and what $750K buys you in each town.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
+
+    <a class="question" href="charts/rate_value_schools.html">
+      <h2>Rate, value, and what you get</h2>
+      <p>Tax rates move inversely with home values. This page puts the tax tradeoff next to school staffing ratios and employer health contributions for four towns.</p>
+      <span class="tag tag-charts">Chart</span>
+    </a>
   </div>
 
   <div class="data-section" id="data-sources">


### PR DESCRIPTION
## Summary
- New chart page (`charts/rate_value_schools.html`) showing the tax rate vs. home value tradeoff for Marblehead, Swampscott, Melrose, and Stoneham
- Includes a scatter plot (rate vs. assessed value), school staffing bars (students per teacher, total FTE per 100 students), and employer health insurance contribution cards
- All data sourced from DOR DLS, DESE EPIMS SY2025-26, and town GIC rate sheets/PEC agreements
- Added to the Peer Comparison section on the index page

## Design notes
- Deliberately presents tax data and school staffing side by side without connecting them editorially — readers draw their own conclusions
- Uses the existing four-town comparison set and semantic color system
- Neutral captions throughout (no "better"/"worse" framing)

## Test plan
- [ ] Verify page renders correctly on desktop and mobile
- [ ] Check dark mode styling
- [ ] Confirm all data values match DOR/DESE sources
- [ ] Verify scatter plot dot positions are proportionally correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)