### PR TITLE
Add footer to chart layout

### DIFF
--- a/_layouts/chart.html
+++ b/_layouts/chart.html
@@ -9,4 +9,5 @@ body_class: chart-page
 
   {{ content }}
 
+  {% include footer.html %}
 </div>


### PR DESCRIPTION
## Summary
- The `chart` layout was the only layout missing `{% include footer.html %}`, so all 10 chart pages had no site footer (no About, Privacy, Source, or Report an issue links)
- Adds the one-line include to match `home` and `page` layouts

## Test plan
- [ ] Open any chart page (e.g. `/charts/override_calculator.html`) and verify the footer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)