### PR TITLE
Reorganize homepage by topic, add read-next to all chart pages

### DIFF
--- a/charts/enrollment_vs_staffing.html
+++ b/charts/enrollment_vs_staffing.html
@@ -136,4 +136,18 @@ title: "Enrollment vs. Staffing"
     <p>The declining enrollment / flat staffing pattern is common across Massachusetts and is partly driven by special education mandates (IEP-required staffing), out-of-district placements ($4.6M in FY26 school budget), and federal requirements that do not scale with enrollment.</p>
   </div>
 
-  <a class="btn-link" href="../inside-school-staffing.html">What are all those positions? Mandate vs. discretionary breakdown &rarr;</a>
+  <div class="read-next">
+    <div class="read-next-label">Read next</div>
+    <a class="read-next-link" href="../inside-school-staffing.html">
+      <div class="read-next-title">What are all those school positions? &rarr;</div>
+      <div class="read-next-desc">430 school staff broken down by role: which are legally mandated, how Marblehead compares to peer towns by category, and what options exist.</div>
+    </a>
+    <a class="read-next-link" href="healthcare_costs.html">
+      <div class="read-next-title">Why is health insurance outpacing the levy? &rarr;</div>
+      <div class="read-next-desc">The other major cost driver. Tax levy vs. health insurance, spending vs. headcount, and the annual price of one GIC family plan.</div>
+    </a>
+    <a class="read-next-link" href="rate_value_schools.html">
+      <div class="read-next-title">Rate, value, and what you get &rarr;</div>
+      <div class="read-next-desc">Tax rates, home values, school staffing ratios, and employer health contributions for four North Shore towns.</div>
+    </a>
+  </div>

--- a/charts/healthcare_costs.html
+++ b/charts/healthcare_costs.html
@@ -200,3 +200,19 @@ og_url: https://marbleheaddata.org/charts/healthcare_costs.html
     <p><strong>Education vs. non-education <abbr class="g" title="Full-Time Equivalent">FTE</abbr>:</strong> From <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> "Full-time Equivalent Town Employees by Function" tables, education row vs. total minus education. Education <abbr class="g" title="Full-Time Equivalent">FTE</abbr>: 466 (FY06) to 537 (FY24), +15%. Non-education <abbr class="g" title="Full-Time Equivalent">FTE</abbr>: 188 (FY06) to 169 (FY24), &minus;10%. The FY23 jump from 483 to 537 education <abbr class="g" title="Full-Time Equivalent">FTE</abbr> is unexplained in public records and may reflect ESSER-funded positions or a reporting change.</p>
     <p><strong>Retiree health (<abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr>):</strong> This page covers active-employee health insurance (the "Group Insurance" budget line). The town also carries a long-term liability for retiree health benefits (Other Post-Employment Benefits). The FY2026 budget transferred $250,000 into the retiree benefits trust; the FY2027 proposed budget transfers $0. The underlying <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr> liability continues to accrue. Active-employee <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr> cost in FY2024 was $695 per employee; retiree <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr> cost was $731 per retiree (<abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> FY2024). These are separate from the Group Insurance premiums charted above.</p>
   </div>
+
+  <div class="read-next">
+    <div class="read-next-label">Read next</div>
+    <a class="read-next-link" href="peer_compensation.html">
+      <div class="read-next-title">What does teacher pay look like when you count benefits? &rarr;</div>
+      <div class="read-next-desc">Marblehead pays 83% of premiums but lower salaries. Estimated total compensation for eight peer towns narrows the gap to $3,700.</div>
+    </a>
+    <a class="read-next-link" href="enrollment_vs_staffing.html">
+      <div class="read-next-title">Did enrollment drive the budget? &rarr;</div>
+      <div class="read-next-desc">Student enrollment down 21% while education staffing grew to 537 FTE. The other side of the cost equation.</div>
+    </a>
+    <a class="read-next-link" href="sustainability.html">
+      <div class="read-next-title">Is this a one-time reset? &rarr;</div>
+      <div class="read-next-desc">Ten years of general fund revenue and expenses, and how each override tier compares to projected expenses through FY30.</div>
+    </a>
+  </div>

--- a/charts/levy_vs_bill.html
+++ b/charts/levy_vs_bill.html
@@ -109,3 +109,19 @@ title: "Tax Levy, Median Bill, and Inflation"
   <p><strong>Why "collected" and not "levy limit."</strong> The chart's levy line is the collected property tax levy, which is the Proposition 2&frac12; base levy plus any voter-approved debt exclusions for bonded projects. This is the figure most directly comparable to the median single-family bill, because homeowners pay both the base levy and the debt exclusion portion. The base levy limit alone is tracked in <a href="data/marblehead_levy.csv">data/marblehead_levy.csv</a>.</p>
   <p><strong>Individual variation.</strong> The median single-family tax bill reflects the bill paid on a median-valued single-family home each year. Individual bills depend on each property's assessed value, which is reassessed annually. A home that appreciated faster than the town median will have seen bill growth above the median line; a home that appreciated slower will have seen bill growth below it.</p>
 </div>
+
+<div class="read-next">
+  <div class="read-next-label">Read next</div>
+  <a class="read-next-link" href="four_town_rates.html">
+    <div class="read-next-title">How does Marblehead compare? &rarr;</div>
+    <div class="read-next-desc">Tax rates and average bills for four North Shore towns, with override projections.</div>
+  </a>
+  <a class="read-next-link" href="per_capita_levy.html">
+    <div class="read-next-title">Per-capita property tax levy &rarr;</div>
+    <div class="read-next-desc">Total property tax divided by population for four peer towns. Swampscott is highest; Marblehead is second.</div>
+  </a>
+  <a class="read-next-link" href="sustainability.html">
+    <div class="read-next-title">Is this a one-time reset? &rarr;</div>
+    <div class="read-next-desc">Where the $8.5M gap came from and how each override tier compares to projected expenses through FY30.</div>
+  </a>
+</div>

--- a/charts/override_calculator.html
+++ b/charts/override_calculator.html
@@ -122,6 +122,22 @@ title: "What the Override Costs You"
     <p><span class="footnote-marker"></span>Trash/recycling (Question 2) is not included above. You'll pay for it either way: as a levy increase (~$19/mo on a $1M home) or as a flat fee (~$23/mo per household) if the override fails. See <a href="../question-2-trash.html">Question 2: trash funding</a> for the full personal-cost calculator and context.</p>
   </div>
 
+  <div class="read-next">
+    <div class="read-next-label">Read next</div>
+    <a class="read-next-link" href="../no-override-budget.html">
+      <div class="read-next-title">What's in the no-override budget? &rarr;</div>
+      <div class="read-next-desc">22 town positions removed, 14 school positions, library reduced 43%, and what other MA towns did after similar votes.</div>
+    </a>
+    <a class="read-next-link" href="sustainability.html">
+      <div class="read-next-title">Is this a one-time reset? &rarr;</div>
+      <div class="read-next-desc">Ten years of revenue and expenses, and how each override tier compares to projected expenses through FY30.</div>
+    </a>
+    <a class="read-next-link" href="../senior-tax-relief.html">
+      <div class="read-next-title">What relief can seniors claim? &rarr;</div>
+      <div class="read-next-desc">The state Circuit Breaker, Marblehead's pending means-tested exemption, and how both interact with the override.</div>
+    </a>
+  </div>
+
 <script>
 // Anchor: Town Administrator's override presentation, April 8, 2026.
 // Each number is the annual tax increase (dollars) on a home assessed at

--- a/charts/per_capita_levy.html
+++ b/charts/per_capita_levy.html
@@ -57,3 +57,19 @@ title: "Per-Capita Property Tax Levy"
   <p><strong>On Census population.</strong> The Census 2020 figures are the most recent decennial count. More recent ACS 5-year estimates exist but introduce sampling error and are not used here. Marblehead's FY2024 <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> reports population as 20,576 (vs Census 2020's 20,412); using the <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> figure would lower Marblehead's per-capita from $4,144 to $4,113 without changing the ranking. Swampscott would need to have grown by roughly 700 residents (~4.6%) since 2020 to fall below Marblehead on per-capita levy.</p>
   <p><strong>On total budget vs tax levy.</strong> Some per-capita comparisons use total town budget as the numerator. A total-budget comparison would change the ranking because it includes enterprise fund revenue (e.g., Marblehead's Municipal Light Department), state aid, and other non-tax-levy revenue sources. This chart uses the property tax levy alone because it is the cost borne directly by property taxpayers and is the figure most relevant to the override question.</p>
 </div>
+
+<div class="read-next">
+  <div class="read-next-label">Read next</div>
+  <a class="read-next-link" href="four_town_rates.html">
+    <div class="read-next-title">Rate and bill: four North Shore towns &rarr;</div>
+    <div class="read-next-desc">The same four towns compared by tax rate (Marblehead lowest) and average bill (Marblehead second-highest), with override projections.</div>
+  </a>
+  <a class="read-next-link" href="levy_vs_bill.html">
+    <div class="read-next-title">Levy, median bill, and inflation &rarr;</div>
+    <div class="read-next-desc">Three indexed growth rates over twelve years. The levy and median bill tracked closely; both grew faster than CPI.</div>
+  </a>
+  <a class="read-next-link" href="tax_comparison.html">
+    <div class="read-next-title">Marblehead vs. Swampscott, side by side &rarr;</div>
+    <div class="read-next-desc">Tax rates, home values, median bills, and what $750K buys you in each town.</div>
+  </a>
+</div>

--- a/charts/sustainability.html
+++ b/charts/sustainability.html
@@ -247,6 +247,22 @@ title: "General Fund Revenue, Free Cash, and Expenses"
     <p>FY28&ndash;FY30 are <strong>illustrative projections</strong>, not forecasts. Base revenue grows at 3% annually (Prop 2.5 levy limit plus estimated new growth). Expenses grow at 5% annually (near the FY22&ndash;FY27 average). Free cash held at $5M/yr. Override phase-in uses the draw schedule from the ballot questions (<a href="/data/override_draws_schedule.csv">override_draws_schedule.csv</a>). After full phase-in, the override levy stays flat while expenses continue growing.</p>
   </div>
 
+  <div class="read-next">
+    <div class="read-next-label">Read next</div>
+    <a class="read-next-link" href="override_calculator.html">
+      <div class="read-next-title">What does the override cost me? &rarr;</div>
+      <div class="read-next-desc">Monthly cost by home value for each tier, at full phase-in.</div>
+    </a>
+    <a class="read-next-link" href="../no-override-budget.html">
+      <div class="read-next-title">What's in the no-override budget? &rarr;</div>
+      <div class="read-next-desc">The specific cuts if the override fails: 22 town positions, 14 school positions, library reduced 43%.</div>
+    </a>
+    <a class="read-next-link" href="../where-has-the-money-gone.html">
+      <div class="read-next-title">Where has the money gone? &rarr;</div>
+      <div class="read-next-desc">A ten-year walkthrough of how the town has spent the tax levy, and where the biggest line-item changes landed.</div>
+    </a>
+  </div>
+
 <script>
 document.querySelectorAll('.tab').forEach(function(btn) {
   btn.addEventListener('click', function() {

--- a/index.html
+++ b/index.html
@@ -87,61 +87,11 @@ m-170 -340 l0 -145 -120 0 c-98 0 -120 3 -120 14 0 8 4 18 10 21 5 3 53 62
     </ol>
   </div>
 
-  <p class="section-label">Spending</p>
-  <div class="question-list">
-    <a class="question" href="where-has-the-money-gone.html">
-      <h2>Where has Marblehead's money gone?</h2>
-      <p>A ten-year walkthrough of how the town has actually spent the tax levy, who has been checking the books, and where the biggest line-item changes landed.</p>
-    </a>
-  </div>
-
-  <p class="section-label">Cost drivers</p>
-  <div class="question-list">
-    <a class="question" href="charts/healthcare_costs.html">
-      <svg class="spark-bg" viewBox="50 80 500 175" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
-        <path class="spark-area sf-revenue" d="M60,246 87,242 113,236 140,231 167,223 193,218 220,209 247,205 273,197 300,188 327,179 353,169 380,160 407,154 433,146 460,137 487,121 513,110 540,98 L540,255 60,255 Z"/>
-        <polyline class="spark-line sf-revenue" points="60,246 87,242 113,236 140,231 167,223 193,218 220,209 247,205 273,197 300,188 327,179 353,169 380,160 407,154 433,146 460,137 487,121 513,110 540,98"/>
-        <path class="spark-area sf-cost" d="M60,246 87,234 113,216 140,187 167,201 193,191 220,164 247,184 273,168 300,156 327,145 353,136 380,135 407,127 460,120 487,105 513,89 540,117 L540,255 60,255 Z"/>
-        <polyline class="spark-line sf-cost" points="60,246 87,234 113,216 140,187 167,201 193,191 220,164 247,184 273,168 300,156 327,145 353,136 380,135 407,127 460,120 487,105 513,89 540,117"/>
-      </svg>
-      <h2>Why is health insurance outpacing the levy?</h2>
-      <p>Three charts and one loss ratio. Tax levy vs health insurance, spending vs headcount, and the actual annual price of one <abbr class="g" title="Group Insurance Commission">GIC</abbr> family plan. $24K to $39K in 7 years, not driven by hiring.</p>
-      <span class="tag tag-charts">Chart</span>
-    </a>
-
-    <a class="question" href="charts/enrollment_vs_staffing.html">
-      <svg class="spark-bg" viewBox="60 25 560 130" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
-        <path class="spark-area sf-neutral" d="M70,115 93,104 117,90 140,86 164,77 187,67 211,52 234,56 258,49 281,54 305,57 328,62 352,48 375,40 399,52 422,57 446,49 469,60 493,79 516,91 540,128 563,142 587,139 610,140 L610,155 70,155 Z"/>
-        <polyline class="spark-line sf-neutral" points="70,115 93,104 117,90 140,86 164,77 187,67 211,52 234,56 258,49 281,54 305,57 328,62 352,48 375,40 399,52 422,57 446,49 469,60 493,79 516,91 540,128 563,142 587,139 610,140"/>
-        <path class="spark-area sf-navy" d="M70,127 93,117 117,111 140,109 164,94 187,82 211,77 234,73 258,68 281,68 305,68 328,73 352,67 375,65 399,67 422,67 446,65 469,57 493,71 516,73 540,71 563,72 587,35 610,35 L610,155 70,155 Z"/>
-        <polyline class="spark-line sf-navy" points="70,127 93,117 117,111 140,109 164,94 187,82 211,77 234,73 258,68 281,68 305,68 328,73 352,67 375,65 399,67 422,67 446,65 469,57 493,71 516,73 540,71 563,72 587,35 610,35"/>
-      </svg>
-      <h2>Did enrollment drive the budget?</h2>
-      <p>Student enrollment down 21% from its FY14 peak while education staffing grew to 537 <abbr class="g" title="Full-Time Equivalent">FTE</abbr>.</p>
-      <span class="tag tag-charts">Chart</span>
-    </a>
-
-    <a class="question" href="inside-school-staffing.html">
-      <h2>What are all those school positions?</h2>
-      <p>430 school staff broken down by role: which are legally mandated, how Marblehead compares to peer towns by category, and what options exist.</p>
-    </a>
-  </div>
-
-  <p class="section-label">The override</p>
+  <p class="section-label">The override vote</p>
   <div class="question-list">
     <a class="question" href="what-is-the-override.html">
       <h2>What is the override?</h2>
       <p>The three-tier structure, what each tier funds, key terms, and history.</p>
-    </a>
-
-    <a class="question" href="how-we-got-here.html">
-      <h2>How did we get here?</h2>
-      <p>Seven years of Finance Committee warnings, in their own words. From "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025.</p>
-    </a>
-
-    <a class="question" href="marblehead-voting-record.html">
-      <h2>Has Marblehead voted yes before?</h2>
-      <p>Every Prop 2&frac12; vote since 1988: what passed, what failed, and how much.</p>
     </a>
 
     <a class="question" href="charts/override_calculator.html">
@@ -195,14 +145,22 @@ m-170 -340 l0 -145 -120 0 c-98 0 -120 3 -120 14 0 8 4 18 10 21 5 3 53 62
       <span class="tag tag-charts">Chart</span>
     </a>
 
-    <a class="question" href="senior-tax-relief.html">
-      <h2>What relief can seniors claim?</h2>
-      <p>The state Circuit Breaker (up to $2,820), Marblehead's pending means-tested exemption (H.4225), and how both interact with the override.</p>
+    <a class="question" href="marblehead-voting-record.html">
+      <h2>Has Marblehead voted yes before?</h2>
+      <p>Every Prop 2&frac12; vote since 1988: what passed, what failed, and how much.</p>
+    </a>
+  </div>
+
+  <p class="section-label">Town budget</p>
+  <div class="question-list">
+    <a class="question" href="where-has-the-money-gone.html">
+      <h2>Where has Marblehead's money gone?</h2>
+      <p>A ten-year walkthrough of how the town has actually spent the tax levy, who has been checking the books, and where the biggest line-item changes landed.</p>
     </a>
 
-    <a class="question" href="what-you-can-do.html">
-      <h2>What can you do?</h2>
-      <p>Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight of the town budget.</p>
+    <a class="question" href="how-we-got-here.html">
+      <h2>How did we get here?</h2>
+      <p>Seven years of Finance Committee warnings, in their own words. From "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025.</p>
     </a>
 
     <a class="question" href="data/case_studies">
@@ -211,13 +169,79 @@ m-170 -340 l0 -145 -120 0 c-98 0 -120 3 -120 14 0 8 4 18 10 21 5 3 53 62
     </a>
   </div>
 
-  <p class="section-label">Peer comparison</p>
+  <p class="section-label">Schools</p>
   <div class="question-list">
-    <a class="question" href="why-not-elsewhere.html">
-      <h2>Why do some MA towns run overrides and others don't?</h2>
-      <p>Residential share of tax levy, new growth rates, and override history for 21 Massachusetts peer towns, grouped into four structural archetypes.</p>
+    <a class="question" href="charts/enrollment_vs_staffing.html">
+      <svg class="spark-bg" viewBox="60 25 560 130" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
+        <path class="spark-area sf-neutral" d="M70,115 93,104 117,90 140,86 164,77 187,67 211,52 234,56 258,49 281,54 305,57 328,62 352,48 375,40 399,52 422,57 446,49 469,60 493,79 516,91 540,128 563,142 587,139 610,140 L610,155 70,155 Z"/>
+        <polyline class="spark-line sf-neutral" points="70,115 93,104 117,90 140,86 164,77 187,67 211,52 234,56 258,49 281,54 305,57 328,62 352,48 375,40 399,52 422,57 446,49 469,60 493,79 516,91 540,128 563,142 587,139 610,140"/>
+        <path class="spark-area sf-navy" d="M70,127 93,117 117,111 140,109 164,94 187,82 211,77 234,73 258,68 281,68 305,68 328,73 352,67 375,65 399,67 422,67 446,65 469,57 493,71 516,73 540,71 563,72 587,35 610,35 L610,155 70,155 Z"/>
+        <polyline class="spark-line sf-navy" points="70,127 93,117 117,111 140,109 164,94 187,82 211,77 234,73 258,68 281,68 305,68 328,73 352,67 375,65 399,67 422,67 446,65 469,57 493,71 516,73 540,71 563,72 587,35 610,35"/>
+      </svg>
+      <h2>Did enrollment drive the budget?</h2>
+      <p>Student enrollment down 21% from its FY14 peak while education staffing grew to 537 <abbr class="g" title="Full-Time Equivalent">FTE</abbr>.</p>
+      <span class="tag tag-charts">Chart</span>
     </a>
 
+    <a class="question" href="inside-school-staffing.html">
+      <h2>What are all those school positions?</h2>
+      <p>430 school staff broken down by role: which are legally mandated, how Marblehead compares to peer towns by category, and what options exist.</p>
+    </a>
+  </div>
+
+  <p class="section-label">Healthcare</p>
+  <div class="question-list">
+    <a class="question" href="charts/healthcare_costs.html">
+      <svg class="spark-bg" viewBox="50 80 500 175" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
+        <path class="spark-area sf-revenue" d="M60,246 87,242 113,236 140,231 167,223 193,218 220,209 247,205 273,197 300,188 327,179 353,169 380,160 407,154 433,146 460,137 487,121 513,110 540,98 L540,255 60,255 Z"/>
+        <polyline class="spark-line sf-revenue" points="60,246 87,242 113,236 140,231 167,223 193,218 220,209 247,205 273,197 300,188 327,179 353,169 380,160 407,154 433,146 460,137 487,121 513,110 540,98"/>
+        <path class="spark-area sf-cost" d="M60,246 87,234 113,216 140,187 167,201 193,191 220,164 247,184 273,168 300,156 327,145 353,136 380,135 407,127 460,120 487,105 513,89 540,117 L540,255 60,255 Z"/>
+        <polyline class="spark-line sf-cost" points="60,246 87,234 113,216 140,187 167,201 193,191 220,164 247,184 273,168 300,156 327,145 353,136 380,135 407,127 460,120 487,105 513,89 540,117"/>
+      </svg>
+      <h2>Why is health insurance outpacing the levy?</h2>
+      <p>Three charts and one loss ratio. Tax levy vs health insurance, spending vs headcount, and the actual annual price of one <abbr class="g" title="Group Insurance Commission">GIC</abbr> family plan. $24K to $39K in 7 years, not driven by hiring.</p>
+      <span class="tag tag-charts">Chart</span>
+    </a>
+
+    <a class="question" href="charts/peer_compensation.html">
+      <svg class="spark-bg" viewBox="0 0 200 160" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
+        <rect class="spark-bar sf-neutral" x="0" y="4"   width="200" height="14" rx="3"/>
+        <rect class="spark-bar sf-neutral" x="0" y="22"  width="181" height="14" rx="3"/>
+        <rect class="spark-bar sf-neutral" x="0" y="40"  width="171" height="14" rx="3"/>
+        <rect class="spark-bar sf-neutral" x="0" y="58"  width="168" height="14" rx="3"/>
+        <rect class="spark-bar sf-neutral" x="0" y="76"  width="164" height="14" rx="3"/>
+        <rect class="spark-bar sf-navy"    x="0" y="94"  width="148" height="14" rx="3"/>
+        <rect class="spark-bar sf-neutral" x="0" y="112" width="140" height="14" rx="3"/>
+        <rect class="spark-bar sf-neutral" x="0" y="130" width="133" height="14" rx="3"/>
+      </svg>
+      <h2>What does teacher pay look like when you count benefits?</h2>
+      <p>Marblehead pays 83% of health premiums but lower salaries. Hingham pays 50% but higher salaries. Estimated total compensation for eight peer towns narrows the gap to $3,700.</p>
+      <span class="tag tag-charts">Chart</span>
+    </a>
+  </div>
+
+  <p class="section-label">Your tax bill</p>
+  <div class="question-list">
+    <a class="question" href="charts/levy_vs_bill.html">
+      <svg class="spark-bg" viewBox="60 70 570 240" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
+        <path class="spark-area sf-cost" d="M70,300 116,292 162,277 208,259 254,242 299,222 345,205 391,193 437,179 483,158 528,129 574,108 620,80 L620,310 70,310 Z"/>
+        <polyline class="spark-line sf-neutral" points="70,300 116,294 162,288 208,287 254,282 299,273 345,263 391,255 437,249 483,228 528,190 574,169 620,153"/>
+        <polyline class="spark-line sf-revenue" points="70,300 116,292 162,277 208,260 254,243 299,223 345,206 391,194 437,180 483,162 528,131 574,110 620,87"/>
+        <polyline class="spark-line sf-cost" points="70,300 116,292 162,277 208,259 254,242 299,222 345,205 391,193 437,179 483,158 528,129 574,108 620,80"/>
+      </svg>
+      <h2>Tax levy, median bill, and inflation</h2>
+      <p>Three indexed growth rates over twelve years. The levy and median bill tracked each other closely, both growing faster than <abbr class="g" title="Consumer Price Index">CPI</abbr>.</p>
+      <span class="tag tag-charts">Chart</span>
+    </a>
+
+    <a class="question" href="senior-tax-relief.html">
+      <h2>What relief can seniors claim?</h2>
+      <p>The state Circuit Breaker (up to $2,820), Marblehead's pending means-tested exemption (H.4225), and how both interact with the override.</p>
+    </a>
+  </div>
+
+  <p class="section-label">Peer towns</p>
+  <div class="question-list">
     <a class="question" href="charts/four_town_rates.html">
       <svg class="spark-bg" viewBox="45 45 660 240" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
         <polyline class="spark-line sf-neutral" points="55,160 83,188 111,204 138,186 166,173 194,157 222,143 250,100 277,98 305,70 333,53 361,56 389,87 416,83 444,81 472,110 500,126 528,144 555,154 583,173 611,195 639,200 667,201 694,190"/>
@@ -231,15 +255,9 @@ m-170 -340 l0 -145 -120 0 c-98 0 -120 3 -120 14 0 8 4 18 10 21 5 3 53 62
       <span class="tag tag-charts">Chart</span>
     </a>
 
-    <a class="question" href="charts/levy_vs_bill.html">
-      <svg class="spark-bg" viewBox="60 70 570 240" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
-        <path class="spark-area sf-cost" d="M70,300 116,292 162,277 208,259 254,242 299,222 345,205 391,193 437,179 483,158 528,129 574,108 620,80 L620,310 70,310 Z"/>
-        <polyline class="spark-line sf-neutral" points="70,300 116,294 162,288 208,287 254,282 299,273 345,263 391,255 437,249 483,228 528,190 574,169 620,153"/>
-        <polyline class="spark-line sf-revenue" points="70,300 116,292 162,277 208,260 254,243 299,223 345,206 391,194 437,180 483,162 528,131 574,110 620,87"/>
-        <polyline class="spark-line sf-cost" points="70,300 116,292 162,277 208,259 254,242 299,222 345,205 391,193 437,179 483,158 528,129 574,108 620,80"/>
-      </svg>
-      <h2>Tax levy, median bill, and inflation</h2>
-      <p>Three indexed growth rates over twelve years. The levy and median bill tracked each other closely, both growing faster than <abbr class="g" title="Consumer Price Index">CPI</abbr>.</p>
+    <a class="question" href="charts/per_capita_levy.html">
+      <h2>Per-capita property tax levy</h2>
+      <p>Total property tax divided by population for four peer towns. Swampscott is highest; Marblehead is second.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
 
@@ -265,21 +283,19 @@ m-170 -340 l0 -145 -120 0 c-98 0 -120 3 -120 14 0 8 4 18 10 21 5 3 53 62
       <span class="tag tag-charts">Chart</span>
     </a>
 
-    <a class="question" href="charts/peer_compensation.html">
-      <svg class="spark-bg" viewBox="0 0 200 160" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
-        <rect class="spark-bar sf-neutral" x="0" y="4"   width="200" height="14" rx="3"/>
-        <rect class="spark-bar sf-neutral" x="0" y="22"  width="181" height="14" rx="3"/>
-        <rect class="spark-bar sf-neutral" x="0" y="40"  width="171" height="14" rx="3"/>
-        <rect class="spark-bar sf-neutral" x="0" y="58"  width="168" height="14" rx="3"/>
-        <rect class="spark-bar sf-neutral" x="0" y="76"  width="164" height="14" rx="3"/>
-        <rect class="spark-bar sf-navy"    x="0" y="94"  width="148" height="14" rx="3"/>
-        <rect class="spark-bar sf-neutral" x="0" y="112" width="140" height="14" rx="3"/>
-        <rect class="spark-bar sf-neutral" x="0" y="130" width="133" height="14" rx="3"/>
-      </svg>
-      <h2>What does teacher pay look like when you count benefits?</h2>
-      <p>Marblehead pays 83% of health premiums but lower salaries. Hingham pays 50% but higher salaries. Estimated total compensation for eight peer towns narrows the gap to $3,700.</p>
-      <span class="tag tag-charts">Chart</span>
+    <a class="question" href="why-not-elsewhere.html">
+      <h2>Why do some MA towns run overrides and others don't?</h2>
+      <p>Residential share of tax levy, new growth rates, and override history for 21 Massachusetts peer towns, grouped into four structural archetypes.</p>
     </a>
+  </div>
+
+  <p class="section-label">Taking action</p>
+  <div class="question-list">
+    <a class="question" href="what-you-can-do.html">
+      <h2>What can you do?</h2>
+      <p>Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight of the town budget.</p>
+    </a>
+
   </div>
 
   <div class="data-section" id="data-sources">


### PR DESCRIPTION
## Summary
- Regroups homepage from analytical categories (Spending, Cost drivers, The override, Peer comparison) into topic clusters: The override vote, Town budget, Schools, Healthcare, Your tax bill, Peer towns, Taking action
- Adds read-next navigation blocks to the 6 chart pages that were dead ends: enrollment_vs_staffing, healthcare_costs, levy_vs_bill, override_calculator, per_capita_levy, sustainability
- Every page on the site now links forward to related content

## Test plan
- [ ] Verify homepage renders with correct section labels and page groupings
- [ ] Check each of the 6 updated chart pages for working read-next links
- [ ] Confirm sparkline SVGs still render on homepage cards
- [ ] Test mobile layout of read-next blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)