### PR TITLE
Fix mobile dropdown appearing at bottom of screen

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -112,9 +112,11 @@
           dd.classList.add('is-open');
           toggle.setAttribute('aria-expanded', 'true');
           if (isMobile()) {
-            // Copy menu links into the portal panel
             var menu = dd.querySelector('.nav-dropdown-menu');
             mobilePanel.innerHTML = menu.innerHTML;
+            // Position below the nav bar
+            var navRect = nav.getBoundingClientRect();
+            mobilePanel.style.top = (navRect.bottom + window.scrollY) + 'px';
             mobilePanel.classList.add('is-open');
           }
         }

--- a/assets/site.css
+++ b/assets/site.css
@@ -366,8 +366,7 @@ nav.site-nav a[aria-current="page"] {
 /* Mobile dropdown panel (appended to body by JS, outside all nav CSS) */
 .nav-mobile-panel {
   display: none;
-  position: fixed;
-  top: 49px;
+  position: absolute;
   left: var(--gutter);
   right: var(--gutter);
   background: var(--surface);


### PR DESCRIPTION
## Summary
- `position: fixed; top: 49px` on the mobile panel was rendering at the bottom of the screen on iOS Safari
- Switch to `position: absolute` with `top` set dynamically via JS from `nav.getBoundingClientRect().bottom + window.scrollY`

## Playwright results (injected into live site)
20/20 on Chromium + WebKit: panel at top=49px, 6 links, 14px font, inline menu hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)