### PR TITLE
Wire voting record page into read-next flows

### DIFF
--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -107,9 +107,9 @@ title: "How did we get here?"
       <div class="read-next-title">What's in the no-override budget? &rarr;</div>
       <div class="read-next-desc">The specific staffing and service cuts in the FY27 balanced budget without an override, line by line.</div>
     </a>
-    <a class="read-next-link" href="what-you-can-do.html">
-      <div class="read-next-title">What can you do? &rarr;</div>
-      <div class="read-next-desc">Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight.</div>
+    <a class="read-next-link" href="marblehead-voting-record.html">
+      <div class="read-next-title">Has Marblehead voted yes before? &rarr;</div>
+      <div class="read-next-desc">Every Prop 2&frac12; ballot question since 1988, charted. What passed, what failed, and how much.</div>
     </a>
   </div>
 

--- a/marblehead-voting-record.html
+++ b/marblehead-voting-record.html
@@ -1772,6 +1772,18 @@ og_url: https://marbleheaddata.org/marblehead-voting-record.html
 </details>
 </div>
 
+<div class="read-next">
+    <div class="read-next-label">Read next</div>
+    <a class="read-next-link" href="how-we-got-here.html">
+      <div class="read-next-title">How did we get here? &rarr;</div>
+      <div class="read-next-desc">Seven years of Finance Committee warnings, in their own words. The FY27 override was predicted, in writing, as far back as 2019.</div>
+    </a>
+    <a class="read-next-link" href="what-is-the-override.html">
+      <div class="read-next-title">What is the override? &rarr;</div>
+      <div class="read-next-desc">The three-tier structure, what each tier funds, key terms, and how the current proposal compares to the historical pattern.</div>
+    </a>
+  </div>
+
 <div class="notes">
   <p>Vote data sourced from the Massachusetts Department of Revenue Proposition 2&frac12; database. Debt exclusion amounts sourced from Marblehead ACFRs (long-term debt schedules and MD&amp;A sections), Town Meeting warrants, and DOR records. Inflation adjustment uses BLS CPI-U annual averages; all real-dollar amounts are in 2024 dollars (the latest full-year CPI available).</p>
 </div>

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -552,9 +552,9 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
       <div class="read-next-title">How did we get here? &rarr;</div>
       <div class="read-next-desc">Seven years of Finance Committee warnings, in their own words. The FY27 override was predicted, in writing, as far back as 2019.</div>
     </a>
-    <a class="read-next-link" href="what-you-can-do.html">
-      <div class="read-next-title">What can you do? &rarr;</div>
-      <div class="read-next-desc">Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight.</div>
+    <a class="read-next-link" href="marblehead-voting-record.html">
+      <div class="read-next-title">Has Marblehead voted yes before? &rarr;</div>
+      <div class="read-next-desc">Every Prop 2&frac12; ballot question since 1988, charted. What passed, what failed, and how much.</div>
     </a>
   </div>
 


### PR DESCRIPTION
## Summary
- Add read-next block to voting record page (links to how-we-got-here and what-is-the-override)
- Replace less-relevant "What can you do?" link with voting record on how-we-got-here and what-is-the-override read-next sections

## Test plan
- [ ] Voting record page shows read-next links at bottom
- [ ] how-we-got-here read-next includes voting record link
- [ ] what-is-the-override read-next includes voting record link

🤖 Generated with [Claude Code](https://claude.com/claude-code)