### PR TITLE
Redesign voting record as horizontal diverging bar chart

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1997,25 +1997,23 @@ button.ballot-oval[aria-pressed="true"] .ballot-oval-fill ellipse {
   fill: var(--text-subtle);
 }
 .ballot-timeline .vote-dot {
-  stroke: var(--surface);
   stroke-width: 1.5;
 }
-.ballot-timeline .vote-dot--win {
-  fill: var(--c-sage);
+.ballot-timeline .vote-dot--approved {
+  fill: var(--c-teal);
+  stroke: var(--surface);
 }
-.ballot-timeline .vote-dot--loss {
-  fill: var(--c-buoy);
+.ballot-timeline .vote-dot--rejected {
+  fill: none;
+  stroke: var(--c-buoy);
+  stroke-width: 2;
 }
 .ballot-timeline .annotation {
   font-size: 10px;
   fill: var(--text-mid);
 }
-.ballot-timeline .annotation--buoy {
+.ballot-timeline .annotation--upcoming {
   fill: var(--c-buoy);
-  font-weight: 600;
-}
-.ballot-timeline .annotation--sage {
-  fill: var(--c-sage);
   font-weight: 600;
 }
 .ballot-timeline .future-line {
@@ -2039,8 +2037,8 @@ button.ballot-oval[aria-pressed="true"] .ballot-oval-fill ellipse {
   width: 10px; height: 10px; border-radius: 50%;
   display: inline-block;
 }
-.ballot-timeline-legend .sw--win { background: var(--c-sage); }
-.ballot-timeline-legend .sw--loss { background: var(--c-buoy); }
+.ballot-timeline-legend .sw--approved { background: var(--c-teal); }
+.ballot-timeline-legend .sw--rejected { background: none; border: 2px solid var(--c-buoy); box-sizing: border-box; }
 
 @media (max-width: 600px) {
   .ballot-timeline { padding: 14px 12px 10px; }

--- a/data/build_voting_record.py
+++ b/data/build_voting_record.py
@@ -181,47 +181,41 @@ def build_key_stats(rows):
 
 
 # ---------------------------------------------------------------------------
-# SVG CHART
+# SVG CHART  (horizontal diverging bar chart)
 # ---------------------------------------------------------------------------
 
-# Viewbox / layout constants
-VB_W, VB_H   = 880, 520
-ML, MR       = 65, 15          # left / right margin
-MT, MB       = 35, 60          # top / bottom margin
-CHART_W      = VB_W - ML - MR  # 800
-CHART_H      = VB_H - MT - MB  # 425
+# Layout constants
+H_ML   = 55          # left margin (year labels)
+H_MR   = 15          # right margin
+H_MT   = 22          # top margin (for "Failed" / "Passed" labels + grid labels)
+H_MB   = 10          # bottom margin
+H_VB_W = 880         # viewBox width
 
-LOSS_FRAC    = 0.20            # 20% of chart height below baseline
-WIN_H        = CHART_H * (1 - LOSS_FRAC)   # 340 px
-LOSS_H       = CHART_H * LOSS_FRAC         # 85 px
+ROW_H  = 20          # total height per row (bar + gap)
+BAR_H  = 14          # bar height within row
 
-# Y pixel of the baseline
-BASELINE_Y   = MT + WIN_H      # 375
-
-# Minimum bar height for zero-amount rows (marker)
-MARKER_PX    = 2
-
-# Bar width / gap inside each year group
-BAR_W        = 5               # per bar; will be adjusted dynamically
-BAR_GAP      = 2               # gap between override and debt-exclusion bar
+FAIL_MIN_W = 80      # minimum pixel width for the fail (left) side
+MARKER_W   = 3       # thin marker for unsourced amounts
 
 
 def build_chart(rows):
-    """Return a complete <svg> string."""
+    """Return a complete <svg> string (horizontal diverging bar chart)."""
 
     # ------------------------------------------------------------------
-    # 1. Group rows by calendar year, skip zero-vote clerk error from chart
+    # 1. Group rows by calendar year, skip clerk-error rows
     # ------------------------------------------------------------------
     chart_rows = [r for r in rows if not is_clerk_error(r)]
 
-    by_year = defaultdict(lambda: {"Override": [], "Debt Exclusion": []})
+    by_year = defaultdict(lambda: {"pass": [], "fail": []})
     for r in chart_rows:
         yr = calendar_year(r["vote_date"])
         if yr is None:
             continue
         mtype = r["measure_type"]
-        if mtype in ("Override", "Debt Exclusion"):
-            by_year[yr][mtype].append(r)
+        if mtype not in ("Override", "Debt Exclusion"):
+            continue
+        key = "pass" if r["win_loss"] == "WIN" else "fail"
+        by_year[yr][key].append(r)
 
     all_years = sorted(by_year.keys())
     if not all_years:
@@ -230,62 +224,64 @@ def build_chart(rows):
     n_years = len(all_years)
 
     # ------------------------------------------------------------------
-    # 2. Find maximum real dollar amount for scaling
+    # 2. Compute per-year totals for pass and fail sides (real dollars)
     # ------------------------------------------------------------------
-    max_real = 0
-    for yr, groups in by_year.items():
-        for mtype, rlist in groups.items():
-            for r in rlist:
-                v = r["real_val"] or 0
-                if v > max_real:
-                    max_real = v
+    year_pass_total = {}
+    year_fail_total = {}
+    for yr in all_years:
+        year_pass_total[yr] = sum(r["real_val"] or 0 for r in by_year[yr]["pass"])
+        year_fail_total[yr] = sum(r["real_val"] or 0 for r in by_year[yr]["fail"])
 
-    if max_real == 0:
-        max_real = 1  # guard against all-empty
-
-    # ------------------------------------------------------------------
-    # 3. Compute x positions
-    #    Each year slot gets equal width; bars are centred in the slot.
-    # ------------------------------------------------------------------
-    slot_w = CHART_W / n_years
-
-    # Dynamic bar width: at most 12px, at least 3px
-    bar_w = max(3, min(12, slot_w * 0.35))
-    bar_gap = max(1, bar_w * 0.4)
-
-    def slot_x(yr):
-        """Left edge of the year slot in chart coordinates (add ML to get SVG x)."""
-        idx = all_years.index(yr)
-        return idx * slot_w
-
-    def bar_center_x(yr):
-        """Centre x of the year slot in SVG coordinates."""
-        return ML + slot_x(yr) + slot_w / 2
+    max_pass = max(year_pass_total.values()) if year_pass_total else 1
+    max_fail = max(year_fail_total.values()) if year_fail_total else 1
+    if max_pass == 0:
+        max_pass = 1
+    if max_fail == 0:
+        max_fail = 1
 
     # ------------------------------------------------------------------
-    # 4. Helpers: pixel height for a real-dollar amount
+    # 3. Layout geometry
     # ------------------------------------------------------------------
-    def win_px(real_val):
-        if real_val is None:
-            return MARKER_PX
-        if real_val <= 0:
-            return MARKER_PX
-        return max(MARKER_PX, (real_val / max_real) * WIN_H)
+    chart_w = H_VB_W - H_ML - H_MR                  # 810
+    # Fail side gets the larger of FAIL_MIN_W or its proportional share
+    proportional_fail = chart_w * (max_fail / (max_pass + max_fail))
+    fail_w = max(FAIL_MIN_W, proportional_fail)
+    pass_w = chart_w - fail_w
 
-    def loss_px(real_val):
-        """For failed votes: bar goes down, capped at LOSS_H."""
-        if real_val is None:
-            return MARKER_PX
-        if real_val <= 0:
-            return MARKER_PX
-        return max(MARKER_PX, min((real_val / max_real) * WIN_H, LOSS_H))
+    baseline_x = H_ML + fail_w                       # vertical center line
+
+    # Same dollar-per-pixel scale on both sides (use the pass side scale
+    # since it always has more data; the fail side gets the same scale
+    # but is guaranteed at least FAIL_MIN_W pixels of space)
+    px_per_dollar = pass_w / max_pass
+
+    vb_h = H_MT + n_years * ROW_H + H_MB
+    chart_area_h = n_years * ROW_H
+
+    def row_y(idx):
+        """Top y of row idx."""
+        return H_MT + idx * ROW_H
+
+    def bar_y(idx):
+        """Top y of the bar within row idx (centred vertically)."""
+        return row_y(idx) + (ROW_H - BAR_H) / 2
 
     # ------------------------------------------------------------------
-    # 5. Build SVG elements list
+    # 4. Sort votes within each side
+    #    Overrides first, then debt exclusions; within each type by
+    #    amount descending.
+    # ------------------------------------------------------------------
+    def sort_key(r):
+        type_order = 0 if r["measure_type"] == "Override" else 1
+        amt = r["real_val"] or 0
+        return (type_order, -amt)
+
+    # ------------------------------------------------------------------
+    # 5. Build SVG parts
     # ------------------------------------------------------------------
     parts = []
 
-    # -- 5a. defs: hatch patterns for each dept color --
+    # -- 5a. defs: hatch patterns --
     defs_patterns = []
     for dept, color_token in DEPT_COLOR.items():
         pid = f"hatch-{color_token}"
@@ -300,149 +296,136 @@ def build_chart(rows):
     parts.extend(defs_patterns)
     parts.append('</defs>')
 
-    # -- 5b. Grid lines (25%, 50%, 75%, 100% of max above baseline; 50% below) --
-    grid_fracs_above = [0.25, 0.50, 0.75, 1.00]
-    grid_x1 = ML
-    grid_x2 = ML + CHART_W
+    # -- 5b. "Failed" / "Passed" header labels --
+    parts.append(
+        f'<text class="tick-label" x="{H_ML + 2}" y="{H_MT - 6}" '
+        f'text-anchor="start" font-size="9">Failed</text>'
+    )
+    parts.append(
+        f'<text class="tick-label" x="{H_VB_W - H_MR - 2}" y="{H_MT - 6}" '
+        f'text-anchor="end" font-size="9">Passed</text>'
+    )
 
-    for frac in grid_fracs_above:
-        gy = BASELINE_Y - frac * WIN_H
-        label = fmt_dollars(max_real * frac)
+    # -- 5c. Vertical dollar grid lines on the pass side --
+    # Choose a nice interval: $20M steps
+    grid_interval = 20_000_000
+    grid_val = grid_interval
+    while grid_val <= max_pass:
+        gx = baseline_x + grid_val * px_per_dollar
+        if gx <= H_VB_W - H_MR:
+            parts.append(
+                f'<line class="grid-minor" x1="{gx:.1f}" y1="{H_MT}" '
+                f'x2="{gx:.1f}" y2="{H_MT + chart_area_h}"/>'
+            )
+            parts.append(
+                f'<text class="tick-label tick-label--minor" '
+                f'x="{gx:.1f}" y="{H_MT - 6}" '
+                f'text-anchor="middle" font-size="8">{fmt_dollars(grid_val)}</text>'
+            )
+        grid_val += grid_interval
+
+    # -- 5d. Vertical baseline --
+    parts.append(
+        f'<line class="axis-base" x1="{baseline_x:.1f}" y1="{H_MT}" '
+        f'x2="{baseline_x:.1f}" y2="{H_MT + chart_area_h}"/>'
+    )
+
+    # -- 5e. Year labels and bar segments --
+    for idx, yr in enumerate(all_years):
+        by = bar_y(idx)
+        label_y = row_y(idx) + ROW_H / 2 + 4   # vertically centred text
+
+        # Year label (2-digit with apostrophe)
+        yr_short = f"'{yr % 100:02d}"
         parts.append(
-            f'<line class="grid-major" x1="{grid_x1}" y1="{gy:.1f}" '
-            f'x2="{grid_x2}" y2="{gy:.1f}"/>'
-        )
-        parts.append(
-            f'<text class="tick-label" x="{ML - 5}" y="{gy + 4:.1f}" '
-            f'text-anchor="end">{label}</text>'
+            f'<text class="tick-label" x="{H_ML - 4}" y="{label_y:.1f}" '
+            f'text-anchor="end" font-size="9">{yr_short}</text>'
         )
 
-    # One grid line 50% of loss height below baseline
-    loss_grid_y = BASELINE_Y + LOSS_H * 0.5
-    parts.append(
-        f'<line class="grid-major" x1="{grid_x1}" y1="{loss_grid_y:.1f}" '
-        f'x2="{grid_x2}" y2="{loss_grid_y:.1f}"/>'
-    )
-    parts.append(
-        f'<text class="tick-label" x="{ML - 5}" y="{loss_grid_y + 4:.1f}" '
-        f'text-anchor="end">{fmt_dollars(max_real * 0.5)}</text>'
-    )
+        pass_votes = sorted(by_year[yr]["pass"], key=sort_key)
+        fail_votes = sorted(by_year[yr]["fail"], key=sort_key)
 
-    # -- 5c. Baseline --
-    parts.append(
-        f'<line class="axis-base" x1="{ML}" y1="{BASELINE_Y:.1f}" '
-        f'x2="{ML + CHART_W}" y2="{BASELINE_Y:.1f}"/>'
-    )
-
-    # "Passed ↑" / "Failed ↓" labels near baseline on left
-    parts.append(
-        f'<text class="tick-label" x="{ML + 4}" y="{BASELINE_Y - 6:.1f}" '
-        f'text-anchor="start" font-size="8">Passed &#x2191;</text>'
-    )
-    parts.append(
-        f'<text class="tick-label" x="{ML + 4}" y="{BASELINE_Y + 14:.1f}" '
-        f'text-anchor="start" font-size="8">Failed &#x2193;</text>'
-    )
-
-    # -- 5d. Bars --
-    for yr in all_years:
-        cx = bar_center_x(yr)
-        ov_list = by_year[yr]["Override"]
-        de_list = by_year[yr]["Debt Exclusion"]
-
-        # Centre the two bars (override left, debt exclusion right)
-        # Total group width = 2*bar_w + bar_gap; offset from centre
-        half_group = bar_w + bar_gap / 2
-
-        # Override bars
-        ov_x = cx - half_group
-        for r in ov_list:
+        # --- Pass side (extending RIGHT from baseline) ---
+        cursor_x = baseline_x
+        for r in pass_votes:
             color = dept_color(r["department"])
-            wl = r["win_loss"]
             rv = r["real_val"]
             av = r["amount_val"]
-            h = win_px(rv) if wl == "WIN" else loss_px(rv)
-            if wl == "WIN":
-                bx = ov_x - bar_w / 2
-                by = BASELINE_Y - h
+            mtype = r["measure_type"]
+
+            if rv is not None and rv > 0:
+                w = rv * px_per_dollar
             else:
-                bx = ov_x - bar_w / 2
-                by = BASELINE_Y
+                w = MARKER_W
+
+            fill_cls = f"bar-solid-{color}" if mtype == "Override" else f"bar-hatch-{color}"
             dept_attr = r["department"].replace(" ", "_").replace("&", "and")
+            data_type = "override" if mtype == "Override" else "debt-exclusion"
+            result_label = "Passed" if r["win_loss"] == "WIN" else "Failed"
+
             parts.append(
-                f'<rect class="bar-solid-{color}" '
-                f'x="{bx:.1f}" y="{by:.1f}" '
-                f'width="{bar_w:.1f}" height="{h:.1f}" '
+                f'<rect class="{fill_cls}" '
+                f'x="{cursor_x:.1f}" y="{by:.1f}" '
+                f'width="{w:.1f}" height="{BAR_H}" '
                 f'data-nominal="{int(av) if av else ""}" '
                 f'data-real="{int(rv) if rv else ""}" '
-                f'data-win="{wl}" '
+                f'data-win="1" '
                 f'data-dept="{dept_attr}" '
-                f'data-type="override">'
-                f'<title>{r["description"]} ({yr}, {wl}, {fmt_dollars(rv)})</title>'
+                f'data-type="{data_type}" '
+                f'data-year="{yr}">'
+                f'<title>{r["description"]} ({yr}, {result_label}, {fmt_dollars(rv)})</title>'
                 f'</rect>'
             )
+            cursor_x += w
 
-        # Debt Exclusion bars
-        de_x = cx + bar_gap / 2
-        for r in de_list:
+        # --- Fail side (extending LEFT from baseline) ---
+        cursor_x = baseline_x
+        for r in fail_votes:
             color = dept_color(r["department"])
-            wl = r["win_loss"]
             rv = r["real_val"]
             av = r["amount_val"]
-            h = win_px(rv) if wl == "WIN" else loss_px(rv)
-            if wl == "WIN":
-                bx = de_x
-                by = BASELINE_Y - h
+            mtype = r["measure_type"]
+
+            if rv is not None and rv > 0:
+                w = rv * px_per_dollar
             else:
-                bx = de_x
-                by = BASELINE_Y
+                w = MARKER_W
+
+            fill_cls = f"bar-solid-{color}" if mtype == "Override" else f"bar-hatch-{color}"
             dept_attr = r["department"].replace(" ", "_").replace("&", "and")
+            data_type = "override" if mtype == "Override" else "debt-exclusion"
+            result_label = "Passed" if r["win_loss"] == "WIN" else "Failed"
+
+            rect_x = cursor_x - w
             parts.append(
-                f'<rect class="bar-hatch-{color}" '
-                f'x="{bx:.1f}" y="{by:.1f}" '
-                f'width="{bar_w:.1f}" height="{h:.1f}" '
+                f'<rect class="{fill_cls}" '
+                f'x="{rect_x:.1f}" y="{by:.1f}" '
+                f'width="{w:.1f}" height="{BAR_H}" '
                 f'data-nominal="{int(av) if av else ""}" '
                 f'data-real="{int(rv) if rv else ""}" '
-                f'data-win="{wl}" '
+                f'data-win="0" '
                 f'data-dept="{dept_attr}" '
-                f'data-type="debt-exclusion">'
-                f'<title>{r["description"]} ({yr}, {wl}, {fmt_dollars(rv)})</title>'
+                f'data-type="{data_type}" '
+                f'data-year="{yr}">'
+                f'<title>{r["description"]} ({yr}, {result_label}, {fmt_dollars(rv)})</title>'
                 f'</rect>'
             )
+            cursor_x -= w
 
-    # -- 5e. X-axis year labels --
-    # Compute minimum pixel spacing to decide which to show
-    prev_label_x = None
-    MIN_LABEL_GAP = 22
-
-    for yr in all_years:
-        cx = bar_center_x(yr)
-        is_mult5 = (yr % 5 == 0)
-        cls = "tick-label tick-label--major" if is_mult5 else "tick-label tick-label--minor"
-
-        # Skip if too close to previous label
-        if prev_label_x is not None and abs(cx - prev_label_x) < MIN_LABEL_GAP:
-            continue
-
-        parts.append(
-            f'<text class="{cls}" x="{cx:.1f}" y="{VB_H - MB + 16}" '
-            f'text-anchor="middle">{yr}</text>'
-        )
-        prev_label_x = cx
-
-    # Assemble final SVG
+    # -- Assemble SVG --
     inner = "\n".join(parts)
     min_yr = all_years[0]
     max_yr = all_years[-1]
     svg = (
-        f'<svg class="chart" viewBox="0 0 {VB_W} {VB_H}" '
+        f'<svg class="chart" viewBox="0 0 {H_VB_W} {vb_h}" '
         f'xmlns="http://www.w3.org/2000/svg" '
         f'role="img" '
-        f'aria-label="Diverging bar chart of Marblehead Proposition 2½ votes '
-        f'from {min_yr} to {max_yr}. '
-        f'Bars above the baseline are passed questions; bars below are failed. '
+        f'aria-label="Horizontal diverging bar chart of Marblehead Proposition 2½ '
+        f'votes from {min_yr} to {max_yr}. '
+        f'Bars extending right of the center line are passed questions; '
+        f'bars extending left are failed. '
         f'Solid bars are overrides; hatched bars are debt exclusions. '
-        f'Bar height represents the inflation-adjusted dollar amount.">\n'
+        f'Bar width represents the inflation-adjusted dollar amount.">\n'
         f'{inner}\n'
         f'</svg>'
     )

--- a/marblehead-voting-record.html
+++ b/marblehead-voting-record.html
@@ -45,7 +45,7 @@ og_url: https://marbleheaddata.org/marblehead-voting-record.html
 </div>
 
 <div class="chart-wrap">
-<svg class="chart" viewBox="0 0 880 520" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Diverging bar chart of Marblehead Proposition 2½ votes from 1982 to 2025. Bars above the baseline are passed questions; bars below are failed. Solid bars are overrides; hatched bars are debt exclusions. Bar height represents the inflation-adjusted dollar amount.">
+<svg class="chart" viewBox="0 0 880 632" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Horizontal diverging bar chart of Marblehead Proposition 2½ votes from 1982 to 2025. Bars extending right of the center line are passed questions; bars extending left are failed. Solid bars are overrides; hatched bars are debt exclusions. Bar width represents the inflation-adjusted dollar amount.">
 <defs>
     <pattern id="hatch-teal" patternUnits="userSpaceOnUse" width="4" height="4" patternTransform="rotate(45)">
       <rect width="2" height="4" class="hatch-stripe hatch-stripe--teal"/>
@@ -66,118 +66,114 @@ og_url: https://marbleheaddata.org/marblehead-voting-record.html
       <rect width="2" height="4" class="hatch-stripe hatch-stripe--plum"/>
     </pattern>
 </defs>
-<line class="grid-major" x1="65" y1="290.0" x2="865" y2="290.0"/>
-<text class="tick-label" x="60" y="294.0" text-anchor="end">$19.8M</text>
-<line class="grid-major" x1="65" y1="205.0" x2="865" y2="205.0"/>
-<text class="tick-label" x="60" y="209.0" text-anchor="end">$39.7M</text>
-<line class="grid-major" x1="65" y1="120.0" x2="865" y2="120.0"/>
-<text class="tick-label" x="60" y="124.0" text-anchor="end">$59.5M</text>
-<line class="grid-major" x1="65" y1="35.0" x2="865" y2="35.0"/>
-<text class="tick-label" x="60" y="39.0" text-anchor="end">$79.3M</text>
-<line class="grid-major" x1="65" y1="417.5" x2="865" y2="417.5"/>
-<text class="tick-label" x="60" y="421.5" text-anchor="end">$39.7M</text>
-<line class="axis-base" x1="65" y1="375.0" x2="865" y2="375.0"/>
-<text class="tick-label" x="69" y="369.0" text-anchor="start" font-size="8">Passed &#x2191;</text>
-<text class="tick-label" x="69" y="389.0" text-anchor="start" font-size="8">Failed &#x2193;</text>
-<rect class="bar-hatch-sage" x="80.2" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion"><title>Reconst Sewers For Drainage Purposes (1982, WIN, —)</title></rect>
-<rect class="bar-hatch-teal" x="106.9" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Schools (1988, WIN, —)</title></rect>
-<rect class="bar-solid-navy" x="115.8" y="375.0" width="9.3" height="10.3" data-nominal="1000000" data-real="2400153" data-win="LOSS" data-dept="General_Government" data-type="override"><title>General Operating Budget (1990, LOSS, $2.4M)</title></rect>
-<rect class="bar-hatch-teal" x="133.5" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Remodel/Repair Mid.Sch Heat System (1990, WIN, —)</title></rect>
-<rect class="bar-hatch-teal" x="133.5" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Remodel/Repair H Sch Sci Labs (1990, WIN, —)</title></rect>
-<rect class="bar-hatch-brass" x="133.5" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="Culture_and_Recreation" data-type="debt-exclusion"><title>Remodel/Equip Exsisting Library (1990, WIN, —)</title></rect>
-<rect class="bar-solid-navy" x="142.5" y="375.0" width="9.3" height="5.7" data-nominal="575000" data-real="1324358" data-win="LOSS" data-dept="General_Government" data-type="override"><title>General Operating Expenseds (1991, LOSS, $1.3M)</title></rect>
-<rect class="bar-solid-navy" x="142.5" y="375.0" width="9.3" height="2.0" data-nominal="15716" data-real="36198" data-win="LOSS" data-dept="General_Government" data-type="override"><title>Funding Salaries For Town Clerks Office (1991, LOSS, $36K)</title></rect>
-<rect class="bar-solid-plum" x="142.5" y="375.0" width="9.3" height="2.0" data-nominal="508" data-real="1170" data-win="LOSS" data-dept="Health_and_Human_Services" data-type="override"><title>Funding Meals On Wheels (1991, LOSS, $1K)</title></rect>
-<rect class="bar-hatch-teal" x="186.9" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>School Renovations (1992, WIN, —)</title></rect>
-<rect class="bar-hatch-sage" x="213.5" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion"><title>Surface-Drains Construction (1994, WIN, —)</title></rect>
-<rect class="bar-hatch-teal" x="213.5" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>School Renovation (1994, WIN, —)</title></rect>
-<rect class="bar-solid-teal" x="222.5" y="375.0" width="9.3" height="3.1" data-nominal="348929" data-real="718235" data-win="LOSS" data-dept="School" data-type="override"><title>School Department Salaries (1995, LOSS, $718K)</title></rect>
-<rect class="bar-hatch-teal" x="240.2" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Repairs To Schools (1995, WIN, —)</title></rect>
-<rect class="bar-hatch-buoy" x="240.2" y="369.7" width="9.3" height="5.3" data-nominal="600000" data-real="1235039" data-win="WIN" data-dept="Public_Safety" data-type="debt-exclusion"><title>Repairs To Police And Inspectors Build. (1995, WIN, $1.2M)</title></rect>
-<rect class="bar-hatch-plum" x="240.2" y="353.8" width="9.3" height="21.2" data-nominal="2400000" data-real="4940157" data-win="WIN" data-dept="Health_and_Human_Services" data-type="debt-exclusion"><title>Const. Building For Council On Aging (1995, WIN, $4.9M)</title></rect>
-<rect class="bar-hatch-teal" x="240.2" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Computers For School Department (1995, WIN, —)</title></rect>
-<rect class="bar-hatch-sage" x="240.2" y="369.3" width="9.3" height="5.7" data-nominal="650000" data-real="1337959" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion"><title>Surface Storm Drains (1995, WIN, $1.3M)</title></rect>
-<rect class="bar-solid-teal" x="249.1" y="375.0" width="9.3" height="7.5" data-nominal="870084" data-real="1739613" data-win="LOSS" data-dept="School" data-type="override"><title>School Department Expenses (1996, LOSS, $1.7M)</title></rect>
-<rect class="bar-hatch-sage" x="266.9" y="367.3" width="9.3" height="7.7" data-nominal="900000" data-real="1799426" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion"><title>Surface Drain Construction (1996, WIN, $1.8M)</title></rect>
-<rect class="bar-hatch-teal" x="266.9" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Computer Equipment For School Dept. (1996, WIN, —)</title></rect>
-<rect class="bar-hatch-buoy" x="266.9" y="371.1" width="9.3" height="3.9" data-nominal="450000" data-real="899713" data-win="WIN" data-dept="Public_Safety" data-type="debt-exclusion"><title>Equipment For Fire Department (1996, WIN, $900K)</title></rect>
-<rect class="bar-hatch-teal" x="266.9" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Repair-Construct-Equip School Bldgs. (1996, WIN, —)</title></rect>
-<rect class="bar-hatch-teal" x="293.5" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Remodeling Of Several Town Schools (1997, WIN, —)</title></rect>
-<rect class="bar-hatch-teal" x="320.2" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Repairs To Several Schools (1998, WIN, —)</title></rect>
-<rect class="bar-hatch-teal" x="320.2" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Computers And Software For School Dept. (1998, WIN, —)</title></rect>
-<rect class="bar-hatch-teal" x="346.9" y="35.0" width="9.3" height="340.0" data-nominal="42115000" data-real="79300573" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Const.Equip-Furnish New High School (1999, WIN, $79.3M)</title></rect>
-<rect class="bar-solid-navy" x="355.8" y="375.0" width="9.3" height="2.0" data-nominal="149000" data-real="271436" data-win="LOSS" data-dept="General_Government" data-type="override"><title>Improvements At The Old Town House (2000, LOSS, $271K)</title></rect>
-<rect class="bar-hatch-sage" x="373.5" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion"><title>Repairs To Existing Drainage Infrastruction (2000, WIN, —)</title></rect>
-<rect class="bar-solid-sage" x="382.5" y="372.7" width="9.3" height="2.3" data-nominal="300000" data-real="531395" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="override"><title>Construction Of Sewers And Surface Drains (2001, WIN, $531K)</title></rect>
-<rect class="bar-hatch-teal" x="400.2" y="370.4" width="9.3" height="4.6" data-nominal="600000" data-real="1062789" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Plans For Conversion Of Schools (2001, WIN, $1.1M)</title></rect>
-<rect class="bar-hatch-teal" x="400.2" y="203.4" width="9.3" height="171.6" data-nominal="22600000" data-real="40031733" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Bonds Issued To Plan, Remodel, Reconstruct Additions To Existing High School And Convert To Middle School (2001, WIN, $40.0M)</title></rect>
-<rect class="bar-hatch-brass" x="426.9" y="375.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="LOSS" data-dept="Culture_and_Recreation" data-type="debt-exclusion"><title>Bonds Issued For Remodeling, Reconstruction And Making Repairs To Tucker's Wharf (2002, LOSS, —)</title></rect>
-<rect class="bar-solid-navy" x="435.8" y="364.9" width="9.3" height="10.1" data-nominal="1381017" data-real="2354484" data-win="WIN" data-dept="General_Government" data-type="override"><title>Supplemental Budget Expenses (2003, WIN, $2.4M)</title></rect>
-<rect class="bar-solid-buoy" x="462.5" y="375.0" width="9.3" height="3.4" data-nominal="482590" data-real="801421" data-win="LOSS" data-dept="Public_Safety" data-type="override"><title>Cruiser For Police Dept.-Van For Dog Officer-Front End Loader And Backlhoe For Waste Coll. Dept. (2004, LOSS, $801K)</title></rect>
-<rect class="bar-solid-teal" x="462.5" y="372.0" width="9.3" height="3.0" data-nominal="422246" data-real="701210" data-win="WIN" data-dept="School" data-type="override"><title>Supplemental Expenses For School Department (2004, WIN, $701K)</title></rect>
-<rect class="bar-solid-buoy" x="462.5" y="375.0" width="9.3" height="2.0" data-nominal="132500" data-real="220038" data-win="LOSS" data-dept="Public_Safety" data-type="override"><title>Supplemental Expenses Of Police Department (2004, LOSS, $220K)</title></rect>
-<rect class="bar-solid-sage" x="462.5" y="373.0" width="9.3" height="2.0" data-nominal="17100" data-real="28397" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="override"><title>Supplemental Expenses For Waste Collection (2004, WIN, $28K)</title></rect>
-<rect class="bar-solid-navy" x="462.5" y="375.0" width="9.3" height="2.0" data-nominal="55000" data-real="91337" data-win="LOSS" data-dept="General_Government" data-type="override"><title>General Operating Expenditures (2004, LOSS, $91K)</title></rect>
-<rect class="bar-solid-brass" x="462.5" y="373.0" width="9.3" height="2.0" data-nominal="73051" data-real="121313" data-win="WIN" data-dept="Culture_and_Recreation" data-type="override"><title>Library Expenses (2004, WIN, $121K)</title></rect>
-<rect class="bar-hatch-buoy" x="480.2" y="372.0" width="9.3" height="3.0" data-nominal="415000" data-real="689177" data-win="WIN" data-dept="Public_Safety" data-type="debt-exclusion"><title>Purchase Fire Pumper Truck (2004, WIN, $689K)</title></rect>
-<rect class="bar-solid-navy" x="489.1" y="356.2" width="9.3" height="18.8" data-nominal="2730167" data-real="4385322" data-win="WIN" data-dept="General_Government" data-type="override"><title>Supplemental Expenses Of Several Town Departments (2005, WIN, $4.4M)</title></rect>
-<rect class="bar-hatch-navy" x="506.9" y="369.4" width="9.3" height="5.6" data-nominal="811500" data-real="1303469" data-win="WIN" data-dept="General_Government" data-type="debt-exclusion"><title>Purchase Equipment For Several Town Departments (2005, WIN, $1.3M)</title></rect>
-<rect class="bar-hatch-navy" x="506.9" y="361.1" width="9.3" height="13.9" data-nominal="2025000" data-real="3252650" data-win="WIN" data-dept="General_Government" data-type="debt-exclusion"><title>Purchase 3 Certain Parcels Of Land Owned By Robinson Farm Realty Trust (2005, WIN, $3.3M)</title></rect>
-<rect class="bar-hatch-sage" x="533.5" y="318.6" width="9.3" height="56.4" data-nominal="8700000" data-real="13165412" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion"><title>Construct, Reconstruct Ocean Ave Causewayl (2007, WIN, $13.2M)</title></rect>
-<rect class="bar-hatch-sage" x="533.5" y="368.4" width="9.3" height="6.6" data-nominal="1010000" data-real="1528398" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion"><title>Landfill Cap, Transfer Station, Drop Off (2007, WIN, $1.5M)</title></rect>
-<rect class="bar-hatch-teal" x="560.2" y="372.5" width="9.3" height="2.5" data-nominal="395000" data-real="575529" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Feasibility Study For The Glover School Project (2008, WIN, $576K)</title></rect>
-<rect class="bar-hatch-teal" x="560.2" y="239.4" width="9.3" height="135.6" data-nominal="21700000" data-real="31617696" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Village School Project -Reconstruction (2008, WIN, $31.6M)</title></rect>
-<rect class="bar-solid-navy" x="569.1" y="375.0" width="9.3" height="4.0" data-nominal="667793" data-real="931466" data-win="LOSS" data-dept="General_Government" data-type="override"><title>Final Design, Public Bidding And Construction For Improvements To The Old Town House (2011, LOSS, $931K)</title></rect>
-<rect class="bar-hatch-teal" x="586.9" y="222.8" width="9.3" height="152.2" data-nominal="25450000" data-real="35498733" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Funding The Design, Project Management And Construction Of A New Elementary School (2011, WIN, $35.5M)</title></rect>
-<rect class="bar-hatch-sage" x="586.9" y="266.3" width="9.3" height="108.7" data-nominal="18174578" data-real="25350667" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion"><title>Funding The Permitting, Public Bidding And Construction Of A Cap For The Encompassing The Old Landfill, Etc (2011, WIN, $25.4M)</title></rect>
-<rect class="bar-hatch-buoy" x="613.5" y="368.3" width="9.3" height="6.7" data-nominal="1150000" data-real="1571233" data-win="WIN" data-dept="Public_Safety" data-type="debt-exclusion"><title>Quint Fire Truck (2012, WIN, $1.6M)</title></rect>
-<rect class="bar-hatch-navy" x="613.5" y="371.4" width="9.3" height="3.6" data-nominal="610168" data-real="833666" data-win="WIN" data-dept="General_Government" data-type="debt-exclusion"><title>Old Town House Accessibility Project (2012, WIN, $834K)</title></rect>
-<rect class="bar-hatch-navy" x="613.5" y="366.2" width="9.3" height="8.8" data-nominal="1500000" data-real="2049434" data-win="WIN" data-dept="General_Government" data-type="debt-exclusion"><title>Lead Mills Land Acquisition (2012, WIN, $2.0M)</title></rect>
-<rect class="bar-hatch-sage" x="613.5" y="346.1" width="9.3" height="28.9" data-nominal="4937687" data-real="6746308" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion"><title>Pleasant Street Area Drainage Project (2012, WIN, $6.7M)</title></rect>
-<rect class="bar-hatch-sage" x="640.2" y="368.3" width="9.3" height="6.7" data-nominal="1165000" data-real="1568500" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion"><title>Green Street Remediation (2013, WIN, $1.6M)</title></rect>
-<rect class="bar-hatch-navy" x="640.2" y="360.8" width="9.3" height="14.2" data-nominal="2465966" data-real="3320058" data-win="WIN" data-dept="General_Government" data-type="debt-exclusion"><title>Abbot Hall Tower Repairs (2013, WIN, $3.3M)</title></rect>
-<rect class="bar-hatch-sage" x="666.9" y="329.6" width="9.3" height="45.4" data-nominal="8000000" data-real="10589030" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion"><title>Bonds To Pay For Repair And Replacement Of Drainage Pipe And Construction Of New Xfer Station (2015, WIN, $10.6M)</title></rect>
-<rect class="bar-hatch-teal" x="693.5" y="370.8" width="9.3" height="4.2" data-nominal="750000" data-real="980312" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Bonds For Study, Renovation And Recon Of Elbridge Gerry School (2016, WIN, $980K)</title></rect>
-<rect class="bar-hatch-buoy" x="693.5" y="371.5" width="9.3" height="3.5" data-nominal="620000" data-real="810392" data-win="WIN" data-dept="Public_Safety" data-type="debt-exclusion"><title>Bonds For A Pumper Truck For The Fire Dept (2016, WIN, $810K)</title></rect>
-<rect class="bar-hatch-sage" x="720.2" y="370.3" width="9.3" height="4.7" data-nominal="871894" data-real="1089260" data-win="WIN" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion"><title>Costs Of Constructing And Reconstructing Seawalls And Fences (2018, WIN, $1.1M)</title></rect>
-<rect class="bar-hatch-teal" x="746.9" y="86.5" width="9.3" height="288.5" data-nominal="54844767" data-real="67285113" data-win="WIN" data-dept="School" data-type="debt-exclusion"><title>Bonds For New Gerry School (2019, WIN, $67.3M)</title></rect>
-<rect class="bar-hatch-navy" x="746.9" y="371.1" width="9.3" height="3.9" data-nominal="750000" data-real="920121" data-win="WIN" data-dept="General_Government" data-type="debt-exclusion"><title>Bonds For Repairs To Fort Sewall (2019, WIN, $920K)</title></rect>
-<rect class="bar-hatch-brass" x="773.5" y="332.8" width="9.3" height="42.2" data-nominal="8500000" data-real="9839299" data-win="WIN" data-dept="Culture_and_Recreation" data-type="debt-exclusion"><title>Renovation Of Abbot Public Library (2021, WIN, $9.8M)</title></rect>
-<rect class="bar-hatch-buoy" x="773.5" y="371.3" width="9.3" height="3.7" data-nominal="750000" data-real="868173" data-win="WIN" data-dept="Public_Safety" data-type="debt-exclusion"><title>New Fire Pumper Truck (2021, WIN, $868K)</title></rect>
-<rect class="bar-solid-teal" x="782.5" y="375.0" width="9.3" height="14.0" data-nominal="3051093" data-real="3269996" data-win="LOSS" data-dept="School" data-type="override"><title>School Department Operating Budget (2022, LOSS, $3.3M)</title></rect>
-<rect class="bar-hatch-navy" x="800.2" y="324.9" width="9.3" height="50.1" data-nominal="10902598" data-real="11684814" data-win="WIN" data-dept="General_Government" data-type="debt-exclusion"><title>Roof Replacements, Road & Sidewalk Improvements, Smart Panels, Hvac, Salt Shed, Hs Boiler (2022, WIN, $11.7M)</title></rect>
-<rect class="bar-solid-navy" x="809.1" y="375.0" width="9.3" height="10.9" data-nominal="2472056" data-real="2545074" data-win="LOSS" data-dept="General_Government" data-type="override"><title>General Government Operating Budget (2023, LOSS, $2.5M)</title></rect>
-<rect class="bar-hatch-navy" x="853.5" y="373.0" width="9.3" height="2.0" data-nominal="" data-real="" data-win="WIN" data-dept="General_Government" data-type="debt-exclusion"><title>Mary Alley Building Improvement & Hvac (2025, WIN, —)</title></rect>
-<text class="tick-label tick-label--minor" x="78.3" y="476" text-anchor="middle">1982</text>
-<text class="tick-label tick-label--minor" x="105.0" y="476" text-anchor="middle">1988</text>
-<text class="tick-label tick-label--major" x="131.7" y="476" text-anchor="middle">1990</text>
-<text class="tick-label tick-label--minor" x="158.3" y="476" text-anchor="middle">1991</text>
-<text class="tick-label tick-label--minor" x="185.0" y="476" text-anchor="middle">1992</text>
-<text class="tick-label tick-label--minor" x="211.7" y="476" text-anchor="middle">1994</text>
-<text class="tick-label tick-label--major" x="238.3" y="476" text-anchor="middle">1995</text>
-<text class="tick-label tick-label--minor" x="265.0" y="476" text-anchor="middle">1996</text>
-<text class="tick-label tick-label--minor" x="291.7" y="476" text-anchor="middle">1997</text>
-<text class="tick-label tick-label--minor" x="318.3" y="476" text-anchor="middle">1998</text>
-<text class="tick-label tick-label--minor" x="345.0" y="476" text-anchor="middle">1999</text>
-<text class="tick-label tick-label--major" x="371.7" y="476" text-anchor="middle">2000</text>
-<text class="tick-label tick-label--minor" x="398.3" y="476" text-anchor="middle">2001</text>
-<text class="tick-label tick-label--minor" x="425.0" y="476" text-anchor="middle">2002</text>
-<text class="tick-label tick-label--minor" x="451.7" y="476" text-anchor="middle">2003</text>
-<text class="tick-label tick-label--minor" x="478.3" y="476" text-anchor="middle">2004</text>
-<text class="tick-label tick-label--major" x="505.0" y="476" text-anchor="middle">2005</text>
-<text class="tick-label tick-label--minor" x="531.7" y="476" text-anchor="middle">2007</text>
-<text class="tick-label tick-label--minor" x="558.3" y="476" text-anchor="middle">2008</text>
-<text class="tick-label tick-label--minor" x="585.0" y="476" text-anchor="middle">2011</text>
-<text class="tick-label tick-label--minor" x="611.7" y="476" text-anchor="middle">2012</text>
-<text class="tick-label tick-label--minor" x="638.3" y="476" text-anchor="middle">2013</text>
-<text class="tick-label tick-label--major" x="665.0" y="476" text-anchor="middle">2015</text>
-<text class="tick-label tick-label--minor" x="691.7" y="476" text-anchor="middle">2016</text>
-<text class="tick-label tick-label--minor" x="718.3" y="476" text-anchor="middle">2018</text>
-<text class="tick-label tick-label--minor" x="745.0" y="476" text-anchor="middle">2019</text>
-<text class="tick-label tick-label--minor" x="771.7" y="476" text-anchor="middle">2021</text>
-<text class="tick-label tick-label--minor" x="798.3" y="476" text-anchor="middle">2022</text>
-<text class="tick-label tick-label--minor" x="825.0" y="476" text-anchor="middle">2023</text>
-<text class="tick-label tick-label--major" x="851.7" y="476" text-anchor="middle">2025</text>
+<text class="tick-label" x="57" y="16" text-anchor="start" font-size="9">Failed</text>
+<text class="tick-label" x="863" y="16" text-anchor="end" font-size="9">Passed</text>
+<line class="grid-minor" x1="319.1" y1="22" x2="319.1" y2="622"/>
+<text class="tick-label tick-label--minor" x="319.1" y="16" text-anchor="middle" font-size="8">$20.0M</text>
+<line class="grid-minor" x1="503.2" y1="22" x2="503.2" y2="622"/>
+<text class="tick-label tick-label--minor" x="503.2" y="16" text-anchor="middle" font-size="8">$40.0M</text>
+<line class="grid-minor" x1="687.3" y1="22" x2="687.3" y2="622"/>
+<text class="tick-label tick-label--minor" x="687.3" y="16" text-anchor="middle" font-size="8">$60.0M</text>
+<line class="axis-base" x1="135.0" y1="22" x2="135.0" y2="622"/>
+<text class="tick-label" x="51" y="36.0" text-anchor="end" font-size="9">'82</text>
+<rect class="bar-hatch-sage" x="135.0" y="25.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="1982"><title>Reconst Sewers For Drainage Purposes (1982, Passed, —)</title></rect>
+<text class="tick-label" x="51" y="56.0" text-anchor="end" font-size="9">'88</text>
+<rect class="bar-hatch-teal" x="135.0" y="45.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1988"><title>Schools (1988, Passed, —)</title></rect>
+<text class="tick-label" x="51" y="76.0" text-anchor="end" font-size="9">'90</text>
+<rect class="bar-hatch-teal" x="135.0" y="65.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1990"><title>Remodel/Repair Mid.Sch Heat System (1990, Passed, —)</title></rect>
+<rect class="bar-hatch-teal" x="138.0" y="65.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1990"><title>Remodel/Repair H Sch Sci Labs (1990, Passed, —)</title></rect>
+<rect class="bar-hatch-brass" x="141.0" y="65.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="Culture_and_Recreation" data-type="debt-exclusion" data-year="1990"><title>Remodel/Equip Exsisting Library (1990, Passed, —)</title></rect>
+<rect class="bar-solid-navy" x="112.9" y="65.0" width="22.1" height="14" data-nominal="1000000" data-real="2400153" data-win="0" data-dept="General_Government" data-type="override" data-year="1990"><title>General Operating Budget (1990, Failed, $2.4M)</title></rect>
+<text class="tick-label" x="51" y="96.0" text-anchor="end" font-size="9">'91</text>
+<rect class="bar-solid-navy" x="122.8" y="85.0" width="12.2" height="14" data-nominal="575000" data-real="1324358" data-win="0" data-dept="General_Government" data-type="override" data-year="1991"><title>General Operating Expenseds (1991, Failed, $1.3M)</title></rect>
+<rect class="bar-solid-navy" x="122.5" y="85.0" width="0.3" height="14" data-nominal="15716" data-real="36198" data-win="0" data-dept="General_Government" data-type="override" data-year="1991"><title>Funding Salaries For Town Clerks Office (1991, Failed, $36K)</title></rect>
+<rect class="bar-solid-plum" x="122.5" y="85.0" width="0.0" height="14" data-nominal="508" data-real="1170" data-win="0" data-dept="Health_and_Human_Services" data-type="override" data-year="1991"><title>Funding Meals On Wheels (1991, Failed, $1K)</title></rect>
+<text class="tick-label" x="51" y="116.0" text-anchor="end" font-size="9">'92</text>
+<rect class="bar-hatch-teal" x="135.0" y="105.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1992"><title>School Renovations (1992, Passed, —)</title></rect>
+<text class="tick-label" x="51" y="136.0" text-anchor="end" font-size="9">'94</text>
+<rect class="bar-hatch-sage" x="135.0" y="125.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="1994"><title>Surface-Drains Construction (1994, Passed, —)</title></rect>
+<rect class="bar-hatch-teal" x="138.0" y="125.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1994"><title>School Renovation (1994, Passed, —)</title></rect>
+<text class="tick-label" x="51" y="156.0" text-anchor="end" font-size="9">'95</text>
+<rect class="bar-hatch-plum" x="135.0" y="145.0" width="45.5" height="14" data-nominal="2400000" data-real="4940157" data-win="1" data-dept="Health_and_Human_Services" data-type="debt-exclusion" data-year="1995"><title>Const. Building For Council On Aging (1995, Passed, $4.9M)</title></rect>
+<rect class="bar-hatch-sage" x="180.5" y="145.0" width="12.3" height="14" data-nominal="650000" data-real="1337959" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="1995"><title>Surface Storm Drains (1995, Passed, $1.3M)</title></rect>
+<rect class="bar-hatch-buoy" x="192.8" y="145.0" width="11.4" height="14" data-nominal="600000" data-real="1235039" data-win="1" data-dept="Public_Safety" data-type="debt-exclusion" data-year="1995"><title>Repairs To Police And Inspectors Build. (1995, Passed, $1.2M)</title></rect>
+<rect class="bar-hatch-teal" x="204.2" y="145.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1995"><title>Repairs To Schools (1995, Passed, —)</title></rect>
+<rect class="bar-hatch-teal" x="207.2" y="145.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1995"><title>Computers For School Department (1995, Passed, —)</title></rect>
+<rect class="bar-solid-teal" x="128.4" y="145.0" width="6.6" height="14" data-nominal="348929" data-real="718235" data-win="0" data-dept="School" data-type="override" data-year="1995"><title>School Department Salaries (1995, Failed, $718K)</title></rect>
+<text class="tick-label" x="51" y="176.0" text-anchor="end" font-size="9">'96</text>
+<rect class="bar-hatch-sage" x="135.0" y="165.0" width="16.6" height="14" data-nominal="900000" data-real="1799426" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="1996"><title>Surface Drain Construction (1996, Passed, $1.8M)</title></rect>
+<rect class="bar-hatch-buoy" x="151.6" y="165.0" width="8.3" height="14" data-nominal="450000" data-real="899713" data-win="1" data-dept="Public_Safety" data-type="debt-exclusion" data-year="1996"><title>Equipment For Fire Department (1996, Passed, $900K)</title></rect>
+<rect class="bar-hatch-teal" x="159.8" y="165.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1996"><title>Computer Equipment For School Dept. (1996, Passed, —)</title></rect>
+<rect class="bar-hatch-teal" x="162.8" y="165.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1996"><title>Repair-Construct-Equip School Bldgs. (1996, Passed, —)</title></rect>
+<rect class="bar-solid-teal" x="119.0" y="165.0" width="16.0" height="14" data-nominal="870084" data-real="1739613" data-win="0" data-dept="School" data-type="override" data-year="1996"><title>School Department Expenses (1996, Failed, $1.7M)</title></rect>
+<text class="tick-label" x="51" y="196.0" text-anchor="end" font-size="9">'97</text>
+<rect class="bar-hatch-teal" x="135.0" y="185.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1997"><title>Remodeling Of Several Town Schools (1997, Passed, —)</title></rect>
+<text class="tick-label" x="51" y="216.0" text-anchor="end" font-size="9">'98</text>
+<rect class="bar-hatch-teal" x="135.0" y="205.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1998"><title>Repairs To Several Schools (1998, Passed, —)</title></rect>
+<rect class="bar-hatch-teal" x="138.0" y="205.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1998"><title>Computers And Software For School Dept. (1998, Passed, —)</title></rect>
+<text class="tick-label" x="51" y="236.0" text-anchor="end" font-size="9">'99</text>
+<rect class="bar-hatch-teal" x="135.0" y="225.0" width="730.0" height="14" data-nominal="42115000" data-real="79300573" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1999"><title>Const.Equip-Furnish New High School (1999, Passed, $79.3M)</title></rect>
+<text class="tick-label" x="51" y="256.0" text-anchor="end" font-size="9">'00</text>
+<rect class="bar-hatch-sage" x="135.0" y="245.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2000"><title>Repairs To Existing Drainage Infrastruction (2000, Passed, —)</title></rect>
+<rect class="bar-solid-navy" x="132.5" y="245.0" width="2.5" height="14" data-nominal="149000" data-real="271436" data-win="0" data-dept="General_Government" data-type="override" data-year="2000"><title>Improvements At The Old Town House (2000, Failed, $271K)</title></rect>
+<text class="tick-label" x="51" y="276.0" text-anchor="end" font-size="9">'01</text>
+<rect class="bar-solid-sage" x="135.0" y="265.0" width="4.9" height="14" data-nominal="300000" data-real="531395" data-win="1" data-dept="Public_Works_and_Facilities" data-type="override" data-year="2001"><title>Construction Of Sewers And Surface Drains (2001, Passed, $531K)</title></rect>
+<rect class="bar-hatch-teal" x="139.9" y="265.0" width="368.5" height="14" data-nominal="22600000" data-real="40031733" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2001"><title>Bonds Issued To Plan, Remodel, Reconstruct Additions To Existing High School And Convert To Middle School (2001, Passed, $40.0M)</title></rect>
+<rect class="bar-hatch-teal" x="508.4" y="265.0" width="9.8" height="14" data-nominal="600000" data-real="1062789" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2001"><title>Plans For Conversion Of Schools (2001, Passed, $1.1M)</title></rect>
+<text class="tick-label" x="51" y="296.0" text-anchor="end" font-size="9">'02</text>
+<rect class="bar-hatch-brass" x="132.0" y="285.0" width="3.0" height="14" data-nominal="" data-real="" data-win="0" data-dept="Culture_and_Recreation" data-type="debt-exclusion" data-year="2002"><title>Bonds Issued For Remodeling, Reconstruction And Making Repairs To Tucker's Wharf (2002, Failed, —)</title></rect>
+<text class="tick-label" x="51" y="316.0" text-anchor="end" font-size="9">'03</text>
+<rect class="bar-solid-navy" x="135.0" y="305.0" width="21.7" height="14" data-nominal="1381017" data-real="2354484" data-win="1" data-dept="General_Government" data-type="override" data-year="2003"><title>Supplemental Budget Expenses (2003, Passed, $2.4M)</title></rect>
+<text class="tick-label" x="51" y="336.0" text-anchor="end" font-size="9">'04</text>
+<rect class="bar-solid-teal" x="135.0" y="325.0" width="6.5" height="14" data-nominal="422246" data-real="701210" data-win="1" data-dept="School" data-type="override" data-year="2004"><title>Supplemental Expenses For School Department (2004, Passed, $701K)</title></rect>
+<rect class="bar-solid-brass" x="141.5" y="325.0" width="1.1" height="14" data-nominal="73051" data-real="121313" data-win="1" data-dept="Culture_and_Recreation" data-type="override" data-year="2004"><title>Library Expenses (2004, Passed, $121K)</title></rect>
+<rect class="bar-solid-sage" x="142.6" y="325.0" width="0.3" height="14" data-nominal="17100" data-real="28397" data-win="1" data-dept="Public_Works_and_Facilities" data-type="override" data-year="2004"><title>Supplemental Expenses For Waste Collection (2004, Passed, $28K)</title></rect>
+<rect class="bar-hatch-buoy" x="142.8" y="325.0" width="6.3" height="14" data-nominal="415000" data-real="689177" data-win="1" data-dept="Public_Safety" data-type="debt-exclusion" data-year="2004"><title>Purchase Fire Pumper Truck (2004, Passed, $689K)</title></rect>
+<rect class="bar-solid-buoy" x="127.6" y="325.0" width="7.4" height="14" data-nominal="482590" data-real="801421" data-win="0" data-dept="Public_Safety" data-type="override" data-year="2004"><title>Cruiser For Police Dept.-Van For Dog Officer-Front End Loader And Backlhoe For Waste Coll. Dept. (2004, Failed, $801K)</title></rect>
+<rect class="bar-solid-buoy" x="125.6" y="325.0" width="2.0" height="14" data-nominal="132500" data-real="220038" data-win="0" data-dept="Public_Safety" data-type="override" data-year="2004"><title>Supplemental Expenses Of Police Department (2004, Failed, $220K)</title></rect>
+<rect class="bar-solid-navy" x="124.8" y="325.0" width="0.8" height="14" data-nominal="55000" data-real="91337" data-win="0" data-dept="General_Government" data-type="override" data-year="2004"><title>General Operating Expenditures (2004, Failed, $91K)</title></rect>
+<text class="tick-label" x="51" y="356.0" text-anchor="end" font-size="9">'05</text>
+<rect class="bar-solid-navy" x="135.0" y="345.0" width="40.4" height="14" data-nominal="2730167" data-real="4385322" data-win="1" data-dept="General_Government" data-type="override" data-year="2005"><title>Supplemental Expenses Of Several Town Departments (2005, Passed, $4.4M)</title></rect>
+<rect class="bar-hatch-navy" x="175.4" y="345.0" width="29.9" height="14" data-nominal="2025000" data-real="3252650" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2005"><title>Purchase 3 Certain Parcels Of Land Owned By Robinson Farm Realty Trust (2005, Passed, $3.3M)</title></rect>
+<rect class="bar-hatch-navy" x="205.3" y="345.0" width="12.0" height="14" data-nominal="811500" data-real="1303469" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2005"><title>Purchase Equipment For Several Town Departments (2005, Passed, $1.3M)</title></rect>
+<text class="tick-label" x="51" y="376.0" text-anchor="end" font-size="9">'07</text>
+<rect class="bar-hatch-sage" x="135.0" y="365.0" width="121.2" height="14" data-nominal="8700000" data-real="13165412" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2007"><title>Construct, Reconstruct Ocean Ave Causewayl (2007, Passed, $13.2M)</title></rect>
+<rect class="bar-hatch-sage" x="256.2" y="365.0" width="14.1" height="14" data-nominal="1010000" data-real="1528398" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2007"><title>Landfill Cap, Transfer Station, Drop Off (2007, Passed, $1.5M)</title></rect>
+<text class="tick-label" x="51" y="396.0" text-anchor="end" font-size="9">'08</text>
+<rect class="bar-hatch-teal" x="135.0" y="385.0" width="291.1" height="14" data-nominal="21700000" data-real="31617696" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2008"><title>Village School Project -Reconstruction (2008, Passed, $31.6M)</title></rect>
+<rect class="bar-hatch-teal" x="426.1" y="385.0" width="5.3" height="14" data-nominal="395000" data-real="575529" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2008"><title>Feasibility Study For The Glover School Project (2008, Passed, $576K)</title></rect>
+<text class="tick-label" x="51" y="416.0" text-anchor="end" font-size="9">'11</text>
+<rect class="bar-hatch-teal" x="135.0" y="405.0" width="326.8" height="14" data-nominal="25450000" data-real="35498733" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2011"><title>Funding The Design, Project Management And Construction Of A New Elementary School (2011, Passed, $35.5M)</title></rect>
+<rect class="bar-hatch-sage" x="461.8" y="405.0" width="233.4" height="14" data-nominal="18174578" data-real="25350667" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2011"><title>Funding The Permitting, Public Bidding And Construction Of A Cap For The Encompassing The Old Landfill, Etc (2011, Passed, $25.4M)</title></rect>
+<rect class="bar-solid-navy" x="126.4" y="405.0" width="8.6" height="14" data-nominal="667793" data-real="931466" data-win="0" data-dept="General_Government" data-type="override" data-year="2011"><title>Final Design, Public Bidding And Construction For Improvements To The Old Town House (2011, Failed, $931K)</title></rect>
+<text class="tick-label" x="51" y="436.0" text-anchor="end" font-size="9">'12</text>
+<rect class="bar-hatch-sage" x="135.0" y="425.0" width="62.1" height="14" data-nominal="4937687" data-real="6746308" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2012"><title>Pleasant Street Area Drainage Project (2012, Passed, $6.7M)</title></rect>
+<rect class="bar-hatch-navy" x="197.1" y="425.0" width="18.9" height="14" data-nominal="1500000" data-real="2049434" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2012"><title>Lead Mills Land Acquisition (2012, Passed, $2.0M)</title></rect>
+<rect class="bar-hatch-buoy" x="216.0" y="425.0" width="14.5" height="14" data-nominal="1150000" data-real="1571233" data-win="1" data-dept="Public_Safety" data-type="debt-exclusion" data-year="2012"><title>Quint Fire Truck (2012, Passed, $1.6M)</title></rect>
+<rect class="bar-hatch-navy" x="230.4" y="425.0" width="7.7" height="14" data-nominal="610168" data-real="833666" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2012"><title>Old Town House Accessibility Project (2012, Passed, $834K)</title></rect>
+<text class="tick-label" x="51" y="456.0" text-anchor="end" font-size="9">'13</text>
+<rect class="bar-hatch-navy" x="135.0" y="445.0" width="30.6" height="14" data-nominal="2465966" data-real="3320058" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2013"><title>Abbot Hall Tower Repairs (2013, Passed, $3.3M)</title></rect>
+<rect class="bar-hatch-sage" x="165.6" y="445.0" width="14.4" height="14" data-nominal="1165000" data-real="1568500" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2013"><title>Green Street Remediation (2013, Passed, $1.6M)</title></rect>
+<text class="tick-label" x="51" y="476.0" text-anchor="end" font-size="9">'15</text>
+<rect class="bar-hatch-sage" x="135.0" y="465.0" width="97.5" height="14" data-nominal="8000000" data-real="10589030" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2015"><title>Bonds To Pay For Repair And Replacement Of Drainage Pipe And Construction Of New Xfer Station (2015, Passed, $10.6M)</title></rect>
+<text class="tick-label" x="51" y="496.0" text-anchor="end" font-size="9">'16</text>
+<rect class="bar-hatch-teal" x="135.0" y="485.0" width="9.0" height="14" data-nominal="750000" data-real="980312" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2016"><title>Bonds For Study, Renovation And Recon Of Elbridge Gerry School (2016, Passed, $980K)</title></rect>
+<rect class="bar-hatch-buoy" x="144.0" y="485.0" width="7.5" height="14" data-nominal="620000" data-real="810392" data-win="1" data-dept="Public_Safety" data-type="debt-exclusion" data-year="2016"><title>Bonds For A Pumper Truck For The Fire Dept (2016, Passed, $810K)</title></rect>
+<text class="tick-label" x="51" y="516.0" text-anchor="end" font-size="9">'18</text>
+<rect class="bar-hatch-sage" x="135.0" y="505.0" width="10.0" height="14" data-nominal="871894" data-real="1089260" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2018"><title>Costs Of Constructing And Reconstructing Seawalls And Fences (2018, Passed, $1.1M)</title></rect>
+<text class="tick-label" x="51" y="536.0" text-anchor="end" font-size="9">'19</text>
+<rect class="bar-hatch-teal" x="135.0" y="525.0" width="619.4" height="14" data-nominal="54844767" data-real="67285113" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2019"><title>Bonds For New Gerry School (2019, Passed, $67.3M)</title></rect>
+<rect class="bar-hatch-navy" x="754.4" y="525.0" width="8.5" height="14" data-nominal="750000" data-real="920121" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2019"><title>Bonds For Repairs To Fort Sewall (2019, Passed, $920K)</title></rect>
+<text class="tick-label" x="51" y="556.0" text-anchor="end" font-size="9">'21</text>
+<rect class="bar-hatch-brass" x="135.0" y="545.0" width="90.6" height="14" data-nominal="8500000" data-real="9839299" data-win="1" data-dept="Culture_and_Recreation" data-type="debt-exclusion" data-year="2021"><title>Renovation Of Abbot Public Library (2021, Passed, $9.8M)</title></rect>
+<rect class="bar-hatch-buoy" x="225.6" y="545.0" width="8.0" height="14" data-nominal="750000" data-real="868173" data-win="1" data-dept="Public_Safety" data-type="debt-exclusion" data-year="2021"><title>New Fire Pumper Truck (2021, Passed, $868K)</title></rect>
+<text class="tick-label" x="51" y="576.0" text-anchor="end" font-size="9">'22</text>
+<rect class="bar-hatch-navy" x="135.0" y="565.0" width="107.6" height="14" data-nominal="10902598" data-real="11684814" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2022"><title>Roof Replacements, Road & Sidewalk Improvements, Smart Panels, Hvac, Salt Shed, Hs Boiler (2022, Passed, $11.7M)</title></rect>
+<rect class="bar-solid-teal" x="104.9" y="565.0" width="30.1" height="14" data-nominal="3051093" data-real="3269996" data-win="0" data-dept="School" data-type="override" data-year="2022"><title>School Department Operating Budget (2022, Failed, $3.3M)</title></rect>
+<text class="tick-label" x="51" y="596.0" text-anchor="end" font-size="9">'23</text>
+<rect class="bar-solid-navy" x="111.6" y="585.0" width="23.4" height="14" data-nominal="2472056" data-real="2545074" data-win="0" data-dept="General_Government" data-type="override" data-year="2023"><title>General Government Operating Budget (2023, Failed, $2.5M)</title></rect>
+<text class="tick-label" x="51" y="616.0" text-anchor="end" font-size="9">'25</text>
+<rect class="bar-hatch-navy" x="135.0" y="605.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2025"><title>Mary Alley Building Improvement & Hvac (2025, Passed, —)</title></rect>
 </svg>
 </div>
 
@@ -196,7 +192,7 @@ og_url: https://marbleheaddata.org/marblehead-voting-record.html
   </div>
 </div>
 
-<p class="caption">Each bar is one ballot question. Bars above zero passed; bars below failed. Heights show inflation-adjusted (2024 dollar) amounts. Solid bars are operating overrides; hatched bars are debt exclusions. CPI-U adjustment uses Bureau of Labor Statistics annual averages (series CUUR0000SA0), base year 2024.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride" data-source="MA DOR, Proposition 2½ Override &amp; Underride Votes (Marblehead)"></sup></p>
+<p class="caption">Each bar segment is one ballot question. Bars extending right of the center line passed; bars extending left failed. Widths show inflation-adjusted (2024 dollar) amounts. Solid bars are operating overrides; hatched bars are debt exclusions. CPI-U adjustment uses Bureau of Labor Statistics annual averages (series CUUR0000SA0), base year 2024.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride" data-source="MA DOR, Proposition 2½ Override &amp; Underride Votes (Marblehead)"></sup></p>
 
 <h2>Detail by year</h2>
 <p>Click any year to see the individual ballot questions, vote counts, and sources.</p>
@@ -1808,39 +1804,95 @@ og_url: https://marbleheaddata.org/marblehead-voting-record.html
 
     if (chart) {
       var rects = chart.querySelectorAll('rect[data-nominal]');
-      var maxWin = 1, maxLoss = 1;
-      rects.forEach(function (r) {
-        var val = parseFloat(r.getAttribute('data-' + mode)) || 0;
-        var win = r.getAttribute('data-win') === '1';
-        if (win && val > maxWin) maxWin = val;
-        if (!win && val > maxLoss) maxLoss = val;
-      });
+      var MARKER_W = 3;
+      var ML = 55, MR = 15;
+      var FAIL_MIN_W = 80;
+      var chartW = 880 - ML - MR;
 
-      var vbH = 520, mTop = 35, mBot = 60;
-      var chartH = vbH - mTop - mBot;
-      var lossFrac = 0.20;
-      var aboveH = chartH * (1 - lossFrac);
-      var belowH = chartH * lossFrac;
-      var baselineY = mTop + aboveH;
-
+      /* Group rects by year and side, compute per-year totals */
+      var byYear = {};
       rects.forEach(function (r) {
-        var val = parseFloat(r.getAttribute('data-' + mode)) || 0;
+        var yr = r.getAttribute('data-year');
         var win = r.getAttribute('data-win') === '1';
-        var h, y;
+        var val = parseFloat(r.getAttribute('data-' + mode)) || 0;
+        if (!byYear[yr]) byYear[yr] = { pass: [], fail: [], passTotal: 0, failTotal: 0 };
         if (win) {
-          h = maxWin > 0 ? (val / maxWin * aboveH) : 0;
-          if (val > 0 && h < 1) h = 1;
-          if (val === 0) h = 0;
-          y = baselineY - h;
+          byYear[yr].pass.push(r);
+          byYear[yr].passTotal += val;
         } else {
-          h = maxLoss > 0 ? (val / maxLoss * belowH) : 0;
-          if (val > 0 && h < 1) h = 1;
-          if (val === 0) h = 0;
-          y = baselineY;
+          byYear[yr].fail.push(r);
+          byYear[yr].failTotal += val;
         }
-        r.setAttribute('y', y.toFixed(1));
-        r.setAttribute('height', h.toFixed(1));
       });
+
+      var maxPass = 1, maxFail = 1;
+      Object.keys(byYear).forEach(function (yr) {
+        if (byYear[yr].passTotal > maxPass) maxPass = byYear[yr].passTotal;
+        if (byYear[yr].failTotal > maxFail) maxFail = byYear[yr].failTotal;
+      });
+
+      var propFail = chartW * (maxFail / (maxPass + maxFail));
+      var failW = Math.max(FAIL_MIN_W, propFail);
+      var passW = chartW - failW;
+      var baselineX = ML + failW;
+      var pxPerDollar = passW / maxPass;
+
+      /* Re-stack bars from baseline outward */
+      Object.keys(byYear).forEach(function (yr) {
+        var cursor;
+
+        /* Pass side: extend right */
+        cursor = baselineX;
+        byYear[yr].pass.forEach(function (r) {
+          var val = parseFloat(r.getAttribute('data-' + mode)) || 0;
+          var w = (val > 0) ? val * pxPerDollar : MARKER_W;
+          r.setAttribute('x', cursor.toFixed(1));
+          r.setAttribute('width', w.toFixed(1));
+          cursor += w;
+        });
+
+        /* Fail side: extend left */
+        cursor = baselineX;
+        byYear[yr].fail.forEach(function (r) {
+          var val = parseFloat(r.getAttribute('data-' + mode)) || 0;
+          var w = (val > 0) ? val * pxPerDollar : MARKER_W;
+          cursor -= w;
+          r.setAttribute('x', cursor.toFixed(1));
+          r.setAttribute('width', w.toFixed(1));
+        });
+      });
+
+      /* Update baseline position */
+      var baseline = chart.querySelector('.axis-base');
+      if (baseline) {
+        baseline.setAttribute('x1', baselineX.toFixed(1));
+        baseline.setAttribute('x2', baselineX.toFixed(1));
+      }
+
+      /* Update grid lines on pass side */
+      var gridInterval = 20000000;
+      var gridLines = chart.querySelectorAll('.grid-minor');
+      var gridTexts = chart.querySelectorAll('text.tick-label--minor');
+      var gi = 0;
+      var gv = gridInterval;
+      while (gv <= maxPass && gi < gridLines.length) {
+        var gx = baselineX + gv * pxPerDollar;
+        gridLines[gi].setAttribute('x1', gx.toFixed(1));
+        gridLines[gi].setAttribute('x2', gx.toFixed(1));
+        if (gi < gridTexts.length) {
+          gridTexts[gi].setAttribute('x', gx.toFixed(1));
+          gridTexts[gi].textContent = formatCurrency(gv);
+        }
+        gi++;
+        gv += gridInterval;
+      }
+      /* Hide extra grid lines if scale changed */
+      while (gi < gridLines.length) {
+        gridLines[gi].setAttribute('x1', '-999');
+        gridLines[gi].setAttribute('x2', '-999');
+        if (gi < gridTexts.length) gridTexts[gi].textContent = '';
+        gi++;
+      }
     }
 
     var summaryAmounts = document.querySelectorAll('.vote-year-amount');

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -355,8 +355,8 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
 
   <div class="ballot-timeline">
     <h3>Every Prop 2&frac12; ballot attempt in Marblehead</h3>
-    <p class="ballot-timeline-intro">Each dot is one ballot attempt. Green if the town approved it, red if it was rejected. Debt exclusions sail through almost without exception. Operating overrides are a different story: four successes clustered in the early 2000s, then a 17-year quiet, then three straight losses leading into the FY2027 vote.</p>
-    <svg viewBox="0 0 800 230" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Strip-plot timeline of every Marblehead Prop 2.5 ballot attempt, 1982 to 2026. Operating overrides on top row, debt exclusions on bottom row, dots colored green for approved or red for rejected.">
+    <p class="ballot-timeline-intro">Each dot is one ballot attempt. Filled dots were approved by voters; hollow dots were rejected. Debt exclusions have been approved in 28 of 29 attempts. Operating overrides have been approved 4 of 13 times, with the last approval in 2005.</p>
+    <svg viewBox="0 0 800 230" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Strip-plot timeline of every Marblehead Prop 2.5 ballot attempt, 1982 to 2026. Operating overrides on top row, debt exclusions on bottom row. Filled dots are approved, hollow dots are rejected.">
       <!-- Row labels -->
       <text class="row-label" x="10" y="58">Operating</text>
       <text class="row-label" x="10" y="71">overrides</text>
@@ -377,64 +377,64 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
 
       <!-- FY27 vote upcoming indicator -->
       <line class="future-line" x1="759" y1="40" x2="759" y2="175"/>
-      <text class="annotation annotation--buoy" x="762" y="52">FY2027</text>
-      <text class="annotation annotation--buoy" x="762" y="64">vote</text>
-      <text class="annotation annotation--buoy" x="762" y="76">Jun 9</text>
+      <text class="annotation annotation--upcoming" x="762" y="52">FY2027</text>
+      <text class="annotation annotation--upcoming" x="762" y="64">vote</text>
+      <text class="annotation annotation--upcoming" x="762" y="76">Jun 9</text>
 
       <!-- Operating override dots (13 attempts, chronological) -->
-      <circle class="vote-dot vote-dot--loss" cx="192.4" cy="70" r="6"/>
-      <circle class="vote-dot vote-dot--loss" cx="208.8" cy="70" r="6"/>
-      <circle class="vote-dot vote-dot--loss" cx="211.5" cy="70" r="6"/>
-      <circle class="vote-dot vote-dot--loss" cx="271.2" cy="70" r="6"/>
-      <circle class="vote-dot vote-dot--loss" cx="287.1" cy="70" r="6"/>
-      <circle class="vote-dot vote-dot--loss" cx="350.5" cy="70" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="366.1" cy="70" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="397.5" cy="70" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="413.5" cy="70" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="428.9" cy="70" r="6"/>
-      <circle class="vote-dot vote-dot--loss" cx="523.2" cy="70" r="6"/>
-      <circle class="vote-dot vote-dot--loss" cx="696.6" cy="70" r="6"/>
-      <circle class="vote-dot vote-dot--loss" cx="712.3" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--rejected" cx="192.4" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--rejected" cx="208.8" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--rejected" cx="211.5" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--rejected" cx="271.2" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--rejected" cx="287.1" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--rejected" cx="350.5" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="366.1" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="397.5" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="413.5" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="428.9" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--rejected" cx="523.2" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--rejected" cx="696.6" cy="70" r="6"/>
+      <circle class="vote-dot vote-dot--rejected" cx="712.3" cy="70" r="6"/>
 
       <!-- Annotation: last successful operating override -->
       <line class="grid-line" x1="428.9" y1="80" x2="428.9" y2="100"/>
-      <text class="annotation annotation--sage" x="428.9" y="113" text-anchor="middle">Last operating win</text>
+      <text class="annotation" x="428.9" y="113" text-anchor="middle">Last approved override</text>
       <text class="annotation" x="428.9" y="125" text-anchor="middle">June 2005 &middot; $2.7M</text>
 
       <!-- Debt exclusion dots (29 attempts, chronological) -->
-      <circle class="vote-dot vote-dot--win"  cx="67.3"  cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="160.9" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="188.4" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="192.4" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="223.8" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="255.3" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="271.2" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="287.1" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="302.8" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="318.5" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="334.5" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="350.5" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="366.1" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="373.7" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--loss" cx="382.1" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="413.5" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="428.9" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="460.8" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="476.2" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="523.2" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="539.3" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="555.2" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="586.3" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="601.9" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="633.7" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="649.3" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="680.9" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="696.6" cy="140" r="6"/>
-      <circle class="vote-dot vote-dot--win"  cx="743.3" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="67.3"  cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="160.9" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="188.4" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="192.4" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="223.8" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="255.3" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="271.2" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="287.1" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="302.8" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="318.5" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="334.5" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="350.5" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="366.1" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="373.7" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--rejected" cx="382.1" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="413.5" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="428.9" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="460.8" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="476.2" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="523.2" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="539.3" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="555.2" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="586.3" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="601.9" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="633.7" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="649.3" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="680.9" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="696.6" cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="743.3" cy="140" r="6"/>
 
       <!-- Annotation: only debt exclusion loss -->
       <line class="grid-line" x1="382.1" y1="150" x2="382.1" y2="168"/>
-      <text class="annotation annotation--buoy" x="382.1" y="192" text-anchor="middle">Only debt-exclusion loss</text>
+      <text class="annotation" x="382.1" y="192" text-anchor="middle">Only debt exclusion rejected</text>
       <text class="annotation" x="382.1" y="204" text-anchor="middle">2002 &middot; Tucker's Wharf bonds</text>
 
       <!-- X-axis tick labels -->
@@ -446,8 +446,8 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
       <text class="tick-label" x="752" y="222" text-anchor="middle">2026</text>
     </svg>
     <div class="ballot-timeline-legend">
-      <div class="li"><span class="sw sw--win"></span> Approved at the ballot</div>
-      <div class="li"><span class="sw sw--loss"></span> Rejected at the ballot</div>
+      <div class="li"><span class="sw sw--approved"></span> Approved at the ballot</div>
+      <div class="li"><span class="sw sw--rejected"></span> Rejected at the ballot</div>
       <div class="li">Source: <a href="data/marblehead_prop25_votes.csv">marblehead_prop25_votes.csv</a> (MA DOR Municipal Databank, pulled April 11, 2026)</div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Replaces the unreadable vertical bar chart (69 thin bars crammed into 800px) with a horizontal diverging layout: one row per election year, bars extending right (passed) and left (failed) from a center baseline
- Stacked bar segments within each row, colored by department, solid (override) or hatched (debt exclusion), sorted overrides-first then by amount descending
- Same dollar-per-pixel scale on both sides with a generous minimum width (80px) for the fail side so small fail bars remain visible
- Fixes data-win attribute mismatch: now uses `1`/`0` values matching what the JS toggle expected
- Updated toggle JS to recompute horizontal widths and re-stack bars from baseline when switching between inflation-adjusted and nominal modes
- Updated caption text for horizontal orientation

## Test plan

- [ ] Load the page and verify the chart renders as horizontal rows with year labels on the left
- [ ] Verify the 1999 High School bar ($79.3M) fills the full pass-side width
- [ ] Verify failed votes appear as bars extending left of the center baseline
- [ ] Toggle between "Inflation-adjusted" and "Nominal dollars" and verify bars rescale correctly
- [ ] Verify tooltips appear on hover showing description, year, result, and amount
- [ ] Check mobile responsiveness (chart should scale down cleanly via viewBox)
- [ ] Verify legend and detail table still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)