### PR TITLE
Fix bar chart colors on per-capita levy chart

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1181,6 +1181,9 @@ svg.chart .data-line--thin    { stroke-width: 1.5; }
 svg.chart .data-line--dashed  { stroke-dasharray: 5 4; }
 svg.chart .data-line--dotted  { stroke-dasharray: 2 3; }
 
+svg.chart .data-bar {
+  fill: currentColor;
+}
 svg.chart .data-dot {
   fill: currentColor;
   stroke: none;


### PR DESCRIPTION
## Summary
- Adds missing `svg.chart .data-bar { fill: currentColor; }` rule to `site.css`
- Bar charts now pick up their series colors (navy, brass, buoy, plum) instead of rendering all-black
- Affects `charts/per_capita_levy.html` and any future bar charts using the `data-bar` class

## Test plan
- [ ] Verify per-capita levy chart bars show distinct colors for each town (not all black)
- [ ] Check light and dark mode both work
- [ ] Confirm no regression on other chart types (line charts, area fills, dots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)