### PR TITLE
Add tabbed sustainability chart, page-lead intros, and start-here flow

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -2927,3 +2927,121 @@ sup.cite a:target {
   .waterfall-label,
   .waterfall-value { font-size: 11px; }
 }
+
+/* ==========================================================================
+   Glossary tooltips (abbr)
+   ========================================================================== */
+
+abbr.g {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: var(--text-faint);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  cursor: help;
+  position: relative;
+}
+abbr.g[title]:hover,
+abbr.g[title]:focus {
+  text-decoration-color: var(--link);
+}
+/* Tooltip on hover/focus — pure CSS, no JS */
+abbr.g::after {
+  content: attr(title);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--text);
+  color: var(--bg);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  padding: 5px 10px;
+  border-radius: 6px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  z-index: 10;
+}
+abbr.g:hover::after,
+abbr.g:focus::after {
+  opacity: 1;
+}
+/* On mobile, tooltips go below to avoid clipping at top */
+@media (max-width: 600px) {
+  abbr.g::after {
+    bottom: auto;
+    top: calc(100% + 4px);
+    font-size: 11px;
+    max-width: 220px;
+    white-space: normal;
+  }
+}
+
+/* ==========================================================================
+   Start-here reading path (homepage)
+   ========================================================================== */
+
+.start-here {
+  background: color-mix(in srgb, var(--c-teal) 5%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--c-teal) 20%, var(--border));
+  border-radius: var(--radius-md);
+  padding: 20px 22px 18px;
+  margin: 0 0 28px;
+}
+.start-here-eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.4px;
+  color: var(--c-teal);
+  margin-bottom: 6px;
+}
+.start-here p {
+  font-size: 14px;
+  color: var(--text-muted);
+  line-height: 1.55;
+  margin: 0 0 12px;
+}
+.start-here-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  counter-reset: step;
+}
+.start-here-steps li {
+  counter-increment: step;
+  padding: 8px 0;
+  border-top: 1px solid var(--divider);
+  font-size: 14px;
+}
+.start-here-steps li::before {
+  content: counter(step) ".";
+  font-weight: 700;
+  color: var(--c-teal);
+  margin-right: 8px;
+}
+.start-here-steps a {
+  font-weight: 600;
+}
+.start-here-steps .start-here-desc {
+  color: var(--text-subtle);
+  font-size: 13px;
+  display: block;
+  margin: 2px 0 0 22px;
+}
+
+/* ==========================================================================
+   Page lead-in (plain-English opener for data pages)
+   ========================================================================== */
+
+.page-lead {
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--text);
+  margin: 0 0 20px;
+  padding: 0 0 16px;
+  border-bottom: 1px solid var(--divider);
+}

--- a/charts/sustainability.html
+++ b/charts/sustainability.html
@@ -2,215 +2,264 @@
 title: "General Fund Revenue, Free Cash, and Expenses"
 ---
 <style>
-  .chart-desktop { display: block; }
-  .chart-mobile  { display: none; }
-  @media (max-width: 880px) {
-    .chart-desktop { display: none; }
-    .chart-mobile  { display: block; }
-  }
+  .chart-view { display: none; }
+  .chart-view.active { display: inline; }
+  .legend .legend-tier { display: none; }
+  .legend .legend-tier.active { display: inline-flex; }
+  .view-caption { display: none; }
+  .view-caption.active { display: block; }
 </style>
+<h1 class="h-center">General Fund: revenue vs. expenses</h1>
+  <p class="subtitle h-center">FY15&ndash;FY24 are ACFR actuals. FY25&ndash;FY27 from the January 2026 State of the Town. FY28&ndash;FY30 are illustrative projections. Use the tabs to compare override scenarios.</p>
 
-<h1 class="h-center">General Fund Revenue, Free Cash, and Expenses</h1>
-  <p class="subtitle h-center">Annual general fund revenue (base plus free cash) compared to expenditures, FY15&ndash;FY30. FY15&ndash;FY24 are ACFR actuals. FY25&ndash;FY30 are projected, with FY28&ndash;FY30 showing each override tier under the phased rollout.</p>
+  <div class="tabs">
+    <button class="tab active" data-view="none">No override</button>
+    <button class="tab" data-view="tier1">Tier 1 ($9M)</button>
+    <button class="tab" data-view="tier2">Tier 2 ($12M)</button>
+    <button class="tab" data-view="tier3">Tier 3 ($15M)</button>
+  </div>
 
   <div class="legend">
     <div class="legend-item s-revenue"><span class="legend-swatch"></span><span class="legend-text">Base revenue</span></div>
     <div class="legend-item s-swampscott"><span class="legend-swatch"></span><span class="legend-text">Free cash drawn</span></div>
-    <div class="legend-item s-tier-1"><span class="legend-swatch"></span><span class="legend-text">Tier 1 ($9M)</span></div>
-    <div class="legend-item s-tier-2"><span class="legend-swatch"></span><span class="legend-text">Tier 2 ($12M)</span></div>
-    <div class="legend-item s-tier-3"><span class="legend-swatch"></span><span class="legend-text">Tier 3 ($15M)</span></div>
+    <div class="legend-item s-tier-1 legend-tier" id="legend-t1"><span class="legend-swatch"></span><span class="legend-text">Tier 1 override</span></div>
+    <div class="legend-item s-tier-2 legend-tier" id="legend-t2"><span class="legend-swatch"></span><span class="legend-text">Tier 2 override</span></div>
+    <div class="legend-item s-tier-3 legend-tier" id="legend-t3"><span class="legend-swatch"></span><span class="legend-text">Tier 3 override</span></div>
     <div class="legend-item s-neutral"><span class="legend-swatch"></span><span class="legend-text">Total expenditures</span></div>
   </div>
 
-  <!-- ====== DESKTOP: unified FY15-FY30 chart ====== -->
-  <div class="chart-wrapper chart-desktop">
-    <svg class="chart" viewBox="0 0 1050 440" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Wide chart combining the FY15 to FY27 historical arc with FY28 to FY30 override tier comparison. Historical bars show base revenue plus free cash drawn. From FY28 onward, grouped bars compare no override, Tier 1, Tier 2, and Tier 3 phased scenarios. The expense line runs above all bars at FY27 and above the no-override bar through FY30, showing the growing gap.">
-      <!-- Grid: $60M to $140M, 3.5 units/$M -->
-      <line class="axis-base" x1="80" y1="360" x2="920" y2="360"/>
-      <line class="grid-minor" x1="80" y1="290" x2="920" y2="290"/>
-      <line class="grid-minor" x1="80" y1="220" x2="920" y2="220"/>
-      <line class="grid-minor" x1="80" y1="150" x2="920" y2="150"/>
-      <line class="grid-minor" x1="80" y1="80" x2="920" y2="80"/>
+  <div class="chart-wrapper">
+    <svg class="chart" viewBox="0 0 800 430" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stacked bar chart from FY15 to FY30 showing general fund base revenue plus free cash compared to an expense line. Tabs switch between no-override and three override tier scenarios.">
 
-      <!-- Y labels -->
-      <text class="tick-label" x="73" y="364" text-anchor="end">$60M</text>
-      <text class="tick-label" x="73" y="294" text-anchor="end">$80M</text>
-      <text class="tick-label" x="73" y="224" text-anchor="end">$100M</text>
-      <text class="tick-label" x="73" y="154" text-anchor="end">$120M</text>
-      <text class="tick-label" x="73" y="84" text-anchor="end">$140M</text>
+      <!-- Grid: $60M at y=380, scale 4px/$1M, up to $140M at y=60 -->
+      <line class="axis-base" x1="70" y1="380" x2="740" y2="380"/>
+      <line class="grid-minor" x1="70" y1="340" x2="740" y2="340"/>
+      <line class="grid-minor" x1="70" y1="300" x2="740" y2="300"/>
+      <line class="grid-minor" x1="70" y1="260" x2="740" y2="260"/>
+      <line class="grid-minor" x1="70" y1="220" x2="740" y2="220"/>
+      <line class="grid-minor" x1="70" y1="180" x2="740" y2="180"/>
+      <line class="grid-minor" x1="70" y1="140" x2="740" y2="140"/>
+      <line class="grid-minor" x1="70" y1="100" x2="740" y2="100"/>
+      <line class="grid-minor" x1="70" y1="60" x2="740" y2="60"/>
 
-      <!-- Dividers -->
-      <line class="annotation-line" x1="430" y1="60" x2="430" y2="360"/>
-      <line class="annotation-line" x1="545" y1="60" x2="545" y2="360"/>
-      <text class="annotation" x="255" y="54" text-anchor="middle">ACFR actuals</text>
-      <text class="annotation" x="488" y="54" text-anchor="middle">projected</text>
-      <text class="annotation" x="740" y="54" text-anchor="middle">override scenarios (phased)</text>
+      <!-- Y-axis ticks and labels -->
+      <line class="tick" x1="66" y1="380" x2="70" y2="380"/>
+      <text class="tick-label" x="63" y="384" text-anchor="end">$60M</text>
+      <line class="tick" x1="66" y1="300" x2="70" y2="300"/>
+      <text class="tick-label" x="63" y="304" text-anchor="end">$80M</text>
+      <line class="tick" x1="66" y1="220" x2="70" y2="220"/>
+      <text class="tick-label" x="63" y="224" text-anchor="end">$100M</text>
+      <line class="tick" x1="66" y1="140" x2="70" y2="140"/>
+      <text class="tick-label" x="63" y="144" text-anchor="end">$120M</text>
+      <line class="tick" x1="66" y1="60" x2="70" y2="60"/>
+      <text class="tick-label" x="63" y="64" text-anchor="end">$140M</text>
 
-      <!-- X labels: historical -->
-      <text class="tick-label tick-label--minor" x="98" y="382" text-anchor="middle">FY15</text>
-      <text class="tick-label tick-label--major" x="203" y="382" text-anchor="middle">FY18</text>
-      <text class="tick-label tick-label--minor" x="308" y="382" text-anchor="middle">FY21</text>
-      <text class="tick-label tick-label--major" x="378" y="382" text-anchor="middle">FY23</text>
-      <text class="tick-label tick-label--major" x="518" y="382" text-anchor="middle">FY27</text>
-      <!-- X labels: grouped -->
-      <text class="tick-label tick-label--major" x="608" y="382" text-anchor="middle">FY28</text>
-      <text class="tick-label tick-label--major" x="728" y="382" text-anchor="middle">FY29</text>
-      <text class="tick-label tick-label--major" x="848" y="382" text-anchor="middle">FY30</text>
+      <!-- X-axis labels. Bars: x = 80 + index*40, width 28, center x+14. -->
+      <text class="tick-label tick-label--minor" x="94" y="398" text-anchor="middle">FY15</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="134" y="398" text-anchor="middle">FY16</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="174" y="398" text-anchor="middle">FY17</text>
+      <text class="tick-label tick-label--major" x="214" y="398" text-anchor="middle">FY18</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="254" y="398" text-anchor="middle">FY19</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="294" y="398" text-anchor="middle">FY20</text>
+      <text class="tick-label tick-label--minor" x="334" y="398" text-anchor="middle">FY21</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="374" y="398" text-anchor="middle">FY22</text>
+      <text class="tick-label tick-label--major" x="414" y="398" text-anchor="middle">FY23</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="454" y="398" text-anchor="middle">FY24</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="494" y="398" text-anchor="middle">FY25</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="534" y="398" text-anchor="middle">FY26</text>
+      <text class="tick-label tick-label--major" x="574" y="398" text-anchor="middle">FY27</text>
+      <text class="tick-label tick-label--minor annotation--hide-sm" x="614" y="398" text-anchor="middle">FY28</text>
+      <text class="tick-label tick-label--major" x="654" y="398" text-anchor="middle">FY29</text>
+      <text class="tick-label tick-label--major" x="694" y="398" text-anchor="middle">FY30</text>
 
-      <!-- Historical single bars FY15-FY27 -->
-      <rect class="data-fill s-revenue" x="85" y="323" width="26" height="37"/>
-      <rect class="data-fill s-revenue" x="120" y="314" width="26" height="46"/>
-      <rect class="data-fill s-revenue" x="155" y="301" width="26" height="59"/>
-      <rect class="data-fill s-revenue" x="190" y="291" width="26" height="69"/>
-      <rect class="data-fill s-swampscott" x="190" y="284" width="26" height="7"/>
-      <rect class="data-fill s-revenue" x="225" y="281" width="26" height="79"/>
-      <rect class="data-fill s-swampscott" x="225" y="279" width="26" height="2"/>
-      <rect class="data-fill s-revenue" x="260" y="273" width="26" height="87"/>
-      <rect class="data-fill s-swampscott" x="260" y="272" width="26" height="1"/>
-      <rect class="data-fill s-revenue" x="295" y="271" width="26" height="89"/>
-      <rect class="data-fill s-swampscott" x="295" y="270" width="26" height="1"/>
-      <rect class="data-fill s-revenue" x="330" y="250" width="26" height="110"/>
-      <rect class="data-fill s-swampscott" x="330" y="242" width="26" height="8"/>
-      <rect class="data-fill s-revenue" x="365" y="237" width="26" height="123"/>
-      <rect class="data-fill s-swampscott" x="365" y="231" width="26" height="6"/>
-      <rect class="data-fill s-revenue" x="400" y="224" width="26" height="136"/>
-      <rect class="data-fill s-swampscott" x="400" y="220" width="26" height="4"/>
-      <!-- FY25-FY26 projected balanced -->
-      <rect class="data-fill s-revenue" x="435" y="221" width="26" height="139" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="435" y="202" width="26" height="19" opacity="0.65"/>
-      <rect class="data-fill s-revenue" x="470" y="201" width="26" height="159" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="470" y="177" width="26" height="24" opacity="0.65"/>
-      <!-- FY27 deficit -->
-      <rect class="data-fill s-revenue" x="505" y="195" width="26" height="165" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="505" y="178" width="26" height="17" opacity="0.65"/>
+      <!-- Actuals/projected divider (between FY24 and FY25) -->
+      <line class="annotation-line" x1="474" y1="48" x2="474" y2="380"/>
+      <text class="annotation annotation--hide-sm" x="270" y="42" text-anchor="middle">ACFR actuals</text>
 
-      <!-- FY28 grouped bars -->
-      <rect class="data-fill s-revenue" x="561" y="169" width="22" height="191" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="561" y="152" width="22" height="17" opacity="0.65"/>
-      <rect class="data-fill s-tier-1" x="585" y="147" width="22" height="213" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="585" y="130" width="22" height="17" opacity="0.65"/>
-      <rect class="data-fill s-tier-2" x="609" y="139" width="22" height="221" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="609" y="121" width="22" height="18" opacity="0.65"/>
-      <rect class="data-fill s-tier-3" x="633" y="132" width="22" height="228" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="633" y="115" width="22" height="17" opacity="0.65"/>
+      <!-- FinCom annotation at FY19 -->
+      <line class="annotation-line" x1="254" y1="55" x2="254" y2="250"/>
+      <text class="annotation annotation--hide-sm" x="254" y="50" text-anchor="middle">FinCom 2019: &ldquo;unsustainable&rdquo;</text>
 
-      <!-- FY29 grouped bars -->
-      <rect class="data-fill s-revenue" x="681" y="160" width="22" height="200" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="681" y="143" width="22" height="17" opacity="0.65"/>
-      <rect class="data-fill s-tier-1" x="705" y="129" width="22" height="231" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="705" y="111" width="22" height="18" opacity="0.65"/>
-      <rect class="data-fill s-tier-2" x="729" y="118" width="22" height="242" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="729" y="101" width="22" height="17" opacity="0.65"/>
-      <rect class="data-fill s-tier-3" x="753" y="108" width="22" height="252" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="753" y="90" width="22" height="18" opacity="0.65"/>
+      <!-- ================================================================
+           BARS: base revenue (sage) + free cash (brass).
+           Shared across all views. Override revenue stacked per view.
+           y = 380 - (value_M - 60) * 4.
+           ================================================================ -->
 
-      <!-- FY30 grouped bars -->
-      <rect class="data-fill s-revenue" x="801" y="151" width="22" height="209" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="801" y="133" width="22" height="18" opacity="0.65"/>
-      <rect class="data-fill s-tier-1" x="825" y="119" width="22" height="241" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="825" y="101" width="22" height="18" opacity="0.65"/>
-      <rect class="data-fill s-tier-2" x="849" y="108" width="22" height="252" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="849" y="90" width="22" height="18" opacity="0.65"/>
-      <rect class="data-fill s-tier-3" x="873" y="97" width="22" height="263" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="873" y="79" width="22" height="18" opacity="0.65"/>
+      <!-- FY15 exp 70.50, rev 71.32 > exp: green bar to expense level -->
+      <rect class="data-fill s-revenue" x="80" y="338" width="28" height="42"/>
+      <!-- FY16 exp 73.20 -->
+      <rect class="data-fill s-revenue" x="120" y="327" width="28" height="53"/>
+      <!-- FY17 exp 76.86 -->
+      <rect class="data-fill s-revenue" x="160" y="313" width="28" height="67"/>
+      <!-- FY18 exp 81.76, rev 79.73 -->
+      <rect class="data-fill s-revenue" x="200" y="301" width="28" height="79"/>
+      <rect class="data-fill s-swampscott" x="200" y="293" width="28" height="8"/>
+      <!-- FY19 exp 83.27, rev 82.54 -->
+      <rect class="data-fill s-revenue" x="240" y="290" width="28" height="90"/>
+      <rect class="data-fill s-swampscott" x="240" y="287" width="28" height="3"/>
+      <!-- FY20 exp 85.21, rev 84.77 -->
+      <rect class="data-fill s-revenue" x="280" y="281" width="28" height="99"/>
+      <rect class="data-fill s-swampscott" x="280" y="279" width="28" height="2"/>
+      <!-- FY21 exp 85.80, rev 85.39 -->
+      <rect class="data-fill s-revenue" x="320" y="278" width="28" height="102"/>
+      <rect class="data-fill s-swampscott" x="320" y="277" width="28" height="1"/>
+      <!-- FY22 exp 93.58, rev 91.45 -->
+      <rect class="data-fill s-revenue" x="360" y="254" width="28" height="126"/>
+      <rect class="data-fill s-swampscott" x="360" y="246" width="28" height="8"/>
+      <!-- FY23 exp 96.83, rev 95.13 -->
+      <rect class="data-fill s-revenue" x="400" y="239" width="28" height="141"/>
+      <rect class="data-fill s-swampscott" x="400" y="233" width="28" height="6"/>
+      <!-- FY24 exp 100.10, rev 98.79 -->
+      <rect class="data-fill s-revenue" x="440" y="225" width="28" height="155"/>
+      <rect class="data-fill s-swampscott" x="440" y="220" width="28" height="5"/>
 
-      <!-- Expense line: solid FY15-FY24, dashed FY25-FY30 -->
+      <!-- FY25 projected: rev 99.60, fc 5.50 -->
+      <rect class="data-fill s-revenue" x="480" y="222" width="28" height="158" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="480" y="200" width="28" height="22" opacity="0.65"/>
+      <!-- FY26 projected: rev 105.42, fc 7.00 -->
+      <rect class="data-fill s-revenue" x="520" y="198" width="28" height="182" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="520" y="170" width="28" height="28" opacity="0.65"/>
+      <!-- FY27 projected: rev 107.12, fc 5.00 -->
+      <rect class="data-fill s-revenue" x="560" y="191" width="28" height="189" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="560" y="171" width="28" height="20" opacity="0.65"/>
+      <!-- FY28 illustrative: rev ~110, fc 5 -->
+      <rect class="data-fill s-revenue" x="600" y="180" width="28" height="200" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="600" y="160" width="28" height="20" opacity="0.65"/>
+      <!-- FY29 illustrative: rev ~113, fc 5 -->
+      <rect class="data-fill s-revenue" x="640" y="168" width="28" height="212" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="640" y="148" width="28" height="20" opacity="0.65"/>
+      <!-- FY30 illustrative: rev ~116, fc 5 -->
+      <rect class="data-fill s-revenue" x="680" y="156" width="28" height="224" opacity="0.65"/>
+      <rect class="data-fill s-swampscott" x="680" y="136" width="28" height="20" opacity="0.65"/>
+
+      <!-- ================================================================
+           EXPENSE LINE: solid FY15-FY24, dashed FY24-FY30.
+           Same trajectory for all views (expenses don't change with override).
+           ================================================================ -->
       <polyline class="data-line data-line--bold s-neutral"
-                points="98,323 133,314 168,301 203,284 238,279 273,272 308,270 343,242 378,231 413,220"/>
+                points="94,338 134,327 174,313 214,293 254,287 294,279 334,277 374,246 414,233 454,220"/>
       <polyline class="data-line data-line--bold data-line--dashed s-neutral"
-                points="413,220 448,202 483,177 518,148 608,128 728,106 848,83"/>
+                points="454,220 494,200 534,170 574,138 614,114 654,88 694,62"/>
 
-      <!-- Data dots -->
-      <circle class="data-dot s-neutral" cx="98" cy="323" r="2"/>
-      <circle class="data-dot s-neutral" cx="203" cy="284" r="2"/>
-      <circle class="data-dot s-neutral" cx="308" cy="270" r="2"/>
-      <circle class="data-dot s-neutral" cx="413" cy="220" r="2"/>
-      <circle class="data-dot s-neutral" cx="518" cy="148" r="3"/>
-      <circle class="data-dot s-neutral" cx="608" cy="128" r="3"/>
-      <circle class="data-dot s-neutral" cx="728" cy="106" r="3"/>
-      <circle class="data-dot s-neutral" cx="848" cy="83" r="3"/>
+      <circle class="data-dot s-neutral" cx="94" cy="338" r="3"/>
+      <circle class="data-dot s-neutral" cx="134" cy="327" r="3"/>
+      <circle class="data-dot s-neutral" cx="174" cy="313" r="3"/>
+      <circle class="data-dot s-neutral" cx="214" cy="293" r="3"/>
+      <circle class="data-dot s-neutral" cx="254" cy="287" r="3"/>
+      <circle class="data-dot s-neutral" cx="294" cy="279" r="3"/>
+      <circle class="data-dot s-neutral" cx="334" cy="277" r="3"/>
+      <circle class="data-dot s-neutral" cx="374" cy="246" r="3"/>
+      <circle class="data-dot s-neutral" cx="414" cy="233" r="3"/>
+      <circle class="data-dot s-neutral" cx="454" cy="220" r="3"/>
+      <circle class="data-dot s-neutral" cx="494" cy="200" r="3"/>
+      <circle class="data-dot s-neutral" cx="534" cy="170" r="3"/>
+      <circle class="data-dot s-neutral" cx="574" cy="138" r="3"/>
+      <circle class="data-dot s-neutral" cx="614" cy="114" r="3"/>
+      <circle class="data-dot s-neutral" cx="654" cy="88" r="3"/>
+      <circle class="data-dot s-neutral" cx="694" cy="62" r="4"/>
 
-      <!-- Annotations -->
-      <line class="annotation-line" x1="238" y1="100" x2="238" y2="279"/>
-      <text class="annotation" x="238" y="95" text-anchor="middle">FinCom 2019: "unsustainable"</text>
+      <!-- Expense end label -->
+      <text class="end-label s-neutral" x="710" y="58">$140M expenses</text>
 
-      <text class="annotation" x="525" y="166" text-anchor="start">$8.5M gap</text>
+      <!-- ================================================================
+           VIEW: No override
+           Growing structural gap from $8.5M (FY27) to ~$18M (FY30).
+           ================================================================ -->
+      <g id="view-none" class="chart-view active">
+        <text class="annotation annotation--hide-sm" x="607" y="42" text-anchor="middle">projected</text>
+        <text class="annotation annotation--hide-sm" x="590" y="155" text-anchor="start">$8.5M gap</text>
+        <text class="annotation" x="714" y="92" text-anchor="start">$18M</text>
+        <text class="annotation" x="714" y="104" text-anchor="start">gap</text>
+      </g>
 
-      <!-- End labels -->
-      <text class="end-label s-neutral" x="860" y="78">$139M expenses</text>
-      <text class="end-label s-tier-3" x="893" y="76">T3</text>
-      <text class="end-label s-revenue" x="815" y="128">no override</text>
+      <!-- ================================================================
+           VIEW: Tier 1 ($9M override, phased over 3 years)
+           FY27 $1.27M, FY28 $6.30M cumul., FY29+ $9M full.
+           FY30 gap: ~$10M.
+           ================================================================ -->
+      <g id="view-tier1" class="chart-view">
+        <text class="annotation annotation--hide-sm" x="514" y="42" text-anchor="middle">projected</text>
+        <line class="annotation-line" x1="554" y1="48" x2="554" y2="380"/>
+        <text class="annotation annotation--hide-sm" x="647" y="42" text-anchor="middle">with Tier 1 override</text>
+        <rect class="data-fill s-tier-1" x="560" y="166" width="28" height="5" opacity="0.65"/>
+        <rect class="data-fill s-tier-1" x="600" y="135" width="28" height="25" opacity="0.65"/>
+        <rect class="data-fill s-tier-1" x="640" y="112" width="28" height="36" opacity="0.65"/>
+        <rect class="data-fill s-tier-1" x="680" y="100" width="28" height="36" opacity="0.65"/>
+        <text class="annotation" x="714" y="84" text-anchor="start">$10M</text>
+        <text class="annotation" x="714" y="96" text-anchor="start">gap</text>
+      </g>
+
+      <!-- ================================================================
+           VIEW: Tier 2 ($12M override, phased over 3 years)
+           FY27 $2.81M, FY28 $8.71M cumul., FY29+ $12M full.
+           FY30 gap: ~$7M.
+           ================================================================ -->
+      <g id="view-tier2" class="chart-view">
+        <text class="annotation annotation--hide-sm" x="514" y="42" text-anchor="middle">projected</text>
+        <line class="annotation-line" x1="554" y1="48" x2="554" y2="380"/>
+        <text class="annotation annotation--hide-sm" x="647" y="42" text-anchor="middle">with Tier 2 override</text>
+        <rect class="data-fill s-tier-2" x="560" y="160" width="28" height="11" opacity="0.65"/>
+        <rect class="data-fill s-tier-2" x="600" y="125" width="28" height="35" opacity="0.65"/>
+        <rect class="data-fill s-tier-2" x="640" y="100" width="28" height="48" opacity="0.65"/>
+        <rect class="data-fill s-tier-2" x="680" y="88" width="28" height="48" opacity="0.65"/>
+        <text class="annotation" x="714" y="78" text-anchor="start">$7M</text>
+        <text class="annotation" x="714" y="90" text-anchor="start">gap</text>
+      </g>
+
+      <!-- ================================================================
+           VIEW: Tier 3 ($15M override, phased over 3 years)
+           FY27 $4.30M, FY28 $10.54M cumul., FY29+ $15M full.
+           Gap closes in FY29, reopens to ~$4M by FY30.
+           ================================================================ -->
+      <g id="view-tier3" class="chart-view">
+        <text class="annotation annotation--hide-sm" x="514" y="42" text-anchor="middle">projected</text>
+        <line class="annotation-line" x1="554" y1="48" x2="554" y2="380"/>
+        <text class="annotation annotation--hide-sm" x="647" y="42" text-anchor="middle">with Tier 3 override</text>
+        <rect class="data-fill s-tier-3" x="560" y="154" width="28" height="17" opacity="0.65"/>
+        <rect class="data-fill s-tier-3" x="600" y="118" width="28" height="42" opacity="0.65"/>
+        <rect class="data-fill s-tier-3" x="640" y="88" width="28" height="60" opacity="0.65"/>
+        <rect class="data-fill s-tier-3" x="680" y="76" width="28" height="60" opacity="0.65"/>
+        <text class="annotation annotation--hide-sm" x="654" y="80" text-anchor="middle">gap closed</text>
+        <text class="annotation" x="714" y="72" text-anchor="start">$4M</text>
+        <text class="annotation" x="714" y="84" text-anchor="start">gap</text>
+      </g>
+
     </svg>
   </div>
 
-  <!-- ====== MOBILE: historical FY15-FY27 only ====== -->
-  <div class="chart-wrapper chart-mobile">
-    <svg class="chart" viewBox="0 0 780 440" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stacked bar chart FY15 to FY27 showing base revenue plus free cash drawn, compared to an expense line.">
-      <line class="axis-base" x1="80" y1="360" x2="730" y2="360"/>
-      <line class="grid-minor" x1="80" y1="320" x2="730" y2="320"/>
-      <line class="grid-minor" x1="80" y1="280" x2="730" y2="280"/>
-      <line class="grid-minor" x1="80" y1="240" x2="730" y2="240"/>
-      <line class="grid-minor" x1="80" y1="200" x2="730" y2="200"/>
-      <line class="grid-minor" x1="80" y1="160" x2="730" y2="160"/>
-      <line class="grid-minor" x1="80" y1="120" x2="730" y2="120"/>
-
-      <text class="tick-label" x="73" y="364" text-anchor="end">$60M</text>
-      <text class="tick-label" x="73" y="284" text-anchor="end">$80M</text>
-      <text class="tick-label" x="73" y="204" text-anchor="end">$100M</text>
-      <text class="tick-label" x="73" y="124" text-anchor="end">$120M</text>
-
-      <text class="tick-label tick-label--minor" x="103" y="382" text-anchor="middle">FY15</text>
-      <text class="tick-label tick-label--major" x="238" y="382" text-anchor="middle">FY18</text>
-      <text class="tick-label tick-label--minor" x="373" y="382" text-anchor="middle">FY21</text>
-      <text class="tick-label tick-label--major" x="463" y="382" text-anchor="middle">FY23</text>
-      <text class="tick-label tick-label--major" x="643" y="382" text-anchor="middle">FY27</text>
-
-      <!-- Bars: same as PR #140 -->
-      <rect class="data-fill s-revenue" x="87" y="318" width="32" height="42"/>
-      <rect class="data-fill s-revenue" x="132" y="307" width="32" height="53"/>
-      <rect class="data-fill s-revenue" x="177" y="293" width="32" height="67"/>
-      <rect class="data-fill s-revenue" x="222" y="281" width="32" height="79"/>
-      <rect class="data-fill s-swampscott" x="222" y="273" width="32" height="8"/>
-      <rect class="data-fill s-revenue" x="267" y="270" width="32" height="90"/>
-      <rect class="data-fill s-swampscott" x="267" y="267" width="32" height="3"/>
-      <rect class="data-fill s-revenue" x="312" y="261" width="32" height="99"/>
-      <rect class="data-fill s-swampscott" x="312" y="259" width="32" height="2"/>
-      <rect class="data-fill s-revenue" x="357" y="258" width="32" height="102"/>
-      <rect class="data-fill s-swampscott" x="357" y="257" width="32" height="1"/>
-      <rect class="data-fill s-revenue" x="402" y="234" width="32" height="126"/>
-      <rect class="data-fill s-swampscott" x="402" y="226" width="32" height="8"/>
-      <rect class="data-fill s-revenue" x="447" y="219" width="32" height="141"/>
-      <rect class="data-fill s-swampscott" x="447" y="213" width="32" height="6"/>
-      <rect class="data-fill s-revenue" x="492" y="205" width="32" height="155"/>
-      <rect class="data-fill s-swampscott" x="492" y="200" width="32" height="5"/>
-      <rect class="data-fill s-revenue" x="537" y="202" width="32" height="158" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="537" y="180" width="32" height="22" opacity="0.65"/>
-      <rect class="data-fill s-revenue" x="582" y="178" width="32" height="182" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="582" y="150" width="32" height="28" opacity="0.65"/>
-      <rect class="data-fill s-revenue" x="627" y="171" width="32" height="189" opacity="0.65"/>
-      <rect class="data-fill s-swampscott" x="627" y="151" width="32" height="20" opacity="0.65"/>
-
-      <polyline class="data-line data-line--bold s-neutral" points="103,318 148,307 193,293 238,273 283,267 328,259 373,257 418,226 463,213 508,200"/>
-      <polyline class="data-line data-line--bold data-line--dashed s-neutral" points="508,200 553,180 598,150 643,118"/>
-
-      <circle class="data-dot s-neutral" cx="103" cy="318" r="3"/>
-      <circle class="data-dot s-neutral" cx="238" cy="273" r="3"/>
-      <circle class="data-dot s-neutral" cx="373" cy="257" r="3"/>
-      <circle class="data-dot s-neutral" cx="508" cy="200" r="3"/>
-      <circle class="data-dot s-neutral" cx="643" cy="118" r="4"/>
-
-      <text class="end-label s-neutral" x="660" y="114">$120.6M expenses</text>
-      <text class="annotation" x="660" y="138" text-anchor="start">$8.5M gap</text>
-    </svg>
-    <p class="caption" aria-hidden="true">View on a wider screen to see the FY28&ndash;FY30 override tier comparison.</p>
-  </div>
-
-  <p class="caption">
-    Each historical bar (FY15&ndash;FY24) is sized to actual general fund expenditures. The green portion is base revenue collected and the brass portion is fund balance drawn. From FY15 to FY17 no draw was needed. Starting in FY18 the brass layer appears and grows through FY22. In FY27, the expense line breaks above the bar: even $5M of free cash leaves an $8.5M shortfall. FY28&ndash;FY30 show each override tier under Kezer's phased rollout alongside the no-override scenario. At FY30, only Tier 3 reaches the expense line.
+  <p class="caption view-caption active" id="caption-none">
+    Without override revenue, the gap between projected expenses and available revenue (base plus free cash) grows from $8.5M in FY27 to roughly $18M by FY30. Each bar is base revenue (green) plus free cash appropriated (brass). The expense line shows projected total expenditures. FY28&ndash;FY30 assume 3% annual revenue growth and 5% annual expense growth.
+  </p>
+  <p class="caption view-caption" id="caption-tier1">
+    Tier 1 ($9M) phases in over three years: $1.3M in FY27, $6.3M cumulative by FY28, fully drawn ($9M) by FY29. At full phase-in the override covers $9M of the projected gap, but expenses grow faster than the fixed override amount, leaving roughly $10M uncovered by FY30. Override draw schedule from <a href="/data/override_draws_schedule.csv">override_draws_schedule.csv</a>.
+  </p>
+  <p class="caption view-caption" id="caption-tier2">
+    Tier 2 ($12M) phases in over three years: $2.8M in FY27, $8.7M cumulative by FY28, fully drawn ($12M) by FY29. The gap narrows to roughly $3M in FY29 but reopens to roughly $7M by FY30 as expenses continue to outpace the fixed override levy.
+  </p>
+  <p class="caption view-caption" id="caption-tier3">
+    Tier 3 ($15M) phases in over three years: $4.3M in FY27, $10.5M cumulative by FY28, fully drawn ($15M) by FY29. The gap briefly closes in FY29, but reopens to roughly $4M by FY30 as expenses outpace the fixed override levy.
   </p>
 
   <div class="notes">
     <p>FY15&ndash;FY24: ACFR Schedule of Revenues, Expenditures and Changes in Fund Balance &ndash; Budget and Actual &ndash; General Fund. Persisted in <a href="/data/general_fund_budgetary_FY15-24.csv">data/general_fund_budgetary_FY15-24.csv</a>.</p>
-    <p>FY25&ndash;FY27: Town Administrator's State of the Town presentation (January 2026), adjusted to include excluded debt service (~$11M) for consistency with ACFR totals.</p>
-    <p>FY28&ndash;FY30: expenses projected at 5.4%/yr (Finance Committee blended rate); baseline revenue at 2.5%/yr; override draws per the three-year phase-in schedule on <a href="/what-is-the-override.html">How the override works</a>; from FY30 onward override grows with the levy at 2.5%/yr. Free cash held at $5M/yr projected.</p>
+    <p>FY25&ndash;FY27: Town Administrator's State of the Town presentation (January 2026), adjusted to include excluded debt service for consistency with ACFR totals.</p>
+    <p>FY28&ndash;FY30 are <strong>illustrative projections</strong>, not forecasts. Base revenue grows at 3% annually (Prop 2.5 levy limit plus estimated new growth). Expenses grow at 5% annually (near the FY22&ndash;FY27 average). Free cash held at $5M/yr. Override phase-in uses the draw schedule from the ballot questions (<a href="/data/override_draws_schedule.csv">override_draws_schedule.csv</a>). After full phase-in, the override levy stays flat while expenses continue growing.</p>
   </div>
+
+<script>
+document.querySelectorAll('.tab').forEach(function(btn) {
+  btn.addEventListener('click', function() {
+    var view = btn.dataset.view;
+    document.querySelectorAll('.tab').forEach(function(b) { b.classList.remove('active'); });
+    document.querySelectorAll('.chart-view').forEach(function(v) { v.classList.remove('active'); });
+    document.querySelectorAll('.view-caption').forEach(function(c) { c.classList.remove('active'); });
+    document.querySelectorAll('.legend-tier').forEach(function(l) { l.classList.remove('active'); });
+    btn.classList.add('active');
+    document.getElementById('view-' + view).classList.add('active');
+    document.getElementById('caption-' + view).classList.add('active');
+    var tierMap = { tier1: 'legend-t1', tier2: 'legend-t2', tier3: 'legend-t3' };
+    if (tierMap[view]) document.getElementById(tierMap[view]).classList.add('active');
+  });
+});
+</script>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,17 @@ og_url: https://marbleheaddata.org/
     <div class="featured-card-desc">Five tensions in the local debate, with the strongest version of each case. Neither a recommendation nor a summary. A map of the real disagreements, for readers still working through their vote.</div>
   </a>
 
+  <div class="start-here">
+    <div class="start-here-eyebrow">New to this?</div>
+    <p>If you just learned about the override vote, start with these four pages in order.</p>
+    <ol class="start-here-steps">
+      <li><a href="what-is-the-override.html">What is the override?</a><span class="start-here-desc">The three-tier ballot structure, what each tier funds, and what it costs.</span></li>
+      <li><a href="how-we-got-here.html">How did we get here?</a><span class="start-here-desc">Seven years of warnings from the Finance Committee, in their own words.</span></li>
+      <li><a href="no-override-budget.html">What's in the no-override budget?</a><span class="start-here-desc">The specific cuts if the override fails.</span></li>
+      <li><a href="the-debate.html">Both sides of the debate</a><span class="start-here-desc">The strongest case for and against, on six dividing lines.</span></li>
+    </ol>
+  </div>
+
   <p class="section-label">The override</p>
   <div class="question-list">
     <a class="question" href="what-is-the-override.html">

--- a/inside-school-staffing.html
+++ b/inside-school-staffing.html
@@ -26,6 +26,8 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
 </style>
 <h1>Inside school staffing</h1>
 
+  <p class="page-lead">Marblehead employs about 430 school staff for 2,400 students. This page breaks down what those positions are, which ones are legally required, and how the staffing mix compares to similar towns.</p>
+
   <div class="key-stats">
     <div class="key-stat">
       <div class="key-stat-value">430 FTE</div>

--- a/no-override-budget.html
+++ b/no-override-budget.html
@@ -5,6 +5,9 @@ og_description: The line-item changes in the town's FY27 No-Override Balanced Bu
 og_url: https://marbleheaddata.org/no-override-budget.html
 ---
 <h1>What's in the no-override budget?</h1>
+
+  <p class="page-lead">If the override fails, the town has a backup plan. It balances the budget by cutting 36 positions across town and school departments, reducing the library by 43%, and drawing down reserves. Here is what that looks like, line by line.</p>
+
   <p>The town published a <a href="https://marbleheadma.gov/wp-content/uploads/2026/04/PROPOSED-FY27-BALANCED-BUDGET-WITH-NO-OVERRIDE.pdf">FY27 Proposed Balanced Budget With No Override</a> in April 2026. It balances using $5M in free cash (unspent surplus certified by the state), staffing reductions across town and school departments, and the elimination of the town's OPEB (retiree health insurance) trust contribution. This page lists the specific line-item changes from that document.</p>
 
   <h2 data-stance-section="town-side-reductions">Town-side reductions</h2>

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -131,6 +131,10 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
     <a class="btn-link" href="question-2-trash.html">Question 2: trash funding</a>
   </div>
 
+  <div class="takeaway takeaway--neutral">
+    The tiers are nested, not additive. Voting yes on all three does not produce a $36 million override. The highest tier that passes sets the amount: $9M, $12M, or $15M.
+  </div>
+
   <p>The nesting matters more than it looks. At the April 8, 2026 Select Board meeting where the tiered structure was first presented, one resident added the three dollar amounts together and described the ballot as a $36 million ask.</p>
 
   <blockquote class="quote">
@@ -324,6 +328,10 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
     </div>
 
     <p class="phase-chart-caption">Cumulative override levy active in each fiscal year, by tier. Bar widths show each year's draw as a percentage of that tier's full amount.</p>
+  </div>
+
+  <div class="takeaway takeaway--neutral">
+    You do not pay the full override amount in year one. The cost phases in over three fiscal years, reaching its full amount only in FY29.
   </div>
 
   <p>See the <a href="charts/override_calculator.html">override cost calculator</a> for year-by-year costs at different home values.</p>

--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -107,62 +107,64 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
     .tldr { padding: 16px 18px 14px; }
     .tldr li { font-size: 13px; }
 
-    /* Stack the "Who decides what" table into cards on mobile so
-       the 3-column text content doesn't wrap cell-by-cell at 390px.
-       Keeps the normal peer-table rendering on desktop. */
-    table.civic-decide-table { display: block; }
-    table.civic-decide-table thead {
-      position: absolute;
-      width: 1px; height: 1px;
-      padding: 0; margin: -1px; overflow: hidden;
-      clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
-    }
-    table.civic-decide-table tbody { display: block; }
-    table.civic-decide-table tbody tr {
-      display: block;
-      background: var(--surface);
-      border-radius: var(--radius-sm);
-      box-shadow: var(--shadow-sm);
-      padding: 14px 16px 12px;
-      margin-bottom: 10px;
-    }
-    table.civic-decide-table tbody tr:last-child { margin-bottom: 0; }
-    table.civic-decide-table tbody td {
-      display: block;
-      padding: 0;
-      text-align: left;
-      border-bottom: none;
-      font-size: 13px;
-      line-height: 1.5;
-      color: var(--text-muted);
-    }
-    table.civic-decide-table tbody td:first-child {
-      font-size: 14px;
-      color: var(--text);
-      padding-bottom: 6px;
-      margin-bottom: 8px;
-      border-bottom: 1px solid var(--divider);
-    }
-    table.civic-decide-table tbody td:nth-child(2),
-    table.civic-decide-table tbody td:nth-child(3) {
-      padding-top: 6px;
-    }
-    table.civic-decide-table tbody td:nth-child(2)::before {
-      content: "Who decides";
-      display: block;
-      font-size: 10px; font-weight: 700;
-      text-transform: uppercase; letter-spacing: 0.6px;
-      color: var(--text-subtle);
-      margin-bottom: 2px;
-    }
-    table.civic-decide-table tbody td:nth-child(3)::before {
-      content: "How residents engage";
-      display: block;
-      font-size: 10px; font-weight: 700;
-      text-transform: uppercase; letter-spacing: 0.6px;
-      color: var(--text-subtle);
-      margin-bottom: 2px;
-    }
+  }
+
+  /* "Who decides what" cards */
+  .decide-cards {
+    display: grid;
+    gap: 10px;
+    margin: 18px 0 24px;
+  }
+  @media (min-width: 720px) {
+    .decide-cards { grid-template-columns: repeat(2, 1fr); }
+  }
+  .decide-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 16px 18px 14px;
+  }
+  .decide-card h3 {
+    margin: 0 0 10px;
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--text);
+    line-height: 1.3;
+  }
+  .decide-card-field {
+    margin-bottom: 8px;
+  }
+  .decide-card-field:last-child { margin-bottom: 0; }
+  .decide-card-label {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    color: var(--text-subtle);
+    margin-bottom: 2px;
+  }
+  .decide-card-value {
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--text-mid);
+  }
+
+  /* Town Meeting tips card */
+  .tm-tips dl {
+    margin: 0;
+  }
+  .tm-tips dt {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--text);
+    margin-top: 12px;
+  }
+  .tm-tips dt:first-of-type { margin-top: 0; }
+  .tm-tips dd {
+    margin: 2px 0 0;
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--text-muted);
   }
 </style>
 
@@ -232,62 +234,107 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
 <h2>Who decides what</h2>
 <p>Most civic decisions in Marblehead are distributed across several bodies, each with different authority. Knowing which body handles which decision is the difference between writing the right email and writing to no one.</p>
 
-<table class="peer-table civic-decide-table">
-  <thead>
-    <tr>
-      <th>Decision</th>
-      <th>Who decides</th>
-      <th>How residents engage</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Annual operating budget</strong></td>
-      <td>Town Administrator drafts &rarr; Select Board reviews &rarr; Finance Committee recommends &rarr; Town Meeting votes</td>
-      <td>Attend Select Board and Finance Committee meetings during the budget cycle; speak and vote at Town Meeting</td>
-    </tr>
-    <tr>
-      <td><strong>Proposition 2&frac12; override or debt exclusion</strong></td>
-      <td>Select Board puts the question on the ballot; Town Meeting approves the budget; voters decide at the ballot</td>
-      <td>Speak and vote at Town Meeting; vote at the ballot</td>
-    </tr>
-    <tr>
-      <td><strong>Operational decisions (hiring, scheduling, procurement)</strong></td>
-      <td>Town Administrator and department heads, with Select Board oversight</td>
-      <td>Contact the Town Administrator or the relevant Select Board member</td>
-    </tr>
-    <tr>
-      <td><strong>School spending priorities</strong> (within the school budget)</td>
-      <td>School Committee</td>
-      <td>Attend School Committee meetings; contact members directly</td>
-    </tr>
-    <tr>
-      <td><strong>Tax classification</strong> (single vs. split residential / commercial rate)</td>
-      <td>Select Board, annually at a public hearing</td>
-      <td>Attend the annual tax classification hearing</td>
-    </tr>
-    <tr>
-      <td><strong>Zoning and land use bylaws</strong></td>
-      <td>Planning Board proposes; Town Meeting votes</td>
-      <td>Attend Planning Board hearings; speak at Town Meeting; petition a warrant article</td>
-    </tr>
-    <tr>
-      <td><strong>Town bylaws and warrant articles</strong></td>
-      <td>Town Meeting votes (some require Attorney General approval)</td>
-      <td>Petition a warrant article with 10 registered-voter signatures for the Annual Town Meeting, or support one</td>
-    </tr>
-    <tr>
-      <td><strong>Licensing</strong> (alcohol, food, entertainment, lodging)</td>
-      <td>Select Board</td>
-      <td>Contact Select Board members directly</td>
-    </tr>
-    <tr>
-      <td><strong>State aid, pension contribution formulas, health insurance (GIC)</strong></td>
-      <td>Massachusetts legislature and state agencies</td>
-      <td>Contact your state senator or state representative</td>
-    </tr>
-  </tbody>
-</table>
+<div class="decide-cards">
+  <div class="decide-card">
+    <h3>Annual operating budget</h3>
+    <div class="decide-card-field">
+      <div class="decide-card-label">Who decides</div>
+      <div class="decide-card-value">Town Administrator drafts &rarr; Select Board reviews &rarr; Finance Committee recommends &rarr; Town Meeting votes</div>
+    </div>
+    <div class="decide-card-field">
+      <div class="decide-card-label">How to engage</div>
+      <div class="decide-card-value">Attend Select Board and Finance Committee meetings during the budget cycle; speak and vote at Town Meeting</div>
+    </div>
+  </div>
+  <div class="decide-card">
+    <h3>Proposition 2&frac12; override or debt exclusion</h3>
+    <div class="decide-card-field">
+      <div class="decide-card-label">Who decides</div>
+      <div class="decide-card-value">Select Board puts the question on the ballot; Town Meeting approves the budget; voters decide at the ballot</div>
+    </div>
+    <div class="decide-card-field">
+      <div class="decide-card-label">How to engage</div>
+      <div class="decide-card-value">Speak and vote at Town Meeting; vote at the ballot</div>
+    </div>
+  </div>
+  <div class="decide-card">
+    <h3>Operational decisions (hiring, scheduling, procurement)</h3>
+    <div class="decide-card-field">
+      <div class="decide-card-label">Who decides</div>
+      <div class="decide-card-value">Town Administrator and department heads, with Select Board oversight</div>
+    </div>
+    <div class="decide-card-field">
+      <div class="decide-card-label">How to engage</div>
+      <div class="decide-card-value">Contact the Town Administrator or the relevant Select Board member</div>
+    </div>
+  </div>
+  <div class="decide-card">
+    <h3>School spending priorities (within the school budget)</h3>
+    <div class="decide-card-field">
+      <div class="decide-card-label">Who decides</div>
+      <div class="decide-card-value">School Committee</div>
+    </div>
+    <div class="decide-card-field">
+      <div class="decide-card-label">How to engage</div>
+      <div class="decide-card-value">Attend School Committee meetings; contact members directly</div>
+    </div>
+  </div>
+  <div class="decide-card">
+    <h3>Tax classification (single vs. split rate)</h3>
+    <div class="decide-card-field">
+      <div class="decide-card-label">Who decides</div>
+      <div class="decide-card-value">Select Board, annually at a public hearing</div>
+    </div>
+    <div class="decide-card-field">
+      <div class="decide-card-label">How to engage</div>
+      <div class="decide-card-value">Attend the annual tax classification hearing</div>
+    </div>
+  </div>
+  <div class="decide-card">
+    <h3>Zoning and land use bylaws</h3>
+    <div class="decide-card-field">
+      <div class="decide-card-label">Who decides</div>
+      <div class="decide-card-value">Planning Board proposes; Town Meeting votes</div>
+    </div>
+    <div class="decide-card-field">
+      <div class="decide-card-label">How to engage</div>
+      <div class="decide-card-value">Attend Planning Board hearings; speak at Town Meeting; petition a warrant article</div>
+    </div>
+  </div>
+  <div class="decide-card">
+    <h3>Town bylaws and warrant articles</h3>
+    <div class="decide-card-field">
+      <div class="decide-card-label">Who decides</div>
+      <div class="decide-card-value">Town Meeting votes (some require Attorney General approval)</div>
+    </div>
+    <div class="decide-card-field">
+      <div class="decide-card-label">How to engage</div>
+      <div class="decide-card-value">Petition a warrant article with 10 registered-voter signatures, or support one</div>
+    </div>
+  </div>
+  <div class="decide-card">
+    <h3>Licensing (alcohol, food, entertainment, lodging)</h3>
+    <div class="decide-card-field">
+      <div class="decide-card-label">Who decides</div>
+      <div class="decide-card-value">Select Board</div>
+    </div>
+    <div class="decide-card-field">
+      <div class="decide-card-label">How to engage</div>
+      <div class="decide-card-value">Contact Select Board members directly</div>
+    </div>
+  </div>
+  <div class="decide-card">
+    <h3>State aid, pensions, health insurance (GIC)</h3>
+    <div class="decide-card-field">
+      <div class="decide-card-label">Who decides</div>
+      <div class="decide-card-value">Massachusetts legislature and state agencies</div>
+    </div>
+    <div class="decide-card-field">
+      <div class="decide-card-label">How to engage</div>
+      <div class="decide-card-value">Contact your state senator or state representative</div>
+    </div>
+  </div>
+</div>
 
 <div class="takeaway takeaway--pos">
   <p><strong>Most meaningful budget decisions run through Town Meeting.</strong> If you care about the overall size of the town's operating budget, the warrant articles, or any structural change to how the town is governed, the lever is Town Meeting. Contacting individual Select Board members is effective for operational questions but does not change the total budget size.</p>
@@ -383,16 +430,22 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
   <p>The Moderator controls who gets recognized to speak: you raise your hand, wait to be called on, state your name and address, and confine your remarks to the motion on the floor. Speakers who wander into unrelated material can be ruled out of order. Budget articles often pass with limited floor debate when the Finance Committee has recommended in favor. Contested articles draw longer discussion. Votes are usually by show of hands; nine or more voters can call for a written ballot.</p>
 </div>
 
-<div class="card">
+<div class="card tm-tips">
   <h3>Practical things to know before you go</h3>
-  <ul>
-    <li>The warrant (the list of articles to be voted on) is published in advance. Pick the articles you actually care about. You do not have to pay attention to the rest.</li>
-    <li>The Finance Committee's annual report explains each article and gives a recommendation on each. It will tell you what you are voting on and why.</li>
-    <li>If you just want to vote, you do not have to speak at all.</li>
-    <li>The auditorium is warm. Bring water.</li>
-    <li>If Town Meeting adjourns before reaching your article, it resumes on a later night. Check the town calendar for the continuation date.</li>
-    <li>If you do speak, keep it short. State your position in your first sentence ("I am in favor of Article X" or "I am opposed to Article X"), address the specific motion on the table, and aim for a minute or less. Longer speeches rarely change votes and often test the Moderator's patience.</li>
-  </ul>
+  <dl>
+    <dt>Read the warrant first</dt>
+    <dd>The warrant (the list of articles to be voted on) is published in advance. Pick the articles you actually care about. You do not have to pay attention to the rest.</dd>
+    <dt>Read the FinCom report</dt>
+    <dd>The Finance Committee's annual report explains each article and gives a recommendation on each. It will tell you what you are voting on and why.</dd>
+    <dt>You do not have to speak</dt>
+    <dd>If you just want to vote, you can sit and raise your hand when the vote is called. No speech required.</dd>
+    <dt>Bring water</dt>
+    <dd>The auditorium is warm, and meetings can run long.</dd>
+    <dt>It may take more than one night</dt>
+    <dd>If Town Meeting adjourns before reaching your article, it resumes on a later night. Check the town calendar for the continuation date.</dd>
+    <dt>If you do speak, keep it short</dt>
+    <dd>State your position in your first sentence ("I am in favor of Article X" or "I am opposed to Article X"), address the specific motion on the table, and aim for a minute or less.</dd>
+  </dl>
 </div>
 
 <p>Town Meeting is the only place residents vote directly on the town budget and on warrant articles. Every registered voter in the room has the same vote as anyone else.</p>

--- a/where-has-the-money-gone.html
+++ b/where-has-the-money-gone.html
@@ -50,6 +50,8 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
 </style>
 <h1>Where has Marblehead's money gone?</h1>
 
+  <p class="page-lead">Marblehead's general fund grew by $35.7 million over the last decade. This page shows which departments absorbed that growth, who has been checking the books, and where spending outpaced what enrollment or inflation alone would explain.</p>
+
   <div class="key-stats">
     <div class="key-stat">
       <div class="key-stat-value">$70M&rarr;$106M</div>

--- a/why-not-elsewhere.html
+++ b/why-not-elsewhere.html
@@ -128,6 +128,9 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
   }
 </style>
 <h1>Why do some MA towns run overrides and others don't?</h1>
+
+  <p class="page-lead">Some towns run override votes regularly and others never do. Two structural factors explain most of the difference: how much of the tax base is residential, and how much new construction helps the town grow revenue without raising rates. Marblehead is at the extreme end of both.</p>
+
   <p>Massachusetts has 351 cities and towns. Some are running Proposition 2&frac12; override votes this year, some never have, and some haven't in decades. What separates the groups isn't primarily about management or spending levels. It's structural. Two metrics from the MA Department of Revenue explain most of the variation: what share of a town's property tax levy falls on residential homeowners, and how much new construction expands the levy ceiling each year.</p>
 
   <p>This page walks through those two metrics for a 21-town peer set spanning residential suburbs, mixed-use suburbs, commercial-anchor cities, and gateway cities. Whether any given town's situation constitutes a "problem" is a separate judgment that depends on values, priorities, and what residents want from their local government. The data here is meant to inform that judgment, not to make it.</p>


### PR DESCRIPTION
## Summary

- **Sustainability chart**: Restructured from grouped side-by-side bars into 4 tabbed views (No override, Tier 1, Tier 2, Tier 3) using a single SVG with show/hide `<g>` groups. Each tab shows identical historical bars and expense line, with only the override revenue segments toggling. Extends to FY30 to show all tiers' gaps reopening as expenses outpace the fixed override levy.
- **Page-lead intros**: Added `page-lead` paragraphs to 5 explainer pages giving readers a one-sentence summary before diving in.
- **Start-here flow**: Added a "New to this?" guided path on the homepage with 4 pages in recommended reading order.
- **Override clarifications**: Added two `takeaway--neutral` callouts on the override page explaining tier nesting and phased costs.

## Test plan

- [ ] Verify tab switching works on the sustainability chart (all 4 tabs)
- [ ] Confirm legend updates to show the correct tier color swatch
- [ ] Confirm caption swaps with each tab
- [ ] Check mobile rendering (tabs should wrap, chart should scale)
- [ ] Verify page-lead text appears on each updated explainer page
- [ ] Verify start-here section on homepage links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)