### PR TITLE
Add read-next cross-links for rate-value-schools page

### DIFF
--- a/charts/four_town_rates.html
+++ b/charts/four_town_rates.html
@@ -163,3 +163,15 @@ title: "Rate and Bill Comparison"
     <p>Marblehead override tiers on the rate chart are estimates: current rate + (override amount / $9.89B assessed value). Tier 1 ($9M) ~$9.46, Tier 2 ($12M) ~$9.76, Tier 3 ($15M) ~$10.06.</p>
     <p>The rate and bill charts use different start years because the underlying DOR reports have different coverage.</p>
   </div>
+
+  <div class="read-next">
+    <div class="read-next-label">Read next</div>
+    <a class="read-next-link" href="rate_value_schools.html">
+      <div class="read-next-title">Rate, value, and what you get &rarr;</div>
+      <div class="read-next-desc">The same four towns compared on tax rates vs. home values, school staffing ratios, and employer health insurance contributions.</div>
+    </a>
+    <a class="read-next-link" href="tax_comparison.html">
+      <div class="read-next-title">Marblehead vs. Swampscott, side by side &rarr;</div>
+      <div class="read-next-desc">A deeper look at the two towns with the highest bills: rate, home value, median bill, and what $750K buys in each.</div>
+    </a>
+  </div>

--- a/charts/rate_value_schools.html
+++ b/charts/rate_value_schools.html
@@ -317,3 +317,15 @@ title: "Rate, Value, and What You Get"
   <p><span class="footnote-marker"></span>Employer premium share: Town GIC rate sheets and PEC agreements, FY2026. See <a href="/data/SOURCE_LOOKUP">Source Lookup</a> for document links.</p>
   <p><span class="footnote-marker"></span>Melrose FY26 tax rate reflects a $13.5M override passed November 2025. Stoneham's $9.3M override (December 2025) is not yet reflected in FY26 data.</p>
 </div>
+
+<div class="read-next">
+  <div class="read-next-label">Read next</div>
+  <a class="read-next-link" href="four_town_rates.html">
+    <div class="read-next-title">Rate and bill: four North Shore towns &rarr;</div>
+    <div class="read-next-desc">How these same four towns' tax rates and average bills have tracked over 24 years, with override projections.</div>
+  </a>
+  <a class="read-next-link" href="/why-not-elsewhere.html">
+    <div class="read-next-title">Why do some MA towns run overrides? &rarr;</div>
+    <div class="read-next-desc">Residential share, new growth, and override history for 21 peer towns grouped by structural archetype.</div>
+  </a>
+</div>

--- a/charts/tax_comparison.html
+++ b/charts/tax_comparison.html
@@ -227,3 +227,15 @@ title: "Marblehead vs. Swampscott"
     <p><span class="footnote-marker"></span>Property taxes are paid per property, not per person. A family of four pays the same as a single resident.</p>
     <p><span class="footnote-marker"></span>Source: Mass.gov FY2026 tax levy data, Swampscott Assessor's Office, Marblehead Assessor's Office.</p>
   </div>
+
+  <div class="read-next">
+    <div class="read-next-label">Read next</div>
+    <a class="read-next-link" href="rate_value_schools.html">
+      <div class="read-next-title">Rate, value, and what you get &rarr;</div>
+      <div class="read-next-desc">Expand to four towns: tax rate vs. home value, school staffing ratios, and employer health insurance contributions side by side.</div>
+    </a>
+    <a class="read-next-link" href="four_town_rates.html">
+      <div class="read-next-title">Rate and bill: four North Shore towns &rarr;</div>
+      <div class="read-next-desc">How Marblehead, Swampscott, Melrose, and Stoneham tax rates and average bills have tracked from FY2003 to FY2026.</div>
+    </a>
+  </div>

--- a/why-not-elsewhere.html
+++ b/why-not-elsewhere.html
@@ -369,9 +369,9 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
       <div class="read-next-title">Both sides of the override debate &rarr;</div>
       <div class="read-next-desc">The peer-town structural data on this page informs Tension 4 of the debate. See the strongest version of each case across all six tensions.</div>
     </a>
-    <a class="read-next-link" href="senior-tax-relief.html">
-      <div class="read-next-title">Senior property tax relief &rarr;</div>
-      <div class="read-next-desc">Two programs that can reduce what a Marblehead senior pays: the state Senior Circuit Breaker (available today) and a pending local exemption.</div>
+    <a class="read-next-link" href="charts/rate_value_schools.html">
+      <div class="read-next-title">Rate, value, and what you get &rarr;</div>
+      <div class="read-next-desc">Tax rates vs. home values, school staffing ratios, and employer health contributions for four North Shore towns in one view.</div>
     </a>
   </div>
 


### PR DESCRIPTION
## Summary
- Add read-next links **to** the new rate-value-schools page from `four_town_rates`, `tax_comparison`, and `why-not-elsewhere`
- Add read-next links **from** rate-value-schools back to `four_town_rates` and `why-not-elsewhere`
- Replaced the senior-tax-relief link in why-not-elsewhere's read-next with the new page (more topically relevant)

## Navigation paths created
- `four_town_rates` → rate-value-schools, tax_comparison
- `tax_comparison` → rate-value-schools, four_town_rates
- `rate_value_schools` → four_town_rates, why-not-elsewhere
- `why-not-elsewhere` → the-debate, rate-value-schools

## Test plan
- [ ] Verify all read-next links resolve correctly
- [ ] Check mobile layout of read-next cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)