### PR TITLE
Change 60-second link to pill button

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -3703,14 +3703,21 @@ abbr.g:focus::after {
   margin: 2px 0 0 22px;
 }
 .start-here-quick {
-  font-size: 14px;
-  color: var(--text-muted);
-  margin-top: 14px;
-  padding-top: 12px;
-  border-top: 1px solid var(--divider);
-}
-.start-here-quick a {
+  display: inline-block;
+  font-size: 13px;
   font-weight: 600;
+  color: var(--text-subtle);
+  text-decoration: none;
+  margin-top: 14px;
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  transition: background 0.15s, color 0.15s;
+}
+.start-here-quick:hover {
+  background: color-mix(in srgb, var(--link) 8%, var(--surface));
+  color: var(--link);
+  border-color: var(--link);
 }
 
 /* ==========================================================================

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@ og_url: https://marbleheaddata.org/
       <li><a href="no-override-budget.html">What's in the no-override budget?</a><span class="start-here-desc">The specific cuts if the override fails.</span></li>
       <li><a href="the-debate.html">Both sides of the debate</a><span class="start-here-desc">The strongest case for and against, on six dividing lines.</span></li>
     </ol>
+    <a class="start-here-quick" href="super-summary.html">Just need 60 seconds? &rarr;</a>
   </div>
 
   <p class="section-label">The vote</p>


### PR DESCRIPTION
## Summary
- Moves the super-summary link from an inline paragraph (between intro text and numbered list) to a small rounded pill button at the bottom of the start-here block
- Element changed from `<p>` with nested `<a>` to a standalone `<a>` styled as a pill

## Test plan
- [ ] Verify pill renders below the numbered list, not between intro and list
- [ ] Check hover state on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)