### PR TITLE
Add bell buoy branding to favicon and hero

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -636,6 +636,7 @@ details.notes[open] > summary {
   .page > .hero h1 { font-size: 38px; letter-spacing: -0.8px; }
   .page > .hero p { font-size: 17px; max-width: 560px; }
   .page > .hero { margin-bottom: 44px; }
+  .hero-buoy { width: 56px; height: 70px; margin-bottom: 16px; }
   .key-stats {
     padding: 18px 14px;
     margin: 14px 0 28px;
@@ -650,6 +651,7 @@ details.notes[open] > summary {
    ========================================================================== */
 
 .hero { text-align: center; margin-bottom: 36px; }
+.hero-buoy { display: block; width: 48px; height: 60px; margin: 0 auto 12px; color: var(--text); }
 .hero h1 { font-size: 28px; margin-bottom: 10px; }
 .hero p  { font-size: 16px; color: var(--text-subtle); max-width: 520px; margin: 0 auto; }
 
@@ -724,6 +726,7 @@ details.notes[open] > summary {
 
 @media (max-width: 600px) {
   .hero { margin-bottom: 28px; }
+  .hero-buoy { width: 40px; height: 50px; margin-bottom: 8px; }
   .hero h1 { font-size: 24px; }
   .hero p  { font-size: 15px; }
   .question { padding: 18px 20px; }

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,4 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="6" fill="#111"/>
-  <text x="16" y="23" text-anchor="middle" font-family="-apple-system, sans-serif" font-weight="700" font-size="20" fill="white">M</text>
+  <rect width="32" height="32" rx="6" fill="#1B3A57"/>
+  <!-- yoke arch -->
+  <path d="M13 8.5Q16 5 19 8.5" fill="none" stroke="#F4F7FA" stroke-width="1.2" stroke-linecap="round"/>
+  <!-- bell -->
+  <circle cx="16" cy="7.5" r="1.5" fill="#B8860B"/>
+  <!-- buoy body -->
+  <path d="M13 9v7h6V9z" fill="#C8553D"/>
+  <!-- stripe -->
+  <rect x="13" y="13" width="6" height="2" fill="#F4F7FA" opacity=".3"/>
+  <!-- float base -->
+  <rect x="10.5" y="16" width="11" height="3.5" rx="1.75" fill="#C8553D"/>
+  <rect x="10.5" y="16" width="11" height="3.5" rx="1.75" fill="none" stroke="#F4F7FA" stroke-width=".6"/>
+  <!-- wave -->
+  <path d="M7 22.5q2.5-1.8 5 0t5 0 5 0" fill="none" stroke="#2F7D8E" stroke-width="1.2" stroke-linecap="round"/>
+  <path d="M8 25q2.5-1.5 5 0t5 0 4 0" fill="none" stroke="#2F7D8E" stroke-width=".8" stroke-linecap="round" opacity=".45"/>
 </svg>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,24 @@ og_type: website
 og_url: https://marbleheaddata.org/
 ---
 <div class="hero">
+    <svg class="hero-buoy" viewBox="0 0 64 80" aria-hidden="true">
+      <!-- yoke arch -->
+      <path d="M24 22Q32 12 40 22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity=".35"/>
+      <!-- bell -->
+      <circle cx="32" cy="18" r="3.5" fill="var(--c-brass)" opacity=".7"/>
+      <!-- mast -->
+      <rect x="30.5" y="21" width="3" height="8" rx="1" fill="currentColor" opacity=".25"/>
+      <!-- buoy body -->
+      <path d="M24 29v16h16V29z" fill="var(--c-buoy)" opacity=".6"/>
+      <!-- stripe -->
+      <rect x="24" y="37" width="16" height="3" fill="currentColor" opacity=".08"/>
+      <!-- float -->
+      <rect x="20" y="45" width="24" height="7" rx="3.5" fill="var(--c-buoy)" opacity=".5"/>
+      <rect x="20" y="45" width="24" height="7" rx="3.5" fill="none" stroke="currentColor" stroke-width=".8" opacity=".15"/>
+      <!-- waves -->
+      <path d="M10 58q5.5-4 11 0t11 0 11 0" fill="none" stroke="var(--c-teal)" stroke-width="1.5" stroke-linecap="round" opacity=".35"/>
+      <path d="M12 64q5-3.5 10 0t10 0 10 0" fill="none" stroke="var(--c-teal)" stroke-width="1" stroke-linecap="round" opacity=".2"/>
+    </svg>
     <h1>Weighing the FY2027 override?</h1>
     <p>Every claim on this site cites a primary source. Every dollar traces to a town document. Make your own call. <a href="#data-sources">See all sources.</a></p>
   </div>


### PR DESCRIPTION
## Summary
- Replace plain "M" favicon with a bell buoy icon using the coastal palette (navy, buoy red, brass, teal waves)
- Add a decorative bell buoy SVG above the homepage hero headline, themed via CSS custom properties for light/dark mode
- Responsive sizing across three breakpoints (mobile, default, desktop)

## Test plan
- [ ] Verify favicon renders correctly in browser tab (light and dark OS themes)
- [ ] Check hero buoy appearance on homepage at mobile (<600px), tablet, and desktop (>720px)
- [ ] Confirm dark mode theming on hero buoy via `prefers-color-scheme`
- [ ] Verify no layout shift from the added SVG element

🤖 Generated with [Claude Code](https://claude.com/claude-code)