### PR TITLE
Style F.L. Woods footer credit as fine print

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,6 +6,6 @@
     <a href="https://github.com/agbaber/marblehead/issues/new?title=Correction%3A+">Report an issue</a>
   </nav>
   <p class="footer-meta">Built by a Marblehead resident &middot; Updated {{ site.last_updated }}</p>
-  <p class="footer-meta">The bell buoy is the historic logo of <a href="https://flwoods.com">F.L. Woods Inc.</a> (Marblehead, est. 1938). marbleheaddata.org is independent and not affiliated with or endorsed by F.L. Woods.</p>
+  <p class="footer-credits">The bell buoy is the historic logo of <a href="https://flwoods.com">F.L. Woods Inc.</a> (Marblehead, est. 1938). marbleheaddata.org is independent and not affiliated with or endorsed by F.L. Woods.</p>
   <p class="footer-version"><a href="https://github.com/agbaber/marblehead/releases">v{{ site.version }}</a></p>
 </footer>

--- a/assets/site.css
+++ b/assets/site.css
@@ -808,6 +808,25 @@ details.notes[open] > summary {
   letter-spacing: 0.2px;
 }
 
+.footer-credits {
+  font-size: 10px;
+  color: var(--text-faint);
+  opacity: 0.7;
+  max-width: 44ch;
+  margin: 10px auto 0;
+  line-height: 1.5;
+  letter-spacing: 0.15px;
+}
+.footer-credits a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+.footer-credits a:hover {
+  color: var(--text);
+}
+
 .footer-version {
   font-size: 10px;
   color: var(--text-faint);


### PR DESCRIPTION
## Summary

- Follow-up to #211. Styles the F.L. Woods bell-buoy attribution that now lives in the site footer.
- Moves the credit line out of `.footer-meta` (11px, primary weight) into a new `.footer-credits` class: 10px font, 0.7 opacity, 44ch max-width, 1.5 line-height, muted underlined link.
- Result: the attribution reads as fine print beneath the "Built by a Marblehead resident" tagline instead of competing with it, and wraps into a tidy centered block rather than spanning the full footer width.

## Context

This commit was originally pushed to the #211 branch after #211 was merged, leaving it orphaned. Recovered by cherry-picking onto a fresh branch off `main`, per CLAUDE.md's "don't push follow-up commits to a merged branch" guidance.

## Test plan

- [ ] Visit homepage, confirm footer credit sits below the tagline as fine print
- [ ] Check wrap behavior at desktop and mobile widths
- [ ] Verify link to flwoods.com works and matches muted style in both light and dark mode
- [ ] Confirm no horizontal overflow on narrow viewports

https://claude.ai/code/session_01S7BXch29gRZRsyToyyMJAg