### PR TITLE
Plain nav lighthouse icon, bigger mobile hero

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,6 +1,6 @@
 <nav class="site-nav">
   <div class="nav-inner">
-    <a class="nav-brand" href="{{ '/' | relative_url }}"><img class="nav-logo" src="{{ '/' | relative_url }}favicon.svg" alt="" width="20" height="20"> MHD Data</a>
+    <a class="nav-brand" href="{{ '/' | relative_url }}"><span class="nav-logo" role="img" aria-label="Lighthouse"></span> MHD Data</a>
 
     <a href="{{ '/' | relative_url }}the-debate.html"{% if page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Debate</a>
 

--- a/assets/site.css
+++ b/assets/site.css
@@ -282,7 +282,12 @@ nav.site-nav .nav-brand {
   white-space: nowrap; margin-right: 4px;
   display: inline-flex; align-items: center; gap: 6px;
 }
-.nav-logo { width: 20px; height: 20px; border-radius: 4px; }
+.nav-logo {
+  display: inline-block; width: 16px; height: 24px;
+  background: currentColor;
+  -webkit-mask: url(lighthouse/lighthouse.svg) center / contain no-repeat;
+          mask: url(lighthouse/lighthouse.svg) center / contain no-repeat;
+}
 nav.site-nav .nav-inner > a,
 nav.site-nav .nav-dropdown-toggle {
   font-size: 13px; line-height: 1; color: var(--text-subtle);
@@ -833,9 +838,9 @@ details.notes[open] > summary {
 
 .hero { text-align: center; margin-bottom: 36px; }
 .hero-lighthouse {
-  display: block; margin: 0 auto 12px; width: 64px; height: 96px;
+  display: block; margin: 0 auto 12px; width: 80px; height: 120px;
   flex-shrink: 0;
-  opacity: 0.7;
+  opacity: 0.85;
   background: var(--text-subtle);
   -webkit-mask: url(lighthouse/lighthouse.svg) center / contain no-repeat;
           mask: url(lighthouse/lighthouse.svg) center / contain no-repeat;


### PR DESCRIPTION
## Summary
- Nav: swap favicon `<img>` (navy box) for CSS mask `<span>` that inherits `currentColor` -- plain silhouette, adapts to theme
- Hero: bump mobile size 64x96 -> 80x120, opacity 0.7 -> 0.85 for better visibility on phones

## Test plan
- [x] Playwright: mobile light -- nav icon and hero visible
- [x] Playwright: mobile dark -- both adapt to theme
- [x] Playwright: desktop light -- both visible
- [x] Playwright: desktop dark -- both adapt

🤖 Generated with [Claude Code](https://claude.com/claude-code)