### PR TITLE
Fix explore page double nav and read-time label

### DIFF
--- a/explore.html
+++ b/explore.html
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: "Explore the override"
 body_class: explore-page
 community_pulse: off-sections


### PR DESCRIPTION
## Summary
- Set `layout: default` so the `page` layout doesn't wrap content with its own nav, back button, and read-time label
- Fixes the double nav bar and "DEEP DIVE" label visible in the screenshot

## Test plan
- [ ] Single nav bar at top
- [ ] No back arrow or read-time label
- [ ] Topic pills and answer cards still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)