### PR TITLE
Point featured card to 60-second summary

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -3651,39 +3651,6 @@ abbr.g:focus::after {
 }
 
 /* ==========================================================================
-   Start-here reading path (homepage)
-   ========================================================================== */
-
-.start-here-link {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  background: color-mix(in srgb, var(--c-teal) 5%, var(--surface));
-  border: 1px solid color-mix(in srgb, var(--c-teal) 20%, var(--border));
-  border-radius: var(--radius-md);
-  padding: 14px 20px;
-  margin: 0 0 28px;
-  text-decoration: none;
-  transition: background 0.15s, border-color 0.15s;
-}
-.start-here-link:hover {
-  background: color-mix(in srgb, var(--c-teal) 10%, var(--surface));
-  border-color: var(--c-teal);
-}
-.start-here-link-eyebrow {
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1.4px;
-  color: var(--c-teal);
-}
-.start-here-link-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text);
-}
-
-/* ==========================================================================
    Page lead-in (plain-English opener for data pages)
    ========================================================================== */
 

--- a/index.html
+++ b/index.html
@@ -14,15 +14,10 @@ og_url: https://marbleheaddata.org/
     </div>
   </div>
 
-  <a class="featured-card" href="the-debate.html">
-    <div class="featured-card-eyebrow">Still deciding?</div>
-    <div class="featured-card-title">The override debate, the best case for each side</div>
-    <div class="featured-card-desc">Five tensions in the local debate, with the strongest version of each case. Neither a recommendation nor a summary. A map of the real disagreements, for readers still working through their vote.</div>
-  </a>
-
-  <a class="start-here-link" href="super-summary.html">
-    <span class="start-here-link-eyebrow">New to this?</span>
-    <span class="start-here-link-title">The 60-second version &rarr;</span>
+  <a class="featured-card" href="super-summary.html">
+    <div class="featured-card-eyebrow">New to this?</div>
+    <div class="featured-card-title">The whole override in 60 seconds</div>
+    <div class="featured-card-desc">The deficit, the three ballot tiers, what it costs at your home value, and when you vote. One short page.</div>
   </a>
 
   <p class="section-label">The vote</p>


### PR DESCRIPTION
## Summary
- Featured card now links to `super-summary.html` instead of `the-debate.html`
- Copy updated: "New to this? The whole override in 60 seconds"
- Removed the redundant `.start-here-link` element and its CSS

## Test plan
- [ ] Featured card links to super-summary page
- [ ] No duplicate entry points on the homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)