### PR TITLE
Explore: fix voice, embed charts with dual interpretations

### DIFF
--- a/explore.html
+++ b/explore.html
@@ -362,7 +362,7 @@ og_url: https://marbleheaddata.org/explore.html
       <h1>Is this override necessary, or the result of wasteful spending?</h1>
       <p class="question-context">
         The proposed $8.47M override would be the largest in Marblehead's history.
-        Residents disagree on whether the deficit was inevitable or avoidable.
+        Was the deficit inevitable, or could it have been avoided?
       </p>
     </div>
 
@@ -567,7 +567,7 @@ og_url: https://marbleheaddata.org/explore.html
       <p class="question-context">
         The town has published a no-override balanced budget. It cuts
         22 town positions, 18.25 school FTEs, and reduces the library 43%.
-        Residents disagree on what that means in practice.
+        What does that actually look like?
       </p>
     </div>
 
@@ -802,15 +802,42 @@ og_url: https://marbleheaddata.org/explore.html
 
       <div class="evidence-point">
         <h4>Enrollment fell 21%, staffing grew</h4>
-        <p>
-          Student enrollment peaked at 3,327 (FY14) and declined to
-          2,617 (FY24). Over the same period, education FTEs rose from
-          roughly 480 to 537. Students per education FTE dropped from
-          6.8 (FY07) to 4.9 (FY24).
+
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 740 185" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Student enrollment FY2001 to FY2024, peaking at 3,327 in FY2014 and declining to 2,617.">
+            <line class="axis-base" x1="70" y1="170" x2="610" y2="170"/>
+            <line class="tick" x1="66" y1="156" x2="70" y2="156"/>
+            <text class="tick-label" x="63" y="160" text-anchor="end">2,500</text>
+            <line class="tick" x1="66" y1="86" x2="70" y2="86"/>
+            <text class="tick-label" x="63" y="90" text-anchor="end">3,000</text>
+            <polyline class="data-line s-neutral" points="70,115 93,104 117,90 140,86 164,77 187,67 211,52 234,56 258,49 281,54 305,57 328,62 352,48 375,40 399,52 422,57 446,49 469,60 493,79 516,91 540,128 563,142 587,139 610,140"/>
+            <text class="end-label s-neutral" x="616" y="136">2,617</text>
+            <text class="annotation" x="375" y="34" text-anchor="middle">peak: 3,327</text>
+            <text class="tick-label tick-label--major" x="70" y="184" text-anchor="middle">FY01</text>
+            <text class="tick-label tick-label--major" x="352" y="184" text-anchor="middle">FY13</text>
+            <text class="tick-label tick-label--major" x="610" y="184" text-anchor="middle">FY24</text>
+          </svg>
+        </div>
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 740 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Education FTE FY2001 to FY2024, rising from 400 to 537.">
+            <line class="axis-base" x1="70" y1="140" x2="610" y2="140"/>
+            <line class="tick" x1="66" y1="127" x2="70" y2="127"/>
+            <text class="tick-label" x="63" y="131" text-anchor="end">400</text>
+            <line class="tick" x1="66" y1="60" x2="70" y2="60"/>
+            <text class="tick-label" x="63" y="64" text-anchor="end">500</text>
+            <polyline class="data-line s-marblehead" points="70,127 93,117 117,111 140,109 164,94 187,82 211,77 234,73 258,68 281,68 305,68 328,73 352,67 375,65 399,67 422,67 446,65 469,57 493,71 516,73 540,71 563,72 587,35 610,35"/>
+            <text class="end-label s-marblehead" x="616" y="31">537</text>
+            <text class="tick-label tick-label--major" x="70" y="160" text-anchor="middle">FY01</text>
+            <text class="tick-label tick-label--major" x="352" y="160" text-anchor="middle">FY13</text>
+            <text class="tick-label tick-label--major" x="610" y="160" text-anchor="middle">FY24</text>
+          </svg>
+        </div>
+
+        <p class="caption">
+          Look at these together: enrollment drops 21% while staffing rises.
+          Students per FTE fell from 6.8 to 4.9. If staffing had tracked
+          enrollment, we would have fewer positions and lower costs.
         </p>
-        <a class="evidence-chart-link" href="charts/enrollment_vs_staffing.html">
-          Enrollment vs. staffing chart
-        </a>
         <p class="evidence-caveat">
           The FY23 jump from 483 to 537 education FTE is unexplained in
           public records and may reflect ESSER-funded positions or a
@@ -873,12 +900,43 @@ og_url: https://marbleheaddata.org/explore.html
 
       <div class="evidence-point">
         <h4>Special education needs grew while enrollment fell</h4>
-        <p>
-          Marblehead's high-needs student population grew from 27% to 32%
-          of enrollment between FY2015 and FY2024. Students with autism
-          increased 34%, and students with neurological or health
-          disabilities increased 48%. Each IEP specifying a 1:1 aide
-          generates a full FTE that the district must provide.
+
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 740 185" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Student enrollment FY2001 to FY2024, peaking at 3,327 in FY2014 and declining to 2,617.">
+            <line class="axis-base" x1="70" y1="170" x2="610" y2="170"/>
+            <line class="tick" x1="66" y1="156" x2="70" y2="156"/>
+            <text class="tick-label" x="63" y="160" text-anchor="end">2,500</text>
+            <line class="tick" x1="66" y1="86" x2="70" y2="86"/>
+            <text class="tick-label" x="63" y="90" text-anchor="end">3,000</text>
+            <polyline class="data-line s-neutral" points="70,115 93,104 117,90 140,86 164,77 187,67 211,52 234,56 258,49 281,54 305,57 328,62 352,48 375,40 399,52 422,57 446,49 469,60 493,79 516,91 540,128 563,142 587,139 610,140"/>
+            <text class="end-label s-neutral" x="616" y="136">2,617</text>
+            <text class="annotation" x="375" y="34" text-anchor="middle">peak: 3,327</text>
+            <text class="tick-label tick-label--major" x="70" y="184" text-anchor="middle">FY01</text>
+            <text class="tick-label tick-label--major" x="352" y="184" text-anchor="middle">FY13</text>
+            <text class="tick-label tick-label--major" x="610" y="184" text-anchor="middle">FY24</text>
+          </svg>
+        </div>
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 740 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Education FTE FY2001 to FY2024, rising from 400 to 537.">
+            <line class="axis-base" x1="70" y1="140" x2="610" y2="140"/>
+            <line class="tick" x1="66" y1="127" x2="70" y2="127"/>
+            <text class="tick-label" x="63" y="131" text-anchor="end">400</text>
+            <line class="tick" x1="66" y1="60" x2="70" y2="60"/>
+            <text class="tick-label" x="63" y="64" text-anchor="end">500</text>
+            <polyline class="data-line s-marblehead" points="70,127 93,117 117,111 140,109 164,94 187,82 211,77 234,73 258,68 281,68 305,68 328,73 352,67 375,65 399,67 422,67 446,65 469,57 493,71 516,73 540,71 563,72 587,35 610,35"/>
+            <text class="end-label s-marblehead" x="616" y="31">537</text>
+            <text class="tick-label tick-label--major" x="70" y="160" text-anchor="middle">FY01</text>
+            <text class="tick-label tick-label--major" x="352" y="160" text-anchor="middle">FY13</text>
+            <text class="tick-label tick-label--major" x="610" y="160" text-anchor="middle">FY24</text>
+          </svg>
+        </div>
+
+        <p class="caption">
+          Same chart, different reading: enrollment fell but the students
+          who remained have higher needs. High-needs students grew from
+          27% to 32% of enrollment. Students with autism increased 34%,
+          neurological disabilities 48%. Each IEP requiring a 1:1 aide
+          generates a full FTE the district must provide under IDEA.
         </p>
         <p class="evidence-caveat">
           SPED percentages from DESE data cited in a Marblehead Current
@@ -961,7 +1019,7 @@ og_url: https://marbleheaddata.org/explore.html
       <h1>Why is the library the one getting cut the most?</h1>
       <p class="question-context">
         In the no-override budget, the library loses the most as a share of
-        its current funding. Residents want to know why.
+        its current funding. Why?
       </p>
     </div>
 
@@ -1069,7 +1127,7 @@ og_url: https://marbleheaddata.org/explore.html
       <h1>How do we trust the people making these decisions?</h1>
       <p class="question-context">
         Elected and appointed boards set the budget and propose overrides.
-        Residents disagree on whether the existing oversight is sufficient.
+        What oversight exists, and is it enough?
       </p>
     </div>
 


### PR DESCRIPTION
## Summary
- Replace third-person "Residents disagree" language with direct questions to the reader
- Embed enrollment vs. staffing chart inline in the schools evidence panels
- Same chart appears in both Position A and Position B with different captions demonstrating the same-data-different-reading pattern

## Voice changes
- "Residents disagree on whether the deficit was inevitable" → "Was the deficit inevitable, or could it have been avoided?"
- "Residents disagree on what that means in practice" → "What does that actually look like?"
- "Residents want to know why" → "Why?"
- "Residents disagree on whether the existing oversight is sufficient" → "What oversight exists, and is it enough?"

## Test plan
- [ ] Question context lines read as direct address, not third-person narration
- [ ] Schools Position A evidence shows enrollment + FTE charts with "if staffing tracked enrollment" caption
- [ ] Schools Position B evidence shows same charts with "remaining students have higher needs" caption
- [ ] Charts render correctly in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)