### PR TITLE
Fix lighthouse hero and add side-by-side layout

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -828,17 +828,23 @@ details.notes[open] > summary {
 
 .hero { text-align: center; margin-bottom: 36px; }
 .hero-lighthouse {
-  display: block; margin: 0 auto 16px; width: 80px; height: 120px;
-  opacity: 0.75;
+  display: block; margin: 0 auto 12px; width: 64px; height: 96px;
+  flex-shrink: 0;
+  opacity: 0.7;
   background: var(--text-subtle);
-  -webkit-mask: url(assets/lighthouse/lighthouse.svg) center / contain no-repeat;
-          mask: url(assets/lighthouse/lighthouse.svg) center / contain no-repeat;
-}
-@media (min-width: 600px) {
-  .hero-lighthouse { width: 120px; height: 180px; }
+  -webkit-mask: url(lighthouse/lighthouse.svg) center / contain no-repeat;
+          mask: url(lighthouse/lighthouse.svg) center / contain no-repeat;
 }
 .hero h1 { font-size: 28px; margin-bottom: 10px; }
 .hero p  { font-size: 16px; color: var(--text-subtle); max-width: 520px; margin: 0 auto; }
+@media (min-width: 600px) {
+  .hero {
+    display: flex; align-items: center; justify-content: center;
+    gap: 24px; text-align: left;
+  }
+  .hero-lighthouse { width: 80px; height: 120px; margin: 0; }
+  .hero p { margin: 0; }
+}
 
 .question-list {
   display: flex; flex-direction: column; gap: 12px;

--- a/index.html
+++ b/index.html
@@ -8,8 +8,10 @@ og_url: https://marbleheaddata.org/
 ---
 <div class="hero">
     <div class="hero-lighthouse" role="img" aria-label="Marblehead lighthouse"></div>
-    <h1>Weighing the FY2027 override?</h1>
-    <p>Every claim on this site cites a primary source. Every dollar traces to a town document. Make your own call. <a href="#data-sources">See all sources.</a></p>
+    <div class="hero-text">
+      <h1>Weighing the FY2027 override?</h1>
+      <p>Every claim on this site cites a primary source. Every dollar traces to a town document. Make your own call. <a href="#data-sources">See all sources.</a></p>
+    </div>
   </div>
 
   <a class="featured-card" href="the-debate.html">


### PR DESCRIPTION
## Summary
- Fix broken CSS mask URL that made lighthouse invisible on the live site (path resolved to `/assets/assets/...`)
- Desktop: lighthouse left, text right, vertically centered
- Mobile: stacked, lighthouse centered above text
- Verified with Playwright in light mode, dark mode, desktop, and mobile

## Test plan
- [x] Playwright: desktop light -- lighthouse visible, side-by-side
- [x] Playwright: desktop dark -- lighthouse visible, light colored
- [x] Playwright: mobile light -- lighthouse visible, stacked
- [x] Playwright: mobile dark -- lighthouse visible, stacked

🤖 Generated with [Claude Code](https://claude.com/claude-code)