### PR TITLE
Add 'What surprised me' section to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -121,6 +121,29 @@ og_title: "Who made this?"
 
   <p>This vote matters. So before voting, I wanted to understand two things: how we got here, and what each possible outcome would actually mean. I apply the same editorial rules to both sides of the debate. The <a href="https://github.com/agbaber/marblehead/blob/main/STYLE_GUIDE.md">STYLE_GUIDE.md</a> enforces them. The <a href="bias-audit.html">bias audit</a> tests them. If you find a violation, <a href="https://github.com/agbaber/marblehead/issues/new?title=Bias%3A+">report it</a>.</p>
 
+  <h2 data-stance-section="off">What surprised me</h2>
+
+  <p><strong>Schools added 58 support staff while enrollment dropped 19%.</strong>
+  I assumed staffing tracked enrollment. It doesn't. Since 2015, student enrollment fell from 3,245 to 2,617, but administrative and support positions increased by 58. The student-to-teacher ratio is now 10.7, the lowest among peer towns. <a href="/charts/enrollment_vs_staffing.html">See the chart</a>.</p>
+
+  <p><strong>Schools drove less than half of spending growth.</strong>
+  Between 2015 and 2024, the town's operating budget grew by $35.7M. I expected schools to account for most of it. They accounted for 48%. Healthcare, public safety, debt service, and pensions made up the other half. <a href="/where-has-the-money-gone.html">See the breakdown</a>.</p>
+
+  <p><strong>Healthcare is the fastest-growing cost, and it's mostly outside the town's control.</strong>
+  I didn't appreciate how much of the budget pressure comes from health insurance. Costs are growing at 11% annually, driven by GLP-1 medications and hospital rate increases. Marblehead's claims exceed its premiums (a 114&ndash;119% loss ratio). <a href="/charts/healthcare_costs.html">See the data</a>.</p>
+
+  <p><strong>The Finance Committee predicted this override seven years ago.</strong>
+  I assumed this was a sudden fiscal crisis. It wasn't. FinCom called the budget "unsustainable" in 2019. In 2022, they explicitly predicted an override would be needed by FY24. In 2023, they formally endorsed one for the first time since 2005. The timeline is documented. <a href="/how-we-got-here.html">Read the history</a>.</p>
+
+  <p><strong>Town Meeting and the ballot box are different electorates.</strong>
+  The 2023 override passed Town Meeting 534&ndash;230 (70%) but lost at the ballot 2,992&ndash;3,399 (47%). That's a 23-point swing between roughly 800 Town Meeting attendees and 6,300+ ballot voters. I hadn't realized how different those two groups are. <a href="/how-we-got-here.html">See the timeline</a>.</p>
+
+  <p><strong>When peer towns reject an override, they come back for more.</strong>
+  Melrose rejected a $7.7M override in June 2024, then approved $13.5M seventeen months later &ndash; after living through 61 FTE cuts. I found the same pattern in Stoneham, Auburn, and Reading. Delay increases the eventual ask. <a href="/why-not-elsewhere.html">See the comparisons</a>.</p>
+
+  <p><strong>Trash funding is a restructuring, not new money.</strong>
+  I assumed Question 2 was $2.3M of new spending. It's not. Curbside trash collection is already funded through property taxes. Q2 moves it to a dedicated levy line and frees $1.15M of general fund capacity. <a href="/question-2-trash.html">See how it works</a>.</p>
+
   <h2 data-stance-section="off">How I use AI</h2>
   <p>An AI assistant (Claude) handles the research, analysis, and digital infrastructure behind this site. Reading 39 primary-source PDFs totaling over 3,000 pages of ACFRs, DLS reports, PERAC valuations, and budget documents and turning them into charts is a good fit for what current AI tools are actually useful for. That said, they can and do make mistakes, and I don't re-verify every number against the original document myself. I try to keep it as neutral as I can. If you catch an error, the "Report an issue" link in the footer of any page opens a new GitHub issue.</p>
 


### PR DESCRIPTION
## Summary

- Adds a new "What surprised me" section to `about.html`, placed between the opening paragraph and "How I use AI"
- Seven first-person reflections on counter-intuitive findings from building the site
- Each surprise follows an "I expected X / I found Y" pattern with a link to the relevant data page for verification
- Section uses `data-stance-section="off"` to disable community pulse reactions

## Test plan

- [ ] Verify the section renders correctly between the opening paragraph and "How I use AI"
- [ ] Click all 7 links and confirm they resolve to the correct pages
- [ ] Check light and dark mode
- [ ] Check mobile layout
- [ ] Review wording for tone (first-person, non-editorial, factual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)