### PR TITLE
Fix mobile dropdown menus via DOM portal

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -80,42 +80,54 @@
   </div>
 </nav>
 <script>
-  // Dropdown toggle (tap on mobile, hover handled by CSS on desktop)
+  // Dropdown toggle
   (function () {
+    var nav = document.querySelector('nav.site-nav');
     var dropdowns = document.querySelectorAll('.nav-dropdown');
+    var isMobile = function () { return window.matchMedia('(max-width: 799px)').matches; };
+
+    // Create a mobile panel that lives outside .nav-inner (avoids overflow clipping)
+    var mobilePanel = document.createElement('div');
+    mobilePanel.className = 'nav-mobile-panel';
+    nav.appendChild(mobilePanel);
+
+    function closeAll() {
+      dropdowns.forEach(function (dd) {
+        dd.classList.remove('is-open');
+        dd.querySelector('.nav-dropdown-toggle').setAttribute('aria-expanded', 'false');
+      });
+      mobilePanel.classList.remove('is-open');
+      mobilePanel.innerHTML = '';
+    }
+
     dropdowns.forEach(function (dd) {
       var toggle = dd.querySelector('.nav-dropdown-toggle');
       toggle.addEventListener('click', function (e) {
         e.preventDefault();
+        e.stopPropagation();
         var wasOpen = dd.classList.contains('is-open');
-        // Close all other dropdowns first
-        dropdowns.forEach(function (other) {
-          other.classList.remove('is-open');
-          other.querySelector('.nav-dropdown-toggle').setAttribute('aria-expanded', 'false');
-        });
+        closeAll();
         if (!wasOpen) {
           dd.classList.add('is-open');
           toggle.setAttribute('aria-expanded', 'true');
+          if (isMobile()) {
+            // Copy menu links into the portal panel
+            var menu = dd.querySelector('.nav-dropdown-menu');
+            mobilePanel.innerHTML = menu.innerHTML;
+            mobilePanel.classList.add('is-open');
+          }
         }
       });
     });
-    // Close dropdowns when clicking outside
+
     document.addEventListener('click', function (e) {
-      if (!e.target.closest('.nav-dropdown')) {
-        dropdowns.forEach(function (dd) {
-          dd.classList.remove('is-open');
-          dd.querySelector('.nav-dropdown-toggle').setAttribute('aria-expanded', 'false');
-        });
+      if (!e.target.closest('.nav-dropdown') && !e.target.closest('.nav-mobile-panel')) {
+        closeAll();
       }
     });
-    // Close on Escape
+
     document.addEventListener('keydown', function (e) {
-      if (e.key === 'Escape') {
-        dropdowns.forEach(function (dd) {
-          dd.classList.remove('is-open');
-          dd.querySelector('.nav-dropdown-toggle').setAttribute('aria-expanded', 'false');
-        });
-      }
+      if (e.key === 'Escape') closeAll();
     });
   })();
 

--- a/assets/site.css
+++ b/assets/site.css
@@ -359,20 +359,32 @@ nav.site-nav a[aria-current="page"] {
   .nav-dropdown:hover .nav-dropdown-menu { display: block; }
   .nav-dropdown:hover .nav-caret { transform: rotate(180deg); }
 }
-/* Mobile: when a dropdown is open, disable nav scroll so menus aren't clipped */
-@media (max-width: 799px) {
-  .nav-inner:has(.nav-dropdown.is-open) {
-    overflow-x: visible;
-  }
-  .nav-dropdown-menu {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: auto;
-    transform: none;
-    min-width: min(280px, calc(100vw - 2 * var(--gutter)));
-    max-width: calc(100vw - 2 * var(--gutter));
-  }
+/* Mobile dropdown panel (portalled outside .nav-inner by JS) */
+.nav-mobile-panel {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: var(--gutter);
+  right: var(--gutter);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 0;
+  box-shadow: 0 8px 24px rgba(0,0,0,.15);
+  z-index: 200;
+}
+.nav-mobile-panel.is-open { display: block; }
+.nav-mobile-panel a {
+  display: block;
+  padding: 10px 16px;
+  font-size: 14px;
+  color: var(--text-subtle);
+}
+.nav-mobile-panel a:hover,
+.nav-mobile-panel a:active {
+  color: var(--text);
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+  text-decoration: none;
 }
 
 /* Theme toggle button */


### PR DESCRIPTION
## Summary
- Root cause: `backdrop-filter` on `nav.site-nav` creates a containing block, trapping fixed-position elements inside `overflow-x: auto` on `.nav-inner`
- CSS-only fixes (`:has()`, overflow toggling) didn't reliably work across mobile browsers
- New approach: JS creates a `.nav-mobile-panel` as a direct child of `nav.site-nav` (outside `.nav-inner`), and copies dropdown links into it on tap
- Desktop hover behavior unchanged

## Test plan
- [ ] Mobile: tap any dropdown toggle -- panel appears below nav bar
- [ ] Tap a different dropdown -- panel content swaps
- [ ] Tap outside or on a link -- panel closes
- [ ] Desktop: hover dropdowns still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)