### PR TITLE
Add collapsible deep-dives to spending, senior relief, and staffing pages

### DIFF
--- a/inside-school-staffing.html
+++ b/inside-school-staffing.html
@@ -133,7 +133,12 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
   </div>
 
   <!-- Section 2: Mandate vs discretionary -->
-  <h2 id="mandate-vs-discretionary">Which positions are legally mandated?</h2>
+  <details class="deep-dive">
+    <summary>
+      <h2 id="mandate-vs-discretionary">Which positions are legally mandated?</h2>
+      <p class="deep-dive-teaser">Roughly 60-65% of positions are driven by federal or state mandates. Here's the breakdown.</p>
+    </summary>
+    <div class="deep-dive-body">
 
   <p>Not all school staff are the same kind of expense. Some positions are required by federal or state law regardless of enrollment. Others are at the district's discretion. The following table classifies the ~58 non-teaching positions added between FY2015 and FY2024 by legal status.</p>
 
@@ -224,8 +229,16 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
     <p><strong>Mandated does not mean beyond scrutiny.</strong> IEPs are developed with district participation. The mandate is to deliver the services in the IEP, but the service delivery model (inclusion vs. substantially separate, in-district vs. out-of-district) is a district decision that affects both staffing levels and cost. Massachusetts is a "maximum feasible benefit" state, meaning IEPs here tend to require more services than in states that follow only the federal floor.</p>
   </div>
 
+    </div>
+  </details>
+
   <!-- Section 3: Peer comparison -->
-  <h2 id="peer-comparison">How Marblehead compares to peers</h2>
+  <details class="deep-dive">
+    <summary>
+      <h2 id="peer-comparison">How Marblehead compares to peers</h2>
+      <p class="deep-dive-teaser">How Marblehead's staffing ratios compare to Melrose, Stoneham, and Swampscott by role.</p>
+    </summary>
+    <div class="deep-dive-body">
 
   <p>The existing <a href="charts/enrollment_vs_staffing.html">enrollment vs. staffing</a> chart compares student-to-teacher ratios across four towns. DESE's staffing database (EPIMS, the Education Personnel Information Management System) allows a broader comparison: all staff, broken out by role.<sup class="cite" data-href="data/dese_peer_staffing_SY2026.csv" data-source="DESE EPIMS SY2025-26 via E2C Hub Socrata API"></sup></p>
 
@@ -397,8 +410,19 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
 
   <p>These are not all discretionary gaps. Some counselor and medical positions are driven by special education caseloads. And some peer districts may be understaffed rather than Marblehead being overstaffed. The comparison shows where Marblehead is an outlier, not where it is necessarily wrong.</p>
 
+    </div>
+  </details>
+
   <!-- Section 4: The FY23 mystery -->
-  <h2 id="the-fy23-mystery">The FY23 data jump</h2>
+  <details class="deep-dive deep-dive--prose">
+    <summary>
+      <h2 id="the-fy23-mystery">The FY23 data jump</h2>
+      <div class="deep-dive-preview">
+        <p>The ACFR shows education FTE jumping from 483 to 537 between FY22 and FY23, an increase of 54 positions in a single year. This jump has been flagged on the enrollment vs. staffing chart as unexplained.</p>
+      </div>
+      <span class="deep-dive-more">Continue reading <span class="arrow">&#x25B8;</span></span>
+    </summary>
+    <div class="deep-dive-body">
 
   <p>The ACFR shows education FTE jumping from 483 to 537 between FY22 and FY23, an increase of 54 positions in a single year. This jump has been flagged on the <a href="charts/enrollment_vs_staffing.html">enrollment vs. staffing</a> chart as unexplained.</p>
 
@@ -415,6 +439,9 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
   <div class="takeaway takeaway--neutral">
     <p><strong>Meanwhile, DESE data shows staffing declining.</strong> Total DESE school staff fell from ~445 (2023) to 430.2 (2025&ndash;26 school year). Licensed teaching positions fell from 263.9 (2016&ndash;17) to 215.4 (proposed 2025&ndash;26), a 19% drop that closely mirrors the 19% enrollment decline. The district has also cut approximately 50 positions over FY25&ndash;FY27 through layoffs, unfilled vacancies, and stipend reductions.<sup class="cite" data-href="https://www.marbleheadindependent.com/concerns-over-staffing-cuts-shape-marblehead-school-budget-hearing/" data-source="Marblehead Independent, 'Concerns over staffing cuts shape budget hearing'"></sup></p>
   </div>
+
+    </div>
+  </details>
 
   <!-- Section 5: Options -->
   <h2 id="options">What are the options?</h2>

--- a/senior-tax-relief.html
+++ b/senior-tax-relief.html
@@ -165,7 +165,12 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     For a qualifying senior, the state Senior Circuit Breaker formula refunds <em>more</em>, not less, as the property tax bill goes up. The override increases the credit for seniors who are not yet at the $2,820 cap.
   </div>
 
-  <h2 data-stance-section="circuit-breaker">1. The state Senior Circuit Breaker</h2>
+  <details class="deep-dive">
+    <summary>
+      <h2 data-stance-section="circuit-breaker" id="circuit-breaker">1. The state Senior Circuit Breaker</h2>
+      <p class="deep-dive-teaser">A refundable state tax credit worth up to $2,820/year. The formula, worked examples, and how Marblehead homes qualify.</p>
+    </summary>
+    <div class="deep-dive-body">
   <p>The Senior Circuit Breaker is a refundable Massachusetts income tax credit claimed on Schedule CB with your state return. "Refundable" means you get a check even if you owe no state income tax. Social Security income does not disqualify you.</p>
 
   <div class="card">
@@ -285,8 +290,15 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     <p>The median Marblehead single-family home is well under the $1,298,000 Circuit Breaker cap. The FY26 average is just under the cap, meaning well over half of single-family homes qualify on the value test. Waterfront and Peach's Point properties are more likely to exceed the cap and be excluded.</p>
     <p class="source">Sources: <a href="https://itemlive.com/2025/12/03/marblehead-fy26-valuations-rise/">Itemlive, "Marblehead valuations go high, taxes go low" (Dec 3, 2025)</a>, from the FY26 tax classification hearing.</p>
   </div>
+    </div>
+  </details>
 
-  <h2 data-stance-section="local-exemption">2. The local exemption Marblehead voted for</h2>
+  <details class="deep-dive">
+    <summary>
+      <h2 data-stance-section="local-exemption" id="local-exemption">2. The local exemption Marblehead voted for</h2>
+      <p class="deep-dive-teaser">The means-tested exemption Marblehead voted for at Town Meeting. What it does, eligibility, and legislative status.</p>
+    </summary>
+    <div class="deep-dive-body">
   <p>At the May 5, 2025 Annual Town Meeting, voters approved <strong>Article 28</strong> by a reported 93% margin.<sup class="cite" data-href="https://itemlive.com/2025/05/11/marblehead-town-meeting-passes-key-articles/" data-source="Itemlive, &quot;Marblehead Town Meeting passes key articles&quot; (May 11 2025), confirms Article 28 passage with ~93% support"></sup> Article 28 is a home rule petition asking the state legislature to authorize Marblehead to create a local means-tested senior exemption on top of the Circuit Breaker. It was filed at the State House as <strong>House Bill H.4225</strong>.<sup class="cite" data-href="https://malegislature.gov/Bills/194/H4225" data-source="MA House Bill H.4225 (Marblehead home rule petition for means-tested senior exemption)"></sup></p>
 
   <div class="card">
@@ -357,8 +369,15 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
   <div class="term">
     <p><strong>Has any other town done this?</strong> Yes. Sudbury was the first in 2006. Concord, Wayland, Lincoln, Boxford, and dozens of other Massachusetts municipalities have since passed similar home rule acts. These are collectively referred to as "Sudbury-style" means-tested senior exemptions. Marblehead is joining an established template, not creating something untested.</p>
   </div>
+    </div>
+  </details>
 
-  <h2 data-stance-section="other-exemptions">3. Other exemptions that already exist</h2>
+  <details class="deep-dive">
+    <summary>
+      <h2 data-stance-section="other-exemptions" id="other-exemptions">3. Other exemptions that already exist</h2>
+      <p class="deep-dive-teaser">Veteran, elderly, surviving spouse, deferral, and work-off programs already available.</p>
+    </summary>
+    <div class="deep-dive-body">
   <p>The following exemptions are available to Marblehead residents today. Veteran exemption amounts were verified from the 2025 Finance Committee Report. The elderly and surviving spouse amounts are set by Town Meeting adoption and need to be confirmed directly with the Assessor's office.</p>
 
   <div class="card">
@@ -414,6 +433,8 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     <p>Marblehead participates in the state Senior Citizen Property Tax Work-Off Program, administered through the <a href="https://marbleheadma.gov/council-aging/pages/property-tax-abatement-program">Marblehead Council on Aging</a>. Qualifying seniors earn a credit against their property tax bill in exchange for volunteer work in town departments such as clerical support, phone coverage, and light office work. Contact the Council on Aging at <strong>781-631-6225</strong> for current slot availability, hourly credit rate, and eligibility requirements.</p>
     <p class="source">Source: <a href="https://marbleheadma.gov/council-aging/pages/property-tax-abatement-program">Marblehead Council on Aging</a>.</p>
   </div>
+    </div>
+  </details>
 
   <h2 data-stance-section="override-connection">4. The override connection</h2>
   <p>For a qualifying Marblehead senior, the combination of the state Circuit Breaker ($2,820 max) and, if H.4225 is enacted, the local Article 28 exemption (Select Board-set cap, first-year funded at $200,000 town-wide from the overlay) can exceed $4,000 per year in combined relief for households at the lower end of the income range. For a household receiving the full state credit and a modest local exemption, that is more than the roughly $1,500 per year an operating override is projected to add to a median bill.</p>

--- a/where-has-the-money-gone.html
+++ b/where-has-the-money-gone.html
@@ -424,7 +424,12 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
   </ol>
 
   <!-- Act 2: Who has been checking the books. Filled by Task 7. -->
-  <h2 id="who-checks-books" data-stance-section="who-checks-books">Who has been checking the books</h2>
+  <details class="deep-dive">
+    <summary>
+      <h2 id="who-checks-books" data-stance-section="who-checks-books">Who has been checking the books</h2>
+      <p class="deep-dive-teaser">Six independent reviewers check the town's finances every year.</p>
+    </summary>
+    <div class="deep-dive-body">
 
   <p>Marblehead's finances have been independently reviewed every year going back to at least 2001. What follows is a plain-language list of the outside reviewers who check the town's books, what each review actually looks at, and where to read their findings.</p>
 
@@ -473,8 +478,16 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
 
   <p>These reviewers do not all agree the town is doing everything right. The Finance Committee has specifically flagged the town's reliance on leftover surplus from prior years to balance the operating budget as a pattern that cannot continue indefinitely, and the next section lists the specific lines that have grown faster than enrollment, inflation, or headcount would explain, including that pattern.</p>
 
+    </div>
+  </details>
+
   <!-- Act 3: What grew faster. Filled by Task 8. -->
-  <h2 id="what-grew-faster" data-stance-section="what-grew-faster">What grew faster</h2>
+  <details class="deep-dive">
+    <summary>
+      <h2 id="what-grew-faster" data-stance-section="what-grew-faster">What grew faster</h2>
+      <p class="deep-dive-teaser">Four specific budget lines grew faster than enrollment, inflation, or headcount would explain.</p>
+    </summary>
+    <div class="deep-dive-body">
 
   <p>Four specific lines in the town's budget have grown faster than enrollment, inflation, or headcount would explain. Each is documented below with its primary sources.</p>
 
@@ -504,6 +517,9 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
     <p>Marblehead has used "free cash" (the state's term for prior-year surplus certified each fall by the Department of Revenue) to balance its operating budget for several years in a row. At Town Meeting, voters appropriated $7,000,000 of free cash into the FY2026 operating budget, up from $5,500,000 in FY2025 and $10,200,000 in FY2023. The Finance Committee's 2025 annual report stated that "the Town continues to use a significant portion of available Free Cash to balance the budget while upholding reserves equivalent to only 2.5 percent of the operating budget. This amount falls short of the state's recommended range of 5 to 10 percent." The 2022 Finance Committee report described the town's situation as a "structural budget challenge" caused by "recurring costs structurally outpacing recurring revenues." Free cash is certified annually from the prior year's unspent surplus; the amount available in any given year depends on the prior year's results.</p>
     <p class="source">Source: Finance Committee annual reports for 2025 (the free cash warning quoted above) and 2022 (the "structural budget challenge" framing); Town Meeting approved free cash appropriations for FY2023 (Article 29, $10.2 million), FY2025 (Article 19, $5.5 million), and FY2026 (Article 18, $7.0 million); and the 2026 State of the Town presentation for the FY2025 through FY2027 projected free cash usage.</p>
   </div>
+
+    </div>
+  </details>
 
   <!-- Close. Filled by Task 9. -->
   <h2 id="means-for-override" data-stance-section="means-for-override">What this means for the override</h2>


### PR DESCRIPTION
## Summary

Wave 2 of progressive disclosure rollout. Applies the same collapsible deep-dive patterns from #180 to the next three densest pages:

- **where-has-the-money-gone.html** (2 sections): "Who checks the books" and "What grew faster" collapse. The stacked spending chart/table and closing "What this means" stay visible.
- **senior-tax-relief.html** (3 sections): Circuit Breaker formula, local exemption (Article 28), and other existing exemptions collapse. The TL;DR, override connection, and "how to get this" action steps stay visible.
- **inside-school-staffing.html** (3 sections): Mandate table, peer comparison, and FY23 data jump collapse. The role breakdown chart and options discussion stay visible.

No CSS or JS changes -- uses the infrastructure from #180.

## Test plan

- [ ] Spending page: chart and "What this means" visible without expanding; "Who checks" and "What grew faster" collapse/expand
- [ ] Senior relief: TL;DR + override connection visible; three program sections collapse/expand
- [ ] Staffing: bar chart visible; mandate table, peer comparison, FY23 jump collapse/expand
- [ ] "Expand all sections" toggle appears on all three pages
- [ ] Page TOC links (spending, staffing) scroll to correct section and auto-open
- [ ] citations.js still generates Sources sections correctly
- [ ] Mobile viewport: tappable, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)