### PR TITLE
Follow-up bias audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An open dataset and visualization project tracking Marblehead, Massachusetts mun
 - [`data/MASTER_DATA.csv`](data/MASTER_DATA.csv) -- Every verified time-series data point in one file (FY2001-FY2027)
 - [`data/DATA_CATALOG.md`](data/DATA_CATALOG.md) -- What every field means, where it came from, and what the caveats are
 - [`data/SOURCE_LOOKUP.md`](data/SOURCE_LOOKUP.md) -- Trace any number back to its specific document and page
-- [`data/case_studies.md`](data/case_studies.md) -- What happened in Melrose and Stoneham after failed overrides
+- [`data/case_studies.md`](data/case_studies.md) -- What happened after four MA towns voted no on overrides
 
 ### Charts
 Interactive HTML charts viewable at **[marbleheaddata.org](https://marbleheaddata.org/)** (or open the HTML files directly in a browser):

--- a/data/case_studies.md
+++ b/data/case_studies.md
@@ -79,7 +79,7 @@ title: case studies
 - **Result:** Stoneham received $9.3M instead of the $14.6M originally requested. Service gaps will persist.
 
 <div class="takeaway">
-  <strong>Key lesson.</strong> Even after living through cuts, the larger amount <em>still</em> nearly failed &mdash; by 43 votes. The community was deeply divided. An active information campaign (Override Study Committee, weekly public meetings) was critical to getting even the $9.3M across.
+  <strong>Key lesson.</strong> Even after living through cuts, the larger amount <em>still</em> nearly failed, by 43 votes. The community was deeply divided. An active information campaign (Override Study Committee, weekly public meetings) was critical to getting even the $9.3M across.
 </div>
 
 ---

--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@ m-170 -340 l0 -145 -120 0 c-98 0 -120 3 -120 14 0 8 4 18 10 21 5 3 53 62
 
     <a class="question" href="data/case_studies">
       <h2>What happened in towns that voted no?</h2>
-      <p>Melrose and Stoneham both rejected overrides, experienced cuts, and came back with larger asks. What the data shows about what followed each vote.</p>
+      <p>What happened in four Massachusetts towns after override votes failed: two came back with larger asks, two absorbed years of cuts without returning.</p>
     </a>
   </div>
 
@@ -208,7 +208,7 @@ m-170 -340 l0 -145 -120 0 c-98 0 -120 3 -120 14 0 8 4 18 10 21 5 3 53 62
       <a class="data-link" href="data/master-data">
         <div>
           <div class="data-link-title">Annual Rollup (FY01&ndash;FY27)</div>
-          <div class="data-link-desc">Tax levy, revenue, staffing, benefits, enrollment &mdash; year by year</div>
+          <div class="data-link-desc">Tax levy, revenue, staffing, benefits, enrollment, year by year</div>
         </div>
         <span class="data-link-badge">TABLE</span>
       </a>
@@ -229,7 +229,7 @@ m-170 -340 l0 -145 -120 0 c-98 0 -120 3 -120 14 0 8 4 18 10 21 5 3 53 62
       <a class="data-link" href="data/case_studies">
         <div>
           <div class="data-link-title">Case Studies</div>
-          <div class="data-link-desc">What happened in Melrose and Stoneham</div>
+          <div class="data-link-desc">What happened after four towns voted no</div>
         </div>
         <span class="data-link-badge">MD</span>
       </a>

--- a/marblehead-voting-record.html
+++ b/marblehead-voting-record.html
@@ -1,7 +1,7 @@
 ---
 title: "Marblehead's Prop 2½ voting record"
 og_title: "Marblehead's Prop 2½ voting record"
-og_description: "Every Proposition 2½ vote since 1988 — what passed, what failed, and how much. Operating overrides and debt exclusions with vote counts and primary sources."
+og_description: "Every Proposition 2½ vote since 1988: what passed, what failed, and how much. Operating overrides and debt exclusions with vote counts and primary sources."
 og_url: https://marbleheaddata.org/marblehead-voting-record.html
 ---
 

--- a/senior-tax-relief.html
+++ b/senior-tax-relief.html
@@ -161,8 +161,8 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     </ul>
   </div>
 
-  <div class="takeaway takeaway--pos">
-    For a qualifying senior, the state Senior Circuit Breaker formula refunds <em>more</em>, not less, as the property tax bill goes up. The override increases the credit for seniors who are not yet at the $2,820 cap.
+  <div class="takeaway takeaway--neutral">
+    For a qualifying senior, the state Senior Circuit Breaker formula refunds <em>more</em>, not less, as the property tax bill goes up. The override increases the credit for seniors who are not yet at the $2,820 cap, but it also increases the tax bill that created the need for the credit.
   </div>
 
   <nav class="page-toc" aria-label="On this page">

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -40,7 +40,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
     <div class="statute-source">M.G.L. c. 59 &sect; 21C &middot; <a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter59/Section21C">malegislature.gov</a></div>
   </div>
 
-  <p>The deficit was forecast a year in advance. The Finance Committee's signed transmittal letter to the spring 2025 Annual Town Meeting told residents a three-year budget forecast had already identified FY27 as a crisis year.</p>
+  <p>The deficit was forecast a year in advance. The Finance Committee's signed transmittal letter to the spring 2025 Annual Town Meeting told residents a three-year budget forecast had already identified FY27 as a projected deficit year.</p>
 
   <blockquote class="quote quote--mixed">
     <p>The three-year operating budget forecast <span class="quoted">&ldquo;highlighted projected deficits for each of the FY26, FY27, and FY28 periods.&rdquo;</span></p>


### PR DESCRIPTION
## Summary
- Residual issues from the April 11 bias audit remediation, caught in a follow-up re-review
- **"crisis year"** replaced with FinCom's own language ("projected deficit year") in `what-is-the-override.html`
- **Senior tax relief takeaway** changed from `takeaway--pos` (sage/green) to `takeaway--neutral`, with balancing clause added
- **Homepage case studies card** updated to reflect all four towns (Melrose, Stoneham, Easton, Newton), not just the two that returned with larger asks
- **Em-dashes** removed from prose in `index.html`, `case_studies.md`, and `marblehead-voting-record.html` og_description (style guide compliance)
- **README** case studies description updated to match

## Test plan
- [ ] Verify `what-is-the-override.html` no longer says "crisis year"
- [ ] Verify senior-tax-relief takeaway renders with neutral (gray) styling, not sage/green
- [ ] Verify homepage case studies card mentions both outcomes (returned / did not return)
- [ ] Spot-check for remaining em-dashes in prose (data table cells are fine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)