### PR TITLE
Replace start-here box with single 60-second link

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -3654,70 +3654,33 @@ abbr.g:focus::after {
    Start-here reading path (homepage)
    ========================================================================== */
 
-.start-here {
+.start-here-link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   background: color-mix(in srgb, var(--c-teal) 5%, var(--surface));
   border: 1px solid color-mix(in srgb, var(--c-teal) 20%, var(--border));
   border-radius: var(--radius-md);
-  padding: 20px 22px 18px;
+  padding: 14px 20px;
   margin: 0 0 28px;
+  text-decoration: none;
+  transition: background 0.15s, border-color 0.15s;
 }
-.start-here-eyebrow {
+.start-here-link:hover {
+  background: color-mix(in srgb, var(--c-teal) 10%, var(--surface));
+  border-color: var(--c-teal);
+}
+.start-here-link-eyebrow {
   font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 1.4px;
   color: var(--c-teal);
-  margin-bottom: 6px;
 }
-.start-here p {
-  font-size: 14px;
-  color: var(--text-muted);
-  line-height: 1.55;
-  margin: 0 0 12px;
-}
-.start-here-steps {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  counter-reset: step;
-}
-.start-here-steps li {
-  counter-increment: step;
-  padding: 8px 0;
-  border-top: 1px solid var(--divider);
-  font-size: 14px;
-}
-.start-here-steps li::before {
-  content: counter(step) ".";
-  font-weight: 700;
-  color: var(--c-teal);
-  margin-right: 8px;
-}
-.start-here-steps a {
+.start-here-link-title {
+  font-size: 15px;
   font-weight: 600;
-}
-.start-here-steps .start-here-desc {
-  color: var(--text-subtle);
-  font-size: 13px;
-  display: block;
-  margin: 2px 0 0 22px;
-}
-.start-here-quick {
-  display: inline-block;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-subtle);
-  text-decoration: none;
-  margin-top: 14px;
-  padding: 6px 14px;
-  border: 1px solid var(--border);
-  border-radius: 20px;
-  transition: background 0.15s, color 0.15s;
-}
-.start-here-quick:hover {
-  background: color-mix(in srgb, var(--link) 8%, var(--surface));
-  color: var(--link);
-  border-color: var(--link);
+  color: var(--text);
 }
 
 /* ==========================================================================

--- a/index.html
+++ b/index.html
@@ -20,18 +20,10 @@ og_url: https://marbleheaddata.org/
     <div class="featured-card-desc">Five tensions in the local debate, with the strongest version of each case. Neither a recommendation nor a summary. A map of the real disagreements, for readers still working through their vote.</div>
   </a>
 
-  <div class="start-here">
-    <div class="start-here-eyebrow">New to this?</div>
-    <p>If you just learned about the override vote, start with these four pages in order.</p>
-    <p class="start-here-quick"><a href="super-summary.html">Just need 60 seconds?</a> The whole thing on one short page.</p>
-    <ol class="start-here-steps">
-      <li><a href="what-is-the-override.html">What is the override?</a><span class="start-here-desc">The three-tier ballot structure, what each tier funds, and what it costs.</span></li>
-      <li><a href="how-we-got-here.html">How did we get here?</a><span class="start-here-desc">Seven years of warnings from the Finance Committee, in their own words.</span></li>
-      <li><a href="no-override-budget.html">What's in the no-override budget?</a><span class="start-here-desc">The specific cuts if the override fails.</span></li>
-      <li><a href="the-debate.html">Both sides of the debate</a><span class="start-here-desc">The strongest case for and against, on six dividing lines.</span></li>
-    </ol>
-    <a class="start-here-quick" href="super-summary.html">Just need 60 seconds? &rarr;</a>
-  </div>
+  <a class="start-here-link" href="super-summary.html">
+    <span class="start-here-link-eyebrow">New to this?</span>
+    <span class="start-here-link-title">The 60-second version &rarr;</span>
+  </a>
 
   <p class="section-label">The vote</p>
   <div class="question-list">


### PR DESCRIPTION
## Summary
- Replaces the entire "New to this?" box (eyebrow, intro paragraph, four numbered steps, pill link) with a single compact button-link to `super-summary.html`
- The super summary page already covers the same reading path, so the box was redundant

## Test plan
- [ ] Verify the link renders as a compact teal-bordered card between the featured card and "The vote" section
- [ ] Check hover state

🤖 Generated with [Claude Code](https://claude.com/claude-code)