### PR TITLE
Add peer compensation card to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,6 +200,12 @@ m-170 -340 l0 -145 -120 0 c-98 0 -120 3 -120 14 0 8 4 18 10 21 5 3 53 62
       <p>Tax rates move inversely with home values. This page puts the tax tradeoff next to school staffing ratios and employer health contributions for four towns.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
+
+    <a class="question" href="charts/peer_compensation.html">
+      <h2>What does teacher pay look like when you count benefits?</h2>
+      <p>Marblehead pays 83% of health premiums but lower salaries. Hingham pays 50% but higher salaries. Estimated total compensation for eight peer towns narrows the gap to $3,700.</p>
+      <span class="tag tag-charts">Chart</span>
+    </a>
   </div>
 
   <div class="data-section" id="data-sources">


### PR DESCRIPTION
## Summary
- Adds a card linking to `charts/peer_compensation.html` in the Peer comparison section of the homepage
- Framed as "What does teacher pay look like when you count benefits?"

## Test plan
- [ ] Card appears at bottom of Peer comparison section
- [ ] Link works and goes to the peer compensation page
- [ ] Card stacks correctly on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)