### PR TITLE
Fix horizontal scroll on department table

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -919,7 +919,14 @@ table.data {
   border-collapse: separate;
   border-spacing: 0;
   font-size: 14px;
-  min-width: 420px;
+  min-width: 360px;
+}
+table.data caption {
+  caption-side: bottom;
+  text-align: left;
+  font-size: 11px;
+  color: var(--text-subtle);
+  padding: 6px 0 0;
 }
 table.data th {
   padding: 10px 12px;

--- a/where-has-the-money-gone.html
+++ b/where-has-the-money-gone.html
@@ -239,6 +239,7 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
 
   <div class="table-wrap">
     <table class="data data--stack">
+      <caption>Dollar amounts in thousands</caption>
       <thead>
         <tr>
           <th>Department</th>
@@ -251,161 +252,161 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
       <tbody>
         <tr>
           <td>Schools (total appropriation)</td>
-          <td>$32,066,000</td>
-          <td>$49,120,000</td>
-          <td>+$17,054,000</td>
+          <td>$32,066</td>
+          <td>$49,120</td>
+          <td>+$17,054</td>
           <td>+53%</td>
         </tr>
         <tr>
           <td>Fire</td>
-          <td>$3,309,000</td>
-          <td>$5,561,000</td>
-          <td>+$2,252,000</td>
+          <td>$3,309</td>
+          <td>$5,561</td>
+          <td>+$2,252</td>
           <td>+68%</td>
         </tr>
         <tr>
           <td>Police</td>
-          <td>$3,372,000</td>
-          <td>$4,987,000</td>
-          <td>+$1,616,000</td>
+          <td>$3,372</td>
+          <td>$4,987</td>
+          <td>+$1,616</td>
           <td>+48%</td>
         </tr>
         <tr>
           <td>Waste</td>
-          <td>$1,826,000</td>
-          <td>$2,943,000</td>
-          <td>+$1,117,000</td>
+          <td>$1,826</td>
+          <td>$2,943</td>
+          <td>+$1,117</td>
           <td>+61%</td>
         </tr>
         <tr>
           <td>Public Works</td>
-          <td>$1,305,000</td>
-          <td>$2,301,000</td>
-          <td>+$996,000</td>
+          <td>$1,305</td>
+          <td>$2,301</td>
+          <td>+$996</td>
           <td>+76%</td>
         </tr>
         <tr>
           <td>Finance</td>
-          <td>$848,000</td>
-          <td>$1,689,000</td>
-          <td>+$841,000</td>
+          <td>$848</td>
+          <td>$1,689</td>
+          <td>+$841</td>
           <td>+99%</td>
         </tr>
         <tr>
           <td>Snow and Ice</td>
-          <td>$798,000</td>
-          <td>$105,000</td>
-          <td>-$693,000</td>
+          <td>$798</td>
+          <td>$105</td>
+          <td>-$693</td>
           <td id="ref-e1">-87% (<a href="#note-e" class="footnote-ref">note E</a>)</td>
         </tr>
         <tr>
           <td>Insurance Premiums</td>
-          <td>$318,000</td>
-          <td>$865,000</td>
-          <td>+$547,000</td>
+          <td>$318</td>
+          <td>$865</td>
+          <td>+$547</td>
           <td id="ref-f1">+172% (<a href="#note-f" class="footnote-ref">note F</a>)</td>
         </tr>
         <tr>
           <td>Library</td>
-          <td>$999,000</td>
-          <td>$1,493,000</td>
-          <td>+$494,000</td>
+          <td>$999</td>
+          <td>$1,493</td>
+          <td>+$494</td>
           <td>+49%</td>
         </tr>
         <tr>
           <td>Community Development</td>
-          <td>$1,000</td>
-          <td>$494,000</td>
-          <td>+$493,000</td>
+          <td>$1</td>
+          <td>$494</td>
+          <td>+$493</td>
           <td id="ref-a1"><a href="#note-a" class="footnote-ref">see note A</a></td>
         </tr>
         <tr>
           <td>Reserve Fund</td>
           <td>$0</td>
-          <td>$444,000</td>
-          <td>+$444,000</td>
+          <td>$444</td>
+          <td>+$444</td>
           <td id="ref-b1"><a href="#note-b" class="footnote-ref">see note B</a></td>
         </tr>
         <tr>
           <td>Rec and Park</td>
-          <td>$726,000</td>
-          <td>$1,037,000</td>
-          <td>+$311,000</td>
+          <td>$726</td>
+          <td>$1,037</td>
+          <td>+$311</td>
           <td>+43%</td>
         </tr>
         <tr>
           <td>Human Resources</td>
           <td>$0</td>
-          <td>$295,000</td>
-          <td>+$295,000</td>
+          <td>$295</td>
+          <td>+$295</td>
           <td id="ref-c1"><a href="#note-c" class="footnote-ref">see note C</a></td>
         </tr>
         <tr>
           <td>Select Board</td>
-          <td>$456,000</td>
-          <td>$700,000</td>
-          <td>+$244,000</td>
+          <td>$456</td>
+          <td>$700</td>
+          <td>+$244</td>
           <td>+53%</td>
         </tr>
         <tr>
           <td>Inspections</td>
-          <td>$450,000</td>
-          <td>$689,000</td>
-          <td>+$240,000</td>
+          <td>$450</td>
+          <td>$689</td>
+          <td>+$240</td>
           <td>+53%</td>
         </tr>
         <tr>
           <td>Cemetery</td>
-          <td>$313,000</td>
-          <td>$495,000</td>
-          <td>+$182,000</td>
+          <td>$313</td>
+          <td>$495</td>
+          <td>+$182</td>
           <td>+58%</td>
         </tr>
         <tr>
           <td>Council on Aging</td>
-          <td>$243,000</td>
-          <td>$423,000</td>
-          <td>+$180,000</td>
+          <td>$243</td>
+          <td>$423</td>
+          <td>+$180</td>
           <td>+74%</td>
         </tr>
         <tr>
           <td>Town Counsel</td>
-          <td>$71,000</td>
-          <td>$228,000</td>
-          <td>+$157,000</td>
+          <td>$71</td>
+          <td>$228</td>
+          <td>+$157</td>
           <td id="ref-f2">+219% (<a href="#note-f" class="footnote-ref">note F</a>)</td>
         </tr>
         <tr>
           <td>Health</td>
-          <td>$211,000</td>
-          <td>$326,000</td>
-          <td>+$115,000</td>
+          <td>$211</td>
+          <td>$326</td>
+          <td>+$115</td>
           <td>+55%</td>
         </tr>
         <tr>
           <td>Public Buildings</td>
-          <td>$189,000</td>
-          <td>$287,000</td>
-          <td>+$98,000</td>
+          <td>$189</td>
+          <td>$287</td>
+          <td>+$98</td>
           <td>+52%</td>
         </tr>
         <tr>
           <td>Town Clerk</td>
-          <td>$171,000</td>
-          <td>$245,000</td>
-          <td>+$74,000</td>
+          <td>$171</td>
+          <td>$245</td>
+          <td>+$74</td>
           <td>+43%</td>
         </tr>
         <tr>
           <td>Veterans</td>
-          <td>$94,000</td>
-          <td>$149,000</td>
-          <td>+$55,000</td>
+          <td>$94</td>
+          <td>$149</td>
+          <td>+$55</td>
           <td>+58%</td>
         </tr>
         <tr>
           <td>Intergovernmental State and County</td>
-          <td>$2,706,000</td>
+          <td>$2,706</td>
           <td>not directly comparable</td>
           <td id="ref-d1"><a href="#note-d" class="footnote-ref">see note D</a></td>
           <td id="ref-d2"><a href="#note-d" class="footnote-ref">see note D</a></td>


### PR DESCRIPTION
## Summary
- Converts department-by-department table values to "dollars in thousands" to eliminate horizontal scrolling on narrow viewports
- Adds a `<caption>` noting the unit change so readers know the values are in thousands
- Reduces `table.data` min-width from 420px to 360px since shorter numbers need less space

All values were already rounded to the nearest thousand, so no precision is lost.

## Test plan
- [ ] View https://marbleheaddata.org/where-has-the-money-gone.html on a phone-width viewport (~375px) and confirm no horizontal scroll on the department table
- [ ] Verify the "Dollar amounts in thousands" caption appears below the table
- [ ] Check the stacked card layout (under 600px) still renders correctly
- [ ] Spot-check a few rows against the original values (e.g. Schools should show $32,066 / $49,120)

🤖 Generated with [Claude Code](https://claude.com/claude-code)