### PR TITLE
Collapse tier card line items with tease and cumulative school totals

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -2844,6 +2844,27 @@ blockquote.quote--mixed p {
   background: color-mix(in srgb, var(--c-navy) 12%, transparent);
 }
 
+.tier-more {
+  margin-top: 4px;
+}
+.tier-more > summary {
+  cursor: pointer;
+  list-style: none;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--link);
+  padding: 8px 0;
+  border-top: 1px solid var(--divider);
+}
+.tier-more > summary::-webkit-details-marker { display: none; }
+.tier-more > summary::after {
+  content: " \25B8";
+  font-size: 10px;
+}
+.tier-more[open] > summary::after {
+  content: " \25BE";
+}
+
 @media (max-width: 600px) {
   .tier-line { font-size: 13px; }
   .tier-tag { font-size: 9px; }

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -118,6 +118,8 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
         <span class="tier-line-amount">$52,500</span>
       </div>
 
+      <details class="tier-more">
+        <summary>Show all 18 town-side items</summary>
       <div class="tier-group-heading">Public Works</div>
       <div class="tier-line">
         <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> DPW staffing</span>
@@ -192,6 +194,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
         <span class="tier-line-name">Unemployment reduction from restored positions</span>
         <span class="tier-line-amount">&minus;$410,116</span>
       </div>
+      </details>
 
       <div class="tier-line tier-line--school">
         <span class="tier-line-name">Schools</span>
@@ -220,6 +223,8 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
         <span class="tier-line-amount">$148,000</span>
       </div>
 
+      <details class="tier-more">
+        <summary>Show all 15 town-side items</summary>
       <div class="tier-group-heading">Public Works</div>
       <div class="tier-line">
         <span class="tier-line-name"><span class="tier-tag tier-tag--new">New</span> DPW GIS position</span>
@@ -284,10 +289,11 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
         <span class="tier-line-name">Additional unemployment reduction</span>
         <span class="tier-line-amount">&minus;$282,245</span>
       </div>
+      </details>
 
       <div class="tier-line tier-line--school">
         <span class="tier-line-name">Schools</span>
-        <span class="tier-line-amount">~$1.6M</span>
+        <span class="tier-line-amount">~$1.6M (~$9.3M total)</span>
       </div>
     </div>
     <p class="source">Source: Town Administrator's <a href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-08_Override_Presentation.pdf">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items. Amounts shown are incremental to Tier 1.</p>
@@ -327,7 +333,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
 
       <div class="tier-line tier-line--school">
         <span class="tier-line-name">Schools</span>
-        <span class="tier-line-amount">~$1.5M</span>
+        <span class="tier-line-amount">~$1.5M (~$10.8M total)</span>
       </div>
     </div>
     <p class="source">Source: Town Administrator's <a href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-08_Override_Presentation.pdf">April 8, 2026 override presentation</a>. School allocation is the tier total minus town-side line items. Amounts shown are incremental to Tier 2.</p>


### PR DESCRIPTION
## Summary

- Tier 1 and Tier 2 cards now tease the first department group (Public Safety), with remaining items behind a "Show all N items" toggle
- Schools line stays always visible outside the collapse
- Tier 2 Schools shows "~$1.6M (~$9.3M total)" and Tier 3 shows "~$1.5M (~$10.8M total)" to prevent misreading the incremental amounts as a drop in school funding
- Tier 3 card (only 5 items) has no collapse

## Test plan

- [ ] Verify "Show all N items" toggles open/close on desktop and mobile
- [ ] Verify Schools line is visible when items are collapsed
- [ ] Verify cumulative parenthetical on Tier 2 and Tier 3 Schools lines
- [ ] Check light and dark mode for the toggle link color

🤖 Generated with [Claude Code](https://claude.com/claude-code)