### PR TITLE
Add PostHog events: TOC clicks, calculator engagement, scroll depth

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,6 +18,7 @@
 <script defer src="{{ '/' | relative_url }}assets/citations.js"></script>
 <script defer src="{{ '/' | relative_url }}assets/ballot.js"></script>
 <script defer src="{{ '/' | relative_url }}assets/deep-dive.js"></script>
+<script defer src="{{ '/' | relative_url }}assets/analytics.js"></script>
 {% unless page.community_pulse == "off-sections" %}
 <link rel="stylesheet" href="{{ '/' | relative_url }}assets/community-pulse/widget.css">
 <script type="module" src="{{ '/' | relative_url }}assets/community-pulse/widget.js" data-api-base="https://marblehead-community-pulse.agbaber.workers.dev"></script>

--- a/assets/analytics.js
+++ b/assets/analytics.js
@@ -1,0 +1,65 @@
+// Lightweight PostHog event tracking for marbleheaddata.org.
+// Tracks: TOC clicks, calculator engagement (boolean only), scroll depth.
+// No personal data or input values are captured.
+(function () {
+  if (typeof posthog === 'undefined') return;
+
+  var page = window.location.pathname;
+
+  // --- TOC link clicks ---
+  document.addEventListener('click', function (e) {
+    var link = e.target.closest('.page-toc a');
+    if (!link) return;
+    posthog.capture('toc_click', {
+      section: link.textContent.trim(),
+      href: link.getAttribute('href'),
+      page: page
+    });
+  });
+
+  // --- Calculator engagement (fire once, no values) ---
+  var calcFired = false;
+  var calcIds = ['trash-assessed', 'assessed'];
+  calcIds.forEach(function (id) {
+    var input = document.getElementById(id);
+    if (!input) return;
+    var handler = function () {
+      if (calcFired) return;
+      calcFired = true;
+      posthog.capture('calculator_used', {
+        calculator: id === 'trash-assessed' ? 'q2_trash' : 'override',
+        page: page
+      });
+    };
+    input.addEventListener('focus', handler);
+    input.addEventListener('input', handler);
+  });
+
+  // --- Scroll depth milestones ---
+  var milestones = [25, 50, 75, 100];
+  var fired = {};
+  var ticking = false;
+
+  function checkScroll() {
+    var scrollTop = window.pageYOffset;
+    var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+    if (docHeight <= 0) return;
+    var percent = Math.round((scrollTop / docHeight) * 100);
+    milestones.forEach(function (m) {
+      if (!fired[m] && percent >= m) {
+        fired[m] = true;
+        posthog.capture('scroll_milestone', { depth: m, page: page });
+      }
+    });
+  }
+
+  window.addEventListener('scroll', function () {
+    if (!ticking) {
+      ticking = true;
+      requestAnimationFrame(function () {
+        checkScroll();
+        ticking = false;
+      });
+    }
+  }, { passive: true });
+})();


### PR DESCRIPTION
## Summary

New `assets/analytics.js` (65 lines) adds three aggregate behavioral events to PostHog. No personal data or input values are captured.

- **`toc_click`** -- which TOC sections people jump to (section name, href, page)
- **`calculator_used`** -- whether a user engaged with a calculator at all (fires once per page load on first focus/input; captures calculator name only, NOT the assessed value or any other input)
- **`scroll_milestone`** -- 25/50/75/100% scroll depth (fires each threshold once per page load)

These join the existing `deep_dive_expanded` event (in deep-dive.js) to give a picture of how people navigate the site without tracking individual behavior.

## Privacy

- Calculator tracking is a boolean signal ("someone used the calculator"), not input telemetry
- Scroll depth is aggregate page-level, not tied to specific content sections
- No cookies, no user identification beyond PostHog's anonymous session
- Consistent with the privacy policy at /privacy.html

## Test plan

- [ ] Open question-2-trash.html, click a TOC link -- verify `toc_click` event in PostHog (or browser console)
- [ ] Click into the Q2 trash calculator input -- verify single `calculator_used` event fires
- [ ] Scroll to bottom of a long page -- verify `scroll_milestone` events at 25/50/75/100
- [ ] Verify events do NOT fire if PostHog is blocked (e.g. by an ad blocker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)