### PR TITLE
Fix orphaned pages and dead-end navigation

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,7 @@
 <footer class="footer">
   <nav class="footer-links" aria-label="Site footer">
     <a href="{{ '/' | relative_url }}about.html">About</a>
+    <a href="{{ '/' | relative_url }}privacy.html">Privacy</a>
     <a href="https://github.com/agbaber/marblehead">Source</a>
     <a href="https://github.com/agbaber/marblehead/issues/new?title=Correction%3A+">Report an issue</a>
   </nav>

--- a/about.html
+++ b/about.html
@@ -208,6 +208,22 @@ claude "audit this site. find the bias. follow the money. be skeptical."</code><
 
   <p><strong>Found a mistake?</strong> Open an <a href="https://github.com/agbaber/marblehead/issues/new?title=Correction%3A+">issue</a> or a <a href="https://github.com/agbaber/marblehead/pulls">pull request</a> on GitHub.</p>
 
+  <div class="read-next">
+    <div class="read-next-label">Read next</div>
+    <a class="read-next-link" href="the-debate.html">
+      <div class="read-next-title">The override debate &rarr;</div>
+      <div class="read-next-desc">The strongest version of each side, structured around six dividing lines.</div>
+    </a>
+    <a class="read-next-link" href="bias-audit.html">
+      <div class="read-next-title">Bias audit &rarr;</div>
+      <div class="read-next-desc">An independent AI audit of this site for selective framing and editorial tilt.</div>
+    </a>
+    <a class="read-next-link" href="how-we-got-here.html">
+      <div class="read-next-title">How did we get here? &rarr;</div>
+      <div class="read-next-desc">Seven years of Finance Committee warnings, in their own words.</div>
+    </a>
+  </div>
+
   <div class="meta-strip">
     <a class="meta-pill" href="https://github.com/agbaber/marblehead">
       <span class="meta-pill-label">Source</span>

--- a/bias-audit.html
+++ b/bias-audit.html
@@ -203,6 +203,18 @@ og_url: https://marbleheaddata.org/bias-audit.html
 
   <p>The remediation plan for every finding on this page is published at <a href="bias-remediation-plan">bias remediation plan</a>.</p>
 
+  <div class="read-next">
+    <div class="read-next-label">Read next</div>
+    <a class="read-next-link" href="about.html">
+      <div class="read-next-title">Who made this? &rarr;</div>
+      <div class="read-next-desc">Author disclosure, editorial approach, costs, and how to audit the site yourself.</div>
+    </a>
+    <a class="read-next-link" href="the-debate.html">
+      <div class="read-next-title">The override debate &rarr;</div>
+      <div class="read-next-desc">The strongest version of each side, structured around six dividing lines.</div>
+    </a>
+  </div>
+
   <div class="notes">
     <p><strong>Methodology note.</strong> This audit was run by Claude Code (claude-opus-4-6) against the full repository on April 11, 2026. The AI was given the prompt shown at the top of this page and no other instructions beyond the project's own CLAUDE.md and STYLE_GUIDE.md. The output was written directly to this file by the author without substantive edits to the findings. The AI auditor has its own biases: it tends toward measured, both-sides framing, and it cannot verify claims against external documents not in the repository. A human auditor reviewing the same material might reach different conclusions.</p>
   </div>

--- a/docs/superpowers/plans/2026-04-12-override-tier-line-items.md
+++ b/docs/superpowers/plans/2026-04-12-override-tier-line-items.md
@@ -1,0 +1,449 @@
+# Override tier line-item detail — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the sparse prose tier cards on `what-is-the-override.html` with detailed, dollar-denominated line-item breakdowns sourced from `data/override_town_line_items.csv`.
+
+**Architecture:** CSS additions to `assets/site.css` for tier line-item layout and Restore/New tags; HTML replacement of the three tier card blocks in `what-is-the-override.html`. No JS. Hardcoded HTML consistent with the rest of the site.
+
+**Tech Stack:** Static HTML, CSS custom properties, Jekyll/GitHub Pages
+
+---
+
+### Task 1: Add CSS styles for tier line items
+
+**Files:**
+- Modify: `assets/site.css` (after the existing `.tier-list` rules, around line 2739)
+
+- [ ] **Step 1: Add tier line-item CSS rules**
+
+Insert after the `.tier-list` mobile media query (after line 2739 in `assets/site.css`):
+
+```css
+/* ==========================================================================
+   Tier line-item detail (override page)
+   ========================================================================== */
+
+.tier-items { margin: 12px 0 4px; }
+
+.tier-group-heading {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-subtle);
+  margin: 16px 0 4px;
+  padding-top: 8px;
+  border-top: 1px solid var(--divider);
+}
+.tier-group-heading:first-child {
+  margin-top: 4px;
+  padding-top: 0;
+  border-top: none;
+}
+
+.tier-line {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 7px 0;
+  font-size: 14px;
+}
+.tier-line-name { color: var(--text); }
+.tier-line-amount {
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.tier-line--offset .tier-line-name,
+.tier-line--offset .tier-line-amount { color: var(--text-subtle); }
+.tier-line--school {
+  margin-top: 4px;
+  padding-top: 8px;
+  border-top: 1px solid var(--divider);
+  font-weight: 600;
+}
+.tier-line--school .tier-line-name { color: var(--text); }
+.tier-line--school .tier-line-amount { color: var(--text); }
+
+.tier-tag {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  margin-right: 4px;
+  vertical-align: 1px;
+}
+.tier-tag--restore {
+  color: var(--c-teal);
+  background: color-mix(in srgb, var(--c-teal) 12%, transparent);
+}
+.tier-tag--new {
+  color: var(--c-navy);
+  background: color-mix(in srgb, var(--c-navy) 12%, transparent);
+}
+
+@media (max-width: 600px) {
+  .tier-line { font-size: 13px; }
+  .tier-tag { font-size: 9px; }
+}
+```
+
+- [ ] **Step 2: Commit CSS**
+
+```bash
+git add assets/site.css
+git commit -m "Add CSS for tier line-item detail on override page"
+```
+
+---
+
+### Task 2: Replace Tier 1 card with line-item detail
+
+**Files:**
+- Modify: `what-is-the-override.html` (lines 103-116)
+
+- [ ] **Step 1: Replace the Tier 1 card**
+
+Replace the existing Tier 1 card (lines 103-116, from `<div class="card tier-card--1">` through its closing `</div>`) with:
+
+```html
+  <div class="card tier-card--1">
+    <p class="tier-label">Tier 1: Restore ($9 million)</p>
+    <h3>Bring back services cut from the <a href="no-override-budget.html">no-override budget</a></h3>
+    <div class="tier-items">
+      <div class="tier-group-heading">Public Safety</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Police school resource officer</span>
+        <span class="tier-line-amount">$65,482</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Police equipment</span>
+        <span class="tier-line-amount">$2,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Inspections subscriptions and maintenance</span>
+        <span class="tier-line-amount">$52,500</span>
+      </div>
+
+      <div class="tier-group-heading">Public Works</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> DPW staffing</span>
+        <span class="tier-line-amount">$140,594</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> DPW hot top paving</span>
+        <span class="tier-line-amount">$60,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Cemetery laborer</span>
+        <span class="tier-line-amount">$58,692</span>
+      </div>
+
+      <div class="tier-group-heading">Recreation, Library & Parks</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Library staffing for accreditation</span>
+        <span class="tier-line-amount">$311,183</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Recreation and Parks groundskeeper</span>
+        <span class="tier-line-amount">$45,000</span>
+      </div>
+
+      <div class="tier-group-heading">General Government</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Finance staffing</span>
+        <span class="tier-line-amount">$68,287</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Finance technology and training</span>
+        <span class="tier-line-amount">$58,361</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Finance Committee Reserve Fund</span>
+        <span class="tier-line-amount">$26,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> HR advertising and subscriptions</span>
+        <span class="tier-line-amount">$11,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Community Development staffing</span>
+        <span class="tier-line-amount">$137,423</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Public Buildings custodians</span>
+        <span class="tier-line-amount">$122,554</span>
+      </div>
+
+      <div class="tier-group-heading">Health & Human Services</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Council on Aging staffing</span>
+        <span class="tier-line-amount">$76,171</span>
+      </div>
+
+      <div class="tier-group-heading">Reserves & Transfers</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> OPEB trust transfer</span>
+        <span class="tier-line-amount">$96,771</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Stabilization transfer</span>
+        <span class="tier-line-amount">$250,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Workers Comp and Section 111F transfer</span>
+        <span class="tier-line-amount">$97,662</span>
+      </div>
+
+      <div class="tier-line tier-line--offset">
+        <span class="tier-line-name">Unemployment reduction from restored positions</span>
+        <span class="tier-line-amount">&minus;$410,116</span>
+      </div>
+
+      <div class="tier-line tier-line--school">
+        <span class="tier-line-name">Schools</span>
+        <span class="tier-line-amount">~$7.7M</span>
+      </div>
+    </div>
+    <p class="source">Source: Town Administrator's <a href="https://www.marbleheadindependent.com/kezer-presents-9m-to-15m-tiered-override-plan-and-separate-2-2m-trash-tax-option/">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items.</p>
+  </div>
+```
+
+The Dan Fox blockquote immediately after this card (lines 118-121) stays exactly where it is.
+
+- [ ] **Step 2: Commit Tier 1 card**
+
+```bash
+git add what-is-the-override.html
+git commit -m "Replace Tier 1 card with line-item detail"
+```
+
+---
+
+### Task 3: Replace Tier 2 card with line-item detail
+
+**Files:**
+- Modify: `what-is-the-override.html` (lines 123-127 after previous edit)
+
+- [ ] **Step 1: Replace the Tier 2 card**
+
+Replace the existing Tier 2 card (from `<div class="card tier-card--2">` through its closing `</div>`) with:
+
+```html
+  <div class="card tier-card--2">
+    <p class="tier-label">Tier 2: Stabilize ($12 million)</p>
+    <h3>Everything in Tier 1, plus maintenance and staffing</h3>
+    <div class="tier-items">
+      <div class="tier-group-heading">Public Safety</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Police staffing</span>
+        <span class="tier-line-amount">$65,482</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Fire staffing</span>
+        <span class="tier-line-amount">$148,000</span>
+      </div>
+
+      <div class="tier-group-heading">Public Works</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> DPW GIS position</span>
+        <span class="tier-line-amount">$70,000</span>
+      </div>
+
+      <div class="tier-group-heading">Recreation, Library & Parks</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Library staffing</span>
+        <span class="tier-line-amount">$218,980</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Library materials</span>
+        <span class="tier-line-amount">$168,400</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Library PT custodian and assistant</span>
+        <span class="tier-line-amount">$38,378</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Recreation and Parks PT Senior Clerk</span>
+        <span class="tier-line-amount">$27,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Recreation and Parks maintenance</span>
+        <span class="tier-line-amount">$15,000</span>
+      </div>
+
+      <div class="tier-group-heading">General Government</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Finance IT Director</span>
+        <span class="tier-line-amount">$150,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Finance Budget Analyst</span>
+        <span class="tier-line-amount">$70,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Community Development staffing</span>
+        <span class="tier-line-amount">$170,552</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Town Clerk staffing</span>
+        <span class="tier-line-amount">$66,125</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Public Buildings maintenance</span>
+        <span class="tier-line-amount">$450,000</span>
+      </div>
+
+      <div class="tier-group-heading">Health & Human Services</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Council on Aging PT Social Worker</span>
+        <span class="tier-line-amount">$45,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Council on Aging maintenance</span>
+        <span class="tier-line-amount">$15,000</span>
+      </div>
+
+      <div class="tier-line tier-line--offset">
+        <span class="tier-line-name">Additional unemployment reduction</span>
+        <span class="tier-line-amount">&minus;$282,245</span>
+      </div>
+
+      <div class="tier-line tier-line--school">
+        <span class="tier-line-name">Schools</span>
+        <span class="tier-line-amount">~$1.6M</span>
+      </div>
+    </div>
+    <p class="source">Source: Town Administrator's <a href="https://www.marbleheadindependent.com/kezer-presents-9m-to-15m-tiered-override-plan-and-separate-2-2m-trash-tax-option/">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items. Amounts shown are incremental to Tier 1.</p>
+  </div>
+```
+
+- [ ] **Step 2: Commit Tier 2 card**
+
+```bash
+git add what-is-the-override.html
+git commit -m "Replace Tier 2 card with line-item detail"
+```
+
+---
+
+### Task 4: Replace Tier 3 card with line-item detail
+
+**Files:**
+- Modify: `what-is-the-override.html` (lines 129-133 after previous edits)
+
+- [ ] **Step 1: Replace the Tier 3 card**
+
+Replace the existing Tier 3 card (from `<div class="card tier-card--3">` through its closing `</div>`) with:
+
+```html
+  <div class="card tier-card--3">
+    <p class="tier-label">Tier 3: Invest ($15 million)</p>
+    <h3>Everything in Tiers 1 and 2, plus capital</h3>
+    <div class="tier-items">
+      <div class="tier-group-heading">Public Safety</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Police staffing</span>
+        <span class="tier-line-amount">$65,482</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Fire staffing</span>
+        <span class="tier-line-amount">$296,000</span>
+      </div>
+
+      <div class="tier-group-heading">General Government</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Community Development Grant Writer</span>
+        <span class="tier-line-amount">$70,000</span>
+      </div>
+
+      <div class="tier-group-heading">Health & Human Services</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Health Department mental health counseling</span>
+        <span class="tier-line-amount">$60,000</span>
+      </div>
+
+      <div class="tier-group-heading">Recurring Capital</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Capital funding for leases, equipment, and buildings</span>
+        <span class="tier-line-amount">$1,000,000</span>
+      </div>
+
+      <div class="tier-line tier-line--school">
+        <span class="tier-line-name">Schools</span>
+        <span class="tier-line-amount">~$1.5M</span>
+      </div>
+    </div>
+    <p class="source">Source: Town Administrator's <a href="https://www.marbleheadindependent.com/kezer-presents-9m-to-15m-tiered-override-plan-and-separate-2-2m-trash-tax-option/">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items. Amounts shown are incremental to Tier 2.</p>
+  </div>
+```
+
+- [ ] **Step 2: Commit Tier 3 card**
+
+```bash
+git add what-is-the-override.html
+git commit -m "Replace Tier 3 card with line-item detail"
+```
+
+---
+
+### Task 5: Push and open PR
+
+- [ ] **Step 1: Create branch off main, cherry-pick commits, push**
+
+```bash
+git checkout -b override-tier-line-items origin/main
+# cherry-pick or recreate the commits from the worktree
+git push -u origin override-tier-line-items
+```
+
+- [ ] **Step 2: Open pull request**
+
+Title: "Add line-item detail to override tier cards"
+
+Body: Replace the prose bullet-point tier cards on the override page with
+dollar-denominated line items from the Town Administrator's override
+presentation. Each item tagged Restore or New. Incremental framing (Tier 2
+shows only what it adds beyond Tier 1). Schools line in each card to account
+for the full tier amount.
+
+---
+
+## Data derivation notes (for the implementer)
+
+All town-side line items and dollar amounts come directly from
+`data/override_town_line_items.csv`. The CSV has columns:
+`category,description,tier_1_9m,tier_2_12m,tier_3_15m`.
+
+**Tier 1 items:** All rows where `tier_1_9m > 0` (or < 0 for the offset).
+
+**Tier 2 incremental items:** All rows where `tier_2_12m > tier_1_9m`. The
+displayed amount is `tier_2_12m - tier_1_9m`. Two items have this:
+- Community Development staffing: $307,975 - $137,423 = $170,552
+- Offset (unemployment): -$692,361 - (-$410,116) = -$282,245
+
+All other Tier 2 items go from $0 to their Tier 2 value.
+
+**Tier 3 incremental items:** All rows where `tier_3_15m > tier_2_12m`. The
+displayed amount is `tier_3_15m - tier_2_12m`:
+- Police staffing: $130,964 - $65,482 = $65,482
+- Fire staffing: $444,000 - $148,000 = $296,000
+- Grant Writer and Mental Health go from $0 to their values.
+- Recurring Capital: $0 to $1,000,000.
+
+**School allocation per tier (cumulative):**
+- Tier 1: $9,000,000 - $1,269,564 = $7,730,436 (~$7.7M)
+- Tier 2: $12,000,000 - $2,705,236 = $9,294,764 (~$9.3M cumulative)
+- Tier 3: $15,000,000 - $4,196,718 = $10,803,282 (~$10.8M cumulative)
+
+**School allocation per tier (incremental, as displayed):**
+- Tier 1: ~$7.7M
+- Tier 2: $9,294,764 - $7,730,436 = $1,564,328 (~$1.6M)
+- Tier 3: $10,803,282 - $9,294,764 = $1,508,518 (~$1.5M)
+
+**Restore vs New tagging:** If the CSV description starts with "Restore", tag
+as Restore. If it starts with "Increase" or is the Recurring Capital row, tag
+as New. The Offset row gets neither tag.

--- a/docs/superpowers/specs/2026-04-12-override-tier-line-items-design.md
+++ b/docs/superpowers/specs/2026-04-12-override-tier-line-items-design.md
@@ -1,0 +1,129 @@
+# Override tier line-item detail
+
+**Date:** 2026-04-12
+**Page:** `what-is-the-override.html`
+**Data source:** `data/override_town_line_items.csv`
+
+## Problem
+
+The no-override page shows department-by-department cuts with dollar amounts.
+The override page shows three tier cards with prose bullet points ("Firefighter
+position," "School resource officer") and no dollar amounts. A voter can see
+exactly what they lose without an override but not exactly what each tier buys.
+
+## Design
+
+Replace the three existing tier cards (lines ~94-132 of
+`what-is-the-override.html`) with richer cards that show every town-side line
+item from the CSV, grouped by department, with dollar amounts.
+
+### Framing
+
+- **Incremental, not cumulative.** Tier 1 shows its items. Tier 2 shows only
+  what it adds beyond Tier 1. Tier 3 shows only what it adds beyond Tier 2.
+  Consistent with the existing card headers ("Everything in Tier 1, plus...").
+- **Restore vs Increase.** Each line item gets a subtle label distinguishing
+  restorations of no-override cuts from genuinely new spending. The CSV
+  encodes this in the description prefix ("Restore ..." vs "Increase ...").
+  Tier 1 is almost entirely Restores; Tier 2/3 mix in more Increases.
+- **Schools line.** Each card includes a "Schools" line at the bottom showing
+  the school-side allocation (total tier amount minus town-side net). This
+  accounts for the full tier amount so readers don't wonder where the rest
+  went.
+- **Offset line.** The unemployment savings offset (negative) appears in the
+  card where it applies.
+
+### Visual treatment
+
+- Reuse the no-override page's `.cut-row` layout pattern: department/item name
+  on the left, dollar amount on the right. No proportional bars (the existing
+  stacked tier chart at the top of the page already communicates relative
+  size).
+- Department groupings as subheadings within each card.
+- Small inline tag or text prefix for Restore/Increase distinction. Use
+  existing site palette (no new colors). Suggested: muted text label before
+  each item name, e.g. "Restore:" or "New:" in a lighter weight.
+- Source citation at the bottom of each card referencing the Town
+  Administrator's April 8, 2026 override presentation.
+
+### Structure per tier card
+
+```
+Tier label (e.g. "Tier 1: Restore ($9 million)")
+Existing h3 summary line
+
+  Public Safety
+    Restore: Police Department School Resource Officer    $65,482
+    Restore: Police Department Equipment                   $2,000
+    Restore: Inspections subscriptions & maintenance      $52,500
+
+  Public Works
+    Restore: DPW staffing                                $140,594
+    Restore: DPW hot top                                  $60,000
+    Restore: Cemetery laborer                             $58,692
+
+  ... (remaining departments)
+
+  Offset
+    Unemployment reduction with restored positions       -$410,116
+
+  Schools                                              ~$7,730,436
+
+  Source: ...
+```
+
+### What stays unchanged
+
+- The stacked tier bar chart at the top of the section
+- The Dan Fox quote after Tier 1
+- The trash card (Tier card--trash)
+- The "tiers are nested" takeaway box and Ginny O'Brien quote
+- The scrolly nesting visualization
+- Everything else on the page outside the tier cards section
+
+### Data mapping
+
+Town-side line items come directly from `override_town_line_items.csv`.
+Hardcoded in HTML (consistent with the no-override page; no JS build step).
+
+School allocation per tier:
+- Tier 1: $9,000,000 - town net = ~$7,730,436
+- Tier 2: $12,000,000 - town net = ~$9,294,764
+- Tier 3: $15,000,000 - town net = ~$10,803,282
+
+Town net per tier (sum of all line items including the negative offset):
+- Tier 1: $1,269,564
+- Tier 2: $2,705,236
+- Tier 3: $4,196,718
+
+These are derived from the CSV. The school numbers should be presented as
+approximate ("~$7.7M") since we're computing them as a remainder, not from a
+school-specific source document.
+
+### CSS
+
+Minimal new CSS needed:
+- `.tier-line-group` heading style for department category subheadings within
+  each card
+- `.tier-line` layout (name left, amount right) -- may be able to reuse
+  `.cut-row` directly or create a thin variant
+- `.tier-tag--restore` / `.tier-tag--new` for the Restore/Increase label
+
+All scoped within the existing `.tier-card--1/2/3` card classes. Added to
+`assets/site.css` or as a `<style>` block on the page (follow whichever
+pattern the page already uses for page-specific styles).
+
+### Source citation
+
+> Source: Town Administrator's April 8, 2026 override presentation;
+> FY27 Proposed Balanced Budget With No Override (for restoration
+> baselines). School allocation is the tier total minus town-side
+> line items.
+
+### Editorial notes
+
+- No editorial language. Items are listed factually with their dollar amounts.
+- The Restore/Increase distinction is sourced from the official presentation,
+  not an editorial judgment.
+- School amounts are presented as approximate with an explanatory note.
+- Neutral semantic colors per the style guide. No green/red value judgments.

--- a/index.html
+++ b/index.html
@@ -183,6 +183,12 @@ m-170 -340 l0 -145 -120 0 c-98 0 -120 3 -120 14 0 8 4 18 10 21 5 3 53 62
       <span class="tag tag-charts">Chart</span>
     </a>
 
+    <a class="question" href="charts/levy_vs_bill.html">
+      <h2>Tax levy, median bill, and inflation</h2>
+      <p>Three indexed growth rates over twelve years. The levy and median bill tracked each other closely, both growing faster than CPI.</p>
+      <span class="tag tag-charts">Chart</span>
+    </a>
+
     <a class="question" href="charts/tax_comparison.html">
       <h2>Marblehead vs. Swampscott, side by side</h2>
       <p>Tax rates, home values, median bills, and what $750K buys you in each town.</p>

--- a/inside-school-staffing.html
+++ b/inside-school-staffing.html
@@ -478,5 +478,18 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
     <p><strong>Shared services information</strong> from the Northshore Education Consortium (nsedu.org), Massachusetts Organization of Educational Collaboratives (moecnet.org), the MA Inspector General Special Education Transportation Study (Feb 2026), and the Efficiency and Regionalization Grant Program (mass.gov). NEC tuition increase from Marblehead Independent budget reporting.</p>
   </div>
 
-  <a class="btn-link" href="charts/enrollment_vs_staffing.html">Enrollment vs. staffing chart &rarr;</a>
-  <a class="btn-link" href="where-has-the-money-gone.html">Where has the money gone? &rarr;</a>
+  <div class="read-next">
+    <div class="read-next-label">Read next</div>
+    <a class="read-next-link" href="charts/enrollment_vs_staffing.html">
+      <div class="read-next-title">Enrollment vs. staffing chart &rarr;</div>
+      <div class="read-next-desc">Student enrollment down 19% while education staffing grew to 537 FTE. The interactive chart behind this page.</div>
+    </a>
+    <a class="read-next-link" href="where-has-the-money-gone.html">
+      <div class="read-next-title">Where has the money gone? &rarr;</div>
+      <div class="read-next-desc">Schools drove less than half of the $35.7M spending increase. Healthcare, pensions, and debt service made up the rest.</div>
+    </a>
+    <a class="read-next-link" href="why-not-elsewhere.html">
+      <div class="read-next-title">Why not cut elsewhere? &rarr;</div>
+      <div class="read-next-desc">What structural reforms other towns have tried, and why none have permanently bent the cost curve.</div>
+    </a>
+  </div>

--- a/privacy.html
+++ b/privacy.html
@@ -29,3 +29,11 @@ og_url: https://marbleheaddata.org/privacy.html
 <p>If something on this page is unclear or you want to verify any claim above, the full source code for the community pulse feature (front-end widget and server-side Worker) is published at <a href="https://github.com/agbaber/marblehead">github.com/agbaber/marblehead</a> under the <code>community-pulse/</code> and <code>assets/community-pulse/</code> directories. You can read the code and confirm these claims for yourself.</p>
 
 <p class="notes">Last updated: April 12, 2026.</p>
+
+<div class="read-next">
+  <div class="read-next-label">Read next</div>
+  <a class="read-next-link" href="about.html">
+    <div class="read-next-title">Who made this? &rarr;</div>
+    <div class="read-next-desc">Author disclosure, editorial approach, and how to audit the site yourself.</div>
+  </a>
+</div>


### PR DESCRIPTION
## Summary
- **Footer:** Added privacy.html link to the site-wide footer (between About and Source)
- **Read-next sections:** Added to 4 pages that were dead ends: `about.html`, `bias-audit.html`, `inside-school-staffing.html`, `privacy.html`
- **Homepage:** Added `charts/levy_vs_bill.html` to the comparisons section so it's discoverable (was only reachable from other chart pages)

Every content page on the site now has at least one outbound navigation path, and no pages are orphaned from the site UI.

## Test plan
- [ ] Verify privacy.html link appears in footer on all pages
- [ ] Verify read-next sections render correctly on about, bias-audit, inside-school-staffing, and privacy pages
- [ ] Verify levy_vs_bill chart card appears in comparisons section on homepage
- [ ] Spot-check that read-next links point to correct destinations
- [ ] Check dark mode renders read-next sections correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)