### PR TITLE
Add line-item detail to override tier cards

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -2773,6 +2773,11 @@ blockquote.quote--mixed p {
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
+.tier-line--offset {
+  margin-top: 4px;
+  padding-top: 8px;
+  border-top: 1px solid var(--divider);
+}
 .tier-line--offset .tier-line-name,
 .tier-line--offset .tier-line-amount { color: var(--text-subtle); }
 .tier-line--school {
@@ -2781,7 +2786,6 @@ blockquote.quote--mixed p {
   border-top: 1px solid var(--divider);
   font-weight: 600;
 }
-.tier-line--school .tier-line-name { color: var(--text); }
 .tier-line--school .tier-line-amount { color: var(--text); }
 
 .tier-tag {

--- a/assets/site.css
+++ b/assets/site.css
@@ -2739,6 +2739,76 @@ blockquote.quote--mixed p {
 }
 
 /* ==========================================================================
+   Tier line-item detail (override page)
+   ========================================================================== */
+
+.tier-items { margin: 12px 0 4px; }
+
+.tier-group-heading {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-subtle);
+  margin: 16px 0 4px;
+  padding-top: 8px;
+  border-top: 1px solid var(--divider);
+}
+.tier-group-heading:first-child {
+  margin-top: 4px;
+  padding-top: 0;
+  border-top: none;
+}
+
+.tier-line {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 7px 0;
+  font-size: 14px;
+}
+.tier-line-name { color: var(--text); }
+.tier-line-amount {
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.tier-line--offset .tier-line-name,
+.tier-line--offset .tier-line-amount { color: var(--text-subtle); }
+.tier-line--school {
+  margin-top: 4px;
+  padding-top: 8px;
+  border-top: 1px solid var(--divider);
+  font-weight: 600;
+}
+.tier-line--school .tier-line-name { color: var(--text); }
+.tier-line--school .tier-line-amount { color: var(--text); }
+
+.tier-tag {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  margin-right: 4px;
+  vertical-align: 1px;
+}
+.tier-tag--restore {
+  color: var(--c-teal);
+  background: color-mix(in srgb, var(--c-teal) 12%, transparent);
+}
+.tier-tag--new {
+  color: var(--c-navy);
+  background: color-mix(in srgb, var(--c-navy) 12%, transparent);
+}
+
+@media (max-width: 600px) {
+  .tier-line { font-size: 13px; }
+  .tier-tag { font-size: 9px; }
+}
+
+/* ==========================================================================
    Tier card color variants (match tier-chart segment colors)
    ========================================================================== */
 

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -198,7 +198,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
         <span class="tier-line-amount">~$7.7M</span>
       </div>
     </div>
-    <p class="source">Source: Town Administrator's <a href="https://www.marbleheadindependent.com/kezer-presents-9m-to-15m-tiered-override-plan-and-separate-2-2m-trash-tax-option/">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items.</p>
+    <p class="source">Source: Town Administrator's <a href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-08_Override_Presentation.pdf">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items.</p>
   </div>
 
   <blockquote class="quote">
@@ -290,7 +290,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
         <span class="tier-line-amount">~$1.6M</span>
       </div>
     </div>
-    <p class="source">Source: Town Administrator's <a href="https://www.marbleheadindependent.com/kezer-presents-9m-to-15m-tiered-override-plan-and-separate-2-2m-trash-tax-option/">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items. Amounts shown are incremental to Tier 1.</p>
+    <p class="source">Source: Town Administrator's <a href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-08_Override_Presentation.pdf">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items. Amounts shown are incremental to Tier 1.</p>
   </div>
 
   <div class="card tier-card--3">
@@ -330,7 +330,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
         <span class="tier-line-amount">~$1.5M</span>
       </div>
     </div>
-    <p class="source">Source: Town Administrator's <a href="https://www.marbleheadindependent.com/kezer-presents-9m-to-15m-tiered-override-plan-and-separate-2-2m-trash-tax-option/">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items. Amounts shown are incremental to Tier 2.</p>
+    <p class="source">Source: Town Administrator's <a href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-08_Override_Presentation.pdf">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items. Amounts shown are incremental to Tier 2.</p>
   </div>
 
   <div class="card tier-card--trash">

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -103,16 +103,102 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
   <div class="card tier-card--1">
     <p class="tier-label">Tier 1: Restore ($9 million)</p>
     <h3>Bring back services cut from the <a href="no-override-budget.html">no-override budget</a></h3>
-    <ul class="tier-list">
-      <li>Firefighter position</li>
-      <li>School resource officer</li>
-      <li>Full library staffing</li>
-      <li>Custodians</li>
-      <li>Groundskeeper</li>
-      <li>Council on Aging staff</li>
-      <li>Finance department positions</li>
-      <li>Community development positions</li>
-    </ul>
+    <div class="tier-items">
+      <div class="tier-group-heading">Public Safety</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Police school resource officer</span>
+        <span class="tier-line-amount">$65,482</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Police equipment</span>
+        <span class="tier-line-amount">$2,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Inspections subscriptions and maintenance</span>
+        <span class="tier-line-amount">$52,500</span>
+      </div>
+
+      <div class="tier-group-heading">Public Works</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> DPW staffing</span>
+        <span class="tier-line-amount">$140,594</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> DPW hot top paving</span>
+        <span class="tier-line-amount">$60,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Cemetery laborer</span>
+        <span class="tier-line-amount">$58,692</span>
+      </div>
+
+      <div class="tier-group-heading">Recreation, Library &amp; Parks</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Library staffing for accreditation</span>
+        <span class="tier-line-amount">$311,183</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Recreation and Parks groundskeeper</span>
+        <span class="tier-line-amount">$45,000</span>
+      </div>
+
+      <div class="tier-group-heading">General Government</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Finance staffing</span>
+        <span class="tier-line-amount">$68,287</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Finance technology and training</span>
+        <span class="tier-line-amount">$58,361</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Finance Committee Reserve Fund</span>
+        <span class="tier-line-amount">$26,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> HR advertising and subscriptions</span>
+        <span class="tier-line-amount">$11,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Community Development staffing</span>
+        <span class="tier-line-amount">$137,423</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Public Buildings custodians</span>
+        <span class="tier-line-amount">$122,554</span>
+      </div>
+
+      <div class="tier-group-heading">Health &amp; Human Services</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Council on Aging staffing</span>
+        <span class="tier-line-amount">$76,171</span>
+      </div>
+
+      <div class="tier-group-heading">Reserves &amp; Transfers</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> OPEB trust transfer</span>
+        <span class="tier-line-amount">$96,771</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Stabilization transfer</span>
+        <span class="tier-line-amount">$250,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Workers Comp and Section 111F transfer</span>
+        <span class="tier-line-amount">$97,662</span>
+      </div>
+
+      <div class="tier-line tier-line--offset">
+        <span class="tier-line-name">Unemployment reduction from restored positions</span>
+        <span class="tier-line-amount">&minus;$410,116</span>
+      </div>
+
+      <div class="tier-line tier-line--school">
+        <span class="tier-line-name">Schools</span>
+        <span class="tier-line-amount">~$7.7M</span>
+      </div>
+    </div>
+    <p class="source">Source: Town Administrator's <a href="https://www.marbleheadindependent.com/kezer-presents-9m-to-15m-tiered-override-plan-and-separate-2-2m-trash-tax-option/">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items.</p>
   </div>
 
   <blockquote class="quote">
@@ -123,13 +209,128 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
   <div class="card tier-card--2">
     <p class="tier-label">Tier 2: Stabilize ($12 million)</p>
     <h3>Everything in Tier 1, plus maintenance and staffing</h3>
-    <p>Additional public safety staffing, building maintenance funding, and salary adjustments.</p>
+    <div class="tier-items">
+      <div class="tier-group-heading">Public Safety</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Police staffing</span>
+        <span class="tier-line-amount">$65,482</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Fire staffing</span>
+        <span class="tier-line-amount">$148,000</span>
+      </div>
+
+      <div class="tier-group-heading">Public Works</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> DPW GIS position</span>
+        <span class="tier-line-amount">$70,000</span>
+      </div>
+
+      <div class="tier-group-heading">Recreation, Library &amp; Parks</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Library staffing</span>
+        <span class="tier-line-amount">$218,980</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Library materials</span>
+        <span class="tier-line-amount">$168,400</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Library PT custodian and assistant</span>
+        <span class="tier-line-amount">$38,378</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Recreation and Parks PT Senior Clerk</span>
+        <span class="tier-line-amount">$27,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Recreation and Parks maintenance</span>
+        <span class="tier-line-amount">$15,000</span>
+      </div>
+
+      <div class="tier-group-heading">General Government</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Finance IT Director</span>
+        <span class="tier-line-amount">$150,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Finance Budget Analyst</span>
+        <span class="tier-line-amount">$70,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Community Development staffing</span>
+        <span class="tier-line-amount">$170,552</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Town Clerk staffing</span>
+        <span class="tier-line-amount">$66,125</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Public Buildings maintenance</span>
+        <span class="tier-line-amount">$450,000</span>
+      </div>
+
+      <div class="tier-group-heading">Health &amp; Human Services</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Council on Aging PT Social Worker</span>
+        <span class="tier-line-amount">$45,000</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Council on Aging maintenance</span>
+        <span class="tier-line-amount">$15,000</span>
+      </div>
+
+      <div class="tier-line tier-line--offset">
+        <span class="tier-line-name">Additional unemployment reduction</span>
+        <span class="tier-line-amount">&minus;$282,245</span>
+      </div>
+
+      <div class="tier-line tier-line--school">
+        <span class="tier-line-name">Schools</span>
+        <span class="tier-line-amount">~$1.6M</span>
+      </div>
+    </div>
+    <p class="source">Source: Town Administrator's <a href="https://www.marbleheadindependent.com/kezer-presents-9m-to-15m-tiered-override-plan-and-separate-2-2m-trash-tax-option/">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items. Amounts shown are incremental to Tier 1.</p>
   </div>
 
   <div class="card tier-card--3">
     <p class="tier-label">Tier 3: Invest ($15 million)</p>
     <h3>Everything in Tiers 1 and 2, plus capital</h3>
-    <p>Capital investments totaling roughly $2.1 million across schools, town infrastructure, and maintenance.</p>
+    <div class="tier-items">
+      <div class="tier-group-heading">Public Safety</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Police staffing</span>
+        <span class="tier-line-amount">$65,482</span>
+      </div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Fire staffing</span>
+        <span class="tier-line-amount">$296,000</span>
+      </div>
+
+      <div class="tier-group-heading">General Government</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Community Development Grant Writer</span>
+        <span class="tier-line-amount">$70,000</span>
+      </div>
+
+      <div class="tier-group-heading">Health &amp; Human Services</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Health Department mental health counseling</span>
+        <span class="tier-line-amount">$60,000</span>
+      </div>
+
+      <div class="tier-group-heading">Recurring Capital</div>
+      <div class="tier-line">
+        <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> Capital funding for leases, equipment, and buildings</span>
+        <span class="tier-line-amount">$1,000,000</span>
+      </div>
+
+      <div class="tier-line tier-line--school">
+        <span class="tier-line-name">Schools</span>
+        <span class="tier-line-amount">~$1.5M</span>
+      </div>
+    </div>
+    <p class="source">Source: Town Administrator's <a href="https://www.marbleheadindependent.com/kezer-presents-9m-to-15m-tiered-override-plan-and-separate-2-2m-trash-tax-option/">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items. Amounts shown are incremental to Tier 2.</p>
   </div>
 
   <div class="card tier-card--trash">


### PR DESCRIPTION
## Summary

- Replace the three prose tier cards on the override explainer page with dollar-denominated line-item breakdowns from the Town Administrator's April 8 override presentation
- Each item tagged Restore (cut being reversed) or New (genuinely new spending), grouped by department
- Incremental framing: Tier 2 shows only what it adds beyond Tier 1, Tier 3 only what it adds beyond Tier 2
- Schools line in each card to account for the full tier total
- Source citations link to the primary PDF (GitHub release archive)

## Test plan

- [ ] Verify tier cards render correctly on desktop and mobile
- [ ] Verify light and dark mode (Restore/New tag colors, offset line muted text)
- [ ] Spot-check dollar amounts against `data/override_town_line_items.csv`
- [ ] Confirm Dan Fox quote, trash card, and nesting visualization are unchanged
- [ ] Confirm source links go to the primary PDF, quote links go to the newspaper

🤖 Generated with [Claude Code](https://claude.com/claude-code)