### PR TITLE
Add v1.0 version to site footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 title: Marblehead Budget Data
 description: Open data and charts about Marblehead, MA municipal finances
-last_updated: April 11, 2026
+last_updated: April 12, 2026
+version: "1.0"
 url: https://marbleheaddata.org
 baseurl: ""
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,4 +6,5 @@
     <a href="https://github.com/agbaber/marblehead/issues/new?title=Correction%3A+">Report an issue</a>
   </nav>
   <p class="footer-meta">Built by a Marblehead resident &middot; Updated {{ site.last_updated }}</p>
+  <p class="footer-version"><a href="https://github.com/agbaber/marblehead/releases">v{{ site.version }}</a></p>
 </footer>

--- a/assets/site.css
+++ b/assets/site.css
@@ -808,6 +808,20 @@ details.notes[open] > summary {
   letter-spacing: 0.2px;
 }
 
+.footer-version {
+  font-size: 10px;
+  color: var(--text-faint);
+  margin: 6px 0 0;
+  opacity: 0.6;
+}
+.footer-version a {
+  color: inherit;
+  text-decoration: none;
+}
+.footer-version a:hover {
+  text-decoration: underline;
+}
+
 /* ==========================================================================
    Cards (used on text pages)
    ========================================================================== */


### PR DESCRIPTION
## Summary
- Adds `version: "1.0"` to `_config.yml` (also bumps `last_updated` to April 12)
- Adds a subtle `v1.0` link in the footer pointing to GitHub releases
- Styled to be nearly invisible (10px, faint, 60% opacity) -- present for transparency, not prominence

## Test plan
- [ ] Verify footer renders `v1.0` below the "Built by" line
- [ ] Verify the link goes to `github.com/agbaber/marblehead/releases`
- [ ] Check dark mode appearance
- [ ] Check mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)