### PR TITLE
Remove subtitle from super summary

### DIFF
--- a/super-summary.html
+++ b/super-summary.html
@@ -163,10 +163,7 @@ og_url: https://marbleheaddata.org/super-summary.html
   }
 </style>
 
-<div class="ss-header">
-  <h1>The 60-second version</h1>
-  <p>Everything below links to the full explanation if you want more.</p>
-</div>
+<h1 class="ss-header">The 60-second version</h1>
 
 <div class="ss-block">
   <h2>What's happening</h2>


### PR DESCRIPTION
## Summary
- Remove the "Everything below links to the full explanation" subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)