### PR TITLE
Favicon: white lighthouse on navy background

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,5 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="262 50 500 500" fill="currentColor">
-<g transform="translate(0,1536) scale(0.1,-0.1)" stroke="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="232 20 560 560">
+<rect x="232" y="20" width="560" height="560" rx="60" fill="#1B3A57"/>
+<g transform="translate(0,1536) scale(0.1,-0.1)" fill="white" stroke="none">
 <path d="M5106 14168 c-3 -13 -6 -107 -6 -209 l0 -187 -29 -12 c-68 -28 -99
 -106 -67 -168 24 -47 53 -62 118 -62 49 0 62 4 89 28 62 56 44 161 -35 199
 -44 20 -46 32 -46 254 0 163 -8 215 -24 157z"/>


### PR DESCRIPTION
## Summary
- `currentColor` renders black in isolated SVG context (favicons don't inherit CSS)
- Changed to white fill on `#1B3A57` navy rounded rect, matching the site's palette

## Test plan
- [x] Playwright: favicon renders white lighthouse on navy, visible at small sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)