### PR TITLE
Style 404 links as btn-link buttons

### DIFF
--- a/404.html
+++ b/404.html
@@ -10,10 +10,10 @@ permalink: /404.html
   <p>This page doesn't exist or may have moved.</p>
 
   <nav class="four-oh-four-links">
-    <a href="{{ '/' | relative_url }}">Home</a>
-    <a href="{{ '/' | relative_url }}what-is-the-override.html">What is the override?</a>
-    <a href="{{ '/' | relative_url }}the-debate.html">The debate</a>
-    <a href="{{ '/' | relative_url }}charts/override_calculator.html">Override calculator</a>
+    <a class="btn-link" href="{{ '/' | relative_url }}">Home</a>
+    <a class="btn-link" href="{{ '/' | relative_url }}what-is-the-override.html">What is the override?</a>
+    <a class="btn-link" href="{{ '/' | relative_url }}the-debate.html">The debate</a>
+    <a class="btn-link" href="{{ '/' | relative_url }}charts/override_calculator.html">Override calculator</a>
   </nav>
 
   {% include footer.html %}

--- a/assets/site.css
+++ b/assets/site.css
@@ -3630,6 +3630,9 @@ abbr.g:focus::after {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 12px 24px;
+  gap: 12px 16px;
   margin: 2rem 0;
+}
+.four-oh-four-links .btn-link {
+  margin: 0;
 }


### PR DESCRIPTION
## Summary
- Uses the existing `.btn-link` component (outlined pill buttons with arrow + hover effect) instead of unstyled text links
- Zeroes out the default `.btn-link` margin inside the flex container so spacing comes from the gap

## Test plan
- [ ] Visit a nonexistent URL and verify the four links render as outlined buttons
- [ ] Verify hover state works (fill + arrow slide)
- [ ] Check mobile wrap behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)