### PR TITLE
Fix Swampscott employer share (73%) and Marblehead res. share (95.5%)

### DIFF
--- a/charts/rate_value_schools.html
+++ b/charts/rate_value_schools.html
@@ -132,7 +132,7 @@ title: "Rate, Value, and What You Get"
         <td>$8.56</td>
         <td>$1,010,100</td>
         <td>$11,055</td>
-        <td>95.6%</td>
+        <td>95.5%</td>
       </tr>
       <tr class="sw">
         <td>Swampscott</td>
@@ -298,13 +298,13 @@ title: "Rate, Value, and What You Get"
   </div>
   <div class="contrib-card s-swampscott">
     <p class="town-name">Swampscott</p>
-    <p class="pct">75%</p>
+    <p class="pct">73%</p>
     <p class="pct-label">employer share</p>
   </div>
 </div>
 
 <p class="caption">
-  Modal employer premium contribution share for health insurance, FY2026. These are the most common split across each town's plan options. Stoneham has a tiered structure: 80% for post-2009 hires, 90% legacy for pre-2009 hires. Melrose is reported as "over 80%" per PEC agreement. Swampscott's 75/25 split is set by its PEC agreement under the GIC. All four towns participate in the GIC.
+  Modal employer premium contribution share for health insurance, FY2026. These are the most common split across each town's plan options. Stoneham has a tiered structure: 80% for post-2009 hires, 90% legacy for pre-2009 hires. Melrose is reported as "over 80%" per PEC agreement. Swampscott's 73/27 split is per the town's FY2025 Open Enrollment rate sheet. All four towns participate in the GIC.
 </p>
 
 <div class="notes">


### PR DESCRIPTION
## Summary

Follow-up to #170, which was merged with 75% before the sourced value was confirmed.

- **Swampscott employer health contribution: 75% -> 73%** -- sourced from the Swampscott FY2025 Open Enrollment Insurance Rates (swampscottma.gov), which shows a 73/27 town/employee split on Harvard Pilgrim Quality HMO plans. The previous 83% had no primary source; SOURCES.md explicitly flagged Swampscott as a gap.
- **Marblehead residential share: 95.6% -> 95.5%** -- the `peer_tax_levies_by_class` CSV yields 95.5483%, which rounds to 95.5%. The `why-not-elsewhere.html` page already shows 95.5%, so this makes the two pages consistent.

## Test plan

- [ ] Verify Swampscott contrib card shows 73% on `/charts/rate_value_schools.html`
- [ ] Verify Marblehead residential share shows 95.5% in the tradeoff table
- [ ] Verify caption references Swampscott's 73/27 split and FY2025 Open Enrollment source

https://claude.ai/code/session_011C8aukyKTfCwJ3QLcgVTRx