### PR TITLE
Add structural reform goal card to civic guide

### DIFF
--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -214,6 +214,11 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
   </div>
 
   <div class="goal-card">
+    <div class="goal-card-eyebrow">If you want structural reform regardless of the vote</div>
+    <p>Both sides of the override debate, and the <a href="charts/sustainability.html">underlying math</a>, agree that cost drivers need structural attention. The levers with the most long-term impact: the <a href="why-not-elsewhere.html#premium-splits">83/17 health insurance premium split</a> (negotiated between the town and unions under <a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIV/Chapter32B/Section19">MGL c.32B &sect;19</a>; the Select Board represents the town side) and <a href="charts/enrollment_vs_staffing.html">staffing composition</a> (Town Administrator for town departments, School Committee for schools). Concrete steps: ask the Select Board to request a <a href="#better-oversight">DLS Financial Management Review</a> (free, independent, no warrant article needed). Show up at <a href="https://marbleheadma.gov/finance-committee/">Super Saturday budget hearings</a> and ask about premium split and staffing benchmarks relative to peer towns. Track when the next collective bargaining agreement comes up for renewal: that is when the premium split is actually on the table. Attend School Committee meetings and ask how staffing composition has changed relative to enrollment.</p>
+  </div>
+
+  <div class="goal-card">
     <div class="goal-card-eyebrow">If you don't know yet and want to understand the system</div>
     <p>Read the town charter, the most recent <a href="https://marbleheadma.gov/finance-committee/">Finance Committee annual report</a>, and the FY27 proposed budget (linked from <a href="no-override-budget.html">what is in the no-override budget</a>). Attend any Finance Committee or Select Board meeting: they are public, hybrid, and often have a public comment period at the start. Join a committee when seats become available.</p>
   </div>


### PR DESCRIPTION
## Summary
- New fifth goal card: "If you want structural reform regardless of the vote"
- Names the two key levers (83/17 premium split, staffing composition) with links
- Four concrete actions: DLS review request, Super Saturday benchmarks, contract cycle tracking, School Committee attendance
- Links to sustainability chart to ground the case in math, not just political consensus

## Test plan
- [ ] Verify goal card renders correctly between "specific cuts" and "don't know yet" cards
- [ ] Verify all links resolve (sustainability chart, premium splits, staffing, MGL, DLS review anchor, Super Saturday)

🤖 Generated with [Claude Code](https://claude.com/claude-code)