### PR TITLE
Make lens banner more visible

### DIFF
--- a/assets/lens.js
+++ b/assets/lens.js
@@ -114,14 +114,13 @@
       btn.classList.toggle('lens-btn--active', val === lens);
     });
 
-    // Show/hide banner
+    // Show/hide banner with lens-specific color
+    banner.classList.remove('lens-banner--visible', 'lens-banner--for', 'lens-banner--against');
     if (lens) {
-      banner.classList.add('lens-banner--visible');
+      banner.classList.add('lens-banner--visible', 'lens-banner--' + lens);
       banner.querySelector('.lens-banner-text').textContent =
         'Reading through the "' + LABELS[lens].toLowerCase() + '" lens. ' +
         'Collapsed blocks are one click away.';
-    } else {
-      banner.classList.remove('lens-banner--visible');
     }
 
     // Hide meta-note (four-question framing) when a lens is active

--- a/the-debate.html
+++ b/the-debate.html
@@ -315,13 +315,22 @@ og_url: https://marbleheaddata.org/the-debate.html
     align-items: center;
     gap: 10px;
     flex-wrap: wrap;
-    padding: 10px 16px;
+    padding: 12px 18px;
     margin: 0 0 16px;
     border-radius: var(--radius-md);
-    background: color-mix(in srgb, var(--c-navy) 6%, var(--surface));
-    border: 1px solid var(--border);
-    font-size: 13px;
-    color: var(--text-muted);
+    border-left: 4px solid var(--c-navy);
+    background: color-mix(in srgb, var(--c-navy) 10%, var(--surface));
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text);
+  }
+  .lens-banner--for {
+    border-left-color: var(--c-teal);
+    background: color-mix(in srgb, var(--c-teal) 10%, var(--surface));
+  }
+  .lens-banner--against {
+    border-left-color: var(--c-brass);
+    background: color-mix(in srgb, var(--c-brass) 10%, var(--surface));
   }
   .lens-banner--visible { display: flex; }
   .lens-banner-text { flex: 1 1 auto; min-width: 180px; }
@@ -329,20 +338,20 @@ og_url: https://marbleheaddata.org/the-debate.html
   .lens-banner-clear,
   .lens-banner-share {
     font-size: 12px;
-    font-weight: 600;
-    padding: 4px 12px;
+    font-weight: 700;
+    padding: 5px 14px;
     border-radius: 14px;
-    border: 1px solid var(--border);
+    border: 1.5px solid var(--text-muted);
     background: var(--surface);
-    color: var(--text-muted);
+    color: var(--text);
     cursor: pointer;
     white-space: nowrap;
   }
   .lens-banner-switch:hover,
   .lens-banner-clear:hover,
   .lens-banner-share:hover {
-    border-color: var(--text-muted);
-    color: var(--text);
+    border-color: var(--text);
+    background: color-mix(in srgb, var(--text) 6%, var(--surface));
   }
 
   .lens-collapsed {


### PR DESCRIPTION
## Summary
- Banner now uses the active lens color: teal left border + tint for "for," brass for "against"
- Text bumped from `--text-muted` to `--text`, font-size 13px to 14px, weight 500
- Buttons get stronger borders (`--text-muted` instead of `--border`) and bolder weight
- Hover state darkens further so buttons feel clickable

Before: the banner looked like a disabled element. Now it reads as an active filter notification.

## Test plan
- [ ] `?lens=for`: banner has teal left border and teal-tinted background
- [ ] `?lens=against`: banner has brass left border and brass-tinted background
- [ ] Switch between lenses: banner color updates
- [ ] Clear lens: banner disappears
- [ ] Dark mode: colors visible against dark surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)