### PR TITLE
Add lens mode to the debate page

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,6 +23,7 @@
 <script defer src="{{ '/' | relative_url }}assets/ballot.js"></script>
 <script defer src="{{ '/' | relative_url }}assets/deep-dive.js"></script>
 <script defer src="{{ '/' | relative_url }}assets/analytics.js"></script>
+<script defer src="{{ '/' | relative_url }}assets/lens.js"></script>
 {% unless page.community_pulse == "off-sections" %}
 <link rel="stylesheet" href="{{ '/' | relative_url }}assets/community-pulse/widget.css">
 <script type="module" src="{{ '/' | relative_url }}assets/community-pulse/widget.js" data-api-base="https://marblehead-community-pulse.agbaber.workers.dev"></script>

--- a/assets/lens.js
+++ b/assets/lens.js
@@ -1,0 +1,194 @@
+// Lens mode: lets readers filter the debate page to foreground one side's case.
+// Reads ?lens=for or ?lens=against from the URL. Contra perspectives collapse
+// into a clickable summary; the full text is one click away. The tldr box,
+// crux-map, and mini-synthesis blocks stay unfiltered.
+//
+// Progressive enhancement: without this script, both sides show in full.
+(function () {
+  'use strict';
+
+  // Only run on pages that have perspective blocks outside .tldr
+  var perspectives = document.querySelectorAll('.perspective--for, .perspective--against');
+  if (!perspectives.length) return;
+
+  var VALID = { for: 'against', against: 'for' };
+  var LABELS = {
+    for:     'For the override',
+    against: 'Against the override'
+  };
+
+  // --- Read lens from URL ---
+  function getLens() {
+    var params = new URLSearchParams(window.location.search);
+    var v = params.get('lens');
+    return VALID[v] ? v : null;
+  }
+
+  // --- Update URL without reload ---
+  function setLensParam(lens) {
+    var url = new URL(window.location);
+    if (lens) {
+      url.searchParams.set('lens', lens);
+    } else {
+      url.searchParams.delete('lens');
+    }
+    history.replaceState(null, '', url);
+  }
+
+  // --- Build the lens picker (inserted before .meta-note) ---
+  function buildPicker() {
+    var wrap = document.createElement('div');
+    wrap.className = 'lens-picker';
+    wrap.setAttribute('role', 'group');
+    wrap.setAttribute('aria-label', 'Reading lens');
+
+    var label = document.createElement('span');
+    label.className = 'lens-picker-label';
+    label.textContent = 'Read through a lens:';
+    wrap.appendChild(label);
+
+    ['for', 'against'].forEach(function (side) {
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'lens-btn lens-btn--' + side;
+      btn.setAttribute('data-lens', side);
+      btn.textContent = LABELS[side];
+      wrap.appendChild(btn);
+    });
+
+    var clear = document.createElement('button');
+    clear.type = 'button';
+    clear.className = 'lens-btn lens-btn--clear';
+    clear.textContent = 'Both sides';
+    clear.setAttribute('data-lens', '');
+    wrap.appendChild(clear);
+
+    wrap.addEventListener('click', function (e) {
+      var btn = e.target.closest('[data-lens]');
+      if (!btn) return;
+      var next = btn.getAttribute('data-lens') || null;
+      applyLens(next);
+    });
+
+    return wrap;
+  }
+
+  // --- Build the active-lens banner ---
+  function buildBanner() {
+    var bar = document.createElement('div');
+    bar.className = 'lens-banner';
+    bar.setAttribute('role', 'status');
+    bar.innerHTML =
+      '<span class="lens-banner-text"></span>' +
+      '<button type="button" class="lens-banner-switch">Switch</button>' +
+      '<button type="button" class="lens-banner-clear">Show both sides</button>' +
+      '<button type="button" class="lens-banner-share" aria-label="Copy link">Share this view</button>';
+
+    bar.querySelector('.lens-banner-switch').addEventListener('click', function () {
+      var cur = getLens();
+      applyLens(cur === 'for' ? 'against' : 'for');
+    });
+    bar.querySelector('.lens-banner-clear').addEventListener('click', function () {
+      applyLens(null);
+    });
+    bar.querySelector('.lens-banner-share').addEventListener('click', function () {
+      navigator.clipboard.writeText(window.location.href).then(function () {
+        var btn = bar.querySelector('.lens-banner-share');
+        var orig = btn.textContent;
+        btn.textContent = 'Copied!';
+        setTimeout(function () { btn.textContent = orig; }, 1500);
+      });
+    });
+
+    return bar;
+  }
+
+  // --- Collapse / expand perspectives ---
+  function applyLens(lens) {
+    setLensParam(lens);
+
+    // Update picker active states
+    picker.querySelectorAll('[data-lens]').forEach(function (btn) {
+      var val = btn.getAttribute('data-lens') || null;
+      btn.classList.toggle('lens-btn--active', val === lens);
+    });
+
+    // Show/hide banner
+    if (lens) {
+      banner.classList.add('lens-banner--visible');
+      banner.querySelector('.lens-banner-text').textContent =
+        'Reading through the "' + LABELS[lens].toLowerCase() + '" lens. ' +
+        'Collapsed blocks are one click away.';
+    } else {
+      banner.classList.remove('lens-banner--visible');
+    }
+
+    // Walk every perspective block NOT inside .tldr
+    var contraClass = lens ? 'perspective--' + VALID[lens] : null;
+
+    perspectives.forEach(function (el) {
+      // Skip perspectives inside tldr
+      if (el.closest('.tldr')) return;
+
+      var isContra = contraClass && el.classList.contains(contraClass);
+
+      if (!lens || !isContra) {
+        // Expanded state: unwrap from <details> if we wrapped it
+        unwrapDetails(el);
+        return;
+      }
+
+      // Collapsed state: wrap in <details> if not already
+      wrapInDetails(el);
+    });
+  }
+
+  function wrapInDetails(el) {
+    if (el.parentNode && el.parentNode.classList &&
+        el.parentNode.classList.contains('lens-collapsed')) return;
+
+    var details = document.createElement('details');
+    details.className = 'lens-collapsed';
+
+    var summary = document.createElement('summary');
+    summary.className = 'lens-collapsed-summary';
+
+    // Determine which side this is
+    var side = el.classList.contains('perspective--for') ? 'for' : 'against';
+    summary.innerHTML =
+      '<span class="lens-collapsed-label">' + LABELS[side] + '</span>' +
+      '<span class="lens-collapsed-hint">Tap to read</span>';
+
+    el.parentNode.insertBefore(details, el);
+    details.appendChild(summary);
+    details.appendChild(el);
+  }
+
+  function unwrapDetails(el) {
+    var wrapper = el.parentNode;
+    if (!wrapper || !wrapper.classList ||
+        !wrapper.classList.contains('lens-collapsed')) return;
+
+    wrapper.parentNode.insertBefore(el, wrapper);
+    wrapper.remove();
+  }
+
+  // --- Init ---
+  var metaNote = document.querySelector('.meta-note');
+  var picker = buildPicker();
+  var banner = buildBanner();
+
+  if (metaNote) {
+    metaNote.parentNode.insertBefore(picker, metaNote);
+    metaNote.parentNode.insertBefore(banner, metaNote);
+  }
+
+  // Apply initial lens from URL
+  var initial = getLens();
+  applyLens(initial);
+
+  // Analytics (boolean only, no stance value)
+  if (initial && typeof posthog !== 'undefined') {
+    posthog.capture('lens_activated', { page: window.location.pathname });
+  }
+})();

--- a/the-debate.html
+++ b/the-debate.html
@@ -266,6 +266,121 @@ community_pulse: off-sections
       margin-bottom: 2px;
     }
   }
+
+  /* --- Lens mode: reader-driven perspective filtering --- */
+  .lens-picker {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin: 18px 0 14px;
+  }
+  .lens-picker-label {
+    font-size: 13px;
+    color: var(--text-muted);
+    font-weight: 600;
+  }
+  .lens-btn {
+    font-size: 12px;
+    font-weight: 600;
+    padding: 6px 14px;
+    border-radius: 20px;
+    border: 1.5px solid var(--border);
+    background: var(--surface);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s, color 0.15s;
+  }
+  .lens-btn:hover {
+    border-color: var(--text-muted);
+    color: var(--text);
+  }
+  .lens-btn--for.lens-btn--active {
+    border-color: var(--c-teal);
+    background: color-mix(in srgb, var(--c-teal) 12%, var(--surface));
+    color: var(--c-teal);
+  }
+  .lens-btn--against.lens-btn--active {
+    border-color: var(--c-brass);
+    background: color-mix(in srgb, var(--c-brass) 12%, var(--surface));
+    color: var(--c-brass);
+  }
+  .lens-btn--clear.lens-btn--active {
+    border-color: var(--c-navy);
+    background: color-mix(in srgb, var(--c-navy) 10%, var(--surface));
+    color: var(--c-navy);
+  }
+
+  .lens-banner {
+    display: none;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    padding: 10px 16px;
+    margin: 0 0 16px;
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--c-navy) 6%, var(--surface));
+    border: 1px solid var(--border);
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+  .lens-banner--visible { display: flex; }
+  .lens-banner-text { flex: 1 1 auto; min-width: 180px; }
+  .lens-banner-switch,
+  .lens-banner-clear,
+  .lens-banner-share {
+    font-size: 12px;
+    font-weight: 600;
+    padding: 4px 12px;
+    border-radius: 14px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text-muted);
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .lens-banner-switch:hover,
+  .lens-banner-clear:hover,
+  .lens-banner-share:hover {
+    border-color: var(--text-muted);
+    color: var(--text);
+  }
+
+  .lens-collapsed {
+    border-radius: 0 10px 10px 0;
+    margin: 14px 0;
+    border-left: 4px solid var(--border);
+  }
+  .lens-collapsed > .perspective--for { border-left: none; margin: 0; border-radius: 0 10px 10px 0; }
+  .lens-collapsed > .perspective--against { border-left: none; margin: 0; border-radius: 0 10px 10px 0; }
+  .lens-collapsed-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 18px;
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--text-muted);
+    background: color-mix(in srgb, var(--text) 3%, var(--surface));
+    border-radius: 0 10px 10px 0;
+    list-style: none;
+  }
+  .lens-collapsed-summary::-webkit-details-marker { display: none; }
+  .lens-collapsed-summary::marker { content: ''; }
+  .lens-collapsed-label {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 10px;
+  }
+  .lens-collapsed-hint { font-size: 11px; opacity: 0.6; }
+  .lens-collapsed[open] .lens-collapsed-summary { border-radius: 0 10px 0 0; }
+
+  @media (max-width: 600px) {
+    .lens-picker { gap: 6px; }
+    .lens-btn { padding: 5px 10px; font-size: 11px; }
+    .lens-banner { font-size: 12px; padding: 8px 12px; }
+  }
 </style>
 
 <h1>Both sides of the override debate</h1>


### PR DESCRIPTION
## Summary
- Readers can pick a leaning (for/against the override) to foreground one side's case on the debate page
- Contra perspectives collapse into expandable `<details>` summaries (one tap to read)
- Shareable via `?lens=for` or `?lens=against` URL param; Share button copies the link
- TL;DR box, crux map, and mini-synthesis blocks stay unfiltered
- Banner always visible so nobody mistakes a filtered view for the full picture
- No analytics on which lens is chosen (boolean activation event only)

## Files changed
- `assets/lens.js` — new, pure client-side, no dependencies
- `the-debate.html` — lens CSS added to style block
- `_includes/head.html` — script tag for lens.js

## Test plan
- [ ] Visit `/the-debate.html` — both sides visible, picker shows "Both sides" active
- [ ] Click "For the override" — against blocks collapse, banner appears
- [ ] Click collapsed summary — expands to show full text
- [ ] Click "Switch" in banner — flips to against lens
- [ ] Click "Show both sides" — restores default view
- [ ] Visit `?lens=for` directly — loads with for lens active
- [ ] Click "Share this view" — copies URL with lens param
- [ ] Mobile: picker wraps correctly, collapsed summaries tappable
- [ ] Dark mode: colors work with existing theme tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)