### PR TITLE
Add lighthouse favicon as nav brand logo

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,6 +1,6 @@
 <nav class="site-nav">
   <div class="nav-inner">
-    <a class="nav-brand" href="{{ '/' | relative_url }}">MHD Data</a>
+    <a class="nav-brand" href="{{ '/' | relative_url }}"><img class="nav-logo" src="{{ '/' | relative_url }}favicon.svg" alt="" width="20" height="20"> MHD Data</a>
 
     <a href="{{ '/' | relative_url }}the-debate.html"{% if page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Debate</a>
 

--- a/assets/site.css
+++ b/assets/site.css
@@ -280,8 +280,9 @@ nav.site-nav .nav-inner::-webkit-scrollbar { display: none; }
 nav.site-nav .nav-brand {
   font-size: 14px; font-weight: 700; color: var(--text);
   white-space: nowrap; margin-right: 4px;
-  display: inline-flex; align-items: center; gap: 4px;
+  display: inline-flex; align-items: center; gap: 6px;
 }
+.nav-logo { width: 20px; height: 20px; border-radius: 4px; }
 nav.site-nav .nav-inner > a,
 nav.site-nav .nav-dropdown-toggle {
   font-size: 13px; line-height: 1; color: var(--text-subtle);


### PR DESCRIPTION
## Summary
- Adds the favicon SVG as a 20px icon next to "MHD Data" in the nav bar
- Navy background renders well in both light and dark themes
- Rounded corners (4px) at nav size

## Test plan
- [x] Playwright: light mode nav with logo
- [x] Playwright: dark mode nav with logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)