### PR TITLE
Add page TOCs to 5 pages and analytics on deep-dive expansions

### DIFF
--- a/assets/deep-dive.js
+++ b/assets/deep-dive.js
@@ -88,6 +88,20 @@
     }
   });
 
+  // --- Analytics ---
+  dives.forEach(function (el) {
+    el.addEventListener('toggle', function () {
+      if (!el.open) return;
+      if (typeof posthog !== 'undefined') {
+        var heading = el.querySelector('summary h2');
+        posthog.capture('deep_dive_expanded', {
+          section: heading ? heading.textContent.trim() : 'unknown',
+          page: window.location.pathname
+        });
+      }
+    });
+  });
+
   // --- Expand all / Collapse all ---
   if (dives.length >= 3) {
     var btn = document.createElement('button');

--- a/no-override-budget.html
+++ b/no-override-budget.html
@@ -10,7 +10,16 @@ og_url: https://marbleheaddata.org/no-override-budget.html
 
   <p>The town published a <a href="https://marbleheadma.gov/wp-content/uploads/2026/04/PROPOSED-FY27-BALANCED-BUDGET-WITH-NO-OVERRIDE.pdf">FY27 Proposed Balanced Budget With No Override</a> in April 2026. It balances using $5M in free cash (unspent surplus certified by the state), staffing reductions across town and school departments, and the elimination of the town's <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr> (retiree health insurance) trust contribution. This page lists the specific line-item changes from that document.</p>
 
-  <h2 data-stance-section="town-side-reductions">Town-side reductions</h2>
+  <nav class="page-toc" aria-label="On this page">
+    <span class="page-toc-label">On this page</span>
+    <a href="#town-side-reductions">Town-side cuts</a>
+    <a href="#school-side-reductions">School-side cuts</a>
+    <a href="#fy27-gap-calculated">How the gap is calculated</a>
+    <a href="#what-stays-or-grows">What stays or grows</a>
+    <a href="#what-other-towns-did">What other towns did</a>
+  </nav>
+
+  <h2 data-stance-section="town-side-reductions" id="town-side-reductions">Town-side reductions</h2>
 
   <div class="card">
     <h3>22 full-time town positions removed</h3>
@@ -83,7 +92,7 @@ og_url: https://marbleheaddata.org/no-override-budget.html
 
   <p>The library reduction (-43%) would "significantly reduce services in terms of days that the library can be open," per the <a href="https://www.marbleheadindependent.com/marblehead-advances-122-8m-budget-built-on-cuts-defers-override-decisions/">Marblehead Independent</a>.<sup class="cite" data-href="https://www.marbleheadindependent.com/marblehead-advances-122-8m-budget-built-on-cuts-defers-override-decisions/" data-source="Marblehead Independent, &quot;Marblehead advances $122.8M budget built on cuts&quot;"></sup> The library was renovated with a separate $8.5M debt exclusion (voter-approved borrowing outside the levy cap) approved in 2021.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.debtexclusionvotes" data-source="MA DOR, Proposition 2½ Debt Exclusion Votes (Marblehead 2021 Abbot Library debt exclusion, $8.5M)"></sup></p>
 
-  <h2 data-stance-section="school-side-reductions">School-side reductions</h2>
+  <h2 data-stance-section="school-side-reductions" id="school-side-reductions">School-side reductions</h2>
 
   <div class="card">
     <h3>Schools: $1.5M appropriation cut, absorbed by the out-of-district special education line</h3>
@@ -173,7 +182,7 @@ og_url: https://marbleheaddata.org/no-override-budget.html
     <p class="waterfall-footnote"><strong>On debt service.</strong> Voter-approved debt exclusions for projects such as the Abbot Library renovation and the Mary Alley Building HVAC grow $1.98M for FY27, but they are paid from a separate debt exclusion levy surcharge that sits outside the operating budget. They do not contribute to the $8.47M operating gap. Residents pay the debt service either way via the debt exclusion, and will pay the operating gap either way: through spending cuts if no override passes, or through the operating override if one does.</p>
   </div>
 
-  <h2 data-stance-section="what-stays-or-grows">What stays the same or goes up</h2>
+  <h2 data-stance-section="what-stays-or-grows" id="what-stays-or-grows">What stays the same or goes up</h2>
 
   <div class="card">
     <h3>Costs that increase regardless of the override outcome</h3>
@@ -206,7 +215,7 @@ og_url: https://marbleheaddata.org/no-override-budget.html
 
   <p>Health insurance, pensions, and contracted salary increases continue to grow regardless of the override outcome. The reductions above are what the town finance team determined would be required to balance the budget around these fixed-cost increases. Excluded debt service, shown separately in the list, also grows each year but is paid through a different mechanism and is not part of the $8.47M operating gap.</p>
 
-  <h2 data-stance-section="what-other-towns-did">What other MA towns did after similar votes</h2>
+  <h2 data-stance-section="what-other-towns-did" id="what-other-towns-did">What other MA towns did after similar votes</h2>
 
   <p>Melrose (population ~28,000) rejected a $7.7M override in June 2024 and reduced 61.4 FTEs over two years across teachers, library hours, senior van drivers, and other departments. Elementary class sizes were proposed up to 32 students. The middle and high school shared one principal. Melrose returned to the ballot in November 2025 and passed a $13.5M override, 75% larger than the original ask.<sup class="cite" data-href="data/case_studies.md" data-source="case_studies.md: Melrose $7.7M failed June 2024, staffing and service cuts, $13.5M passed November 2025 (+75%)"></sup></p>
 

--- a/senior-tax-relief.html
+++ b/senior-tax-relief.html
@@ -165,6 +165,15 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     For a qualifying senior, the state Senior Circuit Breaker formula refunds <em>more</em>, not less, as the property tax bill goes up. The override increases the credit for seniors who are not yet at the $2,820 cap.
   </div>
 
+  <nav class="page-toc" aria-label="On this page">
+    <span class="page-toc-label">On this page</span>
+    <a href="#circuit-breaker">Circuit Breaker</a>
+    <a href="#local-exemption">Local exemption (Article 28)</a>
+    <a href="#other-exemptions">Other exemptions</a>
+    <a href="#override-connection">Override connection</a>
+    <a href="#how-to-apply">How to apply</a>
+  </nav>
+
   <details class="deep-dive">
     <summary>
       <h2 data-stance-section="circuit-breaker" id="circuit-breaker">1. The state Senior Circuit Breaker</h2>
@@ -436,7 +445,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     </div>
   </details>
 
-  <h2 data-stance-section="override-connection">4. The override connection</h2>
+  <h2 data-stance-section="override-connection" id="override-connection">4. The override connection</h2>
   <p>For a qualifying Marblehead senior, the combination of the state Circuit Breaker ($2,820 max) and, if H.4225 is enacted, the local Article 28 exemption (Select Board-set cap, first-year funded at $200,000 town-wide from the overlay) can exceed $4,000 per year in combined relief for households at the lower end of the income range. For a household receiving the full state credit and a modest local exemption, that is more than the roughly $1,500 per year an operating override is projected to add to a median bill.</p>
 
   <p>Two points worth holding in mind when reading the override debate:</p>
@@ -451,7 +460,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     <p>The local exemption, if enacted, is paid for out of the town's tax overlay, the same pool that funds abatements and normal statutory exemptions. It does not reduce the amount available for schools, public safety, or other services. The tradeoff people sometimes assume (more senior relief means fewer services) does not apply here.</p>
   </div>
 
-  <h2>5. How to actually get this</h2>
+  <h2 id="how-to-apply">5. How to actually get this</h2>
 
   <div class="card">
     <h3>Circuit Breaker</h3>

--- a/the-debate.html
+++ b/the-debate.html
@@ -293,7 +293,18 @@ community_pulse: off-sections
     </div>
   </div>
 
-  <h2 class="tension-heading">1. Where does the cost pressure come from?</h2>
+  <nav class="page-toc" aria-label="On this page">
+    <span class="page-toc-label">On this page</span>
+    <a href="#tension-1">1. Cost pressure</a>
+    <a href="#tension-2">2. Reductions</a>
+    <a href="#tension-3">3. One-time or annual?</a>
+    <a href="#tension-4">4. Alternatives</a>
+    <a href="#tension-5">5. Trust</a>
+    <a href="#tension-6">6. School staffing</a>
+    <a href="#side-by-side">Side by side</a>
+  </nav>
+
+  <h2 class="tension-heading" id="tension-1">1. Where does the cost pressure come from?</h2>
   <p class="tension-framing">Both sides agree costs are rising faster than revenue. They disagree on whether the town chose those costs or they happened to it.</p>
 
   <div class="perspective perspective--for">
@@ -310,7 +321,7 @@ community_pulse: off-sections
     <p><strong>Where they actually disagree:</strong> whether a cost the town could in principle renegotiate counts as "external" depends on whether you are looking at a 12-week budget cycle or a 5-year planning horizon. Both sides are answering different versions of the question. Most of the items the against side names (the 83/17 split, the 20-hour benefits threshold, contract provisions) are subject to collective bargaining under MGL c. 150E and can only be renegotiated at contract renewal, typically every 2&ndash;3 years. Long-horizon controllable; short-horizon fixed.</p>
   </div>
 
-  <h2 class="tension-heading">2. Are the proposed reductions damage or discipline?</h2>
+  <h2 class="tension-heading" id="tension-2">2. Are the proposed reductions damage or discipline?</h2>
   <p class="tension-framing">The no-override budget is published. Both sides have read it and reached opposite conclusions.</p>
   <a class="btn-link" href="no-override-budget.html">What's in the no-override budget</a>
 
@@ -328,7 +339,7 @@ community_pulse: off-sections
     <p><strong>Where they actually disagree:</strong> whether FY26 is the correct baseline against which to measure cuts. Those for the override treat FY26 as the level of service residents have chosen and should maintain. Those against the override treat FY26 as the peak of a trajectory that should have been corrected earlier.</p>
   </div>
 
-  <h2 class="tension-heading">3. Is this a one-time reset or the start of annual asks?</h2>
+  <h2 class="tension-heading" id="tension-3">3. Is this a one-time reset or the start of annual asks?</h2>
   <p class="tension-framing">If the override passes, does the problem go away for years, or does the same pressure rebuild immediately?</p>
 
   <div class="perspective perspective--for">
@@ -345,7 +356,7 @@ community_pulse: off-sections
     <p><strong>Where they actually disagree:</strong> whether "one-time reset" means "no override next year" or "no override for the foreseeable future." Both sides agree costs will keep rising; they disagree on whether the override's capacity absorbs that rise or just delays its arrival.</p>
   </div>
 
-  <h2 class="tension-heading">4. Do meaningful alternatives exist?</h2>
+  <h2 class="tension-heading" id="tension-4">4. Do meaningful alternatives exist?</h2>
   <p class="tension-framing">The debate turns on whether the town has real options other than override versus reductions. The structural data underneath this question is covered separately.</p>
   <a class="btn-link" href="why-not-elsewhere.html">Why some MA towns run overrides and others don't</a>
 
@@ -380,7 +391,7 @@ community_pulse: off-sections
     <p><strong>Where they actually disagree:</strong> whether past behavior plus transparent process is sufficient evidence that future spending will be responsible. Those for the override read the FinCom arc as evidence of disciplined governance. Those against the override read the same arc as the pattern the override perpetuates rather than interrupts.</p>
   </div>
 
-  <h2 class="tension-heading">6. Has school staffing kept pace with enrollment?</h2>
+  <h2 class="tension-heading" id="tension-6">6. Has school staffing kept pace with enrollment?</h2>
   <p class="tension-framing">Enrollment has fallen substantially. Classroom teacher staffing has fallen more slowly. Total school headcount has grown. Both sides draw on the same data and reach different conclusions about what it means.</p>
 
   <div class="perspective perspective--for">
@@ -397,7 +408,7 @@ community_pulse: off-sections
     <p><strong>Where they actually disagree:</strong> which time horizon frames the question. The ten-year picture (FY15&ndash;FY24) shows classroom teacher FTE falling and total school FTE rising together, with enrollment falling faster; the twenty-plus-year picture (FY01&ndash;FY24) shows larger divergence between total headcount and students. The FY23 jump from 483 to 537 education FTE, flagged as a caveat on the <a href="charts/enrollment_vs_staffing.html">enrollment chart</a>, is a known data discontinuity (possibly <abbr class="g" title="Elementary and Secondary School Emergency Relief fund">ESSER</abbr>-funded positions or a reporting-methodology change) and not a single policy choice. Beyond that, the question is values: at what student-to-adult ratio does Marblehead want to run its schools, and whose job is it to answer. For a role-by-role breakdown of what those positions are and which are legally mandated, see <a href="inside-school-staffing.html">Inside school staffing</a>.</p>
   </div>
 
-  <h2 class="tension-heading">The cruxes, side by side</h2>
+  <h2 class="tension-heading" id="side-by-side">The cruxes, side by side</h2>
   <p>The six dividing lines above are not about different facts. Both sides read the same facts: the same FY27 deficit, the same health insurance trajectory, the same Finance Committee letters, the same no-override budget, the same enrollment charts. They reach different conclusions because they apply different frames. Each one's crux, compressed into a phrase:</p>
 
   <div class="crux-map">

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -55,7 +55,16 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
     <footer>Thatcher Kezer, Town Administrator, and Aleesha Benjamin, Finance Director, Town of Marblehead. <a href="https://marbleheadma.gov/wp-content/uploads/2026/02/2026-State-of-the-Town-Presenation-Final.pdf">2026 State of the Town presentation</a>, slide 9, January 28, 2026.</footer>
   </blockquote>
 
-  <h2 data-stance-section="three-tiers">The Three Tiers</h2>
+  <nav class="page-toc" aria-label="On this page">
+    <span class="page-toc-label">On this page</span>
+    <a href="#three-tiers">The three tiers</a>
+    <a href="#how-youll-vote">How you'll vote</a>
+    <a href="#what-it-costs">What it costs</a>
+    <a href="#history">History</a>
+    <a href="#key-terms">Key terms</a>
+  </nav>
+
+  <h2 data-stance-section="three-tiers" id="three-tiers">The Three Tiers</h2>
   <p>The tiers are nested. Each higher tier contains everything in the lower tiers, so the highest tier that gets a majority sets the override amount.</p>
 
   <div class="tier-chart">
@@ -283,7 +292,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
     </div>
   </details>
 
-  <h2 data-stance-section="what-it-costs">What It Costs</h2>
+  <h2 data-stance-section="what-it-costs" id="what-it-costs">What It Costs</h2>
   <p>The override phases in over three years (FY27 to FY29). Year 1 draws only a fraction of the full amount; the full override is active only in Year 3:</p>
 
   <div class="phase-chart">

--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -184,7 +184,17 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
   </ul>
 </div>
 
-<h2>Pick the goal that matches your view</h2>
+<nav class="page-toc" aria-label="On this page">
+  <span class="page-toc-label">On this page</span>
+  <a href="#pick-your-goal">Pick your goal</a>
+  <a href="#better-oversight">Better oversight</a>
+  <a href="#who-decides-what">Who decides what</a>
+  <a href="#how-to-reach-them">How to reach them</a>
+  <a href="#town-meeting">Town Meeting</a>
+  <a href="#petitioning-an-article">Petitioning an article</a>
+</nav>
+
+<h2 id="pick-your-goal">Pick the goal that matches your view</h2>
 <p>Four reader stances, four different next actions. If you recognize your view here, the matching card tells you the concrete lever.</p>
 
 <div class="goal-cards">
@@ -209,7 +219,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
   </div>
 </div>
 
-<h2>Better oversight, regardless of the vote</h2>
+<h2 id="better-oversight">Better oversight, regardless of the vote</h2>
 <p>Budget rigor and clear explanations are not contested goals. The question is how you get there. The town already has real oversight in place, and there are two concrete reform ideas with precedent elsewhere.</p>
 
 <div class="card">
@@ -231,7 +241,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
 
 <p>Both of these are slow. Neither changes this year's vote. Both have concrete precedent in Massachusetts towns of similar or smaller size.</p>
 
-<h2>Who decides what</h2>
+<h2 id="who-decides-what">Who decides what</h2>
 <p>Most civic decisions in Marblehead are distributed across several bodies, each with different authority. Knowing which body handles which decision is the difference between writing the right email and writing to no one.</p>
 
 <div class="decide-cards">
@@ -341,7 +351,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
   <p style="margin-top:10px;"><strong>Some things that feel local are actually state decisions.</strong> Health insurance rates, pension contribution formulas, and most forms of state aid are set at the state level. A resident pushing to change them talks to their state legislator, not the Select Board. This is not a dodge; it is where the legal authority sits.</p>
 </div>
 
-<h2>How to reach each body</h2>
+<h2 id="how-to-reach-them">How to reach each body</h2>
 <p>All of the bodies below are public. Most meetings are hybrid (in-person plus Zoom). Agendas are posted on the <a href="https://marbleheadma.gov/">town calendar</a> at least 48 hours before each meeting.</p>
 
 <div class="body-cards">
@@ -422,7 +432,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
   </div>
 </div>
 
-<h2>What to expect at Town Meeting</h2>
+<h2 id="town-meeting">What to expect at Town Meeting</h2>
 
 <div class="card">
   <h3>The basics</h3>
@@ -450,7 +460,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
 
 <p>Town Meeting is the only place residents vote directly on the town budget and on warrant articles. Every registered voter in the room has the same vote as anyone else.</p>
 
-<h2>Petitioning a warrant article</h2>
+<h2 id="petitioning-an-article">Petitioning a warrant article</h2>
 
 <div class="card">
   <p>To place an article on the warrant for Annual Town Meeting, gather signatures from <strong>10 registered Marblehead voters</strong> and submit the petition to the Select Board at least <strong>60 days before the meeting</strong>. For a Special Town Meeting, the threshold is 100 signatures. The Town Clerk's office provides the petition form and can answer procedural questions about filing requirements.</p>


### PR DESCRIPTION
## Summary

- **Page TOCs** added to the 5 content pages that lacked them: what-is-the-override, senior-tax-relief, the-debate, what-you-can-do, no-override-budget. Uses the same `<nav class="page-toc">` pattern already on 5 other pages. Added `id` attributes to headings that lacked them.
- **Analytics**: deep-dive.js now fires a `deep_dive_expanded` PostHog event when a user opens a collapsible section, with the section heading text and page path. Works regardless of reduced-motion preference.

## Test plan

- [ ] TOC appears on all 5 new pages
- [ ] TOC links scroll to correct sections (including sections inside collapsed deep-dives on override + senior relief pages)
- [ ] PostHog event fires on section expand (check browser console or PostHog dashboard)
- [ ] Existing TOCs on other pages unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)