### PR TITLE
Fix Swampscott employer health contribution: 83% -> 75%

### DIFF
--- a/charts/rate_value_schools.html
+++ b/charts/rate_value_schools.html
@@ -298,13 +298,13 @@ title: "Rate, Value, and What You Get"
   </div>
   <div class="contrib-card s-swampscott">
     <p class="town-name">Swampscott</p>
-    <p class="pct">83%</p>
+    <p class="pct">75%</p>
     <p class="pct-label">employer share</p>
   </div>
 </div>
 
 <p class="caption">
-  Modal employer premium contribution share for health insurance, FY2026. These are the most common split across each town's plan options. Stoneham has a tiered structure: 80% for post-2009 hires, 90% legacy for pre-2009 hires. Melrose is reported as "over 80%" per PEC agreement. Swampscott's rate is set by GIC. All four towns participate in the GIC.
+  Modal employer premium contribution share for health insurance, FY2026. These are the most common split across each town's plan options. Stoneham has a tiered structure: 80% for post-2009 hires, 90% legacy for pre-2009 hires. Melrose is reported as "over 80%" per PEC agreement. Swampscott's 75/25 split is set by its PEC agreement under the GIC. All four towns participate in the GIC.
 </p>
 
 <div class="notes">


### PR DESCRIPTION
## Summary

- Corrects Swampscott's employer health insurance contribution from 83% to 75% on the Rate, Value, and What You Get page
- The previous 83% value had no primary source backing — `data/SOURCES.md` explicitly flagged Swampscott as a gap in peer coverage where the percentage "could not be located via web search"
- Updated caption to clarify Swampscott's 75/25 split is set by its PEC agreement under the GIC

## Test plan

- [ ] Verify the contrib card for Swampscott now shows 75% on `/charts/rate_value_schools.html`
- [ ] Verify the caption text reads correctly with the updated Swampscott language

https://claude.ai/code/session_011C8aukyKTfCwJ3QLcgVTRx