### PR TITLE
Style page-toc nav to match site card language

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -301,9 +301,9 @@ nav.site-nav a[aria-current="page"] {
   gap: 8px 10px;
   padding: 12px 14px;
   margin: 18px 0 28px;
-  background: var(--divider);
-  border: 1px solid var(--border);
+  background: var(--surface);
   border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
 }
 .page-toc-label {
   font-size: 11px;
@@ -316,19 +316,18 @@ nav.site-nav a[aria-current="page"] {
 .page-toc a {
   display: inline-block;
   padding: 6px 12px;
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: var(--divider);
+  border: none;
   border-radius: 999px;
   color: var(--c-navy);
   font-size: 13px;
   font-weight: 600;
   text-decoration: none;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  transition: background 0.15s ease, color 0.15s ease;
 }
 .page-toc a:hover {
   background: var(--c-navy);
   color: var(--bg);
-  border-color: var(--c-navy);
   text-decoration: none;
 }
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary

- Restyle the `.page-toc` "On this page" navigation to match the site's card design language
- Container: `--divider` background + border replaced with `--surface` + `box-shadow: var(--shadow-sm)`
- Pills: drop inner borders, use `--divider` background tint instead (eliminates border-on-border noise)
- Fixes washed-out appearance in dark mode

## Test plan

- [ ] Verify on pages with page-toc: how-we-got-here, where-has-the-money-gone, inside-school-staffing, why-not-elsewhere, question-2-trash
- [ ] Check light and dark mode
- [ ] Check mobile (375px) and desktop (1280px)
- [ ] Hover state still works (navy fill + white text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)