### PR TITLE
Add F.L. Woods attribution for bell buoy in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,6 +6,6 @@
     <a href="https://github.com/agbaber/marblehead/issues/new?title=Correction%3A+">Report an issue</a>
   </nav>
   <p class="footer-meta">Built by a Marblehead resident &middot; Updated {{ site.last_updated }}</p>
-  <p class="footer-meta">The bell buoy is the historic logo of <a href="https://flwoods.com">F.L. Woods Inc.</a> (Marblehead, est. 1938), widely adopted as the town's unofficial symbol. marbleheaddata.org is independent and not affiliated with or endorsed by F.L. Woods.</p>
+  <p class="footer-meta">The bell buoy is the historic logo of <a href="https://flwoods.com">F.L. Woods Inc.</a> (Marblehead, est. 1938). marbleheaddata.org is independent and not affiliated with or endorsed by F.L. Woods.</p>
   <p class="footer-version"><a href="https://github.com/agbaber/marblehead/releases">v{{ site.version }}</a></p>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,5 +6,6 @@
     <a href="https://github.com/agbaber/marblehead/issues/new?title=Correction%3A+">Report an issue</a>
   </nav>
   <p class="footer-meta">Built by a Marblehead resident &middot; Updated {{ site.last_updated }}</p>
+  <p class="footer-meta">The bell buoy is the historic logo of <a href="https://flwoods.com">F.L. Woods Inc.</a> (Marblehead, est. 1938), widely adopted as the town's unofficial symbol. marbleheaddata.org is independent and not affiliated with or endorsed by F.L. Woods.</p>
   <p class="footer-version"><a href="https://github.com/agbaber/marblehead/releases">v{{ site.version }}</a></p>
 </footer>


### PR DESCRIPTION
## Summary

- The bell buoy used on the site (favicon, nav, hero) is the historic logo of F.L. Woods Inc. (Marblehead, est. 1938). Adds a footer credit linking to flwoods.com and an explicit disclaimer that marbleheaddata.org is independent and not affiliated with or endorsed by F.L. Woods.
- Reuses the existing `.footer-meta` class so no CSS changes are needed.
- Strictly factual per STYLE_GUIDE ("state facts, not conclusions"): identifies the source and disclaims affiliation, nothing more.

## Context

The footer credit is a good-faith attribution, not a claim of permission. A separate direct outreach to F.L. Woods is planned to let them know the buoy is on the site, explain the reasoning, and offer a standing takedown if they'd prefer we didn't use it.

## Test plan

- [ ] Verify footer renders the new attribution paragraph on homepage, a chart page, and a doc-page markdown page
- [ ] Confirm the flwoods.com link opens correctly
- [ ] Check light and dark mode legibility
- [ ] Confirm no horizontal overflow on mobile (the paragraph is long-ish)

https://claude.ai/code/session_01S7BXch29gRZRsyToyyMJAg