### PR TITLE
Link employer contribution section to healthcare costs page

### DIFF
--- a/charts/rate_value_schools.html
+++ b/charts/rate_value_schools.html
@@ -304,7 +304,7 @@ title: "Rate, Value, and What You Get"
 </div>
 
 <p class="caption">
-  Modal employer premium contribution share for health insurance, FY2026. These are the most common split across each town's plan options. Stoneham has a tiered structure: 80% for post-2009 hires, 90% legacy for pre-2009 hires. Melrose is reported as "over 80%" per PEC agreement. Swampscott's 73/27 split is per the town's FY2025 Open Enrollment rate sheet. All four towns participate in the GIC.
+  Modal employer premium contribution share for health insurance, FY2026. These are the most common split across each town's plan options. Stoneham has a tiered structure: 80% for post-2009 hires, 90% legacy for pre-2009 hires. Melrose is reported as "over 80%" per PEC agreement. Swampscott's 73/27 split is per the town's FY2025 Open Enrollment rate sheet. All four towns participate in the GIC. For how those premiums have grown relative to the tax levy, see <a href="healthcare_costs.html">Why Health Insurance Keeps Rising</a>.
 </p>
 
 <div class="notes">


### PR DESCRIPTION
## Summary
- Adds an inline cross-link from the employer health insurance contribution caption on `rate_value_schools.html` to the healthcare costs deep dive (`healthcare_costs.html`)
- Lets readers who see the 83% employer share follow the thread to *why* rising premiums matter in the budget

## Test plan
- [ ] Verify link renders correctly on the live page
- [ ] Confirm it navigates to the healthcare costs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)