### PR TITLE
Move calculator to Tax Bill, how-we-got-here to Vote

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -8,11 +8,11 @@
       <button class="nav-dropdown-toggle" aria-expanded="false">Vote <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <div class="nav-dropdown-menu">
         <a href="{{ '/' | relative_url }}what-is-the-override.html"{% if page.url == '/what-is-the-override.html' %} aria-current="page"{% endif %}>What is the override?</a>
-        <a href="{{ '/' | relative_url }}charts/override_calculator.html"{% if page.url == '/charts/override_calculator.html' %} aria-current="page"{% endif %}>What does it cost me?</a>
-        <a href="{{ '/' | relative_url }}no-override-budget.html"{% if page.url == '/no-override-budget.html' %} aria-current="page"{% endif %}>No-override budget</a>
         <a href="{{ '/' | relative_url }}question-2-trash.html"{% if page.url == '/question-2-trash.html' %} aria-current="page"{% endif %}>Trash: levy or fee?</a>
-        <a href="{{ '/' | relative_url }}charts/sustainability.html"{% if page.url == '/charts/sustainability.html' %} aria-current="page"{% endif %}>Sustainability</a>
+        <a href="{{ '/' | relative_url }}how-we-got-here.html"{% if page.url == '/how-we-got-here.html' %} aria-current="page"{% endif %}>How we got here</a>
         <a href="{{ '/' | relative_url }}marblehead-voting-record.html"{% if page.url == '/marblehead-voting-record.html' %} aria-current="page"{% endif %}>Voting record</a>
+        <a href="{{ '/' | relative_url }}no-override-budget.html"{% if page.url == '/no-override-budget.html' %} aria-current="page"{% endif %}>No-override budget</a>
+        <a href="{{ '/' | relative_url }}charts/sustainability.html"{% if page.url == '/charts/sustainability.html' %} aria-current="page"{% endif %}>Sustainability</a>
       </div>
     </div>
 
@@ -20,7 +20,6 @@
       <button class="nav-dropdown-toggle" aria-expanded="false">Budget <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <div class="nav-dropdown-menu">
         <a href="{{ '/' | relative_url }}where-has-the-money-gone.html"{% if page.url == '/where-has-the-money-gone.html' %} aria-current="page"{% endif %}>Where the money went</a>
-        <a href="{{ '/' | relative_url }}how-we-got-here.html"{% if page.url == '/how-we-got-here.html' %} aria-current="page"{% endif %}>How we got here</a>
         <a href="{{ '/' | relative_url }}meeting-tracker.html"{% if page.url == '/meeting-tracker.html' %} aria-current="page"{% endif %}>Meeting changelog</a>
       </div>
     </div>
@@ -44,6 +43,7 @@
     <div class="nav-dropdown">
       <button class="nav-dropdown-toggle" aria-expanded="false">Tax Bill <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <div class="nav-dropdown-menu">
+        <a href="{{ '/' | relative_url }}charts/override_calculator.html"{% if page.url == '/charts/override_calculator.html' %} aria-current="page"{% endif %}>What does it cost me?</a>
         <a href="{{ '/' | relative_url }}charts/levy_vs_bill.html"{% if page.url == '/charts/levy_vs_bill.html' %} aria-current="page"{% endif %}>Levy, bill, and inflation</a>
         <a href="{{ '/' | relative_url }}senior-tax-relief.html"{% if page.url == '/senior-tax-relief.html' %} aria-current="page"{% endif %}>Senior tax relief</a>
       </div>

--- a/index.html
+++ b/index.html
@@ -38,15 +38,14 @@ og_url: https://marbleheaddata.org/
       <p>The three-tier structure, what each tier funds, key terms, and history.</p>
     </a>
 
-    <a class="question" href="charts/override_calculator.html">
-      <h2>What does it cost me?</h2>
-      <p>Monthly cost by home value for each tier, at full phase-in.</p>
-      <span class="tag tag-charts">Calculator</span>
-    </a>
-
     <a class="question" href="question-2-trash.html">
       <h2>What is Question 2 (trash)?</h2>
       <p>The second ballot question. A $2.3M override for curbside trash, or a ~$281/household fee if it fails. What has already been decided, what each option costs by home value, and how other MA towns fund curbside.</p>
+    </a>
+
+    <a class="question" href="how-we-got-here.html">
+      <h2>How did we get here?</h2>
+      <p>Seven years of Finance Committee warnings, in their own words. From "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025.</p>
     </a>
 
     <a class="question" href="marblehead-voting-record.html">
@@ -103,11 +102,6 @@ og_url: https://marbleheaddata.org/
     <a class="question" href="where-has-the-money-gone.html">
       <h2>Where has Marblehead's money gone?</h2>
       <p>A ten-year walkthrough of how the town has actually spent the tax levy, who has been checking the books, and where the biggest line-item changes landed.</p>
-    </a>
-
-    <a class="question" href="how-we-got-here.html">
-      <h2>How did we get here?</h2>
-      <p>Seven years of Finance Committee warnings, in their own words. From "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025.</p>
     </a>
 
     <a class="question" href="meeting-tracker.html">
@@ -169,6 +163,12 @@ og_url: https://marbleheaddata.org/
 
   <p class="section-label">Your tax bill</p>
   <div class="question-list">
+    <a class="question" href="charts/override_calculator.html">
+      <h2>What does it cost me?</h2>
+      <p>Monthly cost by home value for each tier, at full phase-in.</p>
+      <span class="tag tag-charts">Calculator</span>
+    </a>
+
     <a class="question" href="charts/levy_vs_bill.html">
       <svg class="spark-bg" viewBox="60 70 570 240" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
         <path class="spark-area sf-cost" d="M70,300 116,292 162,277 208,259 254,242 299,222 345,205 391,193 437,179 483,158 528,129 574,108 620,80 L620,310 70,310 Z"/>


### PR DESCRIPTION
## Summary
- Calculator moved from Vote to Tax Bill (it's about what it costs you)
- How we got here moved from Budget to Vote (it's the FinCom warnings leading to the override)
- Budget section is now spending history + meeting changelog
- Nav dropdowns updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)