### PR TITLE
Propose cairn mark for site branding

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,6 +1,6 @@
 <nav class="site-nav">
   <div class="nav-inner">
-    <a class="nav-brand" href="{{ '/' | relative_url }}">MHD Data</a>
+    <a class="nav-brand" href="{{ '/' | relative_url }}"><svg class="nav-cairn" viewBox="0 0 64 72" aria-hidden="true"><ellipse cx="32" cy="62" rx="26" ry="10"/><ellipse cx="32" cy="38" rx="18" ry="9"/><ellipse cx="32" cy="16" rx="12" ry="8"/></svg> MHD Data</a>
     <a href="{{ '/' | relative_url }}the-debate.html"{% if page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Debate</a>
     <a href="{{ '/' | relative_url }}what-is-the-override.html"{% if page.url == '/what-is-the-override.html' %} aria-current="page"{% endif %}>Override</a>
     <a href="{{ '/' | relative_url }}question-2-trash.html"{% if page.url == '/question-2-trash.html' %} aria-current="page"{% endif %}>Trash</a>

--- a/assets/cairn.svg
+++ b/assets/cairn.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 72" fill="currentColor" aria-hidden="true">
+  <!-- Bottom stone: widest, anchors the stack -->
+  <ellipse cx="32" cy="62" rx="26" ry="10"/>
+  <!-- Middle stone: narrower, sits on the bottom stone -->
+  <ellipse cx="32" cy="38" rx="18" ry="9"/>
+  <!-- Top stone: smallest, crowns the cairn -->
+  <ellipse cx="32" cy="16" rx="12" ry="8"/>
+</svg>

--- a/assets/site.css
+++ b/assets/site.css
@@ -281,6 +281,7 @@ nav.site-nav .nav-brand {
   white-space: nowrap; margin-right: 4px;
   display: inline-flex; align-items: center; gap: 4px;
 }
+.nav-cairn { width: 15px; height: 17px; flex-shrink: 0; }
 nav.site-nav a {
   font-size: 13px; color: var(--text-subtle);
   white-space: nowrap;
@@ -717,6 +718,7 @@ details.notes[open] > summary {
   .page > .hero h1 { font-size: 38px; letter-spacing: -0.8px; }
   .page > .hero p { font-size: 17px; max-width: 560px; }
   .page > .hero { margin-bottom: 44px; }
+  .hero-cairn { width: 56px; height: 63px; margin-bottom: 16px; }
   .key-stats {
     padding: 18px 14px;
     margin: 14px 0 28px;
@@ -731,6 +733,7 @@ details.notes[open] > summary {
    ========================================================================== */
 
 .hero { text-align: center; margin-bottom: 36px; }
+.hero-cairn { display: block; width: 48px; height: 54px; margin: 0 auto 12px; color: var(--text); }
 .hero h1 { font-size: 28px; margin-bottom: 10px; }
 .hero p  { font-size: 16px; color: var(--text-subtle); max-width: 520px; margin: 0 auto; }
 
@@ -855,6 +858,7 @@ html[data-theme="light"] .question:hover .spark-bg { opacity: 0.14; }
 
 @media (max-width: 600px) {
   .hero { margin-bottom: 28px; }
+  .hero-cairn { width: 38px; height: 43px; margin-bottom: 8px; }
   .hero h1 { font-size: 24px; }
   .hero p  { font-size: 15px; }
   .question { padding: 18px 20px; }

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,4 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="6" fill="#111"/>
-  <text x="16" y="23" text-anchor="middle" font-family="-apple-system, sans-serif" font-weight="700" font-size="20" fill="white">M</text>
+  <rect width="32" height="32" rx="6" fill="#1B3A57"/>
+  <g fill="#F4F7FA">
+    <ellipse cx="16" cy="24" rx="11" ry="4"/>
+    <ellipse cx="16" cy="15" rx="7.5" ry="3"/>
+    <ellipse cx="16" cy="7" rx="5" ry="2.5"/>
+  </g>
 </svg>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,11 @@ og_type: website
 og_url: https://marbleheaddata.org/
 ---
 <div class="hero">
+    <svg class="hero-cairn" viewBox="0 0 64 72" aria-hidden="true">
+      <ellipse cx="32" cy="62" rx="26" ry="10"/>
+      <ellipse cx="32" cy="38" rx="18" ry="9"/>
+      <ellipse cx="32" cy="16" rx="12" ry="8"/>
+    </svg>
     <h1>Weighing the FY2027 override?</h1>
     <p>Every claim on this site cites a primary source. Every dollar traces to a town document. Make your own call. <a href="#data-sources">See all sources.</a></p>
   </div>


### PR DESCRIPTION
## Summary

Proposes a three-stone cairn as the site's visual mark. Follow-up to the buoy removal in #222.

A cairn is a stack of stones that travelers place as wayfinders — markers left by people who've been somewhere to help the next person find their way. For a civic data site trying to help Marblehead residents navigate town finances, that metaphor lines up almost exactly.

## Why a cairn

- **Marblehead:** literal pun on the town's name — Marblehead was named for its rocky coast.
- **Coastal + small town:** vernacular, grounded, unpretentious. Not a tourist-shop nautical cliche.
- **Collaboration:** cairns are stacked by many hands over time. Each stone adds to the marker.
- **Informed opinion:** wayfinders. "Here's what we've learned; here's the way through."
- **Fix what's broken:** the most pragmatic possible object. See a spot, mark it, move on.
- **No IP overlap:** not F.L. Woods (buoy), not Marblehead Current (compass rose), not Marblehead Independent (Old Town House), not the town seal (fisherman in a dory), not the Festival of Arts 2023 winner (Abbot Hall illustrative).

## Implementation

- `assets/cairn.svg` &mdash; standalone asset, 64x72 viewBox, `currentColor` fill so it adapts to theme.
- `favicon.svg` &mdash; cairn in white on the navy rounded square, with ellipse coordinates tuned specifically for the 32x32 favicon viewBox so the gaps between stones remain visible at 16px browser-tab scale.
- `_includes/nav.html` &mdash; inline cairn SVG in the nav-brand link (matching the pattern the old nav-buoy used).
- `index.html` &mdash; inline cairn SVG above the homepage hero headline.
- `assets/site.css` &mdash; `.nav-cairn` (15x17) and `.hero-cairn` rules across the three breakpoints the old `.hero-buoy` rules used (desktop wide 56x63, default 48x54, mobile 38x43).

## Iteration notes

Proportions and stone count are open to feedback. If the current stack feels too:

- **Too tidy / too geometric** &rarr; I can swap to `<path>` data with organic outlines instead of ellipses
- **Too tall** &rarr; shorter stones, flatter stack
- **Too balanced** &rarr; add horizontal offset or tilt to one stone for character
- **Wrong stone count** &rarr; 2-stone minimalist or 4-stone richer variant

Review the PR preview in a browser at multiple zoom levels (favicon in the tab, nav bar brand, homepage hero) and send feedback.

## Test plan

- [ ] Favicon renders as stacked stones on the navy square in the browser tab
- [ ] Nav brand link shows the small cairn beside "MHD Data"
- [ ] Homepage hero shows the cairn centered above the headline at all three breakpoints (900px+, default, 600px-)
- [ ] Light and dark mode both render correctly (the cairn uses `currentColor` so it should adapt automatically)
- [ ] Stones remain visually distinct at 16px favicon scale
- [ ] No horizontal overflow or layout shift

https://claude.ai/code/session_01S7BXch29gRZRsyToyyMJAg