### PR TITLE
Enable community-pulse on the debate page

### DIFF
--- a/the-debate.html
+++ b/the-debate.html
@@ -3,7 +3,6 @@ title: "Both sides of the override debate"
 og_title: "Both sides of the override debate"
 og_description: The six dividing lines in the FY27 override debate, presented as the strongest version of each side's case. A map of where the real disagreements are, for readers still working through their vote.
 og_url: https://marbleheaddata.org/the-debate.html
-community_pulse: off-sections
 ---
 <style>
   /* Perspective blocks: one per side per dividing line */


### PR DESCRIPTION
## Summary
- Remove `community_pulse: off-sections` from the debate page frontmatter
- Each tension heading now gets the standard community-pulse widget: agree/disagree, per-section share link, private note, and flag
- Per-section share buttons give readers a direct way to link to specific tensions (works with `?lens=` param too)

## Why
Previously disabled to prevent reaction tallies from reading as override for/against votes. But the reactions are on tension *sections* (which present both sides), not on individual perspectives. Agree/disagree means "this tension resonates with me," not "I support/oppose the override."

## Test plan
- [ ] Widgets appear below each tension heading
- [ ] Share button copies section URL
- [ ] Agree/disagree toggles work, persist across reload
- [ ] Private note saves to IndexedDB
- [ ] Flag link opens pre-filled GitHub issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)