### PR TITLE
Add surprises and open questions to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -144,6 +144,20 @@ og_title: "Who made this?"
   <p><strong>Trash funding is a restructuring, not new money.</strong>
   I assumed Question 2 was $2.3M of new spending. It's not. Curbside trash collection is already funded through property taxes. Q2 moves it to a dedicated levy line and frees $1.15M of general fund capacity. <a href="/question-2-trash.html">See how it works</a>.</p>
 
+  <p><strong>Municipal data is more available than people think, and more fragmented than it should be.</strong>
+  I expected to find budget numbers in a spreadsheet somewhere. Instead, this site draws from 39 PDFs totaling over 3,000 pages. ACFRs, DOR reports, PERAC valuations, and GIC rate sheets are all public, but they don't talk to each other. Basic peer comparisons &ndash; what do other towns pay their employees? what were health insurance rates before FY19? &ndash; often have no publicly available answer. The agreement that sets Marblehead's 83/17 premium split isn't even posted online. The data exists, but assembling it is its own project.</p>
+
+  <p><strong>Health insurance cost-sharing varies wildly between towns.</strong>
+  Marblehead pays 83% of every employee health insurance premium. Hingham pays 50%. Both towns buy the same plans from the same GIC pool. On a family plan, that gap means roughly $10,000 per employee per year in additional cost to Marblehead. How Hingham negotiated a 50/50 split &ndash; and whether employees pay for it through higher salaries or the town pays for it through harder hiring &ndash; I haven't been able to answer yet. <a href="/charts/healthcare_costs.html">See the healthcare data</a>.</p>
+
+  <h2 data-stance-section="off">What I'm still trying to answer</h2>
+
+  <p><strong>How does Hingham make 50/50 work?</strong>
+  Their employees pay half of every health insurance premium. Marblehead employees pay 17%. Does Hingham compensate with higher salaries? Do they struggle to hire? Are there other tradeoffs I'm not seeing? The premium split is public, but the compensation picture behind it isn't.</p>
+
+  <p><strong>Has any Massachusetts town bent the structural cost curve?</strong>
+  Every case study I've found follows the same arc: reject an override, absorb cuts, come back for a bigger number later. I haven't found a town that enacted lasting structural reform &ndash; healthcare restructuring, pension changes, shared services, regionalization &ndash; and sustained it long enough to measure. If that town exists, I want to find it and document what they did.</p>
+
   <h2 data-stance-section="off">How I use AI</h2>
   <p>An AI assistant (Claude) handles the research, analysis, and digital infrastructure behind this site. Reading 39 primary-source PDFs totaling over 3,000 pages of ACFRs, DLS reports, PERAC valuations, and budget documents and turning them into charts is a good fit for what current AI tools are actually useful for. That said, they can and do make mistakes, and I don't re-verify every number against the original document myself. I try to keep it as neutral as I can. If you catch an error, the "Report an issue" link in the footer of any page opens a new GitHub issue.</p>
 


### PR DESCRIPTION
## Summary
- Two new surprises: municipal data fragmentation (#8) and health insurance cost-sharing variance between towns (#9, Marblehead 83% vs Hingham 50%)
- New "What I'm still trying to answer" section with two open questions: how Hingham makes 50/50 work, and whether any MA town has bent the structural cost curve through lasting reform

## Test plan
- [ ] Verify new paragraphs render correctly on the About page
- [ ] Confirm links to /charts/healthcare_costs.html resolve
- [ ] Check that `data-stance-section="off"` on new h2 prevents community pulse reactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)