### PR TITLE
Add dock-and-push scrolly behavior for text steps

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -2232,15 +2232,17 @@ button.ballot-oval[aria-pressed="true"] .ballot-oval-fill ellipse {
 
 .scrolly-nesting-steps { margin: 0; }
 .scrolly-step {
-  min-height: 30vh;
-  margin-bottom: 6px;
-  display: flex;
-  align-items: center;
+  min-height: 70vh;
+  margin-bottom: 0;
 }
+.scrolly-step:last-child { min-height: 40vh; }
 .scrolly-step-inner {
+  position: sticky;
+  top: var(--step-dock-top, 320px);
   width: 100%;
   padding: 14px 18px;
   border-left: 3px solid var(--divider);
+  background: var(--surface);
   transition: border-color 0.3s ease, background 0.3s ease;
 }
 .scrolly-step.is-active .scrolly-step-inner {
@@ -2265,7 +2267,7 @@ button.ballot-oval[aria-pressed="true"] .ballot-oval-fill ellipse {
   .scrolly-nesting-sticky { padding: 14px 14px 12px; top: 56px; }
   .sn-row { grid-template-columns: 24px 60px 1fr 44px; gap: 8px; padding: 6px 8px; }
   .sn-row-name { font-size: 11px; }
-  .scrolly-step { min-height: 36vh; }
+  .scrolly-step { min-height: 60vh; }
   .scrolly-step-inner { padding: 12px 14px; }
   .scrolly-step h3 { font-size: 16px; }
   .scrolly-step p { font-size: 14px; }

--- a/question-2-trash.html
+++ b/question-2-trash.html
@@ -809,6 +809,18 @@ function update() {
   const section = document.querySelector('.scrolly-trash');
   if (!section || !('IntersectionObserver' in window)) return;
 
+  // Measure the sticky viz panel and set --step-dock-top so step-inner
+  // elements dock right below it.
+  const stickyViz = section.querySelector('.scrolly-trash-sticky');
+  function setDockTop() {
+    if (!stickyViz) return;
+    const vizTop = parseInt(getComputedStyle(stickyViz).top, 10) || 60;
+    const dockTop = vizTop + stickyViz.offsetHeight + 12;
+    section.style.setProperty('--step-dock-top', dockTop + 'px');
+  }
+  setDockTop();
+  window.addEventListener('resize', setDockTop);
+
   const MAX_BAR_DOLLARS = 700;
   const steps = section.querySelectorAll('.scrolly-step');
   const marker = document.getElementById('st-marker');

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -593,6 +593,18 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
   var section = document.querySelector('.scrolly-nesting');
   if (!section || !('IntersectionObserver' in window)) return;
 
+  // Measure the sticky viz panel and set --step-dock-top so step-inner
+  // elements dock right below it.
+  var stickyViz = section.querySelector('.scrolly-nesting-sticky');
+  function setDockTop() {
+    if (!stickyViz) return;
+    var vizTop = parseInt(getComputedStyle(stickyViz).top, 10) || 60;
+    var dockTop = vizTop + stickyViz.offsetHeight + 12;
+    section.style.setProperty('--step-dock-top', dockTop + 'px');
+  }
+  setDockTop();
+  window.addEventListener('resize', setDockTop);
+
   var steps = section.querySelectorAll('.scrolly-step');
   var rows = {
     '1a': section.querySelector('.sn-row--1a'),


### PR DESCRIPTION
## Summary

- Makes scrolly text steps (`scrolly-step-inner`) `position: sticky` so each step docks right below the locked visualization panel
- When the next step scrolls up, it naturally pushes the docked step away (CSS sticky stacking)
- JS measures viz panel height on load/resize and sets `--step-dock-top` CSS variable
- Applies to both the ballot nesting explainer (what-is-the-override) and trash distributional scrolly (question-2-trash)

## Test plan

- [ ] Open what-is-the-override.html, scroll to the nested ballot section. Each text step should dock below the viz panel and stay there until the next step pushes it away.
- [ ] Open question-2-trash.html, scroll to the distributional scrolly. Same dock-and-push behavior.
- [ ] Test on mobile viewport (< 600px). Steps should still dock and push correctly.
- [ ] Resize the browser window. The dock position should recalculate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)