### PR TITLE
Add grouped dropdown navigation

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,18 +1,78 @@
 <nav class="site-nav">
   <div class="nav-inner">
     <a class="nav-brand" href="{{ '/' | relative_url }}">MHD Data</a>
+
     <a href="{{ '/' | relative_url }}the-debate.html"{% if page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Debate</a>
-    <a href="{{ '/' | relative_url }}what-is-the-override.html"{% if page.url == '/what-is-the-override.html' %} aria-current="page"{% endif %}>Override</a>
-    <a href="{{ '/' | relative_url }}question-2-trash.html"{% if page.url == '/question-2-trash.html' %} aria-current="page"{% endif %}>Trash</a>
-    <a href="{{ '/' | relative_url }}how-we-got-here.html"{% if page.url == '/how-we-got-here.html' %} aria-current="page"{% endif %}>History</a>
-    <a href="{{ '/' | relative_url }}marblehead-voting-record.html"{% if page.url == '/marblehead-voting-record.html' %} aria-current="page"{% endif %}>Votes</a>
-    <a href="{{ '/' | relative_url }}where-has-the-money-gone.html"{% if page.url == '/where-has-the-money-gone.html' %} aria-current="page"{% endif %}>Spending</a>
-    <a href="{{ '/' | relative_url }}no-override-budget.html"{% if page.url == '/no-override-budget.html' %} aria-current="page"{% endif %}>No-Override</a>
-    <a href="{{ '/' | relative_url }}why-not-elsewhere.html"{% if page.url == '/why-not-elsewhere.html' %} aria-current="page"{% endif %}>Peer Towns</a>
-    <a href="{{ '/' | relative_url }}senior-tax-relief.html"{% if page.url == '/senior-tax-relief.html' %} aria-current="page"{% endif %}>Senior Relief</a>
+
+    <div class="nav-dropdown">
+      <button class="nav-dropdown-toggle" aria-expanded="false">Override <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+      <div class="nav-dropdown-menu">
+        <a href="{{ '/' | relative_url }}what-is-the-override.html"{% if page.url == '/what-is-the-override.html' %} aria-current="page"{% endif %}>What is the override?</a>
+        <a href="{{ '/' | relative_url }}charts/override_calculator.html"{% if page.url == '/charts/override_calculator.html' %} aria-current="page"{% endif %}>What does it cost me?</a>
+        <a href="{{ '/' | relative_url }}no-override-budget.html"{% if page.url == '/no-override-budget.html' %} aria-current="page"{% endif %}>No-override budget</a>
+        <a href="{{ '/' | relative_url }}question-2-trash.html"{% if page.url == '/question-2-trash.html' %} aria-current="page"{% endif %}>Trash: levy or fee?</a>
+        <a href="{{ '/' | relative_url }}charts/sustainability.html"{% if page.url == '/charts/sustainability.html' %} aria-current="page"{% endif %}>Sustainability</a>
+        <a href="{{ '/' | relative_url }}marblehead-voting-record.html"{% if page.url == '/marblehead-voting-record.html' %} aria-current="page"{% endif %}>Voting record</a>
+      </div>
+    </div>
+
+    <div class="nav-dropdown">
+      <button class="nav-dropdown-toggle" aria-expanded="false">Budget <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+      <div class="nav-dropdown-menu">
+        <a href="{{ '/' | relative_url }}where-has-the-money-gone.html"{% if page.url == '/where-has-the-money-gone.html' %} aria-current="page"{% endif %}>Where the money went</a>
+        <a href="{{ '/' | relative_url }}how-we-got-here.html"{% if page.url == '/how-we-got-here.html' %} aria-current="page"{% endif %}>How we got here</a>
+        <a href="{{ '/' | relative_url }}data/case_studies.html"{% if page.url == '/data/case_studies.html' %} aria-current="page"{% endif %}>Case studies</a>
+      </div>
+    </div>
+
+    <div class="nav-dropdown">
+      <button class="nav-dropdown-toggle" aria-expanded="false">Schools <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+      <div class="nav-dropdown-menu">
+        <a href="{{ '/' | relative_url }}charts/enrollment_vs_staffing.html"{% if page.url == '/charts/enrollment_vs_staffing.html' %} aria-current="page"{% endif %}>Enrollment vs. staffing</a>
+        <a href="{{ '/' | relative_url }}inside-school-staffing.html"{% if page.url == '/inside-school-staffing.html' %} aria-current="page"{% endif %}>Inside school staffing</a>
+      </div>
+    </div>
+
+    <div class="nav-dropdown">
+      <button class="nav-dropdown-toggle" aria-expanded="false">Healthcare <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+      <div class="nav-dropdown-menu">
+        <a href="{{ '/' | relative_url }}charts/healthcare_costs.html"{% if page.url == '/charts/healthcare_costs.html' %} aria-current="page"{% endif %}>Why insurance keeps rising</a>
+        <a href="{{ '/' | relative_url }}charts/peer_compensation.html"{% if page.url == '/charts/peer_compensation.html' %} aria-current="page"{% endif %}>Salary vs. benefits</a>
+      </div>
+    </div>
+
+    <div class="nav-dropdown">
+      <button class="nav-dropdown-toggle" aria-expanded="false">Tax Bill <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+      <div class="nav-dropdown-menu">
+        <a href="{{ '/' | relative_url }}charts/levy_vs_bill.html"{% if page.url == '/charts/levy_vs_bill.html' %} aria-current="page"{% endif %}>Levy, bill, and inflation</a>
+        <a href="{{ '/' | relative_url }}senior-tax-relief.html"{% if page.url == '/senior-tax-relief.html' %} aria-current="page"{% endif %}>Senior tax relief</a>
+      </div>
+    </div>
+
+    <div class="nav-dropdown">
+      <button class="nav-dropdown-toggle" aria-expanded="false">Peer Towns <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+      <div class="nav-dropdown-menu">
+        <a href="{{ '/' | relative_url }}charts/four_town_rates.html"{% if page.url == '/charts/four_town_rates.html' %} aria-current="page"{% endif %}>Four-town tax rates</a>
+        <a href="{{ '/' | relative_url }}charts/per_capita_levy.html"{% if page.url == '/charts/per_capita_levy.html' %} aria-current="page"{% endif %}>Per-capita levy</a>
+        <a href="{{ '/' | relative_url }}charts/tax_comparison.html"{% if page.url == '/charts/tax_comparison.html' %} aria-current="page"{% endif %}>Marblehead vs. Swampscott</a>
+        <a href="{{ '/' | relative_url }}charts/rate_value_schools.html"{% if page.url == '/charts/rate_value_schools.html' %} aria-current="page"{% endif %}>Rate, value, and schools</a>
+        <a href="{{ '/' | relative_url }}why-not-elsewhere.html"{% if page.url == '/why-not-elsewhere.html' %} aria-current="page"{% endif %}>Why not elsewhere?</a>
+      </div>
+    </div>
+
     <a href="{{ '/' | relative_url }}what-you-can-do.html"{% if page.url == '/what-you-can-do.html' %} aria-current="page"{% endif %}>Civic Guide</a>
-    <a href="{{ '/' | relative_url }}meeting-tracker.html"{% if page.url == '/meeting-tracker.html' %} aria-current="page"{% endif %}>Changelog</a>
-    <a href="{{ '/' | relative_url }}about.html"{% if page.url == '/about.html' %} aria-current="page"{% endif %}>About</a>
+
+    <div class="nav-dropdown">
+      <button class="nav-dropdown-toggle" aria-expanded="false">Data <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+      <div class="nav-dropdown-menu">
+        <a href="{{ '/' | relative_url }}data/master-data.html"{% if page.url == '/data/master-data.html' %} aria-current="page"{% endif %}>Annual rollup (FY01-FY27)</a>
+        <a href="{{ '/' | relative_url }}data/DATA_CATALOG.html"{% if page.url == '/data/DATA_CATALOG.html' %} aria-current="page"{% endif %}>Data catalog</a>
+        <a href="{{ '/' | relative_url }}data/SOURCE_LOOKUP.html"{% if page.url == '/data/SOURCE_LOOKUP.html' %} aria-current="page"{% endif %}>Source lookup</a>
+        <a href="{{ '/' | relative_url }}meeting-tracker.html"{% if page.url == '/meeting-tracker.html' %} aria-current="page"{% endif %}>Meeting changelog</a>
+        <a href="{{ '/' | relative_url }}about.html"{% if page.url == '/about.html' %} aria-current="page"{% endif %}>About this project</a>
+      </div>
+    </div>
+
     <button class="theme-toggle" aria-label="Toggle light/dark mode" title="Toggle light/dark mode">
       <svg class="theme-icon theme-icon--sun" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><circle cx="10" cy="10" r="4"/><path d="M10 1v2M10 17v2M1 10h2M17 10h2M3.5 3.5l1.4 1.4M15.1 15.1l1.4 1.4M3.5 16.5l1.4-1.4M15.1 4.9l1.4-1.4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></svg>
       <svg class="theme-icon theme-icon--moon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M17.3 13.4A7.5 7.5 0 016.6 2.7a8 8 0 1010.7 10.7z"/></svg>
@@ -20,13 +80,55 @@
   </div>
 </nav>
 <script>
+  // Dropdown toggle (tap on mobile, hover handled by CSS on desktop)
+  (function () {
+    var dropdowns = document.querySelectorAll('.nav-dropdown');
+    dropdowns.forEach(function (dd) {
+      var toggle = dd.querySelector('.nav-dropdown-toggle');
+      toggle.addEventListener('click', function (e) {
+        e.preventDefault();
+        var wasOpen = dd.classList.contains('is-open');
+        // Close all other dropdowns first
+        dropdowns.forEach(function (other) {
+          other.classList.remove('is-open');
+          other.querySelector('.nav-dropdown-toggle').setAttribute('aria-expanded', 'false');
+        });
+        if (!wasOpen) {
+          dd.classList.add('is-open');
+          toggle.setAttribute('aria-expanded', 'true');
+        }
+      });
+    });
+    // Close dropdowns when clicking outside
+    document.addEventListener('click', function (e) {
+      if (!e.target.closest('.nav-dropdown')) {
+        dropdowns.forEach(function (dd) {
+          dd.classList.remove('is-open');
+          dd.querySelector('.nav-dropdown-toggle').setAttribute('aria-expanded', 'false');
+        });
+      }
+    });
+    // Close on Escape
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        dropdowns.forEach(function (dd) {
+          dd.classList.remove('is-open');
+          dd.querySelector('.nav-dropdown-toggle').setAttribute('aria-expanded', 'false');
+        });
+      }
+    });
+  })();
+
+  // Scroll active dropdown into view on mobile
   (function () {
     if (!window.matchMedia || !window.matchMedia('(max-width: 799px)').matches) return;
     var navInner = document.querySelector('nav.site-nav .nav-inner');
     if (!navInner) return;
+    // Find a dropdown containing the current page, or a direct link with aria-current
     var current = navInner.querySelector('a[aria-current="page"]');
     if (!current) return;
-    var target = current.offsetLeft - (navInner.clientWidth - current.offsetWidth) / 2;
+    var scrollTarget = current.closest('.nav-dropdown') || current;
+    var target = scrollTarget.offsetLeft - (navInner.clientWidth - scrollTarget.offsetWidth) / 2;
     navInner.scrollLeft = Math.max(0, target);
   })();
 

--- a/assets/site.css
+++ b/assets/site.css
@@ -291,6 +291,84 @@ nav.site-nav a[aria-current="page"] {
   font-weight: 700;
 }
 
+/* Nav dropdowns */
+.nav-dropdown {
+  position: relative;
+  flex-shrink: 0;
+  scroll-snap-align: start;
+}
+.nav-dropdown-toggle {
+  font: inherit;
+  font-size: 13px;
+  color: var(--text-subtle);
+  white-space: nowrap;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  transition: color 0.2s;
+}
+.nav-dropdown-toggle:hover { color: var(--text); }
+.nav-caret { width: 8px; height: 5px; flex-shrink: 0; transition: transform 0.2s; }
+/* Highlight toggle when a child page is active */
+.nav-dropdown:has(a[aria-current="page"]) .nav-dropdown-toggle {
+  color: var(--text);
+  font-weight: 700;
+}
+/* Dropdown panel */
+.nav-dropdown-menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 0;
+  min-width: 200px;
+  box-shadow: 0 8px 24px rgba(0,0,0,.15);
+  z-index: 200;
+}
+.nav-dropdown-menu a {
+  display: block;
+  padding: 8px 16px;
+  font-size: 13px;
+  color: var(--text-subtle);
+  white-space: nowrap;
+}
+.nav-dropdown-menu a:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+  text-decoration: none;
+}
+.nav-dropdown-menu a[aria-current="page"] {
+  color: var(--text);
+  font-weight: 700;
+}
+/* Open state (tap / JS toggle) */
+.nav-dropdown.is-open .nav-dropdown-menu { display: block; }
+.nav-dropdown.is-open .nav-caret { transform: rotate(180deg); }
+/* Desktop: also open on hover */
+@media (min-width: 800px) {
+  .nav-dropdown:hover .nav-dropdown-menu { display: block; }
+  .nav-dropdown:hover .nav-caret { transform: rotate(180deg); }
+}
+/* Keep dropdown menus on-screen on mobile */
+@media (max-width: 799px) {
+  .nav-dropdown-menu {
+    position: fixed;
+    top: 49px;
+    left: var(--gutter);
+    right: var(--gutter);
+    transform: none;
+    min-width: 0;
+  }
+}
+
 /* Theme toggle button */
 .theme-toggle {
   flex-shrink: 0;


### PR DESCRIPTION
## Summary
- Replace flat 11-item nav with 8 grouped sections (6 dropdowns + 2 direct links)
- Groups mirror the homepage section layout: Override, Budget, Schools, Healthcare, Tax Bill, Peer Towns, plus Debate and Civic Guide as direct links, and a Data dropdown
- Chart pages that were previously nav-orphaned now have homes in their topic dropdowns
- Desktop: hover to open; Mobile: tap-to-toggle with fixed-position panels
- Active page bolds its parent dropdown label via CSS `:has()` selector
- Escape key and click-outside close open dropdowns

## Test plan
- [ ] Desktop: hover each dropdown, verify all links load correct pages
- [ ] Mobile: tap dropdowns open/close, only one open at a time
- [ ] Verify active page highlighting works (bold dropdown label when on a child page)
- [ ] Check dark mode styling on dropdown panels
- [ ] Verify horizontal scroll still works on mobile for the top-level items

🤖 Generated with [Claude Code](https://claude.com/claude-code)