### PR TITLE
Bump footer version to 1.0.1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Marblehead Budget Data
 description: Open data and charts about Marblehead, MA municipal finances
 last_updated: April 12, 2026
-version: "1.0"
+version: "1.0.1"
 url: https://marbleheaddata.org
 baseurl: ""
 


### PR DESCRIPTION
## Summary
- Updates `_config.yml` version from `1.0` to `1.0.1` so the site footer matches the release tag

## Test plan
- [ ] Footer shows v1.0.1 linking to releases page

🤖 Generated with [Claude Code](https://claude.com/claude-code)