### PR TITLE
Link per-capita levy and levy-vs-bill charts from existing pages

### DIFF
--- a/charts/four_town_rates.html
+++ b/charts/four_town_rates.html
@@ -174,4 +174,12 @@ title: "Rate and Bill Comparison"
       <div class="read-next-title">Marblehead vs. Swampscott, side by side &rarr;</div>
       <div class="read-next-desc">A deeper look at the two towns with the highest bills: rate, home value, median bill, and what $750K buys in each.</div>
     </a>
+    <a class="read-next-link" href="per_capita_levy.html">
+      <div class="read-next-title">Per-capita property tax levy &rarr;</div>
+      <div class="read-next-desc">Total property tax collected divided by population. Swampscott is the highest of the four; Marblehead is second.</div>
+    </a>
+    <a class="read-next-link" href="levy_vs_bill.html">
+      <div class="read-next-title">Levy, median bill, and inflation &rarr;</div>
+      <div class="read-next-desc">Three indexed growth rates over FY2012 to FY2024. The levy and the median bill tracked each other closely; both grew faster than CPI.</div>
+    </a>
   </div>

--- a/why-not-elsewhere.html
+++ b/why-not-elsewhere.html
@@ -376,6 +376,10 @@ og_url: https://marbleheaddata.org/why-not-elsewhere.html
       <div class="read-next-title">Rate, value, and what you get &rarr;</div>
       <div class="read-next-desc">Tax rates vs. home values, school staffing ratios, and employer health contributions for four North Shore towns in one view.</div>
     </a>
+    <a class="read-next-link" href="charts/per_capita_levy.html">
+      <div class="read-next-title">Per-capita property tax levy &rarr;</div>
+      <div class="read-next-desc">Total property tax collected divided by population for Marblehead, Swampscott, Melrose, and Stoneham. Swampscott is the highest; Marblehead is second.</div>
+    </a>
   </div>
 
   <details class="notes">


### PR DESCRIPTION
## Summary

Two chart pages shipped in PRs #155 and #118 had zero inbound links from the main site. This PR makes them discoverable by adding read-next links from two existing hub pages.

## Changes

1. **`charts/four_town_rates.html`** — add two read-next links at the bottom:
   - Per-capita property tax levy (`per_capita_levy.html`)
   - Levy, median bill, and inflation (`levy_vs_bill.html`)

   `four_town_rates.html` is already linked from `index.html` as a featured card, so these new charts become reachable in two clicks from the homepage.

2. **`why-not-elsewhere.html`** — add one read-next link:
   - Per-capita property tax levy (`per_capita_levy.html`)

   The per-capita comparison is a peer-town topic that belongs alongside the existing peer archetype data on this page.

## Discovery paths after this PR

| Chart | Reachable via |
|---|---|
| `per_capita_levy.html` | `index.html` → `four_town_rates.html` → per-capita link; `why-not-elsewhere.html` → per-capita link |
| `levy_vs_bill.html` | `index.html` → `four_town_rates.html` → levy-vs-bill link; `per_capita_levy.html` → cross-link (already existed) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)