### PR TITLE
Add composition shift, peer splits, and policy levers to healthcare page

### DIFF
--- a/charts/healthcare_costs.html
+++ b/charts/healthcare_costs.html
@@ -66,7 +66,9 @@ og_url: https://marbleheaddata.org/charts/healthcare_costs.html
 
   <h2 class="h-center">2. It is not headcount</h2>
 
-  <p>If the spending line went up because the town hired more people, you would see full-time-equivalent employee count rise alongside it. It did not. The town's FTE headcount has been roughly stable around 700 for the entire period, while total health insurance spending roughly doubled in nominal dollars. The growth is per-employee unit cost, not employee count.</p>
+  <p>If the spending line went up because the town hired more people, you would see full-time-equivalent employee count rise alongside it. Total FTE went from 655 in FY2006 to 706 in FY2024, an 8% increase over 18 years, while health insurance spending roughly doubled. That 8% headcount growth explains a small fraction of the spending increase; the rest is per-employee unit cost.</p>
+
+  <p>The flat total line hides a composition shift underneath it. <a href="enrollment_vs_staffing.html">Education FTE grew from 466 to 537</a> (+15%) over the same period, while non-education departments (police, fire, DPW, library, administration) shrank from 188 to 169 FTE (&minus;10%). Schools added staff; the rest of town government cut. For insurance costs, what matters is the total number of employees on plans, and that number barely moved. But a reader who knows schools have been hiring will reasonably question a flat-line chart that does not show where the offsetting cuts came from.</p>
 
   <div class="chart-wrapper">
     <svg class="chart" viewBox="0 0 800 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Two-panel chart. Top: health insurance spending FY06-FY27. Bottom: full-time equivalent employees FY06-FY24. Spending roughly doubled while FTE stayed near 700.">
@@ -170,11 +172,31 @@ og_url: https://marbleheaddata.org/charts/healthcare_costs.html
 
   <p>The town does not set its own rates or plan designs. Those are decisions made at the state level by the GIC board. Marblehead's option is to cover whatever rates the GIC sets, with the town paying 83% and employees paying 17% under an agreement with the Public Employee Committee that cannot be changed unilaterally.</p>
 
+  <h2>How does Marblehead's 83/17 split compare?</h2>
+
+  <p>Among eight Massachusetts peer towns surveyed for FY2026, Marblehead's 83% employer share is <a href="../why-not-elsewhere.html#premium-splits">tied with Brookline for the highest</a>. Stoneham and Melrose pay 80%, Wellesley 78%, Winchester and Natick 75%, and Hingham 50%. The median is 78%. On a $38,562 family plan, the difference between 83% and 78% is roughly $1,928 per employee per year. Multiply that across several hundred enrollees and the premium split becomes a meaningful budget line in its own right.</p>
+
+  <p>There is an important caveat: the premium split is set through the Public Employee Committee under MGL c. 32B s. 19 and can only be changed through collective bargaining, typically at contract renewal every two to three years. It is a policy choice, but not one the town can change in any given budget cycle.</p>
+
+  <h2>What levers does the town have?</h2>
+
+  <p>The healthcare page so far has described a problem the town largely does not control in the short run. But residents reasonably ask: is there anything the town <em>can</em> do? Three categories:</p>
+
+  <p><strong>Premium split renegotiation.</strong> Moving from 83/17 to 75/25 on Marblehead's most-enrolled plans would shift roughly $1.3M per year from the town to employees, based on current GIC family plan rates and estimated enrollment. This requires a negotiated agreement with the Public Employee Committee. It is a real lever, but it operates on a bargaining cycle, not a budget cycle.</p>
+
+  <p><strong>GIC exit.</strong> Massachusetts municipalities can leave the GIC and self-insure or join a municipal health group. Some towns have done this. The trade-off is administrative complexity and risk: the GIC pools claims across dozens of municipalities, which smooths out the kind of loss-ratio spikes Marblehead is experiencing now. A small town self-insuring takes on more volatility, not less. Whether GIC exit would save Marblehead money depends on whether its claims experience would be better or worse outside the pool, and with a 119% loss ratio, the answer right now is probably worse.</p>
+
+  <p><strong>Staffing levels and benefits eligibility.</strong> Under MGL c. 32B s. 2, any employee working 20 or more hours per week is eligible for health benefits. The town cannot change that threshold, but it does decide how many positions are structured at or above it. Reducing headcount is the bluntest lever and carries service-delivery consequences, but it is the only one that directly reduces the number of people on town health plans.</p>
+
+  <p>None of these options is quick or painless, which is part of why health insurance costs have compounded for two decades. The levers exist, but they operate on longer time horizons than a single budget year.</p>
+
   <div class="notes">
     <p><strong>Tax levy:</strong> MA Department of Revenue, Division of Local Services, FY06&ndash;FY24 levy reports (includes debt exclusions). FY25&ndash;FY27 projected at 3% annual growth (Finance Committee rate for levy + new growth).</p>
     <p><strong>Health insurance spending:</strong> "Group Insurance" line from Annual Comprehensive Financial Report budget schedules (FY06&ndash;FY13), Finance Committee reports (FY14&ndash;FY25), and proposed budgets (FY26&ndash;FY27). FY20 not publicly available (shown as dashed connector). Includes active employee health insurance, Medicare supplement, and Medicare reimbursement for all town and school employees.</p>
     <p><strong>Employees:</strong> Full-time equivalent from audited financial report statistical sections (FY06&ndash;FY24). FTE counts a 20 hr/wk employee as 0.5. Total headcount (1,185 in FY25 per Marblehead Independent) is higher because many employees are part-time.</p>
     <p><strong>Family plan premiums:</strong> Rates from GIC published rate charts: FY19 from Wayback Machine archive, FY20 derived from state employee rate sheet, FY23&ndash;FY26 from current mass.gov. Plan is Harvard Pilgrim Independence Plan (FY19&ndash;FY23) / Access America (FY24&ndash;FY26), the most common broad-network option. FY21&ndash;FY22 rate sheets not publicly available.</p>
     <p><strong>Loss ratio and GLP-1 attribution:</strong> Sue Shillue of Hill Group (the town's insurance consultant), reporting to the Public Employee Committee, quoted in Marblehead Independent, <a href="https://www.marbleheadindependent.com/possible-insurance-break-gives-marblehead-budget-outlook-a-lift/" target="_blank" rel="noopener">"Possible insurance break gives Marblehead budget outlook a lift."</a> GLP-1 coverage decision from GIC board vote, February 2026, 10&ndash;7 to drop coverage effective July 2026. GIC rate control authority under MGL c. 32B s. 19 (the PEC statute).</p>
-    <p><strong>Employer-employee split:</strong> Marblehead pays 83% of every GIC premium; employees pay 17%. Set by agreement with the Public Employee Committee and cannot be changed unilaterally by the town.</p>
+    <p><strong>Employer-employee split:</strong> Marblehead pays 83% of every GIC premium; employees pay 17%. Set by agreement with the Public Employee Committee and cannot be changed unilaterally by the town. Peer-town splits from FY2026 rate sheets and PEC agreements; full data in <code>data/peer_premium_splits.csv</code>.</p>
+    <p><strong>Education vs. non-education FTE:</strong> From ACFR "Full-time Equivalent Town Employees by Function" tables, education row vs. total minus education. Education FTE: 466 (FY06) to 537 (FY24), +15%. Non-education FTE: 188 (FY06) to 169 (FY24), &minus;10%. The FY23 jump from 483 to 537 education FTE is unexplained in public records and may reflect ESSER-funded positions or a reporting change.</p>
+    <p><strong>Retiree health (OPEB):</strong> This page covers active-employee health insurance (the "Group Insurance" budget line). The town also carries a long-term liability for retiree health benefits (Other Post-Employment Benefits). The FY2026 budget transferred $250,000 into the retiree benefits trust; the FY2027 proposed budget transfers $0. The underlying OPEB liability continues to accrue. Active-employee OPEB cost in FY2024 was $695 per employee; retiree OPEB cost was $731 per retiree (ACFR FY2024). These are separate from the Group Insurance premiums charted above.</p>
   </div>


### PR DESCRIPTION
## Summary
- Replaces "flat at 700" FTE framing with honest numbers (655→706, +8%) and acknowledges the education/non-education composition shift underneath
- Adds 83/17 peer premium split comparison (tied highest of 8 MA towns, median 78%)
- New "What levers does the town have?" section: split renegotiation, GIC exit trade-offs, staffing/eligibility
- OPEB/retiree health context in notes (including $250K→$0 trust contribution cut)

## Test plan
- [ ] Verify page renders correctly on GitHub Pages
- [ ] Check enrollment_vs_staffing.html link resolves
- [ ] Check why-not-elsewhere.html#premium-splits link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)