### PR TITLE
Replace hatch patterns with opacity, fix dark-mode dot plot

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1360,27 +1360,13 @@ details.glossary .glossary-body p:last-child { margin-bottom: 0; }
 .bar-solid-brass { fill: var(--c-brass); }
 .bar-solid-plum  { fill: var(--c-plum); }
 
-/* SVG bar fills (hatched = debt exclusion) */
-.bar-hatch-teal  { fill: url(#hatch-teal); }
-.bar-hatch-navy  { fill: url(#hatch-navy); }
-.bar-hatch-sage  { fill: url(#hatch-sage); }
-.bar-hatch-buoy  { fill: url(#hatch-buoy); }
-.bar-hatch-brass { fill: url(#hatch-brass); }
-.bar-hatch-plum  { fill: url(#hatch-plum); }
-
-/* Hatch pattern elements */
-.hatch-bg-teal  { fill: var(--surface); }
-.hatch-bg-navy  { fill: var(--surface); }
-.hatch-bg-sage  { fill: var(--surface); }
-.hatch-bg-buoy  { fill: var(--surface); }
-.hatch-bg-brass { fill: var(--surface); }
-.hatch-bg-plum  { fill: var(--surface); }
-.hatch-line-teal  { stroke: var(--c-teal); }
-.hatch-line-navy  { stroke: var(--c-navy); }
-.hatch-line-sage  { stroke: var(--c-sage); }
-.hatch-line-buoy  { stroke: var(--c-buoy); }
-.hatch-line-brass { stroke: var(--c-brass); }
-.hatch-line-plum  { stroke: var(--c-plum); }
+/* SVG bar fills (translucent = debt exclusion) */
+.bar-hatch-teal  { fill: var(--c-teal);  opacity: 0.4; }
+.bar-hatch-navy  { fill: var(--c-navy);  opacity: 0.4; }
+.bar-hatch-sage  { fill: var(--c-sage);  opacity: 0.4; }
+.bar-hatch-buoy  { fill: var(--c-buoy);  opacity: 0.4; }
+.bar-hatch-brass { fill: var(--c-brass); opacity: 0.4; }
+.bar-hatch-plum  { fill: var(--c-plum);  opacity: 0.4; }
 
 /* Legend additions for override vs exclusion */
 .legend-row {
@@ -1390,17 +1376,11 @@ details.glossary .glossary-body p:last-child { margin-bottom: 0; }
   margin-bottom: 4px;
 }
 .legend-swatch--solid {
-  background: var(--text-mid);
+  background: var(--text-muted);
 }
 .legend-swatch--hatch {
-  background: repeating-linear-gradient(
-    45deg,
-    var(--surface),
-    var(--surface) 1px,
-    var(--text-mid) 1px,
-    var(--text-mid) 2.5px
-  );
-  border: 1px solid var(--text-mid);
+  background: var(--text-muted);
+  opacity: 0.4;
 }
 
 /* Year-grouped detail table */
@@ -2010,7 +1990,7 @@ button.ballot-oval[aria-pressed="true"] .ballot-oval-fill ellipse {
 }
 .ballot-timeline .annotation {
   font-size: 10px;
-  fill: var(--text-mid);
+  fill: var(--text-muted);
 }
 .ballot-timeline .annotation--upcoming {
   fill: var(--c-buoy);

--- a/data/build_voting_record.py
+++ b/data/build_voting_record.py
@@ -281,20 +281,7 @@ def build_chart(rows):
     # ------------------------------------------------------------------
     parts = []
 
-    # -- 5a. defs: hatch patterns --
-    defs_patterns = []
-    for dept, color_token in DEPT_COLOR.items():
-        pid = f"hatch-{color_token}"
-        defs_patterns.append(
-            f'    <pattern id="{pid}" patternUnits="userSpaceOnUse" '
-            f'width="4" height="4" patternTransform="rotate(45)">\n'
-            f'      <rect width="2" height="4" class="hatch-stripe hatch-stripe--{color_token}"/>\n'
-            f'    </pattern>'
-        )
-
-    parts.append('<defs>')
-    parts.extend(defs_patterns)
-    parts.append('</defs>')
+    # -- 5a. No defs needed: debt exclusion bars use opacity via CSS --
 
     # -- 5b. "Failed" / "Passed" header labels --
     parts.append(
@@ -424,7 +411,7 @@ def build_chart(rows):
         f'votes from {min_yr} to {max_yr}. '
         f'Bars extending right of the center line are passed questions; '
         f'bars extending left are failed. '
-        f'Solid bars are overrides; hatched bars are debt exclusions. '
+        f'Solid bars are overrides; translucent bars are debt exclusions. '
         f'Bar width represents the inflation-adjusted dollar amount.">\n'
         f'{inner}\n'
         f'</svg>'

--- a/marblehead-voting-record.html
+++ b/marblehead-voting-record.html
@@ -45,27 +45,8 @@ og_url: https://marbleheaddata.org/marblehead-voting-record.html
 </div>
 
 <div class="chart-wrap">
-<svg class="chart" viewBox="0 0 880 632" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Horizontal diverging bar chart of Marblehead Proposition 2½ votes from 1982 to 2025. Bars extending right of the center line are passed questions; bars extending left are failed. Solid bars are overrides; hatched bars are debt exclusions. Bar width represents the inflation-adjusted dollar amount.">
-<defs>
-    <pattern id="hatch-teal" patternUnits="userSpaceOnUse" width="4" height="4" patternTransform="rotate(45)">
-      <rect width="2" height="4" class="hatch-stripe hatch-stripe--teal"/>
-    </pattern>
-    <pattern id="hatch-navy" patternUnits="userSpaceOnUse" width="4" height="4" patternTransform="rotate(45)">
-      <rect width="2" height="4" class="hatch-stripe hatch-stripe--navy"/>
-    </pattern>
-    <pattern id="hatch-sage" patternUnits="userSpaceOnUse" width="4" height="4" patternTransform="rotate(45)">
-      <rect width="2" height="4" class="hatch-stripe hatch-stripe--sage"/>
-    </pattern>
-    <pattern id="hatch-buoy" patternUnits="userSpaceOnUse" width="4" height="4" patternTransform="rotate(45)">
-      <rect width="2" height="4" class="hatch-stripe hatch-stripe--buoy"/>
-    </pattern>
-    <pattern id="hatch-brass" patternUnits="userSpaceOnUse" width="4" height="4" patternTransform="rotate(45)">
-      <rect width="2" height="4" class="hatch-stripe hatch-stripe--brass"/>
-    </pattern>
-    <pattern id="hatch-plum" patternUnits="userSpaceOnUse" width="4" height="4" patternTransform="rotate(45)">
-      <rect width="2" height="4" class="hatch-stripe hatch-stripe--plum"/>
-    </pattern>
-</defs>
+<svg class="chart" viewBox="0 0 880 632" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Horizontal diverging bar chart of Marblehead Proposition 2½ votes from 1982 to 2025. Bars extending right of the center line are passed questions; bars extending left are failed. Solid bars are overrides; translucent bars are debt exclusions. Bar width represents the inflation-adjusted dollar amount.">
+<!-- No defs needed: debt exclusion bars use opacity instead of hatch patterns -->
 <text class="tick-label" x="57" y="16" text-anchor="start" font-size="9">Failed</text>
 <text class="tick-label" x="863" y="16" text-anchor="end" font-size="9">Passed</text>
 <line class="grid-minor" x1="319.1" y1="22" x2="319.1" y2="622"/>
@@ -192,7 +173,7 @@ og_url: https://marbleheaddata.org/marblehead-voting-record.html
   </div>
 </div>
 
-<p class="caption">Each bar segment is one ballot question. Bars extending right of the center line passed; bars extending left failed. Widths show inflation-adjusted (2024 dollar) amounts. Solid bars are operating overrides; hatched bars are debt exclusions. CPI-U adjustment uses Bureau of Labor Statistics annual averages (series CUUR0000SA0), base year 2024.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride" data-source="MA DOR, Proposition 2½ Override &amp; Underride Votes (Marblehead)"></sup></p>
+<p class="caption">Each bar segment is one ballot question. Bars extending right of the center line passed; bars extending left failed. Widths show inflation-adjusted (2024 dollar) amounts. Solid bars are operating overrides; translucent bars are debt exclusions. CPI-U adjustment uses Bureau of Labor Statistics annual averages (series CUUR0000SA0), base year 2024.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride" data-source="MA DOR, Proposition 2½ Override &amp; Underride Votes (Marblehead)"></sup></p>
 
 <h2>Detail by year</h2>
 <p>Click any year to see the individual ballot questions, vote counts, and sources.</p>

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -417,7 +417,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
       <text class="annotation" x="428.9" y="125" text-anchor="middle">June 2005 &middot; $2.7M</text>
 
       <!-- Debt exclusion dots (29 attempts, chronological) -->
-      <circle class="vote-dot vote-dot--approved"  cx="67.3"  cy="140" r="6"/>
+      <circle class="vote-dot vote-dot--approved"  cx="107.3"  cy="140" r="6"/>
       <circle class="vote-dot vote-dot--approved"  cx="160.9" cy="140" r="6"/>
       <circle class="vote-dot vote-dot--approved"  cx="188.4" cy="140" r="6"/>
       <circle class="vote-dot vote-dot--approved"  cx="192.4" cy="140" r="6"/>
@@ -453,7 +453,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
       <text class="annotation" x="382.1" y="204" text-anchor="middle">2002 &middot; Tucker's Wharf bonds</text>
 
       <!-- X-axis tick labels -->
-      <text class="tick-label" x="67"  y="222" text-anchor="middle">1982</text>
+      <text class="tick-label" x="107"  y="222" text-anchor="middle">1982</text>
       <text class="tick-label" x="186" y="222" text-anchor="middle">1990</text>
       <text class="tick-label" x="343" y="222" text-anchor="middle">2000</text>
       <text class="tick-label" x="500" y="222" text-anchor="middle">2010</text>


### PR DESCRIPTION
## Summary
- Debt exclusion bars use 40% opacity instead of stripe/hatch patterns (cleaner in both modes)
- Fix dot plot annotation text: was using undefined `var(--text-mid)` falling back to black in dark mode
- Shift 1982 sewer dot right so it doesn't overlap "exclusions" label
- Update legend swatches to match

## Test plan
- [ ] Voting record chart: debt exclusion bars are translucent, overrides are solid
- [ ] Dot plot annotations readable in dark mode
- [ ] 1982 dot no longer overlaps label text
- [ ] Legend swatches match bar styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)