### PR TITLE
Add PostHog events for chart tabs, pulse, outbound links

### DIFF
--- a/assets/analytics.js
+++ b/assets/analytics.js
@@ -1,5 +1,6 @@
 // Lightweight PostHog event tracking for marbleheaddata.org.
-// Tracks: TOC clicks, calculator engagement (boolean only), scroll depth.
+// Tracks: TOC clicks, calculator engagement (boolean only), scroll depth,
+// chart tab switches, outbound source link clicks.
 // No personal data or input values are captured.
 (function () {
   if (typeof posthog === 'undefined') return;
@@ -62,4 +63,34 @@
       });
     }
   }, { passive: true });
+
+  // --- Chart tab / view switches ---
+  document.addEventListener('click', function (e) {
+    var tab = e.target.closest('.tab[data-view]');
+    if (!tab) return;
+    posthog.capture('chart_tab_switched', {
+      view: tab.dataset.view,
+      page: page
+    });
+  });
+
+  // --- Outbound source link clicks ---
+  document.addEventListener('click', function (e) {
+    var link = e.target.closest('a[href]');
+    if (!link) return;
+    var href = link.href;
+    if (!href) return;
+    try {
+      var url = new URL(href, location.href);
+      if (url.origin === location.origin) return;
+    } catch (_) { return; }
+    // Capture the domain and whether it came from the sources list
+    var inSources = !!link.closest('.sources-list');
+    posthog.capture('outbound_click', {
+      url: href,
+      domain: url.hostname,
+      from_sources: inSources,
+      page: page
+    });
+  });
 })();

--- a/assets/community-pulse/widget.js
+++ b/assets/community-pulse/widget.js
@@ -353,6 +353,12 @@ function wireWidget(root, db, sectionId, sectionUrl, sectionTitle, initialRecord
     }
     countNum.textContent = `${result.total} reactions`;
     countDelta.textContent = result.last_24h > 0 ? `+${result.last_24h} today` : '';
+    if (typeof posthog !== 'undefined') {
+      posthog.capture('pulse_engaged', {
+        section: sectionTitle,
+        page: location.pathname
+      });
+    }
     await persist();
   }
 


### PR DESCRIPTION
## Summary
- **chart_tab_switched**: fires when reader switches override scenario tabs on the sustainability chart
- **pulse_engaged**: fires on first community pulse interaction per section (stance, note, or share) -- intentionally omits agree/disagree direction
- **outbound_click**: fires on any external link click, with `from_sources` flag to distinguish citation verification from other outbound navigation

No personal data or input values captured.

## Test plan
- [ ] Verify PostHog receives `chart_tab_switched` events on sustainability page
- [ ] Verify `pulse_engaged` fires once per section, does not include stance direction
- [ ] Verify `outbound_click` fires on citation links and inline external links
- [ ] Verify internal links do not fire `outbound_click`

🤖 Generated with [Claude Code](https://claude.com/claude-code)