### PR TITLE
Fix lighthouse hero invisible in dark mode

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -817,7 +817,10 @@ details.notes[open] > summary {
 .hero { text-align: center; margin-bottom: 36px; }
 .hero-lighthouse {
   display: block; margin: 0 auto 16px; width: 80px; height: 120px;
-  opacity: 0.75; color: var(--text-subtle);
+  opacity: 0.75;
+  background: var(--text-subtle);
+  -webkit-mask: url(assets/lighthouse/lighthouse.svg) center / contain no-repeat;
+          mask: url(assets/lighthouse/lighthouse.svg) center / contain no-repeat;
 }
 @media (min-width: 600px) {
   .hero-lighthouse { width: 120px; height: 180px; }

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ og_type: website
 og_url: https://marbleheaddata.org/
 ---
 <div class="hero">
-    <img class="hero-lighthouse" src="{{ '/' | relative_url }}assets/lighthouse/lighthouse.svg" alt="Marblehead lighthouse" width="120" height="180">
+    <div class="hero-lighthouse" role="img" aria-label="Marblehead lighthouse"></div>
     <h1>Weighing the FY2027 override?</h1>
     <p>Every claim on this site cites a primary source. Every dollar traces to a town document. Make your own call. <a href="#data-sources">See all sources.</a></p>
   </div>


### PR DESCRIPTION
## Summary
- `<img>` tags render SVGs in isolation, so `currentColor` stays black regardless of theme
- Switched to a CSS `mask-image` on a `<div>` with `background: var(--text-subtle)`, which adapts to dark/light mode

## Test plan
- [ ] Verify lighthouse appears in light mode
- [ ] Toggle to dark mode and verify lighthouse is white/light

🤖 Generated with [Claude Code](https://claude.com/claude-code)