### PR TITLE
Replace bar chart with dot plot on voting record

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1557,6 +1557,43 @@ details.vote-year[open] > summary::before { transform: rotate(90deg); }
   .tabs--compact .tab { font-size: 10px; padding: 4px 8px; }
 }
 
+/* Vote dot tooltip */
+.chart-wrap { position: relative; }
+.vote-tooltip {
+  position: absolute;
+  z-index: 10;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
+  padding: 8px 12px;
+  max-width: 280px;
+  pointer-events: none;
+  font-size: 12px;
+  line-height: 1.4;
+}
+.vote-tooltip-title {
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 2px;
+}
+.vote-tooltip-meta {
+  color: var(--text-subtle);
+  font-size: 11px;
+  margin-bottom: 4px;
+}
+.vote-tooltip-votes {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Ballot timeline link */
+.ballot-timeline-link {
+  font-size: 12px;
+  margin-top: 8px;
+}
+
 /* ==========================================================================
    Reduced motion
    ========================================================================== */

--- a/data/build_voting_record.py
+++ b/data/build_voting_record.py
@@ -181,238 +181,223 @@ def build_key_stats(rows):
 
 
 # ---------------------------------------------------------------------------
-# SVG CHART  (horizontal diverging bar chart)
+# SVG CHART  (dot plot / strip plot)
 # ---------------------------------------------------------------------------
 
-# Layout constants
-H_ML   = 55          # left margin (year labels)
-H_MR   = 15          # right margin
-H_MT   = 22          # top margin (for "Failed" / "Passed" labels + grid labels)
-H_MB   = 10          # bottom margin
-H_VB_W = 880         # viewBox width
+# Layout constants for dot plot
+DOT_VB_W = 800
+DOT_VB_H = 260
+DOT_R = 6
 
-ROW_H  = 20          # total height per row (bar + gap)
-BAR_H  = 14          # bar height within row
+# Timeline area
+TL_X_MIN = 110       # left edge of timeline (room for row labels)
+TL_X_MAX = 760       # right edge of timeline
 
-FAIL_MIN_W = 80      # minimum pixel width for the fail (left) side
-MARKER_W   = 3       # thin marker for unsourced amounts
+# Row Y positions
+ROW_OV_Y = 70        # operating overrides center y
+ROW_DE_Y = 160       # debt exclusions center y
+
+# Timeline date range
+TL_YEAR_MIN = 1982
+TL_YEAR_MAX = 2026
+
+
+def _date_to_x(date_str):
+    """Map a vote_date string to an x position on the timeline."""
+    try:
+        d = datetime.strptime(date_str, "%Y-%m-%d")
+        # Convert to fractional year
+        year_frac = d.year + (d.month - 1) / 12 + (d.day - 1) / 365
+    except (ValueError, TypeError):
+        return None
+    t = (year_frac - TL_YEAR_MIN) / (TL_YEAR_MAX - TL_YEAR_MIN)
+    return TL_X_MIN + t * (TL_X_MAX - TL_X_MIN)
+
+
+def _year_to_x(year):
+    """Map a calendar year (or fractional year) to an x position."""
+    t = (year - TL_YEAR_MIN) / (TL_YEAR_MAX - TL_YEAR_MIN)
+    return TL_X_MIN + t * (TL_X_MAX - TL_X_MIN)
 
 
 def build_chart(rows):
-    """Return a complete <svg> string (horizontal diverging bar chart)."""
+    """Return a complete <svg> string (dot plot / strip plot)."""
 
     # ------------------------------------------------------------------
-    # 1. Group rows by calendar year, skip clerk-error rows
+    # 1. Filter to chart rows, skip clerk-error rows
     # ------------------------------------------------------------------
     chart_rows = [r for r in rows if not is_clerk_error(r)]
+    chart_rows = [r for r in chart_rows
+                  if r["measure_type"] in ("Override", "Debt Exclusion")]
 
-    by_year = defaultdict(lambda: {"pass": [], "fail": []})
-    for r in chart_rows:
-        yr = calendar_year(r["vote_date"])
-        if yr is None:
-            continue
-        mtype = r["measure_type"]
-        if mtype not in ("Override", "Debt Exclusion"):
-            continue
-        key = "pass" if r["win_loss"] == "WIN" else "fail"
-        by_year[yr][key].append(r)
-
-    all_years = sorted(by_year.keys())
-    if not all_years:
+    if not chart_rows:
         return "<svg></svg>"
 
-    n_years = len(all_years)
+    # ------------------------------------------------------------------
+    # 2. Compute pass rates for row labels
+    # ------------------------------------------------------------------
+    ov_rows = [r for r in chart_rows if r["measure_type"] == "Override"]
+    de_rows = [r for r in chart_rows if r["measure_type"] == "Debt Exclusion"]
+    ov_pass = sum(1 for r in ov_rows if r["win_loss"] == "WIN")
+    de_pass = sum(1 for r in de_rows if r["win_loss"] == "WIN")
 
     # ------------------------------------------------------------------
-    # 2. Compute per-year totals for pass and fail sides (real dollars)
+    # 3. Group dots by (row, date) for jitter
     # ------------------------------------------------------------------
-    year_pass_total = {}
-    year_fail_total = {}
-    for yr in all_years:
-        year_pass_total[yr] = sum(r["real_val"] or 0 for r in by_year[yr]["pass"])
-        year_fail_total[yr] = sum(r["real_val"] or 0 for r in by_year[yr]["fail"])
-
-    max_pass = max(year_pass_total.values()) if year_pass_total else 1
-    max_fail = max(year_fail_total.values()) if year_fail_total else 1
-    if max_pass == 0:
-        max_pass = 1
-    if max_fail == 0:
-        max_fail = 1
+    ov_by_date = defaultdict(list)
+    de_by_date = defaultdict(list)
+    for r in chart_rows:
+        if r["measure_type"] == "Override":
+            ov_by_date[r["vote_date"]].append(r)
+        else:
+            de_by_date[r["vote_date"]].append(r)
 
     # ------------------------------------------------------------------
-    # 3. Layout geometry
-    # ------------------------------------------------------------------
-    chart_w = H_VB_W - H_ML - H_MR                  # 810
-    # Fail side gets the larger of FAIL_MIN_W or its proportional share
-    proportional_fail = chart_w * (max_fail / (max_pass + max_fail))
-    fail_w = max(FAIL_MIN_W, proportional_fail)
-    pass_w = chart_w - fail_w
-
-    baseline_x = H_ML + fail_w                       # vertical center line
-
-    # Same dollar-per-pixel scale on both sides (use the pass side scale
-    # since it always has more data; the fail side gets the same scale
-    # but is guaranteed at least FAIL_MIN_W pixels of space)
-    px_per_dollar = pass_w / max_pass
-
-    vb_h = H_MT + n_years * ROW_H + H_MB
-    chart_area_h = n_years * ROW_H
-
-    def row_y(idx):
-        """Top y of row idx."""
-        return H_MT + idx * ROW_H
-
-    def bar_y(idx):
-        """Top y of the bar within row idx (centred vertically)."""
-        return row_y(idx) + (ROW_H - BAR_H) / 2
-
-    # ------------------------------------------------------------------
-    # 4. Sort votes within each side
-    #    Overrides first, then debt exclusions; within each type by
-    #    amount descending.
-    # ------------------------------------------------------------------
-    def sort_key(r):
-        type_order = 0 if r["measure_type"] == "Override" else 1
-        amt = r["real_val"] or 0
-        return (type_order, -amt)
-
-    # ------------------------------------------------------------------
-    # 5. Build SVG parts
+    # 4. Build SVG parts
     # ------------------------------------------------------------------
     parts = []
 
-    # -- 5a. No defs needed: debt exclusion bars use opacity via CSS --
+    # -- Row labels --
+    parts.append('<text class="row-label" x="10" y="58">Operating</text>')
+    parts.append('<text class="row-label" x="10" y="71">overrides</text>')
+    parts.append(f'<text class="row-sub" x="10" y="84">{ov_pass} of {len(ov_rows)}</text>')
 
-    # -- 5b. "Failed" / "Passed" header labels --
-    parts.append(
-        f'<text class="tick-label" x="{H_ML + 2}" y="{H_MT - 6}" '
-        f'text-anchor="start" font-size="9">Failed</text>'
-    )
-    parts.append(
-        f'<text class="tick-label" x="{H_VB_W - H_MR - 2}" y="{H_MT - 6}" '
-        f'text-anchor="end" font-size="9">Passed</text>'
-    )
+    parts.append('<text class="row-label" x="10" y="130">Debt</text>')
+    parts.append('<text class="row-label" x="10" y="143">exclusions</text>')
+    parts.append(f'<text class="row-sub" x="10" y="156">{de_pass} of {len(de_rows)}</text>')
 
-    # -- 5c. Vertical dollar grid lines on the pass side --
-    # Choose a nice interval: $20M steps
-    grid_interval = 20_000_000
-    grid_val = grid_interval
-    while grid_val <= max_pass:
-        gx = baseline_x + grid_val * px_per_dollar
-        if gx <= H_VB_W - H_MR:
-            parts.append(
-                f'<line class="grid-minor" x1="{gx:.1f}" y1="{H_MT}" '
-                f'x2="{gx:.1f}" y2="{H_MT + chart_area_h}"/>'
-            )
-            parts.append(
-                f'<text class="tick-label tick-label--minor" '
-                f'x="{gx:.1f}" y="{H_MT - 6}" '
-                f'text-anchor="middle" font-size="8">{fmt_dollars(grid_val)}</text>'
-            )
-        grid_val += grid_interval
-
-    # -- 5d. Vertical baseline --
-    parts.append(
-        f'<line class="axis-base" x1="{baseline_x:.1f}" y1="{H_MT}" '
-        f'x2="{baseline_x:.1f}" y2="{H_MT + chart_area_h}"/>'
-    )
-
-    # -- 5e. Year labels and bar segments --
-    for idx, yr in enumerate(all_years):
-        by = bar_y(idx)
-        label_y = row_y(idx) + ROW_H / 2 + 4   # vertically centred text
-
-        # Year label (2-digit with apostrophe)
-        yr_short = f"'{yr % 100:02d}"
+    # -- Decade grid lines --
+    for decade in [1990, 2000, 2010, 2020]:
+        gx = _year_to_x(decade)
         parts.append(
-            f'<text class="tick-label" x="{H_ML - 4}" y="{label_y:.1f}" '
-            f'text-anchor="end" font-size="9">{yr_short}</text>'
+            f'<line class="grid-line" x1="{gx:.1f}" y1="40" '
+            f'x2="{gx:.1f}" y2="175"/>'
         )
 
-        pass_votes = sorted(by_year[yr]["pass"], key=sort_key)
-        fail_votes = sorted(by_year[yr]["fail"], key=sort_key)
+    # -- Row baselines --
+    parts.append(f'<line class="axis-line" x1="{TL_X_MIN - 50}" y1="85" x2="{TL_X_MAX}" y2="85"/>')
+    parts.append(f'<line class="axis-line" x1="{TL_X_MIN - 50}" y1="175" x2="{TL_X_MAX}" y2="175"/>')
 
-        # --- Pass side (extending RIGHT from baseline) ---
-        cursor_x = baseline_x
-        for r in pass_votes:
-            color = dept_color(r["department"])
-            rv = r["real_val"]
-            av = r["amount_val"]
-            mtype = r["measure_type"]
+    # -- FY2027 upcoming vote indicator --
+    fy27_x = _year_to_x(2026.4)  # June 2026
+    parts.append(
+        f'<line class="future-line" x1="{fy27_x:.0f}" y1="40" '
+        f'x2="{fy27_x:.0f}" y2="175"/>'
+    )
+    parts.append(f'<text class="annotation annotation--upcoming" x="{fy27_x + 3:.0f}" y="52">FY2027</text>')
+    parts.append(f'<text class="annotation annotation--upcoming" x="{fy27_x + 3:.0f}" y="64">vote</text>')
+    parts.append(f'<text class="annotation annotation--upcoming" x="{fy27_x + 3:.0f}" y="76">Jun 9</text>')
 
-            if rv is not None and rv > 0:
-                w = rv * px_per_dollar
-            else:
-                w = MARKER_W
+    # -- Helper to emit dots for a row --
+    def emit_dots(by_date, base_y):
+        """Emit circle elements for all votes in a row, with jitter."""
+        annotation_dots = {}
+        for date_str in sorted(by_date.keys()):
+            group = by_date[date_str]
+            cx = _date_to_x(date_str)
+            if cx is None:
+                continue
 
-            fill_cls = f"bar-solid-{color}" if mtype == "Override" else f"bar-hatch-{color}"
-            dept_attr = r["department"].replace(" ", "_").replace("&", "and")
-            data_type = "override" if mtype == "Override" else "debt-exclusion"
-            result_label = "Passed" if r["win_loss"] == "WIN" else "Failed"
+            n = len(group)
+            for i, r in enumerate(group):
+                # Jitter vertically when multiple votes share a date
+                if n == 1:
+                    cy = base_y
+                else:
+                    offset = (i - (n - 1) / 2) * 8
+                    cy = base_y + offset
 
-            parts.append(
-                f'<rect class="{fill_cls}" '
-                f'x="{cursor_x:.1f}" y="{by:.1f}" '
-                f'width="{w:.1f}" height="{BAR_H}" '
-                f'data-nominal="{int(av) if av else ""}" '
-                f'data-real="{int(rv) if rv else ""}" '
-                f'data-win="1" '
-                f'data-dept="{dept_attr}" '
-                f'data-type="{data_type}" '
-                f'data-year="{yr}">'
-                f'<title>{r["description"]} ({yr}, {result_label}, {fmt_dollars(rv)})</title>'
-                f'</rect>'
-            )
-            cursor_x += w
+                approved = r["win_loss"] == "WIN"
+                cls = "vote-dot vote-dot--approved" if approved else "vote-dot vote-dot--rejected"
+                result_text = "Approved" if approved else "Rejected"
 
-        # --- Fail side (extending LEFT from baseline) ---
-        cursor_x = baseline_x
-        for r in fail_votes:
-            color = dept_color(r["department"])
-            rv = r["real_val"]
-            av = r["amount_val"]
-            mtype = r["measure_type"]
+                # Format data attributes
+                amt = fmt_dollars(r["amount_val"]) if r["amount_val"] else "\u2014"
+                amt_real = fmt_dollars(r["real_val"]) if r["real_val"] else "\u2014"
+                date_label = fmt_month_year(r["vote_date"])
 
-            if rv is not None and rv > 0:
-                w = rv * px_per_dollar
-            else:
-                w = MARKER_W
+                yes = r["yes_votes"]
+                no = r["no_votes"]
+                margin = vote_margin_pct(yes, no)
+                margin_str = (f"+{margin:.1f}%" if margin is not None and margin >= 0
+                              else (f"{margin:.1f}%" if margin is not None else "\u2014"))
 
-            fill_cls = f"bar-solid-{color}" if mtype == "Override" else f"bar-hatch-{color}"
-            dept_attr = r["department"].replace(" ", "_").replace("&", "and")
-            data_type = "override" if mtype == "Override" else "debt-exclusion"
-            result_label = "Passed" if r["win_loss"] == "WIN" else "Failed"
+                mtype = r["measure_type"]
 
-            rect_x = cursor_x - w
-            parts.append(
-                f'<rect class="{fill_cls}" '
-                f'x="{rect_x:.1f}" y="{by:.1f}" '
-                f'width="{w:.1f}" height="{BAR_H}" '
-                f'data-nominal="{int(av) if av else ""}" '
-                f'data-real="{int(rv) if rv else ""}" '
-                f'data-win="0" '
-                f'data-dept="{dept_attr}" '
-                f'data-type="{data_type}" '
-                f'data-year="{yr}">'
-                f'<title>{r["description"]} ({yr}, {result_label}, {fmt_dollars(rv)})</title>'
-                f'</rect>'
-            )
-            cursor_x -= w
+                # Escape HTML entities in description
+                desc = r["description"].replace("&", "&amp;").replace('"', "&quot;")
+
+                parts.append(
+                    f'<circle class="{cls}" '
+                    f'cx="{cx:.1f}" cy="{cy:.1f}" r="{DOT_R}" '
+                    f'data-desc="{desc}" '
+                    f'data-amount="{amt}" '
+                    f'data-amount-real="{amt_real}" '
+                    f'data-result="{result_text}" '
+                    f'data-yes="{yes:,}" '
+                    f'data-no="{no:,}" '
+                    f'data-margin="{margin_str}" '
+                    f'data-date="{date_label}" '
+                    f'data-type="{mtype}"/>'
+                )
+
+                # Track special dots for annotations
+                if (mtype == "Override" and approved
+                        and r["vote_date"] == "2005-06-15"):
+                    annotation_dots["last_override"] = (cx, cy)
+
+                if (mtype == "Debt Exclusion" and not approved
+                        and "Tucker" in r["description"]):
+                    annotation_dots["only_de_rejected"] = (cx, cy)
+
+        return annotation_dots
+
+    # -- Emit override dots --
+    ov_annotations = emit_dots(ov_by_date, ROW_OV_Y)
+
+    # -- Emit debt exclusion dots --
+    de_annotations = emit_dots(de_by_date, ROW_DE_Y)
+
+    # -- Annotations --
+    if "last_override" in ov_annotations:
+        ax, ay = ov_annotations["last_override"]
+        parts.append(
+            f'<line class="grid-line" x1="{ax:.1f}" y1="{ay + DOT_R + 2:.0f}" '
+            f'x2="{ax:.1f}" y2="{ay + 28:.0f}"/>'
+        )
+        parts.append(
+            f'<text class="annotation" x="{ax:.1f}" y="{ay + 42:.0f}" '
+            f'text-anchor="middle">Last approved override</text>'
+        )
+
+    if "only_de_rejected" in de_annotations:
+        ax, ay = de_annotations["only_de_rejected"]
+        parts.append(
+            f'<line class="grid-line" x1="{ax:.1f}" y1="{ay + DOT_R + 2:.0f}" '
+            f'x2="{ax:.1f}" y2="{ay + 28:.0f}"/>'
+        )
+        parts.append(
+            f'<text class="annotation" x="{ax:.1f}" y="{ay + 42:.0f}" '
+            f'text-anchor="middle">Only debt exclusion rejected</text>'
+        )
+
+    # -- X-axis year labels --
+    for yr in [1982, 1990, 2000, 2010, 2020, 2026]:
+        lx = _year_to_x(yr)
+        parts.append(
+            f'<text class="tick-label" x="{lx:.0f}" y="222" '
+            f'text-anchor="middle">{yr}</text>'
+        )
 
     # -- Assemble SVG --
     inner = "\n".join(parts)
-    min_yr = all_years[0]
-    max_yr = all_years[-1]
     svg = (
-        f'<svg class="chart" viewBox="0 0 {H_VB_W} {vb_h}" '
+        f'<svg class="chart" viewBox="0 0 {DOT_VB_W} {DOT_VB_H}" '
         f'xmlns="http://www.w3.org/2000/svg" '
         f'role="img" '
-        f'aria-label="Horizontal diverging bar chart of Marblehead Proposition 2½ '
-        f'votes from {min_yr} to {max_yr}. '
-        f'Bars extending right of the center line are passed questions; '
-        f'bars extending left are failed. '
-        f'Solid bars are overrides; translucent bars are debt exclusions. '
-        f'Bar width represents the inflation-adjusted dollar amount.">\n'
+        f'aria-label="Dot plot timeline of every Marblehead Proposition 2&#189; '
+        f'vote, 1982 to 2026. Operating overrides on top row, debt exclusions '
+        f'on bottom row. Filled dots are approved, hollow dots are rejected.">\n'
         f'{inner}\n'
         f'</svg>'
     )

--- a/marblehead-voting-record.html
+++ b/marblehead-voting-record.html
@@ -36,147 +36,127 @@ og_url: https://marbleheaddata.org/marblehead-voting-record.html
   </div>
 </div>
 
+<h2>Every vote, 1988&ndash;2025</h2>
+
+<div class="chart-wrap ballot-timeline">
+<svg class="chart" viewBox="0 0 800 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Dot plot timeline of every Marblehead Proposition 2&#189; vote, 1982 to 2026. Operating overrides on top row, debt exclusions on bottom row. Filled dots are approved, hollow dots are rejected.">
+<text class="row-label" x="10" y="58">Operating</text>
+<text class="row-label" x="10" y="71">overrides</text>
+<text class="row-sub" x="10" y="84">6 of 19</text>
+<text class="row-label" x="10" y="130">Debt</text>
+<text class="row-label" x="10" y="143">exclusions</text>
+<text class="row-sub" x="10" y="156">49 of 50</text>
+<line class="grid-line" x1="228.2" y1="40" x2="228.2" y2="175"/>
+<line class="grid-line" x1="375.9" y1="40" x2="375.9" y2="175"/>
+<line class="grid-line" x1="523.6" y1="40" x2="523.6" y2="175"/>
+<line class="grid-line" x1="671.4" y1="40" x2="671.4" y2="175"/>
+<line class="axis-line" x1="60" y1="85" x2="760" y2="85"/>
+<line class="axis-line" x1="60" y1="175" x2="760" y2="175"/>
+<line class="future-line" x1="766" y1="40" x2="766" y2="175"/>
+<text class="annotation annotation--upcoming" x="769" y="52">FY2027</text>
+<text class="annotation annotation--upcoming" x="769" y="64">vote</text>
+<text class="annotation annotation--upcoming" x="769" y="76">Jun 9</text>
+<circle class="vote-dot vote-dot--rejected" cx="234.3" cy="70.0" r="6" data-desc="General Operating Budget" data-amount="$1.0M" data-amount-real="$2.4M" data-result="Rejected" data-yes="2,664" data-no="4,539" data-margin="-26.0%" data-date="June 1990" data-type="Override"/>
+<circle class="vote-dot vote-dot--rejected" cx="249.8" cy="70.0" r="6" data-desc="General Operating Expenseds" data-amount="$575K" data-amount-real="$1.3M" data-result="Rejected" data-yes="1,629" data-no="2,598" data-margin="-22.9%" data-date="June 1991" data-type="Override"/>
+<circle class="vote-dot vote-dot--rejected" cx="252.3" cy="66.0" r="6" data-desc="Funding Salaries For Town Clerks Office" data-amount="$16K" data-amount-real="$36K" data-result="Rejected" data-yes="564" data-no="935" data-margin="-24.7%" data-date="August 1991" data-type="Override"/>
+<circle class="vote-dot vote-dot--rejected" cx="252.3" cy="74.0" r="6" data-desc="Funding Meals On Wheels" data-amount="$508" data-amount-real="$1K" data-result="Rejected" data-yes="716" data-no="782" data-margin="-4.4%" data-date="August 1991" data-type="Override"/>
+<circle class="vote-dot vote-dot--rejected" cx="308.4" cy="70.0" r="6" data-desc="School Department Salaries" data-amount="$349K" data-amount-real="$718K" data-result="Rejected" data-yes="2,473" data-no="2,553" data-margin="-1.6%" data-date="June 1995" data-type="Override"/>
+<circle class="vote-dot vote-dot--rejected" cx="323.3" cy="70.0" r="6" data-desc="School Department Expenses" data-amount="$870K" data-amount-real="$1.7M" data-result="Rejected" data-yes="2,737" data-no="3,376" data-margin="-10.5%" data-date="June 1996" data-type="Override"/>
+<circle class="vote-dot vote-dot--rejected" cx="382.8" cy="70.0" r="6" data-desc="Improvements At The Old Town House" data-amount="$149K" data-amount-real="$271K" data-result="Rejected" data-yes="833" data-no="1,150" data-margin="-16.0%" data-date="June 2000" data-type="Override"/>
+<circle class="vote-dot vote-dot--approved" cx="397.5" cy="70.0" r="6" data-desc="Construction Of Sewers And Surface Drains" data-amount="$300K" data-amount-real="$531K" data-result="Approved" data-yes="3,016" data-no="1,482" data-margin="+34.1%" data-date="June 2001" data-type="Override"/>
+<circle class="vote-dot vote-dot--approved" cx="427.0" cy="70.0" r="6" data-desc="Supplemental Budget Expenses" data-amount="$1.4M" data-amount-real="$2.4M" data-result="Approved" data-yes="3,936" data-no="2,350" data-margin="+25.2%" data-date="June 2003" data-type="Override"/>
+<circle class="vote-dot vote-dot--rejected" cx="442.0" cy="50.0" r="6" data-desc="Cruiser For Police Dept.-Van For Dog Officer-Front End Loader And Backlhoe For Waste Coll. Dept." data-amount="$483K" data-amount-real="$801K" data-result="Rejected" data-yes="2,419" data-no="2,661" data-margin="-4.8%" data-date="June 2004" data-type="Override"/>
+<circle class="vote-dot vote-dot--approved" cx="442.0" cy="58.0" r="6" data-desc="Supplemental Expenses For School Department" data-amount="$422K" data-amount-real="$701K" data-result="Approved" data-yes="2,857" data-no="2,289" data-margin="+11.0%" data-date="June 2004" data-type="Override"/>
+<circle class="vote-dot vote-dot--rejected" cx="442.0" cy="66.0" r="6" data-desc="Supplemental Expenses Of Police Department" data-amount="$132K" data-amount-real="$220K" data-result="Rejected" data-yes="2,288" data-no="2,758" data-margin="-9.3%" data-date="June 2004" data-type="Override"/>
+<circle class="vote-dot vote-dot--approved" cx="442.0" cy="74.0" r="6" data-desc="Supplemental Expenses For Waste Collection" data-amount="$17K" data-amount-real="$28K" data-result="Approved" data-yes="2,849" data-no="2,240" data-margin="+12.0%" data-date="June 2004" data-type="Override"/>
+<circle class="vote-dot vote-dot--rejected" cx="442.0" cy="82.0" r="6" data-desc="General Operating Expenditures" data-amount="$55K" data-amount-real="$91K" data-result="Rejected" data-yes="1,639" data-no="3,384" data-margin="-34.7%" data-date="June 2004" data-type="Override"/>
+<circle class="vote-dot vote-dot--approved" cx="442.0" cy="90.0" r="6" data-desc="Library Expenses" data-amount="$73K" data-amount-real="$121K" data-result="Approved" data-yes="2,775" data-no="2,323" data-margin="+8.9%" data-date="June 2004" data-type="Override"/>
+<circle class="vote-dot vote-dot--approved" cx="456.5" cy="70.0" r="6" data-desc="Supplemental Expenses Of Several Town Departments" data-amount="$2.7M" data-amount-real="$4.4M" data-result="Approved" data-yes="3,869" data-no="3,456" data-margin="+5.6%" data-date="June 2005" data-type="Override"/>
+<circle class="vote-dot vote-dot--rejected" cx="545.1" cy="70.0" r="6" data-desc="Final Design, Public Bidding And Construction For Improvements To The Old Town House" data-amount="$668K" data-amount-real="$931K" data-result="Rejected" data-yes="2,531" data-no="3,567" data-margin="-17.0%" data-date="June 2011" data-type="Override"/>
+<circle class="vote-dot vote-dot--rejected" cx="707.9" cy="70.0" r="6" data-desc="School Department Operating Budget" data-amount="$3.1M" data-amount-real="$3.3M" data-result="Rejected" data-yes="1,802" data-no="3,929" data-margin="-37.1%" data-date="June 2022" data-type="Override"/>
+<circle class="vote-dot vote-dot--rejected" cx="722.6" cy="70.0" r="6" data-desc="General Government Operating Budget" data-amount="$2.5M" data-amount-real="$2.5M" data-result="Rejected" data-yes="2,996" data-no="3,414" data-margin="-6.5%" data-date="June 2023" data-type="Override"/>
+<circle class="vote-dot vote-dot--approved" cx="116.9" cy="160.0" r="6" data-desc="Reconst Sewers For Drainage Purposes" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="1,373" data-no="625" data-margin="+37.4%" data-date="June 1982" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="204.8" cy="160.0" r="6" data-desc="Schools" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="2,322" data-no="2,167" data-margin="+3.5%" data-date="June 1988" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="230.6" cy="156.0" r="6" data-desc="Remodel/Repair H Sch Sci Labs" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="3,593" data-no="1,404" data-margin="+43.8%" data-date="March 1990" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="230.6" cy="164.0" r="6" data-desc="Remodel/Equip Exsisting Library" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="3,468" data-no="1,526" data-margin="+38.9%" data-date="March 1990" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="234.3" cy="160.0" r="6" data-desc="Remodel/Repair Mid.Sch Heat System" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="3,904" data-no="3,241" data-margin="+9.3%" data-date="June 1990" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="263.9" cy="160.0" r="6" data-desc="School Renovations" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="2,481" data-no="1,631" data-margin="+20.7%" data-date="June 1992" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="293.4" cy="156.0" r="6" data-desc="Surface-Drains Construction" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="1,058" data-no="506" data-margin="+35.3%" data-date="June 1994" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="293.4" cy="164.0" r="6" data-desc="School Renovation" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="993" data-no="575" data-margin="+26.7%" data-date="June 1994" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="308.4" cy="144.0" r="6" data-desc="Repairs To Schools" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="3,237" data-no="1,785" data-margin="+28.9%" data-date="June 1995" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="308.4" cy="152.0" r="6" data-desc="Repairs To Police And Inspectors Build." data-amount="$600K" data-amount-real="$1.2M" data-result="Approved" data-yes="2,946" data-no="2,064" data-margin="+17.6%" data-date="June 1995" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="308.4" cy="160.0" r="6" data-desc="Const. Building For Council On Aging" data-amount="$2.4M" data-amount-real="$4.9M" data-result="Approved" data-yes="2,994" data-no="2,032" data-margin="+19.1%" data-date="June 1995" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="308.4" cy="168.0" r="6" data-desc="Computers For School Department" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="3,028" data-no="1,973" data-margin="+21.1%" data-date="June 1995" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="308.4" cy="176.0" r="6" data-desc="Surface Storm Drains" data-amount="$650K" data-amount-real="$1.3M" data-result="Approved" data-yes="3,386" data-no="1,607" data-margin="+35.6%" data-date="June 1995" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="323.3" cy="148.0" r="6" data-desc="Surface Drain Construction" data-amount="$900K" data-amount-real="$1.8M" data-result="Approved" data-yes="3,666" data-no="2,363" data-margin="+21.6%" data-date="June 1996" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="323.3" cy="156.0" r="6" data-desc="Computer Equipment For School Dept." data-amount="—" data-amount-real="—" data-result="Approved" data-yes="3,394" data-no="2,671" data-margin="+11.9%" data-date="June 1996" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="323.3" cy="164.0" r="6" data-desc="Equipment For Fire Department" data-amount="$450K" data-amount-real="$900K" data-result="Approved" data-yes="3,454" data-no="2,594" data-margin="+14.2%" data-date="June 1996" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="323.3" cy="172.0" r="6" data-desc="Repair-Construct-Equip School Bldgs." data-amount="—" data-amount-real="—" data-result="Approved" data-yes="3,538" data-no="2,530" data-margin="+16.6%" data-date="June 1996" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="338.1" cy="160.0" r="6" data-desc="Remodeling Of Several Town Schools" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="1,797" data-no="1,702" data-margin="+2.7%" data-date="June 1997" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="352.8" cy="156.0" r="6" data-desc="Repairs To Several Schools" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="2,569" data-no="1,267" data-margin="+33.9%" data-date="June 1998" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="352.8" cy="164.0" r="6" data-desc="Computers And Software For School Dept." data-amount="—" data-amount-real="—" data-result="Approved" data-yes="2,323" data-no="1,503" data-margin="+21.4%" data-date="June 1998" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="367.8" cy="160.0" r="6" data-desc="Const.Equip-Furnish New High School" data-amount="$42.1M" data-amount-real="$79.3M" data-result="Approved" data-yes="4,659" data-no="2,976" data-margin="+22.0%" data-date="June 1999" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="382.8" cy="160.0" r="6" data-desc="Repairs To Existing Drainage Infrastruction" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="1,361" data-no="635" data-margin="+36.4%" data-date="June 2000" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="397.5" cy="160.0" r="6" data-desc="Plans For Conversion Of Schools" data-amount="$600K" data-amount-real="$1.1M" data-result="Approved" data-yes="2,916" data-no="1,639" data-margin="+28.0%" data-date="June 2001" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="404.6" cy="160.0" r="6" data-desc="Bonds Issued To Plan, Remodel, Reconstruct Additions To Existing High School And Convert To Middle School" data-amount="$22.6M" data-amount-real="$40.0M" data-result="Approved" data-yes="2,849" data-no="1,434" data-margin="+33.0%" data-date="December 2001" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--rejected" cx="412.5" cy="160.0" r="6" data-desc="Bonds Issued For Remodeling, Reconstruction And Making Repairs To Tucker's Wharf" data-amount="—" data-amount-real="—" data-result="Rejected" data-yes="1,049" data-no="1,185" data-margin="-6.1%" data-date="June 2002" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="442.0" cy="160.0" r="6" data-desc="Purchase Fire Pumper Truck" data-amount="$415K" data-amount-real="$689K" data-result="Approved" data-yes="2,931" data-no="2,133" data-margin="+15.8%" data-date="June 2004" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="456.5" cy="156.0" r="6" data-desc="Purchase Equipment For Several Town Departments" data-amount="$812K" data-amount-real="$1.3M" data-result="Approved" data-yes="4,384" data-no="2,778" data-margin="+22.4%" data-date="June 2005" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="456.5" cy="164.0" r="6" data-desc="Purchase 3 Certain Parcels Of Land Owned By Robinson Farm Realty Trust" data-amount="$2.0M" data-amount-real="$3.3M" data-result="Approved" data-yes="4,937" data-no="2,315" data-margin="+36.2%" data-date="June 2005" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="486.4" cy="156.0" r="6" data-desc="Construct, Reconstruct Ocean Ave Causewayl" data-amount="$8.7M" data-amount-real="$13.2M" data-result="Approved" data-yes="1,565" data-no="1,061" data-margin="+19.2%" data-date="June 2007" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="486.4" cy="164.0" r="6" data-desc="Landfill Cap, Transfer Station, Drop Off" data-amount="$1.0M" data-amount-real="$1.5M" data-result="Approved" data-yes="1,747" data-no="864" data-margin="+33.8%" data-date="June 2007" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="500.9" cy="156.0" r="6" data-desc="Feasibility Study For The Glover School Project" data-amount="$395K" data-amount-real="$576K" data-result="Approved" data-yes="2,365" data-no="1,311" data-margin="+28.7%" data-date="June 2008" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="500.9" cy="164.0" r="6" data-desc="Village School Project -Reconstruction" data-amount="$21.7M" data-amount-real="$31.6M" data-result="Approved" data-yes="2,464" data-no="1,213" data-margin="+34.0%" data-date="June 2008" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="545.1" cy="156.0" r="6" data-desc="Funding The Design, Project Management And Construction Of A New Elementary School" data-amount="$25.4M" data-amount-real="$35.5M" data-result="Approved" data-yes="3,394" data-no="2,753" data-margin="+10.4%" data-date="June 2011" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="545.1" cy="164.0" r="6" data-desc="Funding The Permitting, Public Bidding And Construction Of A Cap For The Encompassing The Old Landfill, Etc" data-amount="$18.2M" data-amount-real="$25.4M" data-result="Approved" data-yes="3,416" data-no="2,681" data-margin="+12.1%" data-date="June 2011" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="560.1" cy="148.0" r="6" data-desc="Quint Fire Truck" data-amount="$1.1M" data-amount-real="$1.6M" data-result="Approved" data-yes="1,905" data-no="1,542" data-margin="+10.5%" data-date="June 2012" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="560.1" cy="156.0" r="6" data-desc="Old Town House Accessibility Project" data-amount="$610K" data-amount-real="$834K" data-result="Approved" data-yes="1,990" data-no="1,475" data-margin="+14.9%" data-date="June 2012" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="560.1" cy="164.0" r="6" data-desc="Lead Mills Land Acquisition" data-amount="$1.5M" data-amount-real="$2.0M" data-result="Approved" data-yes="2,263" data-no="1,216" data-margin="+30.1%" data-date="June 2012" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="560.1" cy="172.0" r="6" data-desc="Pleasant Street Area Drainage Project" data-amount="$4.9M" data-amount-real="$6.7M" data-result="Approved" data-yes="2,394" data-no="1,067" data-margin="+38.3%" data-date="June 2012" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="575.1" cy="156.0" r="6" data-desc="Green Street Remediation" data-amount="$1.2M" data-amount-real="$1.6M" data-result="Approved" data-yes="3,186" data-no="2,235" data-margin="+17.5%" data-date="June 2013" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="575.1" cy="164.0" r="6" data-desc="Abbot Hall Tower Repairs" data-amount="$2.5M" data-amount-real="$3.3M" data-result="Approved" data-yes="3,888" data-no="1,617" data-margin="+41.3%" data-date="June 2013" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="604.3" cy="160.0" r="6" data-desc="Bonds To Pay For Repair And Replacement Of Drainage Pipe And Construction Of New Xfer Station" data-amount="$8.0M" data-amount-real="$10.6M" data-result="Approved" data-yes="1,934" data-no="666" data-margin="+48.8%" data-date="June 2015" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="619.0" cy="156.0" r="6" data-desc="Bonds For Study, Renovation And Recon Of Elbridge Gerry School" data-amount="$750K" data-amount-real="$980K" data-result="Approved" data-yes="2,176" data-no="875" data-margin="+42.6%" data-date="June 2016" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="619.0" cy="164.0" r="6" data-desc="Bonds For A Pumper Truck For The Fire Dept" data-amount="$620K" data-amount-real="$810K" data-result="Approved" data-yes="2,403" data-no="628" data-margin="+58.6%" data-date="June 2016" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="648.8" cy="160.0" r="6" data-desc="Costs Of Constructing And Reconstructing Seawalls And Fences" data-amount="$872K" data-amount-real="$1.1M" data-result="Approved" data-yes="1,555" data-no="326" data-margin="+65.3%" data-date="June 2018" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="663.4" cy="156.0" r="6" data-desc="Bonds For New Gerry School" data-amount="$54.8M" data-amount-real="$67.3M" data-result="Approved" data-yes="3,440" data-no="1,976" data-margin="+27.0%" data-date="June 2019" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="663.4" cy="164.0" r="6" data-desc="Bonds For Repairs To Fort Sewall" data-amount="$750K" data-amount-real="$920K" data-result="Approved" data-yes="4,492" data-no="903" data-margin="+66.5%" data-date="June 2019" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="693.1" cy="156.0" r="6" data-desc="Renovation Of Abbot Public Library" data-amount="$8.5M" data-amount-real="$9.8M" data-result="Approved" data-yes="3,021" data-no="1,346" data-margin="+38.4%" data-date="June 2021" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="693.1" cy="164.0" r="6" data-desc="New Fire Pumper Truck" data-amount="$750K" data-amount-real="$868K" data-result="Approved" data-yes="3,418" data-no="894" data-margin="+58.5%" data-date="June 2021" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="707.9" cy="160.0" r="6" data-desc="Roof Replacements, Road &amp; Sidewalk Improvements, Smart Panels, Hvac, Salt Shed, Hs Boiler" data-amount="$10.9M" data-amount-real="$11.7M" data-result="Approved" data-yes="3,347" data-no="2,178" data-margin="+21.2%" data-date="June 2022" data-type="Debt Exclusion"/>
+<circle class="vote-dot vote-dot--approved" cx="751.7" cy="160.0" r="6" data-desc="Mary Alley Building Improvement &amp; Hvac" data-amount="—" data-amount-real="—" data-result="Approved" data-yes="4,088" data-no="1,857" data-margin="+37.5%" data-date="June 2025" data-type="Debt Exclusion"/>
+<line class="grid-line" x1="456.5" y1="78" x2="456.5" y2="98"/>
+<text class="annotation" x="456.5" y="112" text-anchor="middle">Last approved override</text>
+<line class="grid-line" x1="412.5" y1="168" x2="412.5" y2="188"/>
+<text class="annotation" x="412.5" y="202" text-anchor="middle">Only debt exclusion rejected</text>
+<text class="tick-label" x="110" y="222" text-anchor="middle">1982</text>
+<text class="tick-label" x="228" y="222" text-anchor="middle">1990</text>
+<text class="tick-label" x="376" y="222" text-anchor="middle">2000</text>
+<text class="tick-label" x="524" y="222" text-anchor="middle">2010</text>
+<text class="tick-label" x="671" y="222" text-anchor="middle">2020</text>
+<text class="tick-label" x="760" y="222" text-anchor="middle">2026</text>
+</svg>
+<div class="ballot-timeline-legend">
+  <div class="li"><span class="sw sw--approved"></span> Approved at the ballot</div>
+  <div class="li"><span class="sw sw--rejected"></span> Rejected at the ballot</div>
+</div>
+<div class="vote-tooltip" id="vote-tooltip" hidden>
+  <div class="vote-tooltip-title"></div>
+  <div class="vote-tooltip-meta"></div>
+  <div class="vote-tooltip-votes"></div>
+</div>
+</div>
+
+<p class="caption">Each dot is one ballot question. Filled dots were approved; hollow dots were rejected. Hover or tap any dot for details.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride" data-source="MA DOR, Proposition 2&frac12; Override &amp; Underride Votes (Marblehead)"></sup></p>
+
 <div class="chart-header">
-  <h2>Every vote, 1988&ndash;2025</h2>
+  <h2>Detail by year</h2>
   <div class="tabs tabs--compact" role="tablist" aria-label="Dollar mode">
     <button class="tab active" role="tab" aria-selected="true" data-mode="real">Inflation-adjusted (2024$)</button>
     <button class="tab" role="tab" aria-selected="false" data-mode="nominal">Nominal dollars</button>
   </div>
 </div>
 
-<div class="chart-wrap">
-<svg class="chart" viewBox="0 0 880 632" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Horizontal diverging bar chart of Marblehead Proposition 2½ votes from 1982 to 2025. Bars extending right of the center line are passed questions; bars extending left are failed. Solid bars are overrides; translucent bars are debt exclusions. Bar width represents the inflation-adjusted dollar amount.">
-<!-- No defs needed: debt exclusion bars use opacity instead of hatch patterns -->
-<text class="tick-label" x="57" y="16" text-anchor="start" font-size="9">Failed</text>
-<text class="tick-label" x="863" y="16" text-anchor="end" font-size="9">Passed</text>
-<line class="grid-minor" x1="319.1" y1="22" x2="319.1" y2="622"/>
-<text class="tick-label tick-label--minor" x="319.1" y="16" text-anchor="middle" font-size="8">$20.0M</text>
-<line class="grid-minor" x1="503.2" y1="22" x2="503.2" y2="622"/>
-<text class="tick-label tick-label--minor" x="503.2" y="16" text-anchor="middle" font-size="8">$40.0M</text>
-<line class="grid-minor" x1="687.3" y1="22" x2="687.3" y2="622"/>
-<text class="tick-label tick-label--minor" x="687.3" y="16" text-anchor="middle" font-size="8">$60.0M</text>
-<line class="axis-base" x1="135.0" y1="22" x2="135.0" y2="622"/>
-<text class="tick-label" x="51" y="36.0" text-anchor="end" font-size="9">'82</text>
-<rect class="bar-hatch-sage" x="135.0" y="25.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="1982"><title>Reconst Sewers For Drainage Purposes (1982, Passed, —)</title></rect>
-<text class="tick-label" x="51" y="56.0" text-anchor="end" font-size="9">'88</text>
-<rect class="bar-hatch-teal" x="135.0" y="45.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1988"><title>Schools (1988, Passed, —)</title></rect>
-<text class="tick-label" x="51" y="76.0" text-anchor="end" font-size="9">'90</text>
-<rect class="bar-hatch-teal" x="135.0" y="65.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1990"><title>Remodel/Repair Mid.Sch Heat System (1990, Passed, —)</title></rect>
-<rect class="bar-hatch-teal" x="138.0" y="65.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1990"><title>Remodel/Repair H Sch Sci Labs (1990, Passed, —)</title></rect>
-<rect class="bar-hatch-brass" x="141.0" y="65.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="Culture_and_Recreation" data-type="debt-exclusion" data-year="1990"><title>Remodel/Equip Exsisting Library (1990, Passed, —)</title></rect>
-<rect class="bar-solid-navy" x="112.9" y="65.0" width="22.1" height="14" data-nominal="1000000" data-real="2400153" data-win="0" data-dept="General_Government" data-type="override" data-year="1990"><title>General Operating Budget (1990, Failed, $2.4M)</title></rect>
-<text class="tick-label" x="51" y="96.0" text-anchor="end" font-size="9">'91</text>
-<rect class="bar-solid-navy" x="122.8" y="85.0" width="12.2" height="14" data-nominal="575000" data-real="1324358" data-win="0" data-dept="General_Government" data-type="override" data-year="1991"><title>General Operating Expenseds (1991, Failed, $1.3M)</title></rect>
-<rect class="bar-solid-navy" x="122.5" y="85.0" width="0.3" height="14" data-nominal="15716" data-real="36198" data-win="0" data-dept="General_Government" data-type="override" data-year="1991"><title>Funding Salaries For Town Clerks Office (1991, Failed, $36K)</title></rect>
-<rect class="bar-solid-plum" x="122.5" y="85.0" width="0.0" height="14" data-nominal="508" data-real="1170" data-win="0" data-dept="Health_and_Human_Services" data-type="override" data-year="1991"><title>Funding Meals On Wheels (1991, Failed, $1K)</title></rect>
-<text class="tick-label" x="51" y="116.0" text-anchor="end" font-size="9">'92</text>
-<rect class="bar-hatch-teal" x="135.0" y="105.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1992"><title>School Renovations (1992, Passed, —)</title></rect>
-<text class="tick-label" x="51" y="136.0" text-anchor="end" font-size="9">'94</text>
-<rect class="bar-hatch-sage" x="135.0" y="125.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="1994"><title>Surface-Drains Construction (1994, Passed, —)</title></rect>
-<rect class="bar-hatch-teal" x="138.0" y="125.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1994"><title>School Renovation (1994, Passed, —)</title></rect>
-<text class="tick-label" x="51" y="156.0" text-anchor="end" font-size="9">'95</text>
-<rect class="bar-hatch-plum" x="135.0" y="145.0" width="45.5" height="14" data-nominal="2400000" data-real="4940157" data-win="1" data-dept="Health_and_Human_Services" data-type="debt-exclusion" data-year="1995"><title>Const. Building For Council On Aging (1995, Passed, $4.9M)</title></rect>
-<rect class="bar-hatch-sage" x="180.5" y="145.0" width="12.3" height="14" data-nominal="650000" data-real="1337959" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="1995"><title>Surface Storm Drains (1995, Passed, $1.3M)</title></rect>
-<rect class="bar-hatch-buoy" x="192.8" y="145.0" width="11.4" height="14" data-nominal="600000" data-real="1235039" data-win="1" data-dept="Public_Safety" data-type="debt-exclusion" data-year="1995"><title>Repairs To Police And Inspectors Build. (1995, Passed, $1.2M)</title></rect>
-<rect class="bar-hatch-teal" x="204.2" y="145.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1995"><title>Repairs To Schools (1995, Passed, —)</title></rect>
-<rect class="bar-hatch-teal" x="207.2" y="145.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1995"><title>Computers For School Department (1995, Passed, —)</title></rect>
-<rect class="bar-solid-teal" x="128.4" y="145.0" width="6.6" height="14" data-nominal="348929" data-real="718235" data-win="0" data-dept="School" data-type="override" data-year="1995"><title>School Department Salaries (1995, Failed, $718K)</title></rect>
-<text class="tick-label" x="51" y="176.0" text-anchor="end" font-size="9">'96</text>
-<rect class="bar-hatch-sage" x="135.0" y="165.0" width="16.6" height="14" data-nominal="900000" data-real="1799426" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="1996"><title>Surface Drain Construction (1996, Passed, $1.8M)</title></rect>
-<rect class="bar-hatch-buoy" x="151.6" y="165.0" width="8.3" height="14" data-nominal="450000" data-real="899713" data-win="1" data-dept="Public_Safety" data-type="debt-exclusion" data-year="1996"><title>Equipment For Fire Department (1996, Passed, $900K)</title></rect>
-<rect class="bar-hatch-teal" x="159.8" y="165.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1996"><title>Computer Equipment For School Dept. (1996, Passed, —)</title></rect>
-<rect class="bar-hatch-teal" x="162.8" y="165.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1996"><title>Repair-Construct-Equip School Bldgs. (1996, Passed, —)</title></rect>
-<rect class="bar-solid-teal" x="119.0" y="165.0" width="16.0" height="14" data-nominal="870084" data-real="1739613" data-win="0" data-dept="School" data-type="override" data-year="1996"><title>School Department Expenses (1996, Failed, $1.7M)</title></rect>
-<text class="tick-label" x="51" y="196.0" text-anchor="end" font-size="9">'97</text>
-<rect class="bar-hatch-teal" x="135.0" y="185.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1997"><title>Remodeling Of Several Town Schools (1997, Passed, —)</title></rect>
-<text class="tick-label" x="51" y="216.0" text-anchor="end" font-size="9">'98</text>
-<rect class="bar-hatch-teal" x="135.0" y="205.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1998"><title>Repairs To Several Schools (1998, Passed, —)</title></rect>
-<rect class="bar-hatch-teal" x="138.0" y="205.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1998"><title>Computers And Software For School Dept. (1998, Passed, —)</title></rect>
-<text class="tick-label" x="51" y="236.0" text-anchor="end" font-size="9">'99</text>
-<rect class="bar-hatch-teal" x="135.0" y="225.0" width="730.0" height="14" data-nominal="42115000" data-real="79300573" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="1999"><title>Const.Equip-Furnish New High School (1999, Passed, $79.3M)</title></rect>
-<text class="tick-label" x="51" y="256.0" text-anchor="end" font-size="9">'00</text>
-<rect class="bar-hatch-sage" x="135.0" y="245.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2000"><title>Repairs To Existing Drainage Infrastruction (2000, Passed, —)</title></rect>
-<rect class="bar-solid-navy" x="132.5" y="245.0" width="2.5" height="14" data-nominal="149000" data-real="271436" data-win="0" data-dept="General_Government" data-type="override" data-year="2000"><title>Improvements At The Old Town House (2000, Failed, $271K)</title></rect>
-<text class="tick-label" x="51" y="276.0" text-anchor="end" font-size="9">'01</text>
-<rect class="bar-solid-sage" x="135.0" y="265.0" width="4.9" height="14" data-nominal="300000" data-real="531395" data-win="1" data-dept="Public_Works_and_Facilities" data-type="override" data-year="2001"><title>Construction Of Sewers And Surface Drains (2001, Passed, $531K)</title></rect>
-<rect class="bar-hatch-teal" x="139.9" y="265.0" width="368.5" height="14" data-nominal="22600000" data-real="40031733" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2001"><title>Bonds Issued To Plan, Remodel, Reconstruct Additions To Existing High School And Convert To Middle School (2001, Passed, $40.0M)</title></rect>
-<rect class="bar-hatch-teal" x="508.4" y="265.0" width="9.8" height="14" data-nominal="600000" data-real="1062789" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2001"><title>Plans For Conversion Of Schools (2001, Passed, $1.1M)</title></rect>
-<text class="tick-label" x="51" y="296.0" text-anchor="end" font-size="9">'02</text>
-<rect class="bar-hatch-brass" x="132.0" y="285.0" width="3.0" height="14" data-nominal="" data-real="" data-win="0" data-dept="Culture_and_Recreation" data-type="debt-exclusion" data-year="2002"><title>Bonds Issued For Remodeling, Reconstruction And Making Repairs To Tucker's Wharf (2002, Failed, —)</title></rect>
-<text class="tick-label" x="51" y="316.0" text-anchor="end" font-size="9">'03</text>
-<rect class="bar-solid-navy" x="135.0" y="305.0" width="21.7" height="14" data-nominal="1381017" data-real="2354484" data-win="1" data-dept="General_Government" data-type="override" data-year="2003"><title>Supplemental Budget Expenses (2003, Passed, $2.4M)</title></rect>
-<text class="tick-label" x="51" y="336.0" text-anchor="end" font-size="9">'04</text>
-<rect class="bar-solid-teal" x="135.0" y="325.0" width="6.5" height="14" data-nominal="422246" data-real="701210" data-win="1" data-dept="School" data-type="override" data-year="2004"><title>Supplemental Expenses For School Department (2004, Passed, $701K)</title></rect>
-<rect class="bar-solid-brass" x="141.5" y="325.0" width="1.1" height="14" data-nominal="73051" data-real="121313" data-win="1" data-dept="Culture_and_Recreation" data-type="override" data-year="2004"><title>Library Expenses (2004, Passed, $121K)</title></rect>
-<rect class="bar-solid-sage" x="142.6" y="325.0" width="0.3" height="14" data-nominal="17100" data-real="28397" data-win="1" data-dept="Public_Works_and_Facilities" data-type="override" data-year="2004"><title>Supplemental Expenses For Waste Collection (2004, Passed, $28K)</title></rect>
-<rect class="bar-hatch-buoy" x="142.8" y="325.0" width="6.3" height="14" data-nominal="415000" data-real="689177" data-win="1" data-dept="Public_Safety" data-type="debt-exclusion" data-year="2004"><title>Purchase Fire Pumper Truck (2004, Passed, $689K)</title></rect>
-<rect class="bar-solid-buoy" x="127.6" y="325.0" width="7.4" height="14" data-nominal="482590" data-real="801421" data-win="0" data-dept="Public_Safety" data-type="override" data-year="2004"><title>Cruiser For Police Dept.-Van For Dog Officer-Front End Loader And Backlhoe For Waste Coll. Dept. (2004, Failed, $801K)</title></rect>
-<rect class="bar-solid-buoy" x="125.6" y="325.0" width="2.0" height="14" data-nominal="132500" data-real="220038" data-win="0" data-dept="Public_Safety" data-type="override" data-year="2004"><title>Supplemental Expenses Of Police Department (2004, Failed, $220K)</title></rect>
-<rect class="bar-solid-navy" x="124.8" y="325.0" width="0.8" height="14" data-nominal="55000" data-real="91337" data-win="0" data-dept="General_Government" data-type="override" data-year="2004"><title>General Operating Expenditures (2004, Failed, $91K)</title></rect>
-<text class="tick-label" x="51" y="356.0" text-anchor="end" font-size="9">'05</text>
-<rect class="bar-solid-navy" x="135.0" y="345.0" width="40.4" height="14" data-nominal="2730167" data-real="4385322" data-win="1" data-dept="General_Government" data-type="override" data-year="2005"><title>Supplemental Expenses Of Several Town Departments (2005, Passed, $4.4M)</title></rect>
-<rect class="bar-hatch-navy" x="175.4" y="345.0" width="29.9" height="14" data-nominal="2025000" data-real="3252650" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2005"><title>Purchase 3 Certain Parcels Of Land Owned By Robinson Farm Realty Trust (2005, Passed, $3.3M)</title></rect>
-<rect class="bar-hatch-navy" x="205.3" y="345.0" width="12.0" height="14" data-nominal="811500" data-real="1303469" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2005"><title>Purchase Equipment For Several Town Departments (2005, Passed, $1.3M)</title></rect>
-<text class="tick-label" x="51" y="376.0" text-anchor="end" font-size="9">'07</text>
-<rect class="bar-hatch-sage" x="135.0" y="365.0" width="121.2" height="14" data-nominal="8700000" data-real="13165412" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2007"><title>Construct, Reconstruct Ocean Ave Causewayl (2007, Passed, $13.2M)</title></rect>
-<rect class="bar-hatch-sage" x="256.2" y="365.0" width="14.1" height="14" data-nominal="1010000" data-real="1528398" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2007"><title>Landfill Cap, Transfer Station, Drop Off (2007, Passed, $1.5M)</title></rect>
-<text class="tick-label" x="51" y="396.0" text-anchor="end" font-size="9">'08</text>
-<rect class="bar-hatch-teal" x="135.0" y="385.0" width="291.1" height="14" data-nominal="21700000" data-real="31617696" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2008"><title>Village School Project -Reconstruction (2008, Passed, $31.6M)</title></rect>
-<rect class="bar-hatch-teal" x="426.1" y="385.0" width="5.3" height="14" data-nominal="395000" data-real="575529" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2008"><title>Feasibility Study For The Glover School Project (2008, Passed, $576K)</title></rect>
-<text class="tick-label" x="51" y="416.0" text-anchor="end" font-size="9">'11</text>
-<rect class="bar-hatch-teal" x="135.0" y="405.0" width="326.8" height="14" data-nominal="25450000" data-real="35498733" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2011"><title>Funding The Design, Project Management And Construction Of A New Elementary School (2011, Passed, $35.5M)</title></rect>
-<rect class="bar-hatch-sage" x="461.8" y="405.0" width="233.4" height="14" data-nominal="18174578" data-real="25350667" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2011"><title>Funding The Permitting, Public Bidding And Construction Of A Cap For The Encompassing The Old Landfill, Etc (2011, Passed, $25.4M)</title></rect>
-<rect class="bar-solid-navy" x="126.4" y="405.0" width="8.6" height="14" data-nominal="667793" data-real="931466" data-win="0" data-dept="General_Government" data-type="override" data-year="2011"><title>Final Design, Public Bidding And Construction For Improvements To The Old Town House (2011, Failed, $931K)</title></rect>
-<text class="tick-label" x="51" y="436.0" text-anchor="end" font-size="9">'12</text>
-<rect class="bar-hatch-sage" x="135.0" y="425.0" width="62.1" height="14" data-nominal="4937687" data-real="6746308" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2012"><title>Pleasant Street Area Drainage Project (2012, Passed, $6.7M)</title></rect>
-<rect class="bar-hatch-navy" x="197.1" y="425.0" width="18.9" height="14" data-nominal="1500000" data-real="2049434" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2012"><title>Lead Mills Land Acquisition (2012, Passed, $2.0M)</title></rect>
-<rect class="bar-hatch-buoy" x="216.0" y="425.0" width="14.5" height="14" data-nominal="1150000" data-real="1571233" data-win="1" data-dept="Public_Safety" data-type="debt-exclusion" data-year="2012"><title>Quint Fire Truck (2012, Passed, $1.6M)</title></rect>
-<rect class="bar-hatch-navy" x="230.4" y="425.0" width="7.7" height="14" data-nominal="610168" data-real="833666" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2012"><title>Old Town House Accessibility Project (2012, Passed, $834K)</title></rect>
-<text class="tick-label" x="51" y="456.0" text-anchor="end" font-size="9">'13</text>
-<rect class="bar-hatch-navy" x="135.0" y="445.0" width="30.6" height="14" data-nominal="2465966" data-real="3320058" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2013"><title>Abbot Hall Tower Repairs (2013, Passed, $3.3M)</title></rect>
-<rect class="bar-hatch-sage" x="165.6" y="445.0" width="14.4" height="14" data-nominal="1165000" data-real="1568500" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2013"><title>Green Street Remediation (2013, Passed, $1.6M)</title></rect>
-<text class="tick-label" x="51" y="476.0" text-anchor="end" font-size="9">'15</text>
-<rect class="bar-hatch-sage" x="135.0" y="465.0" width="97.5" height="14" data-nominal="8000000" data-real="10589030" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2015"><title>Bonds To Pay For Repair And Replacement Of Drainage Pipe And Construction Of New Xfer Station (2015, Passed, $10.6M)</title></rect>
-<text class="tick-label" x="51" y="496.0" text-anchor="end" font-size="9">'16</text>
-<rect class="bar-hatch-teal" x="135.0" y="485.0" width="9.0" height="14" data-nominal="750000" data-real="980312" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2016"><title>Bonds For Study, Renovation And Recon Of Elbridge Gerry School (2016, Passed, $980K)</title></rect>
-<rect class="bar-hatch-buoy" x="144.0" y="485.0" width="7.5" height="14" data-nominal="620000" data-real="810392" data-win="1" data-dept="Public_Safety" data-type="debt-exclusion" data-year="2016"><title>Bonds For A Pumper Truck For The Fire Dept (2016, Passed, $810K)</title></rect>
-<text class="tick-label" x="51" y="516.0" text-anchor="end" font-size="9">'18</text>
-<rect class="bar-hatch-sage" x="135.0" y="505.0" width="10.0" height="14" data-nominal="871894" data-real="1089260" data-win="1" data-dept="Public_Works_and_Facilities" data-type="debt-exclusion" data-year="2018"><title>Costs Of Constructing And Reconstructing Seawalls And Fences (2018, Passed, $1.1M)</title></rect>
-<text class="tick-label" x="51" y="536.0" text-anchor="end" font-size="9">'19</text>
-<rect class="bar-hatch-teal" x="135.0" y="525.0" width="619.4" height="14" data-nominal="54844767" data-real="67285113" data-win="1" data-dept="School" data-type="debt-exclusion" data-year="2019"><title>Bonds For New Gerry School (2019, Passed, $67.3M)</title></rect>
-<rect class="bar-hatch-navy" x="754.4" y="525.0" width="8.5" height="14" data-nominal="750000" data-real="920121" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2019"><title>Bonds For Repairs To Fort Sewall (2019, Passed, $920K)</title></rect>
-<text class="tick-label" x="51" y="556.0" text-anchor="end" font-size="9">'21</text>
-<rect class="bar-hatch-brass" x="135.0" y="545.0" width="90.6" height="14" data-nominal="8500000" data-real="9839299" data-win="1" data-dept="Culture_and_Recreation" data-type="debt-exclusion" data-year="2021"><title>Renovation Of Abbot Public Library (2021, Passed, $9.8M)</title></rect>
-<rect class="bar-hatch-buoy" x="225.6" y="545.0" width="8.0" height="14" data-nominal="750000" data-real="868173" data-win="1" data-dept="Public_Safety" data-type="debt-exclusion" data-year="2021"><title>New Fire Pumper Truck (2021, Passed, $868K)</title></rect>
-<text class="tick-label" x="51" y="576.0" text-anchor="end" font-size="9">'22</text>
-<rect class="bar-hatch-navy" x="135.0" y="565.0" width="107.6" height="14" data-nominal="10902598" data-real="11684814" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2022"><title>Roof Replacements, Road & Sidewalk Improvements, Smart Panels, Hvac, Salt Shed, Hs Boiler (2022, Passed, $11.7M)</title></rect>
-<rect class="bar-solid-teal" x="104.9" y="565.0" width="30.1" height="14" data-nominal="3051093" data-real="3269996" data-win="0" data-dept="School" data-type="override" data-year="2022"><title>School Department Operating Budget (2022, Failed, $3.3M)</title></rect>
-<text class="tick-label" x="51" y="596.0" text-anchor="end" font-size="9">'23</text>
-<rect class="bar-solid-navy" x="111.6" y="585.0" width="23.4" height="14" data-nominal="2472056" data-real="2545074" data-win="0" data-dept="General_Government" data-type="override" data-year="2023"><title>General Government Operating Budget (2023, Failed, $2.5M)</title></rect>
-<text class="tick-label" x="51" y="616.0" text-anchor="end" font-size="9">'25</text>
-<rect class="bar-hatch-navy" x="135.0" y="605.0" width="3.0" height="14" data-nominal="" data-real="" data-win="1" data-dept="General_Government" data-type="debt-exclusion" data-year="2025"><title>Mary Alley Building Improvement & Hvac (2025, Passed, —)</title></rect>
-</svg>
-</div>
-
-<div class="legend">
-  <div class="legend-row">
-    <div class="legend-item"><span class="legend-swatch legend-swatch--solid"></span><span class="legend-text">Operating override</span></div>
-    <div class="legend-item"><span class="legend-swatch legend-swatch--hatch"></span><span class="legend-text">Debt exclusion</span></div>
-  </div>
-  <div class="legend-row">
-    <div class="legend-item s-teal"><span class="legend-swatch"></span><span class="legend-text">School</span></div>
-    <div class="legend-item s-navy"><span class="legend-swatch"></span><span class="legend-text">General Gov't</span></div>
-    <div class="legend-item s-sage"><span class="legend-swatch"></span><span class="legend-text">Public Works</span></div>
-    <div class="legend-item s-buoy"><span class="legend-swatch"></span><span class="legend-text">Public Safety</span></div>
-    <div class="legend-item s-brass"><span class="legend-swatch"></span><span class="legend-text">Culture &amp; Rec</span></div>
-    <div class="legend-item s-plum"><span class="legend-swatch"></span><span class="legend-text">Health &amp; Human Svcs</span></div>
-  </div>
-</div>
-
-<p class="caption">Each bar segment is one ballot question. Bars extending right of the center line passed; bars extending left failed. Widths show inflation-adjusted (2024 dollar) amounts. Solid bars are operating overrides; translucent bars are debt exclusions. CPI-U adjustment uses Bureau of Labor Statistics annual averages (series CUUR0000SA0), base year 2024.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride" data-source="MA DOR, Proposition 2½ Override &amp; Underride Votes (Marblehead)"></sup></p>
-
-<h2>Detail by year</h2>
-<p>Click any year to see the individual ballot questions, vote counts, and sources.</p>
 
 <div class="vote-history" data-mode="real">
 <details class="vote-year">
@@ -1766,13 +1746,100 @@ og_url: https://marbleheaddata.org/marblehead-voting-record.html
 </div>
 
 <script>
+/* Dot plot tooltip */
+(function () {
+  var tooltip = document.getElementById('vote-tooltip');
+  if (!tooltip) return;
+  var titleEl = tooltip.querySelector('.vote-tooltip-title');
+  var metaEl = tooltip.querySelector('.vote-tooltip-meta');
+  var votesEl = tooltip.querySelector('.vote-tooltip-votes');
+
+  var dots = document.querySelectorAll('.vote-dot');
+  dots.forEach(function (dot) {
+    dot.style.cursor = 'pointer';
+
+    function show(e) {
+      var desc = dot.getAttribute('data-desc') || '';
+      var amount = dot.getAttribute('data-amount') || '';
+      var result = dot.getAttribute('data-result') || '';
+      var date = dot.getAttribute('data-date') || '';
+      var type = dot.getAttribute('data-type') || '';
+      var yes = dot.getAttribute('data-yes') || '';
+      var no = dot.getAttribute('data-no') || '';
+      var margin = dot.getAttribute('data-margin') || '';
+
+      titleEl.textContent = desc;
+      metaEl.textContent = date + ' \u00b7 ' + type + ' \u00b7 ' + result;
+      var voteText = '';
+      if (yes && no && yes !== '0') {
+        voteText = 'Yes ' + yes + ' / No ' + no;
+        if (margin) voteText += ' (' + margin + ')';
+        if (amount && amount !== '\u2014') voteText += ' \u00b7 ' + amount;
+      }
+      votesEl.textContent = voteText;
+
+      tooltip.hidden = false;
+
+      var svg = dot.closest('svg');
+      var wrap = svg.closest('.chart-wrap') || svg.parentElement;
+      var wrapRect = wrap.getBoundingClientRect();
+      var dotRect = dot.getBoundingClientRect();
+
+      var left = dotRect.left - wrapRect.left + dotRect.width / 2;
+      var top = dotRect.top - wrapRect.top - 8;
+
+      tooltip.style.left = left + 'px';
+      tooltip.style.top = top + 'px';
+      tooltip.style.transform = 'translate(-50%, -100%)';
+
+      var tipRect = tooltip.getBoundingClientRect();
+      if (tipRect.left < 8) {
+        tooltip.style.transform = 'translate(0, -100%)';
+        tooltip.style.left = '8px';
+      } else if (tipRect.right > window.innerWidth - 8) {
+        tooltip.style.transform = 'translate(-100%, -100%)';
+        tooltip.style.left = (left - 8) + 'px';
+      }
+    }
+
+    dot.addEventListener('mouseenter', show);
+    dot.addEventListener('click', function(e) {
+      e.stopPropagation();
+      show(e);
+    });
+  });
+
+  document.addEventListener('click', function () {
+    tooltip.hidden = true;
+  });
+
+  var chartWrap = document.querySelector('.chart-wrap');
+  if (chartWrap) {
+    chartWrap.addEventListener('mouseleave', function () {
+      tooltip.hidden = true;
+    });
+  }
+})();
+
+/* Detail table nominal/real toggle */
 (function () {
   var container = document.querySelector('.vote-history');
   if (!container) return;
 
   var tabs = document.querySelectorAll('.tabs--compact .tab');
-  var caption = document.querySelector('.caption');
-  var chart = document.querySelector('.chart-wrap .chart');
+
+  function formatCurrency(val) {
+    if (val === 0) return '$0';
+    if (val >= 1000000) {
+      var m = val / 1000000;
+      return '$' + (m < 100 ? m.toFixed(1) : m.toFixed(0)) + 'M';
+    }
+    if (val >= 1000) {
+      var k = val / 1000;
+      return '$' + (k >= 10 ? k.toFixed(0) : k.toFixed(1)) + 'K';
+    }
+    return '$' + val.toFixed(0);
+  }
 
   function setMode(mode) {
     tabs.forEach(function (t) {
@@ -1782,99 +1849,6 @@ og_url: https://marbleheaddata.org/marblehead-voting-record.html
     });
 
     container.setAttribute('data-mode', mode);
-
-    if (chart) {
-      var rects = chart.querySelectorAll('rect[data-nominal]');
-      var MARKER_W = 3;
-      var ML = 55, MR = 15;
-      var FAIL_MIN_W = 80;
-      var chartW = 880 - ML - MR;
-
-      /* Group rects by year and side, compute per-year totals */
-      var byYear = {};
-      rects.forEach(function (r) {
-        var yr = r.getAttribute('data-year');
-        var win = r.getAttribute('data-win') === '1';
-        var val = parseFloat(r.getAttribute('data-' + mode)) || 0;
-        if (!byYear[yr]) byYear[yr] = { pass: [], fail: [], passTotal: 0, failTotal: 0 };
-        if (win) {
-          byYear[yr].pass.push(r);
-          byYear[yr].passTotal += val;
-        } else {
-          byYear[yr].fail.push(r);
-          byYear[yr].failTotal += val;
-        }
-      });
-
-      var maxPass = 1, maxFail = 1;
-      Object.keys(byYear).forEach(function (yr) {
-        if (byYear[yr].passTotal > maxPass) maxPass = byYear[yr].passTotal;
-        if (byYear[yr].failTotal > maxFail) maxFail = byYear[yr].failTotal;
-      });
-
-      var propFail = chartW * (maxFail / (maxPass + maxFail));
-      var failW = Math.max(FAIL_MIN_W, propFail);
-      var passW = chartW - failW;
-      var baselineX = ML + failW;
-      var pxPerDollar = passW / maxPass;
-
-      /* Re-stack bars from baseline outward */
-      Object.keys(byYear).forEach(function (yr) {
-        var cursor;
-
-        /* Pass side: extend right */
-        cursor = baselineX;
-        byYear[yr].pass.forEach(function (r) {
-          var val = parseFloat(r.getAttribute('data-' + mode)) || 0;
-          var w = (val > 0) ? val * pxPerDollar : MARKER_W;
-          r.setAttribute('x', cursor.toFixed(1));
-          r.setAttribute('width', w.toFixed(1));
-          cursor += w;
-        });
-
-        /* Fail side: extend left */
-        cursor = baselineX;
-        byYear[yr].fail.forEach(function (r) {
-          var val = parseFloat(r.getAttribute('data-' + mode)) || 0;
-          var w = (val > 0) ? val * pxPerDollar : MARKER_W;
-          cursor -= w;
-          r.setAttribute('x', cursor.toFixed(1));
-          r.setAttribute('width', w.toFixed(1));
-        });
-      });
-
-      /* Update baseline position */
-      var baseline = chart.querySelector('.axis-base');
-      if (baseline) {
-        baseline.setAttribute('x1', baselineX.toFixed(1));
-        baseline.setAttribute('x2', baselineX.toFixed(1));
-      }
-
-      /* Update grid lines on pass side */
-      var gridInterval = 20000000;
-      var gridLines = chart.querySelectorAll('.grid-minor');
-      var gridTexts = chart.querySelectorAll('text.tick-label--minor');
-      var gi = 0;
-      var gv = gridInterval;
-      while (gv <= maxPass && gi < gridLines.length) {
-        var gx = baselineX + gv * pxPerDollar;
-        gridLines[gi].setAttribute('x1', gx.toFixed(1));
-        gridLines[gi].setAttribute('x2', gx.toFixed(1));
-        if (gi < gridTexts.length) {
-          gridTexts[gi].setAttribute('x', gx.toFixed(1));
-          gridTexts[gi].textContent = formatCurrency(gv);
-        }
-        gi++;
-        gv += gridInterval;
-      }
-      /* Hide extra grid lines if scale changed */
-      while (gi < gridLines.length) {
-        gridLines[gi].setAttribute('x1', '-999');
-        gridLines[gi].setAttribute('x2', '-999');
-        if (gi < gridTexts.length) gridTexts[gi].textContent = '';
-        gi++;
-      }
-    }
 
     var summaryAmounts = document.querySelectorAll('.vote-year-amount');
     summaryAmounts.forEach(function (el) {
@@ -1894,27 +1868,6 @@ og_url: https://marbleheaddata.org/marblehead-voting-record.html
         el.textContent = formatCurrency(val);
       }
     });
-
-    if (caption) {
-      var modeLabel = mode === 'real' ? 'inflation-adjusted (2024 dollar)' : 'nominal (as-voted)';
-      caption.innerHTML = caption.innerHTML.replace(
-        /inflation-adjusted \(2024 dollar\)|nominal \(as-voted\)/,
-        modeLabel
-      );
-    }
-  }
-
-  function formatCurrency(val) {
-    if (val === 0) return '$0';
-    if (val >= 1000000) {
-      var m = val / 1000000;
-      return '$' + (m < 100 ? m.toFixed(1) : m.toFixed(0)) + 'M';
-    }
-    if (val >= 1000) {
-      var k = val / 1000;
-      return '$' + (k >= 10 ? k.toFixed(0) : k.toFixed(1)) + 'K';
-    }
-    return '$' + val.toFixed(0);
   }
 
   tabs.forEach(function (t) {

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -474,6 +474,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
       <div class="li"><span class="sw sw--rejected"></span> Rejected at the ballot</div>
       <div class="li">Source: <a href="data/marblehead_prop25_votes.csv">marblehead_prop25_votes.csv</a> (MA DOR Municipal Databank, pulled April 11, 2026)</div>
     </div>
+    <p class="ballot-timeline-link"><a href="marblehead-voting-record.html">See every vote with amounts, vote counts, and sources &rarr;</a></p>
   </div>
 
   <p>The structural problem this override addresses is not new. Signed transmittal letters from the Finance Committee show a steadily sharpening warning across seven years, ending in the override request now before voters.</p>


### PR DESCRIPTION
## Summary
- Replace the horizontal diverging bar chart on the voting record page with a dot plot (strip plot) that shows each ballot question as a dot on a 1982-2026 timeline
- Add hover/tap tooltips showing description, vote counts, margin, and amount for each dot
- Move the nominal/real dollar toggle to the detail table section (the dot plot does not encode dollar amounts visually)
- Add a link from the what-is-the-override dot plot to the full voting record page

## Test plan
- [ ] Verify the dot plot renders correctly with filled dots (approved) and hollow dots (rejected)
- [ ] Verify operating overrides appear on the top row, debt exclusions on the bottom row
- [ ] Verify same-date dots are jittered vertically so they don't overlap
- [ ] Verify hovering/tapping a dot shows the tooltip with correct data
- [ ] Verify the tooltip stays within viewport bounds on small screens
- [ ] Verify the "Last approved override" and "Only debt exclusion rejected" annotations are positioned correctly
- [ ] Verify the nominal/real toggle still works for the detail table amounts
- [ ] Verify the link from what-is-the-override leads to the voting record page
- [ ] Verify dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)