### PR TITLE
Restore hero lighthouse (clobbered by parallel merge)

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -832,14 +832,23 @@ details.notes[open] > summary {
 
 .hero { text-align: center; margin-bottom: 36px; }
 .hero-lighthouse {
-  display: block; margin: 0 auto 16px; width: 80px; height: 120px;
-  opacity: 0.75; color: var(--text-subtle);
-}
-@media (min-width: 600px) {
-  .hero-lighthouse { width: 120px; height: 180px; }
+  display: block; margin: 0 auto 12px; width: 64px; height: 96px;
+  flex-shrink: 0;
+  opacity: 0.7;
+  background: var(--text-subtle);
+  -webkit-mask: url(lighthouse/lighthouse.svg) center / contain no-repeat;
+          mask: url(lighthouse/lighthouse.svg) center / contain no-repeat;
 }
 .hero h1 { font-size: 28px; margin-bottom: 10px; }
 .hero p  { font-size: 16px; color: var(--text-subtle); max-width: 520px; margin: 0 auto; }
+@media (min-width: 600px) {
+  .hero {
+    display: flex; align-items: center; justify-content: center;
+    gap: 24px; text-align: left;
+  }
+  .hero-lighthouse { width: 80px; height: 120px; margin: 0; }
+  .hero p { margin: 0; }
+}
 
 .question-list {
   display: flex; flex-direction: column; gap: 12px;


### PR DESCRIPTION
## Summary
- PR #235 (nav-body-portal) was branched from pre-fix main and overwrote the hero mask-image CSS when merged
- Restores mask-image approach, correct relative URL, and side-by-side desktop layout

## Test plan
- [ ] Verify lighthouse visible in light and dark mode after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)