### PR TITLE
Fix mobile dropdown menus not appearing

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -359,15 +359,19 @@ nav.site-nav a[aria-current="page"] {
   .nav-dropdown:hover .nav-dropdown-menu { display: block; }
   .nav-dropdown:hover .nav-caret { transform: rotate(180deg); }
 }
-/* Keep dropdown menus on-screen on mobile */
+/* Mobile: when a dropdown is open, disable nav scroll so menus aren't clipped */
 @media (max-width: 799px) {
+  .nav-inner:has(.nav-dropdown.is-open) {
+    overflow-x: visible;
+  }
   .nav-dropdown-menu {
-    position: fixed;
-    top: 49px;
-    left: var(--gutter);
-    right: var(--gutter);
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: auto;
     transform: none;
-    min-width: 0;
+    min-width: min(280px, calc(100vw - 2 * var(--gutter)));
+    max-width: calc(100vw - 2 * var(--gutter));
   }
 }
 


### PR DESCRIPTION
## Summary
- `backdrop-filter` on `nav.site-nav` creates a new containing block, making `position: fixed` dropdown menus behave as `position: absolute` -- clipped by `.nav-inner`'s `overflow-x: auto`
- Fix: use `:has(.is-open)` to temporarily disable overflow when a dropdown is open on mobile
- Switch mobile menus from `position: fixed` to `position: absolute` with constrained width

## Test plan
- [ ] Mobile: tap any dropdown toggle -- menu appears below the nav
- [ ] Tap a different dropdown -- previous one closes, new one opens
- [ ] Tap outside -- dropdown closes
- [ ] Horizontal scroll still works when no dropdown is open
- [ ] Desktop hover behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)