### PR TITLE
Zoom favicon to fill more space

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="232 20 560 560">
-<rect x="232" y="20" width="560" height="560" rx="60" fill="#1B3A57"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="320 60 380 380">
+<rect x="320" y="60" width="380" height="380" rx="40" fill="#1B3A57"/>
 <g transform="translate(0,1536) scale(0.1,-0.1)" fill="white" stroke="none">
 <path d="M5106 14168 c-3 -13 -6 -107 -6 -209 l0 -187 -29 -12 c-68 -28 -99
 -106 -67 -168 24 -47 53 -62 118 -62 49 0 62 4 89 28 62 56 44 161 -35 199


### PR DESCRIPTION
## Summary
- Tighten viewBox from 560x560 to 380x380
- Lantern room and gallery fill the icon; legs cropped

## Test plan
- [x] Playwright: compared three crop levels, option 2 selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)