### PR TITLE
Polish annotation text positions on sustainability chart

### DIFF
--- a/charts/sustainability.html
+++ b/charts/sustainability.html
@@ -74,7 +74,7 @@ title: "General Fund Revenue, Free Cash, and Expenses"
 
       <!-- Actuals/projected divider (between FY24 and FY25) -->
       <line class="annotation-line" x1="474" y1="48" x2="474" y2="380"/>
-      <text class="annotation annotation--hide-sm" x="270" y="42" text-anchor="middle">ACFR actuals</text>
+      <text class="annotation annotation--hide-sm" x="270" y="36" text-anchor="middle">ACFR actuals</text>
 
       <!-- FinCom annotation at FY19 -->
       <line class="annotation-line" x1="254" y1="55" x2="254" y2="250"/>
@@ -203,8 +203,8 @@ title: "General Fund Revenue, Free Cash, and Expenses"
         <rect class="data-fill s-tier-2" x="600" y="125" width="28" height="35" opacity="0.65"/>
         <rect class="data-fill s-tier-2" x="640" y="100" width="28" height="48" opacity="0.65"/>
         <rect class="data-fill s-tier-2" x="680" y="88" width="28" height="48" opacity="0.65"/>
-        <text class="annotation" x="714" y="78" text-anchor="start">$7M</text>
-        <text class="annotation" x="714" y="90" text-anchor="start">gap</text>
+        <text class="annotation" x="714" y="76" text-anchor="start">$7M</text>
+        <text class="annotation" x="714" y="87" text-anchor="start">gap</text>
       </g>
 
       <!-- ================================================================
@@ -220,9 +220,9 @@ title: "General Fund Revenue, Free Cash, and Expenses"
         <rect class="data-fill s-tier-3" x="600" y="118" width="28" height="42" opacity="0.65"/>
         <rect class="data-fill s-tier-3" x="640" y="88" width="28" height="60" opacity="0.65"/>
         <rect class="data-fill s-tier-3" x="680" y="76" width="28" height="60" opacity="0.65"/>
-        <text class="annotation annotation--hide-sm" x="654" y="80" text-anchor="middle">gap closed</text>
-        <text class="annotation" x="714" y="72" text-anchor="start">$4M</text>
-        <text class="annotation" x="714" y="84" text-anchor="start">gap</text>
+        <text class="annotation annotation--hide-sm" x="654" y="75" text-anchor="middle">gap closed</text>
+        <text class="annotation" x="714" y="67" text-anchor="start">$4M</text>
+        <text class="annotation" x="714" y="78" text-anchor="start">gap</text>
       </g>
 
     </svg>


### PR DESCRIPTION
## Summary
- Nudge gap labels on Tier 2 and Tier 3 views so "$XM gap" text sits within the visual gap between bar top and expense line (was bleeding into the bar)
- Move "ACFR actuals" annotation up 6px for more breathing room from "FinCom 2019" label below it

## Test plan
- [ ] Open sustainability chart, click through all four tabs (No override, Tier 1, Tier 2, Tier 3)
- [ ] Confirm "$XM gap" labels sit in the gap area, not inside the bars
- [ ] Confirm "ACFR actuals" and "FinCom 2019" have clear vertical separation
- [ ] Check mobile viewport (annotations with `annotation--hide-sm` should hide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)