### PR TITLE
Add PostHog disclosure to privacy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -24,6 +24,7 @@ og_url: https://marbleheaddata.org/privacy.html
 
 <h2>What is on the rest of the site</h2>
 <p>The rest of the Marblehead Budget Data site uses Cloudflare Web Analytics for basic, privacy-friendly traffic measurement. Cloudflare Web Analytics does not use cookies, does not track individual users across sites, and does not collect personal data. It records aggregate page views and referrer information only.</p>
+<p>The site also uses PostHog to track anonymous usage events: which table-of-contents links visitors click, whether the tax calculator is used (yes or no, not the values entered), and how far down a page visitors scroll. PostHog does not collect names, emails, or device identifiers. No personal profiles are created. The data helps the author understand which sections are actually being read so the site can improve over time.</p>
 
 <h2>Questions</h2>
 <p>If something on this page is unclear or you want to verify any claim above, the full source code for the community pulse feature (front-end widget and server-side Worker) is published at <a href="https://github.com/agbaber/marblehead">github.com/agbaber/marblehead</a> under the <code>community-pulse/</code> and <code>assets/community-pulse/</code> directories. You can read the code and confirm these claims for yourself.</p>


### PR DESCRIPTION
## Summary
- The site loads PostHog for anonymous event tracking but the privacy page only disclosed Cloudflare Web Analytics
- Adds a paragraph explaining what PostHog tracks (TOC clicks, calculator boolean, scroll depth) and what it does not collect (no PII, no profiles)

## Test plan
- [ ] Verify privacy.html renders correctly on GitHub Pages
- [ ] Confirm the new paragraph reads clearly alongside the existing Cloudflare disclosure

🤖 Generated with [Claude Code](https://claude.com/claude-code)