### PR TITLE
Add inline links throughout super summary

### DIFF
--- a/super-summary.html
+++ b/super-summary.html
@@ -53,6 +53,11 @@ og_url: https://marbleheaddata.org/super-summary.html
     padding: 10px 14px;
     border-radius: var(--radius-sm);
     background: var(--bg);
+    text-decoration: none;
+    transition: background 0.15s;
+  }
+  .ss-tier:hover {
+    background: color-mix(in srgb, var(--link) 6%, var(--bg));
   }
   .ss-tier-name {
     font-weight: 700;
@@ -165,36 +170,36 @@ og_url: https://marbleheaddata.org/super-summary.html
 
 <div class="ss-block">
   <h2>What's happening</h2>
-  <p>Marblehead's recurring expenses exceed recurring revenue by <strong>$8.47 million</strong> in FY27. The town has been patching the gap with one-time money for years. That's run out.</p>
-  <p>Voters will decide on a <a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter59/Section21C">Prop 2.5</a> override to permanently raise property taxes. The last approved override was in 2005.</p>
+  <p>Marblehead's recurring expenses exceed recurring revenue by <strong><a href="charts/sustainability.html">$8.47 million</a></strong> in FY27. The town has been <a href="how-we-got-here.html">patching the gap</a> with one-time money for years. That's run out.</p>
+  <p>Voters will decide on a <a href="what-is-the-override.html">Prop 2.5 override</a> to permanently raise property taxes. The last approved override was <a href="marblehead-voting-record.html">in 2005</a>.</p>
 </div>
 
 <div class="ss-block">
   <h2>The ballot</h2>
-  <p><strong>Question 1</strong> has three nested tiers. The highest tier that gets a majority wins. They are not additive.</p>
+  <p><strong><a href="what-is-the-override.html#three-tiers">Question 1</a></strong> has three nested tiers. The highest tier that gets a majority wins. They are not additive.</p>
   <div class="ss-tiers">
-    <div class="ss-tier ss-tier--1">
+    <a class="ss-tier ss-tier--1" href="what-is-the-override.html#three-tiers">
       <span class="ss-tier-name">Tier 1</span>
       <span class="ss-tier-desc">Restore: undo the cuts</span>
       <span class="ss-tier-amt">$9M</span>
-    </div>
-    <div class="ss-tier ss-tier--2">
+    </a>
+    <a class="ss-tier ss-tier--2" href="what-is-the-override.html#three-tiers">
       <span class="ss-tier-name">Tier 2</span>
       <span class="ss-tier-desc">Stabilize: add positions, reduce reliance on free cash</span>
       <span class="ss-tier-amt">$12M</span>
-    </div>
-    <div class="ss-tier ss-tier--3">
+    </a>
+    <a class="ss-tier ss-tier--3" href="what-is-the-override.html#three-tiers">
       <span class="ss-tier-name">Tier 3</span>
       <span class="ss-tier-desc">Invest: everything in 1 and 2, plus capital</span>
       <span class="ss-tier-amt">$15M</span>
-    </div>
+    </a>
   </div>
-  <p style="margin-top: 14px;"><strong>Question 2</strong> is separate: a <strong>$2.3M</strong> override to fund curbside trash through the tax levy. If it fails, the Board of Health imposes a flat fee (~$281/household) instead.</p>
+  <p style="margin-top: 14px;"><strong><a href="question-2-trash.html">Question 2</a></strong> is separate: a <strong>$2.3M</strong> override to fund curbside trash through the tax levy. If it fails, the Board of Health imposes a flat fee (~$281/household) instead. <a href="question-2-trash.html">Full breakdown &rarr;</a></p>
 </div>
 
 <div class="ss-block">
   <h2>What it costs at the average home ($1.29M)</h2>
-  <p style="font-size: 13px; color: var(--text-muted); margin-bottom: 14px;">Monthly cost at full phase-in (Year 3). <a href="charts/override_calculator.html">Enter your home value.</a></p>
+  <p style="font-size: 13px; color: var(--text-muted); margin-bottom: 14px;">Monthly cost at full phase-in (Year 3). <a href="charts/override_calculator.html">Enter your home value &rarr;</a></p>
   <div class="ss-cost-grid">
     <div class="ss-cost-item">
       <div class="ss-cost-label">Tier 1</div>
@@ -212,6 +217,11 @@ og_url: https://marbleheaddata.org/super-summary.html
 </div>
 
 <div class="ss-block">
+  <h2>If it fails</h2>
+  <p>The <a href="no-override-budget.html">no-override budget</a> cuts 22 town positions, 18.25 school FTEs, and reduces the library 43%.</p>
+</div>
+
+<div class="ss-block">
   <h2>When</h2>
   <div class="ss-vote-date">June 9, 2026</div>
   <p style="text-align: center;">Annual Town Election ballot. Requires a majority on each question.</p>
@@ -225,6 +235,10 @@ og_url: https://marbleheaddata.org/super-summary.html
     <a href="the-debate.html">Both sides of the debate</a>
     <a href="question-2-trash.html">Question 2: trash</a>
     <a href="charts/override_calculator.html">Cost calculator for your home</a>
+    <a href="how-we-got-here.html">How we got here</a>
+    <a href="where-has-the-money-gone.html">Where the money went</a>
+    <a href="charts/healthcare_costs.html">Why insurance keeps rising</a>
+    <a href="senior-tax-relief.html">Senior tax relief</a>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Every content block now links to its deeper page inline (deficit, tiers, trash, voting history, how-we-got-here)
- Tier rows are now clickable `<a>` elements linking to the three-tiers section
- Added "If it fails" block with link to no-override budget
- Expanded "Go deeper" section: added how-we-got-here, where-the-money-went, healthcare costs, senior tax relief

## Test plan
- [ ] All inline links resolve
- [ ] Tier rows show hover state and navigate correctly
- [ ] Page still scans quickly despite added links

🤖 Generated with [Claude Code](https://claude.com/claude-code)