### PR TITLE
Reorganize homepage and nav into clearer topic sections

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -5,7 +5,7 @@
     <a href="{{ '/' | relative_url }}the-debate.html"{% if page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Debate</a>
 
     <div class="nav-dropdown">
-      <button class="nav-dropdown-toggle" aria-expanded="false">Override <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+      <button class="nav-dropdown-toggle" aria-expanded="false">Vote <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <div class="nav-dropdown-menu">
         <a href="{{ '/' | relative_url }}what-is-the-override.html"{% if page.url == '/what-is-the-override.html' %} aria-current="page"{% endif %}>What is the override?</a>
         <a href="{{ '/' | relative_url }}charts/override_calculator.html"{% if page.url == '/charts/override_calculator.html' %} aria-current="page"{% endif %}>What does it cost me?</a>
@@ -21,7 +21,7 @@
       <div class="nav-dropdown-menu">
         <a href="{{ '/' | relative_url }}where-has-the-money-gone.html"{% if page.url == '/where-has-the-money-gone.html' %} aria-current="page"{% endif %}>Where the money went</a>
         <a href="{{ '/' | relative_url }}how-we-got-here.html"{% if page.url == '/how-we-got-here.html' %} aria-current="page"{% endif %}>How we got here</a>
-        <a href="{{ '/' | relative_url }}data/case_studies.html"{% if page.url == '/data/case_studies.html' %} aria-current="page"{% endif %}>Case studies</a>
+        <a href="{{ '/' | relative_url }}meeting-tracker.html"{% if page.url == '/meeting-tracker.html' %} aria-current="page"{% endif %}>Meeting changelog</a>
       </div>
     </div>
 
@@ -34,7 +34,7 @@
     </div>
 
     <div class="nav-dropdown">
-      <button class="nav-dropdown-toggle" aria-expanded="false">Healthcare <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+      <button class="nav-dropdown-toggle" aria-expanded="false">Insurance <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <div class="nav-dropdown-menu">
         <a href="{{ '/' | relative_url }}charts/healthcare_costs.html"{% if page.url == '/charts/healthcare_costs.html' %} aria-current="page"{% endif %}>Why insurance keeps rising</a>
         <a href="{{ '/' | relative_url }}charts/peer_compensation.html"{% if page.url == '/charts/peer_compensation.html' %} aria-current="page"{% endif %}>Salary vs. benefits</a>
@@ -57,10 +57,11 @@
         <a href="{{ '/' | relative_url }}charts/tax_comparison.html"{% if page.url == '/charts/tax_comparison.html' %} aria-current="page"{% endif %}>Marblehead vs. Swampscott</a>
         <a href="{{ '/' | relative_url }}charts/rate_value_schools.html"{% if page.url == '/charts/rate_value_schools.html' %} aria-current="page"{% endif %}>Rate, value, and schools</a>
         <a href="{{ '/' | relative_url }}why-not-elsewhere.html"{% if page.url == '/why-not-elsewhere.html' %} aria-current="page"{% endif %}>Why not elsewhere?</a>
+        <a href="{{ '/' | relative_url }}data/case_studies.html"{% if page.url == '/data/case_studies.html' %} aria-current="page"{% endif %}>Case studies</a>
       </div>
     </div>
 
-    <a href="{{ '/' | relative_url }}what-you-can-do.html"{% if page.url == '/what-you-can-do.html' %} aria-current="page"{% endif %}>Civic Guide</a>
+    <a href="{{ '/' | relative_url }}what-you-can-do.html"{% if page.url == '/what-you-can-do.html' %} aria-current="page"{% endif %}>Civic</a>
 
     <div class="nav-dropdown">
       <button class="nav-dropdown-toggle" aria-expanded="false">Data <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
@@ -68,7 +69,6 @@
         <a href="{{ '/' | relative_url }}data/master-data.html"{% if page.url == '/data/master-data.html' %} aria-current="page"{% endif %}>Annual rollup (FY01-FY27)</a>
         <a href="{{ '/' | relative_url }}data/DATA_CATALOG.html"{% if page.url == '/data/DATA_CATALOG.html' %} aria-current="page"{% endif %}>Data catalog</a>
         <a href="{{ '/' | relative_url }}data/SOURCE_LOOKUP.html"{% if page.url == '/data/SOURCE_LOOKUP.html' %} aria-current="page"{% endif %}>Source lookup</a>
-        <a href="{{ '/' | relative_url }}meeting-tracker.html"{% if page.url == '/meeting-tracker.html' %} aria-current="page"{% endif %}>Meeting changelog</a>
         <a href="{{ '/' | relative_url }}about.html"{% if page.url == '/about.html' %} aria-current="page"{% endif %}>About this project</a>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ og_url: https://marbleheaddata.org/
     </ol>
   </div>
 
-  <p class="section-label">The override vote</p>
+  <p class="section-label">The vote</p>
   <div class="question-list">
     <a class="question" href="what-is-the-override.html">
       <h2>What is the override?</h2>
@@ -44,14 +44,22 @@ og_url: https://marbleheaddata.org/
       <span class="tag tag-charts">Calculator</span>
     </a>
 
-    <a class="question" href="no-override-budget.html">
-      <h2>What's in the no-override budget?</h2>
-      <p>22 town positions removed, 18.25 school FTEs, library reduced 43%, and what other MA towns did after similar votes.</p>
-    </a>
-
     <a class="question" href="question-2-trash.html">
       <h2>What is Question 2 (trash)?</h2>
       <p>The second ballot question. A $2.3M override for curbside trash, or a ~$281/household fee if it fails. What has already been decided, what each option costs by home value, and how other MA towns fund curbside.</p>
+    </a>
+
+    <a class="question" href="marblehead-voting-record.html">
+      <h2>Has Marblehead voted yes before?</h2>
+      <p>Every Prop 2&frac12; vote since 1988: what passed, what failed, and how much.</p>
+    </a>
+  </div>
+
+  <p class="section-label">The stakes</p>
+  <div class="question-list">
+    <a class="question" href="no-override-budget.html">
+      <h2>What's in the no-override budget?</h2>
+      <p>22 town positions removed, 18.25 school FTEs, library reduced 43%, and what other MA towns did after similar votes.</p>
     </a>
 
     <a class="question" href="charts/sustainability.html">
@@ -88,14 +96,9 @@ og_url: https://marbleheaddata.org/
       <p>Ten years of general fund revenue and expenses, from balanced budgets through growing free cash reliance to the FY27 gap. Shows how each override tier compares to projected expenses through FY30.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
-
-    <a class="question" href="marblehead-voting-record.html">
-      <h2>Has Marblehead voted yes before?</h2>
-      <p>Every Prop 2&frac12; vote since 1988: what passed, what failed, and how much.</p>
-    </a>
   </div>
 
-  <p class="section-label">Town budget</p>
+  <p class="section-label">The budget</p>
   <div class="question-list">
     <a class="question" href="where-has-the-money-gone.html">
       <h2>Where has Marblehead's money gone?</h2>
@@ -110,11 +113,6 @@ og_url: https://marbleheaddata.org/
     <a class="question" href="meeting-tracker.html">
       <h2>Meeting changelog</h2>
       <p>How budget and override numbers have shifted after each public meeting, with before/after detail and attribution.</p>
-    </a>
-
-    <a class="question" href="data/case_studies">
-      <h2>What happened in towns that voted no?</h2>
-      <p>What happened in four Massachusetts towns after override votes failed: two came back with larger asks, two absorbed years of cuts without returning.</p>
     </a>
   </div>
 
@@ -138,7 +136,7 @@ og_url: https://marbleheaddata.org/
     </a>
   </div>
 
-  <p class="section-label">Healthcare</p>
+  <p class="section-label">Insurance</p>
   <div class="question-list">
     <a class="question" href="charts/healthcare_costs.html">
       <svg class="spark-bg" viewBox="50 80 500 175" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
@@ -236,15 +234,19 @@ og_url: https://marbleheaddata.org/
       <h2>Why do some MA towns run overrides and others don't?</h2>
       <p>Residential share of tax levy, new growth rates, and override history for 21 Massachusetts peer towns, grouped into four structural archetypes.</p>
     </a>
+
+    <a class="question" href="data/case_studies">
+      <h2>What happened in towns that voted no?</h2>
+      <p>What happened in four Massachusetts towns after override votes failed: two came back with larger asks, two absorbed years of cuts without returning.</p>
+    </a>
   </div>
 
-  <p class="section-label">Taking action</p>
+  <p class="section-label">Get involved</p>
   <div class="question-list">
     <a class="question" href="what-you-can-do.html">
       <h2>What can you do?</h2>
       <p>Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight of the town budget.</p>
     </a>
-
   </div>
 
   <div class="data-section" id="data-sources">


### PR DESCRIPTION
## Summary
- Homepage sections: The vote, The stakes, The budget, Schools, Insurance, Your tax bill, Peer towns, Get involved
- Nav labels shortened: Vote, Budget, Schools, Insurance, Tax Bill, Peer Towns, Civic, Data
- No-override budget and sustainability moved to "The stakes" on homepage (in Vote dropdown in nav)
- Case studies moved to Peer towns
- Meeting changelog moved to Budget

## Test plan
- [ ] Homepage section labels render correctly
- [ ] Nav dropdowns contain correct pages
- [ ] Mobile nav scrolls and dropdowns work

🤖 Generated with [Claude Code](https://claude.com/claude-code)