### PR TITLE
Group header nav into Ballot / Budget dropdowns

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,44 +1,184 @@
+{%- comment -%}
+Primary site navigation. Five top-level slots (three direct links, two
+dropdown groups) so nothing has to horizontally scroll on desktop.
+Ballot-active / budget-active flags drive the "current section"
+highlight on the dropdown trigger.
+{%- endcomment -%}
+{%- assign ballot_active = false -%}
+{%- if page.url == '/what-is-the-override.html'
+   or page.url == '/no-override-budget.html'
+   or page.url == '/question-2-trash.html'
+   or page.url == '/senior-tax-relief.html'
+   or page.url == '/marblehead-voting-record.html' -%}
+  {%- assign ballot_active = true -%}
+{%- endif -%}
+{%- assign budget_active = false -%}
+{%- if page.url == '/where-has-the-money-gone.html'
+   or page.url == '/how-we-got-here.html'
+   or page.url == '/why-not-elsewhere.html'
+   or page.url == '/meeting-tracker.html' -%}
+  {%- assign budget_active = true -%}
+{%- endif -%}
 <nav class="site-nav">
   <div class="nav-inner">
     <a class="nav-brand" href="{{ '/' | relative_url }}">MHD Data</a>
-    <a href="{{ '/' | relative_url }}the-debate.html"{% if page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Debate</a>
-    <a href="{{ '/' | relative_url }}what-is-the-override.html"{% if page.url == '/what-is-the-override.html' %} aria-current="page"{% endif %}>Override</a>
-    <a href="{{ '/' | relative_url }}question-2-trash.html"{% if page.url == '/question-2-trash.html' %} aria-current="page"{% endif %}>Trash</a>
-    <a href="{{ '/' | relative_url }}how-we-got-here.html"{% if page.url == '/how-we-got-here.html' %} aria-current="page"{% endif %}>History</a>
-    <a href="{{ '/' | relative_url }}marblehead-voting-record.html"{% if page.url == '/marblehead-voting-record.html' %} aria-current="page"{% endif %}>Votes</a>
-    <a href="{{ '/' | relative_url }}where-has-the-money-gone.html"{% if page.url == '/where-has-the-money-gone.html' %} aria-current="page"{% endif %}>Spending</a>
-    <a href="{{ '/' | relative_url }}no-override-budget.html"{% if page.url == '/no-override-budget.html' %} aria-current="page"{% endif %}>No-Override</a>
-    <a href="{{ '/' | relative_url }}why-not-elsewhere.html"{% if page.url == '/why-not-elsewhere.html' %} aria-current="page"{% endif %}>Peer Towns</a>
-    <a href="{{ '/' | relative_url }}senior-tax-relief.html"{% if page.url == '/senior-tax-relief.html' %} aria-current="page"{% endif %}>Senior Relief</a>
-    <a href="{{ '/' | relative_url }}what-you-can-do.html"{% if page.url == '/what-you-can-do.html' %} aria-current="page"{% endif %}>Civic Guide</a>
-    <a href="{{ '/' | relative_url }}meeting-tracker.html"{% if page.url == '/meeting-tracker.html' %} aria-current="page"{% endif %}>Changelog</a>
-    <a href="{{ '/' | relative_url }}about.html"{% if page.url == '/about.html' %} aria-current="page"{% endif %}>About</a>
+
+    <ul class="nav-menu" id="primary-menu">
+      <li class="nav-item">
+        <a class="nav-link" href="{{ '/' | relative_url }}the-debate.html"{% if page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Debate</a>
+      </li>
+
+      <li class="nav-item nav-item--dropdown{% if ballot_active %} is-current{% endif %}">
+        <button class="nav-dropdown-toggle" type="button" aria-expanded="false" aria-controls="submenu-ballot"{% if ballot_active %} aria-current="true"{% endif %}>
+          <span>Ballot</span>
+          <svg class="nav-chevron" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <ul class="nav-submenu" id="submenu-ballot">
+          <li><a class="nav-sublink" href="{{ '/' | relative_url }}what-is-the-override.html"{% if page.url == '/what-is-the-override.html' %} aria-current="page"{% endif %}>What is the override?</a></li>
+          <li><a class="nav-sublink" href="{{ '/' | relative_url }}no-override-budget.html"{% if page.url == '/no-override-budget.html' %} aria-current="page"{% endif %}>No-override budget</a></li>
+          <li><a class="nav-sublink" href="{{ '/' | relative_url }}question-2-trash.html"{% if page.url == '/question-2-trash.html' %} aria-current="page"{% endif %}>Question 2 (trash)</a></li>
+          <li><a class="nav-sublink" href="{{ '/' | relative_url }}senior-tax-relief.html"{% if page.url == '/senior-tax-relief.html' %} aria-current="page"{% endif %}>Senior tax relief</a></li>
+          <li><a class="nav-sublink" href="{{ '/' | relative_url }}marblehead-voting-record.html"{% if page.url == '/marblehead-voting-record.html' %} aria-current="page"{% endif %}>Past voting record</a></li>
+        </ul>
+      </li>
+
+      <li class="nav-item nav-item--dropdown{% if budget_active %} is-current{% endif %}">
+        <button class="nav-dropdown-toggle" type="button" aria-expanded="false" aria-controls="submenu-budget"{% if budget_active %} aria-current="true"{% endif %}>
+          <span>Budget</span>
+          <svg class="nav-chevron" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <ul class="nav-submenu" id="submenu-budget">
+          <li><a class="nav-sublink" href="{{ '/' | relative_url }}where-has-the-money-gone.html"{% if page.url == '/where-has-the-money-gone.html' %} aria-current="page"{% endif %}>Where the money went</a></li>
+          <li><a class="nav-sublink" href="{{ '/' | relative_url }}how-we-got-here.html"{% if page.url == '/how-we-got-here.html' %} aria-current="page"{% endif %}>How we got here</a></li>
+          <li><a class="nav-sublink" href="{{ '/' | relative_url }}why-not-elsewhere.html"{% if page.url == '/why-not-elsewhere.html' %} aria-current="page"{% endif %}>Peer towns</a></li>
+          <li><a class="nav-sublink" href="{{ '/' | relative_url }}meeting-tracker.html"{% if page.url == '/meeting-tracker.html' %} aria-current="page"{% endif %}>Meeting changelog</a></li>
+        </ul>
+      </li>
+
+      <li class="nav-item">
+        <a class="nav-link" href="{{ '/' | relative_url }}what-you-can-do.html"{% if page.url == '/what-you-can-do.html' %} aria-current="page"{% endif %}>Take action</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="{{ '/' | relative_url }}about.html"{% if page.url == '/about.html' %} aria-current="page"{% endif %}>About</a>
+      </li>
+    </ul>
+
     <button class="theme-toggle" aria-label="Toggle light/dark mode" title="Toggle light/dark mode">
       <svg class="theme-icon theme-icon--sun" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><circle cx="10" cy="10" r="4"/><path d="M10 1v2M10 17v2M1 10h2M17 10h2M3.5 3.5l1.4 1.4M15.1 15.1l1.4 1.4M3.5 16.5l1.4-1.4M15.1 4.9l1.4-1.4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></svg>
       <svg class="theme-icon theme-icon--moon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M17.3 13.4A7.5 7.5 0 016.6 2.7a8 8 0 1010.7 10.7z"/></svg>
+    </button>
+
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-menu" aria-label="Open menu">
+      <svg class="nav-toggle-icon nav-toggle-icon--open" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <rect x="3" y="5" width="14" height="2" rx="1"/>
+        <rect x="3" y="9" width="14" height="2" rx="1"/>
+        <rect x="3" y="13" width="14" height="2" rx="1"/>
+      </svg>
+      <svg class="nav-toggle-icon nav-toggle-icon--close" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+        <path d="M5 5l10 10M15 5L5 15"/>
+      </svg>
     </button>
   </div>
 </nav>
 <script>
   (function () {
-    if (!window.matchMedia || !window.matchMedia('(max-width: 799px)').matches) return;
-    var navInner = document.querySelector('nav.site-nav .nav-inner');
-    if (!navInner) return;
-    var current = navInner.querySelector('a[aria-current="page"]');
-    if (!current) return;
-    var target = current.offsetLeft - (navInner.clientWidth - current.offsetWidth) / 2;
-    navInner.scrollLeft = Math.max(0, target);
-  })();
+    var nav = document.querySelector('nav.site-nav');
+    if (!nav) return;
 
-  // Theme toggle
-  (function () {
-    var btn = document.querySelector('.theme-toggle');
-    if (!btn) return;
-    btn.addEventListener('click', function () {
-      var current = document.documentElement.getAttribute('data-theme');
-      var next = current === 'dark' ? 'light' : 'dark';
-      document.documentElement.setAttribute('data-theme', next);
-      localStorage.setItem('theme', next);
+    var menu = nav.querySelector('.nav-menu');
+    var navToggle = nav.querySelector('.nav-toggle');
+    var dropdowns = nav.querySelectorAll('.nav-item--dropdown');
+    var mobileBp = window.matchMedia('(max-width: 799px)');
+
+    function closeAllDropdowns() {
+      dropdowns.forEach(function (li) {
+        li.removeAttribute('data-open');
+        var btn = li.querySelector('.nav-dropdown-toggle');
+        if (btn) btn.setAttribute('aria-expanded', 'false');
+      });
+    }
+
+    function setMobileMenu(open) {
+      if (!menu || !navToggle) return;
+      if (open) {
+        menu.setAttribute('data-open', 'true');
+        navToggle.setAttribute('aria-expanded', 'true');
+        navToggle.setAttribute('aria-label', 'Close menu');
+      } else {
+        menu.removeAttribute('data-open');
+        navToggle.setAttribute('aria-expanded', 'false');
+        navToggle.setAttribute('aria-label', 'Open menu');
+      }
+    }
+
+    // Mobile drawer: hamburger opens / closes the full panel.
+    if (navToggle && menu) {
+      navToggle.addEventListener('click', function () {
+        var open = menu.getAttribute('data-open') === 'true';
+        setMobileMenu(!open);
+      });
+    }
+
+    // Desktop dropdowns: click/tap toggles. (Hover also works via CSS.)
+    dropdowns.forEach(function (li) {
+      var btn = li.querySelector('.nav-dropdown-toggle');
+      if (!btn) return;
+      btn.addEventListener('click', function (e) {
+        // On mobile the submenu is always rendered expanded inside the
+        // drawer, so the trigger acts only as a section label.
+        if (mobileBp.matches) {
+          e.preventDefault();
+          return;
+        }
+        e.preventDefault();
+        var wasOpen = li.getAttribute('data-open') === 'true';
+        closeAllDropdowns();
+        if (!wasOpen) {
+          li.setAttribute('data-open', 'true');
+          btn.setAttribute('aria-expanded', 'true');
+        }
+      });
     });
+
+    // Click outside closes any open menu.
+    document.addEventListener('click', function (e) {
+      var inNav = e.target.closest('nav.site-nav');
+      if (!mobileBp.matches) {
+        if (!e.target.closest('.nav-item--dropdown')) closeAllDropdowns();
+        return;
+      }
+      if (!inNav && menu && menu.getAttribute('data-open') === 'true') {
+        setMobileMenu(false);
+      }
+    });
+
+    // Escape closes whatever is open.
+    document.addEventListener('keydown', function (e) {
+      if (e.key !== 'Escape') return;
+      closeAllDropdowns();
+      if (menu && menu.getAttribute('data-open') === 'true') {
+        setMobileMenu(false);
+        if (navToggle) navToggle.focus();
+      }
+    });
+
+    // Reset state when crossing the mobile / desktop breakpoint.
+    var onBpChange = function () {
+      closeAllDropdowns();
+      setMobileMenu(false);
+    };
+    if (mobileBp.addEventListener) mobileBp.addEventListener('change', onBpChange);
+    else if (mobileBp.addListener) mobileBp.addListener(onBpChange);
+
+    // Theme toggle.
+    var themeBtn = nav.querySelector('.theme-toggle');
+    if (themeBtn) {
+      themeBtn.addEventListener('click', function () {
+        var current = document.documentElement.getAttribute('data-theme');
+        var next = current === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', next);
+        localStorage.setItem('theme', next);
+      });
+    }
   })();
 </script>

--- a/assets/site.css
+++ b/assets/site.css
@@ -241,6 +241,15 @@ a:hover {
 
 /* ==========================================================================
    Navigation
+
+   Five top-level slots: Debate / Ballot / Budget / Take action / About.
+   Ballot and Budget are dropdown groups so every page is reachable from
+   the header without horizontal scrolling.
+
+   Desktop (>= 800px): static horizontal row, submenus open on hover,
+     focus-within, or click. No overflow, no mask.
+   Mobile (< 800px): hamburger opens a drop panel; dropdowns render as
+     labelled sections with all sublinks expanded (no double-tap).
    ========================================================================== */
 
 nav.site-nav {
@@ -251,44 +260,202 @@ nav.site-nav {
   border-bottom: 1px solid var(--border);
   padding: 0 var(--gutter);
   display: flex; justify-content: center;
-  /* Right-edge fade to signal horizontal scroll when links overflow. */
-  -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 32px), transparent 100%);
-          mask-image: linear-gradient(to right, #000 calc(100% - 32px), transparent 100%);
 }
 nav.site-nav .nav-inner {
   max-width: var(--chart-max); width: 100%;
-  display: flex; align-items: center; gap: 18px;
+  display: flex; align-items: center;
   min-height: 48px;
-  overflow-x: auto;
-  scrollbar-width: none;
-  /* Leave room on the right so the last link isn't hidden under the fade. */
-  padding-right: 32px;
-  /* Snap the first link's start to the viewport edge on momentum scroll. */
-  scroll-snap-type: x proximity;
-}
-nav.site-nav .nav-inner > a { scroll-snap-align: start; }
-nav.site-nav .nav-inner::-webkit-scrollbar { display: none; }
-/* Disable the fade mask on desktop where all links fit without scrolling. */
-@media (min-width: 800px) {
-  nav.site-nav {
-    -webkit-mask-image: none;
-            mask-image: none;
-  }
-  nav.site-nav .nav-inner { padding-right: 0; }
+  gap: 16px;
+  position: relative;
 }
 nav.site-nav .nav-brand {
   font-size: 14px; font-weight: 700; color: var(--text);
-  white-space: nowrap; margin-right: 4px;
-  display: inline-flex; align-items: center; gap: 4px;
-}
-nav.site-nav a {
-  font-size: 13px; color: var(--text-subtle);
   white-space: nowrap;
+  display: inline-flex; align-items: center; gap: 4px;
+  text-decoration: none;
 }
-nav.site-nav a:hover { color: var(--text); text-decoration: none; }
-nav.site-nav a[aria-current="page"] {
+nav.site-nav .nav-brand:hover { text-decoration: none; }
+
+/* Primary menu list */
+nav.site-nav .nav-menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+nav.site-nav .nav-menu > li { list-style: none; }
+nav.site-nav .nav-submenu > li { list-style: none; }
+
+/* Top-level link + dropdown trigger share base styling */
+nav.site-nav .nav-link,
+nav.site-nav .nav-dropdown-toggle {
+  font: inherit;
+  font-size: 13px;
+  color: var(--text-subtle);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  text-decoration: none;
+}
+nav.site-nav .nav-link:hover,
+nav.site-nav .nav-dropdown-toggle:hover {
+  color: var(--text);
+  text-decoration: none;
+}
+nav.site-nav .nav-link[aria-current="page"],
+nav.site-nav .nav-item--dropdown.is-current > .nav-dropdown-toggle {
   color: var(--text);
   font-weight: 700;
+}
+
+nav.site-nav .nav-chevron {
+  width: 9px; height: 9px;
+  transition: transform 150ms ease;
+}
+
+/* Hamburger (hidden on desktop) */
+nav.site-nav .nav-toggle {
+  display: none;
+  background: none; border: none;
+  padding: 6px;
+  border-radius: 6px;
+  color: var(--text-subtle);
+  cursor: pointer;
+}
+nav.site-nav .nav-toggle:hover { color: var(--text); }
+nav.site-nav .nav-toggle-icon { width: 20px; height: 20px; display: block; }
+nav.site-nav .nav-toggle-icon--close { display: none; }
+nav.site-nav .nav-toggle[aria-expanded="true"] .nav-toggle-icon--open { display: none; }
+nav.site-nav .nav-toggle[aria-expanded="true"] .nav-toggle-icon--close { display: block; }
+
+/* ----- Desktop (>= 800px) ----- */
+@media (min-width: 800px) {
+  nav.site-nav .nav-menu {
+    display: flex;
+    align-items: center;
+    gap: 22px;
+  }
+  nav.site-nav .nav-item--dropdown { position: relative; }
+  nav.site-nav .nav-submenu {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: -12px;
+    list-style: none;
+    margin: 0;
+    padding: 6px 0;
+    min-width: 220px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
+    display: none;
+    z-index: 101;
+  }
+  nav.site-nav .nav-item--dropdown:hover .nav-submenu,
+  nav.site-nav .nav-item--dropdown:focus-within .nav-submenu,
+  nav.site-nav .nav-item--dropdown[data-open="true"] .nav-submenu {
+    display: block;
+  }
+  nav.site-nav .nav-item--dropdown:hover .nav-chevron,
+  nav.site-nav .nav-item--dropdown:focus-within .nav-chevron,
+  nav.site-nav .nav-item--dropdown[data-open="true"] .nav-chevron {
+    transform: rotate(180deg);
+  }
+  nav.site-nav .nav-sublink {
+    display: block;
+    padding: 8px 16px;
+    font-size: 13px;
+    color: var(--text-subtle);
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  nav.site-nav .nav-sublink:hover {
+    color: var(--text);
+    background: var(--divider);
+    text-decoration: none;
+  }
+  nav.site-nav .nav-sublink[aria-current="page"] {
+    color: var(--text);
+    font-weight: 700;
+  }
+  nav.site-nav .theme-toggle { margin-left: auto; }
+}
+
+/* ----- Mobile (< 800px) ----- */
+@media (max-width: 799px) {
+  nav.site-nav .nav-toggle { display: inline-flex; }
+  nav.site-nav .theme-toggle { margin-left: auto; }
+
+  nav.site-nav .nav-menu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: calc(var(--gutter) * -1);
+    right: calc(var(--gutter) * -1);
+    max-height: calc(100vh - 48px);
+    overflow-y: auto;
+    background: var(--surface);
+    border-top: 1px solid var(--divider);
+    border-bottom: 1px solid var(--border);
+    padding: 8px var(--gutter) 16px;
+    flex-direction: column;
+    box-shadow: var(--shadow-md);
+    z-index: 101;
+  }
+  nav.site-nav .nav-menu[data-open="true"] { display: flex; }
+
+  nav.site-nav .nav-menu > li { width: 100%; }
+  nav.site-nav .nav-menu > li + li {
+    border-top: 1px solid var(--divider);
+    margin-top: 8px;
+    padding-top: 12px;
+  }
+
+  nav.site-nav .nav-link {
+    display: block;
+    font-size: 16px;
+    color: var(--text);
+    padding: 6px 0;
+  }
+
+  nav.site-nav .nav-dropdown-toggle {
+    display: block;
+    width: 100%;
+    text-align: left;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--text-subtle);
+    padding: 2px 0 6px;
+    cursor: default;
+  }
+  nav.site-nav .nav-dropdown-toggle:hover { color: var(--text-subtle); }
+  nav.site-nav .nav-chevron { display: none; }
+
+  nav.site-nav .nav-submenu {
+    display: flex;
+    flex-direction: column;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    gap: 0;
+  }
+  nav.site-nav .nav-sublink {
+    display: block;
+    font-size: 16px;
+    color: var(--text-muted);
+    padding: 8px 0;
+    text-decoration: none;
+  }
+  nav.site-nav .nav-sublink[aria-current="page"] {
+    color: var(--text);
+    font-weight: 700;
+  }
 }
 
 /* Theme toggle button */
@@ -300,7 +467,6 @@ nav.site-nav a[aria-current="page"] {
   border-radius: 6px;
   display: flex; align-items: center; justify-content: center;
   transition: color 0.2s;
-  margin-left: auto;
 }
 .theme-toggle:hover { color: var(--text); }
 .theme-icon { width: 16px; height: 16px; }


### PR DESCRIPTION
## Why

The old header was a flat 12-link row with `overflow-x: auto` on `.nav-inner`. On desktop that meant items past the right edge were hidden under a fade mask, so the last few links (Senior Relief, Civic Guide, Changelog, About) were effectively invisible unless you noticed the fade and scrolled sideways. On mobile the JS even auto-centered the current link, which hid the scroll affordance entirely.

## What

Collapse the nav into five top-level slots. Ballot and Budget are dropdown groups so every page is still reachable from the header, and nothing scrolls horizontally.

- **Debate** (direct)
- **Ballot ▾** &ndash; What is the override? / No-override budget / Question 2 (trash) / Senior tax relief / Past voting record
- **Budget ▾** &ndash; Where the money went / How we got here / Peer towns / Meeting changelog
- **Take action** (direct)
- **About** (direct)

Groupings mirror the homepage sections. Trash and Senior Relief go under Ballot because readers weighing the override are thinking about both ballot questions and the tax impact together. Peer towns and Voting record go under Budget as historical context.

### Desktop (&ge; 800px)

- Static horizontal row, no mask, no overflow
- Submenus open on hover, focus-within, or click; chevron rotates
- Parent trigger picks up the bold "current" style when any child is the current page
- Click outside or Escape closes the open menu

### Mobile (&lt; 800px)

- Row collapses to a hamburger button
- Drop panel shows below the header with a dividing border between items
- Dropdown triggers render as small uppercase section labels with all sublinks expanded (no double-tap to reach content)
- Tapping outside the panel or pressing Escape closes it

## Test plan

- [ ] Desktop: confirm none of the five top-level items scroll or clip at `>= 800px`
- [ ] Desktop: hover Ballot and Budget, verify submenu opens and chevron rotates
- [ ] Desktop: click Ballot toggle, submenu opens; click outside, closes; press Escape, closes
- [ ] Desktop: visit any Ballot child page (e.g. `/senior-tax-relief.html`), verify "Ballot" trigger renders bold
- [ ] Mobile: tap hamburger, panel opens and shows Debate / [BALLOT section] / [BUDGET section] / Take action / About
- [ ] Mobile: verify all twelve pages are reachable in one tap (no accordion)
- [ ] Mobile: tap a link, verify navigation works; tap outside panel, verify it closes
- [ ] Light and dark theme both read cleanly (submenu surface, divider, hover background)
- [ ] Keyboard: tab through, submenus open via `:focus-within`, Escape returns focus to trigger

https://claude.ai/code/session_013L3jeDVSMzznRfFam2HwbT