### PR TITLE
Add robots.txt, sitemap.xml, and custom 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,20 @@
+---
+layout: default
+title: Page not found
+permalink: /404.html
+---
+{% include nav.html %}
+
+<div class="page" style="text-align: center; padding-top: 3rem;">
+  <h1>Page not found</h1>
+  <p>This page doesn't exist or may have moved.</p>
+
+  <nav class="four-oh-four-links">
+    <a href="{{ '/' | relative_url }}">Home</a>
+    <a href="{{ '/' | relative_url }}what-is-the-override.html">What is the override?</a>
+    <a href="{{ '/' | relative_url }}the-debate.html">The debate</a>
+    <a href="{{ '/' | relative_url }}charts/override_calculator.html">Override calculator</a>
+  </nav>
+
+  {% include footer.html %}
+</div>

--- a/assets/site.css
+++ b/assets/site.css
@@ -3624,3 +3624,12 @@ abbr.g:focus::after {
 .deep-dive-expand-all:hover {
   text-decoration: underline;
 }
+
+/* 404 page */
+.four-oh-four-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px 24px;
+  margin: 2rem 0;
+}

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,6 @@
+# robots.txt for marbleheaddata.org
+
+User-agent: *
+Allow: /
+
+Sitemap: https://marbleheaddata.org/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,14 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {%- for page in site.pages -%}
+    {%- if page.url contains '/assets/' or page.url contains '/data/' -%}{%- continue -%}{%- endif -%}
+    {%- if page.url == '/sitemap.xml' or page.url == '/robots.txt' -%}{%- continue -%}{%- endif -%}
+    {%- unless page.url contains '.html' or page.url == '/' -%}{%- continue -%}{%- endunless -%}
+  <url>
+    <loc>{{ page.url | absolute_url }}</loc>
+  </url>
+  {%- endfor -%}
+</urlset>


### PR DESCRIPTION
## Summary
- **robots.txt**: Allows all crawlers, points to sitemap
- **sitemap.xml**: Jekyll-generated, auto-discovers all pages at build time
- **404.html**: Custom 404 with nav links to key pages (home, override explainer, debate, calculator)
- **CSS**: Minimal flex layout for 404 link group

## Test plan
- [ ] Verify sitemap.xml renders valid XML after GitHub Pages build
- [ ] Verify 404.html appears for nonexistent URLs (e.g. /asdf)
- [ ] Verify robots.txt is accessible at /robots.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)