### PR TITLE
Add FY28 projections, income chart, and reading-the-data table

### DIFF
--- a/charts/four_town_rates.html
+++ b/charts/four_town_rates.html
@@ -2,9 +2,9 @@
 title: "Rate and Bill Comparison"
 ---
 <h1 class="h-center">Rate and Bill: Four North Shore Towns</h1>
-  <p class="subtitle h-center">Two views of the same question. Marblehead, Swampscott, Melrose, and Stoneham, FY2003&ndash;FY2026. Source: MA Department of Revenue.</p>
+  <p class="subtitle h-center">Three views of the same question. Marblehead, Swampscott, Melrose, and Stoneham, FY2003&ndash;FY2026, with FY2028 projections. Source: MA Department of Revenue, US Census Bureau.</p>
 
-  <p>Tax rate and tax bill answer different questions. The <strong>rate</strong> is the price per $1,000 of assessed value, set by the town each year after the levy is certified by the state. The <strong>bill</strong> is what a homeowner actually pays, which depends on both the rate and the home's value. Two towns with the same tax rate can have very different average bills if their home values differ.</p>
+  <p>Tax rate and tax bill answer different questions. The <strong>rate</strong> is the price per $1,000 of assessed value, set by the town each year after the levy is certified by the state. The <strong>bill</strong> is what a homeowner actually pays, which depends on both the rate and the home's value. Two towns with the same tax rate can have very different average bills if their home values differ. Neither metric alone answers the question "who pays more relative to what they can afford?" A third metric, the tax bill as a share of household income, gets closer.</p>
 
   <p>Marblehead has the lowest rate of the four towns and the second-highest average bill. The gap is explained by home values: Marblehead's median assessed home value ($1,010,100 in FY2026) is materially higher than Melrose ($853,264) or Stoneham.</p>
 
@@ -18,7 +18,7 @@ title: "Rate and Bill Comparison"
   </div>
 
   <div class="chart-wrapper">
-    <svg class="chart" viewBox="0 0 880 400" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart: residential tax rates per thousand dollars of assessed value for Marblehead, Swampscott, Melrose, and Stoneham, FY2003 to FY2026, with projected Marblehead rates under three override tiers.">
+    <svg class="chart" viewBox="0 0 880 400" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart: residential tax rates for Marblehead, Swampscott, Melrose, and Stoneham, FY2003 to FY2026, with FY2028 projections for all four towns.">
       <!-- Grid -->
       <line class="axis-base" x1="55" y1="310" x2="750" y2="310"/>
       <line class="grid-minor" x1="55" y1="270" x2="750" y2="270"/>
@@ -28,7 +28,6 @@ title: "Rate and Bill Comparison"
       <line class="grid-minor" x1="55" y1="110" x2="750" y2="110"/>
       <line class="grid-minor" x1="55" y1="70" x2="750" y2="70"/>
       <line class="grid-minor" x1="55" y1="30" x2="750" y2="30"/>
-
       <!-- Y labels -->
       <text class="tick-label" x="48" y="313" text-anchor="end">$6</text>
       <text class="tick-label" x="48" y="273" text-anchor="end">$8</text>
@@ -38,7 +37,6 @@ title: "Rate and Bill Comparison"
       <text class="tick-label" x="48" y="113" text-anchor="end">$16</text>
       <text class="tick-label" x="48" y="73"  text-anchor="end">$18</text>
       <text class="tick-label" x="48" y="33"  text-anchor="end">$20</text>
-
       <!-- X labels -->
       <text class="tick-label tick-label--major" x="55"  y="330" text-anchor="middle">FY03</text>
       <text class="tick-label tick-label--minor" x="166" y="330" text-anchor="middle">FY07</text>
@@ -47,75 +45,63 @@ title: "Rate and Bill Comparison"
       <text class="tick-label tick-label--minor" x="500" y="330" text-anchor="middle">FY19</text>
       <text class="tick-label tick-label--minor" x="611" y="330" text-anchor="middle">FY23</text>
       <text class="tick-label tick-label--major" x="694" y="330" text-anchor="middle">FY26</text>
-
+      <text class="tick-label tick-label--minor" x="750" y="330" text-anchor="middle">FY28</text>
       <!-- Swampscott -->
-      <polyline class="data-line s-swampscott"
-                points="55,160 83,188 111,204 138,186 166,173 194,157 222,143 250,100 277,98 305,70 333,53 361,56 389,87 416,83 444,81 472,110 500,126 528,144 555,154 583,173 611,195 639,200 667,201 694,190"/>
-
+      <polyline class="data-line s-swampscott" points="55,160 83,188 111,204 138,186 166,173 194,157 222,143 250,100 277,98 305,70 333,53 361,56 389,87 416,83 444,81 472,110 500,126 528,144 555,154 583,173 611,195 639,200 667,201 694,190"/>
       <!-- Stoneham -->
-      <polyline class="data-line s-stoneham"
-                points="55,196 83,187 111,221 138,237 166,235 194,226 222,212 250,200 277,186 305,178 333,169 361,160 389,171 416,176 444,182 472,196 500,206 528,214 555,214 583,222 611,208 639,218 667,225 694,229"/>
-
+      <polyline class="data-line s-stoneham" points="55,196 83,187 111,221 138,237 166,235 194,226 222,212 250,200 277,186 305,178 333,169 361,160 389,171 416,176 444,182 472,196 500,206 528,214 555,214 583,222 611,208 639,218 667,225 694,229"/>
       <!-- Melrose -->
-      <polyline class="data-line data-line--bold s-melrose"
-                points="55,185 83,200 111,235 138,237 166,233 194,221 222,203 250,189 277,181 305,175 333,169 361,164 389,171 416,183 444,194 472,203 500,214 528,209 555,211 583,219 611,222 639,231 667,232 694,201"/>
-
-      <!-- Marblehead (bold, own colour) -->
-      <polyline class="data-line data-line--bold s-marblehead"
-                points="55,262 83,260 111,265 138,261 166,275 194,263 222,250 250,239 277,226 305,220 333,213 361,208 389,208 416,208 444,210 472,210 500,215 528,222 555,222 583,220 611,230 639,251 667,249 694,259"/>
-
-      <!-- Marblehead override projections (dashed to FY28) -->
-      <polyline class="data-line data-line--thin data-line--dashed s-marblehead"
-                points="694,259 750,241" opacity="0.6"/>
-      <polyline class="data-line data-line--thin data-line--dashed s-marblehead"
-                points="694,259 750,235" opacity="0.6"/>
-      <polyline class="data-line data-line--thin data-line--dashed s-marblehead"
-                points="694,259 750,229" opacity="0.6"/>
-
-      <!-- Tier dots at FY28 -->
+      <polyline class="data-line data-line--bold s-melrose" points="55,185 83,200 111,235 138,237 166,233 194,221 222,203 250,189 277,181 305,175 333,169 361,164 389,171 416,183 444,194 472,203 500,214 528,209 555,211 583,219 611,222 639,231 667,232 694,201"/>
+      <!-- Marblehead -->
+      <polyline class="data-line data-line--bold s-marblehead" points="55,262 83,260 111,265 138,261 166,275 194,263 222,250 250,239 277,226 305,220 333,213 361,208 389,208 416,208 444,210 472,210 500,215 528,222 555,222 583,220 611,230 639,251 667,249 694,259"/>
+      <!-- FY28 projections (2.5% levy growth, constant assessed values) -->
+      <polyline class="data-line data-line--thin s-swampscott" points="694,190 750,178" stroke-dasharray="8 3" opacity="0.6"/>
+      <polyline class="data-line data-line--thin s-melrose" points="694,201 750,189" stroke-dasharray="8 3" opacity="0.6"/>
+      <polyline class="data-line data-line--thin s-stoneham" points="694,229 750,192" stroke-dasharray="8 3" opacity="0.6"/>
+      <polyline class="data-line data-line--thin s-marblehead" points="694,259 750,241" stroke-dasharray="8 3" opacity="0.6"/>
+      <polyline class="data-line data-line--thin s-marblehead" points="694,259 750,235" stroke-dasharray="8 3" opacity="0.6"/>
+      <polyline class="data-line data-line--thin s-marblehead" points="694,259 750,229" stroke-dasharray="8 3" opacity="0.6"/>
+      <!-- FY28 projection dots -->
+      <circle class="data-dot s-swampscott" cx="750" cy="178" r="3" opacity="0.6"/>
+      <circle class="data-dot s-melrose" cx="750" cy="189" r="3" opacity="0.6"/>
+      <circle class="data-dot s-stoneham" cx="750" cy="192" r="3" opacity="0.6"/>
       <circle class="data-dot s-marblehead" cx="750" cy="241" r="3" opacity="0.6"/>
       <circle class="data-dot s-marblehead" cx="750" cy="235" r="3" opacity="0.6"/>
       <circle class="data-dot s-marblehead" cx="750" cy="229" r="3" opacity="0.6"/>
-
       <!-- End labels -->
-      <text class="end-label s-swampscott" x="760" y="193">$12.00 Swampscott</text>
-      <text class="end-label s-melrose"    x="760" y="205">$11.47 Melrose</text>
-      <text class="end-label s-stoneham"   x="760" y="232">$10.06 Stoneham</text>
-      <text class="end-label s-marblehead" x="760" y="262">$8.56 Marblehead</text>
-
-      <!-- Override projection callout, upper-right empty area -->
-      <rect x="560" y="40" width="188" height="78" rx="6"
-            fill="var(--surface)" fill-opacity="0.95"
-            stroke="var(--series-marblehead)" stroke-width="0.75"/>
-      <text class="annotation" x="572" y="58" font-weight="700" fill="var(--text-muted)">Override projection, FY28</text>
-      <text class="end-label s-marblehead" x="572" y="76">Tier 1 ($9M): $9.46</text>
-      <text class="end-label s-marblehead" x="572" y="92">Tier 2 ($12M): $9.76</text>
-      <text class="end-label s-marblehead" x="572" y="108">Tier 3 ($15M): $10.06</text>
+      <text class="end-label s-swampscott" x="760" y="178">$12.61 Swampscott</text>
+      <text class="end-label s-melrose"    x="760" y="192">$12.05 Melrose</text>
+      <text class="end-label s-stoneham"   x="760" y="206">$11.91 Stoneham</text>
+      <text class="end-label s-marblehead" x="760" y="238">Marblehead</text>
+      <!-- FY28 projection callout -->
+      <rect x="540" y="30" width="200" height="108" rx="6" fill="var(--surface)" fill-opacity="0.95" stroke="var(--border)" stroke-width="0.75"/>
+      <text class="annotation" x="552" y="48" font-weight="700" fill="var(--text-muted)">FY28 projections</text>
+      <text class="annotation" x="552" y="62" fill="var(--text-subtle)" font-size="9">2.5% levy growth, assessed values constant</text>
+      <text class="end-label s-marblehead" x="552" y="80">Marblehead T1 ($9M): $9.46</text>
+      <text class="end-label s-marblehead" x="552" y="96">Marblehead T2 ($12M): $9.76</text>
+      <text class="end-label s-marblehead" x="552" y="112">Marblehead T3 ($15M): $10.06</text>
+      <text class="annotation" x="552" y="130" fill="var(--text-subtle)" font-size="9">Stoneham incl. $9.3M override (FY27)</text>
     </svg>
   </div>
 
-  <p class="caption">
-    Residential tax rates for four North Shore towns, FY2003&ndash;FY2026. Marblehead's rate has been the lowest throughout the period. Dashed lines show projected Marblehead rates with each override tier at full phase-in. The Melrose FY26 spike reflects a $13.5M override passed in November 2025. Tax rates move inversely with property values and do not directly indicate total tax burden or spending efficiency.
-  </p>
+  <p class="caption">Residential tax rates for four North Shore towns, FY2003&ndash;FY2026, with FY2028 projections (dashed). All projections assume 2.5% annual levy growth and constant assessed values. Stoneham's projection includes its $9.3M override (passed December 2025). Melrose's FY26 spike reflects its $13.5M override (passed November 2025). Marblehead shows three proposed override tiers. Even at full Tier 3 ($15M), Marblehead's projected rate ($10.06) would remain the lowest of the four towns. Tax rates move inversely with property values and do not directly indicate total tax burden or spending efficiency.</p>
 
   <h2 class="h-center">Average single-family tax bill</h2>
 
   <div class="chart-wrapper">
-    <svg class="chart" viewBox="0 0 840 330" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart showing average single-family tax bills for Marblehead, Swampscott, Melrose, and Stoneham from FY2006 to FY2026.">
+    <svg class="chart" viewBox="0 -20 840 350" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart showing average single-family tax bills for four North Shore towns, FY2006 to FY2028.">
       <!-- Grid -->
-      <line class="axis-base" x1="60" y1="280" x2="600" y2="280"/>
-      <line class="grid-minor" x1="60" y1="252" x2="600" y2="252"/>
-      <line class="grid-minor" x1="60" y1="197" x2="600" y2="197"/>
-      <line class="grid-minor" x1="60" y1="141" x2="600" y2="141"/>
-      <line class="grid-minor" x1="60" y1="86" x2="600" y2="86"/>
-      <line class="grid-minor" x1="60" y1="30" x2="600" y2="30"/>
-
+      <line class="axis-base" x1="60" y1="280" x2="654" y2="280"/>
+      <line class="grid-minor" x1="60" y1="252" x2="654" y2="252"/>
+      <line class="grid-minor" x1="60" y1="197" x2="654" y2="197"/>
+      <line class="grid-minor" x1="60" y1="141" x2="654" y2="141"/>
+      <line class="grid-minor" x1="60" y1="86" x2="654" y2="86"/>
+      <line class="grid-minor" x1="60" y1="30" x2="654" y2="30"/>
       <!-- Y labels -->
       <text class="tick-label" x="53" y="199" text-anchor="end">$6K</text>
       <text class="tick-label" x="53" y="143" text-anchor="end">$8K</text>
       <text class="tick-label" x="53" y="88" text-anchor="end">$10K</text>
       <text class="tick-label" x="53" y="32" text-anchor="end">$12K</text>
-
       <!-- X labels -->
       <text class="tick-label tick-label--major" x="60"  y="300" text-anchor="middle">FY06</text>
       <text class="tick-label tick-label--minor" x="168" y="300" text-anchor="middle">FY10</text>
@@ -123,44 +109,153 @@ title: "Rate and Bill Comparison"
       <text class="tick-label tick-label--minor" x="384" y="300" text-anchor="middle">FY18</text>
       <text class="tick-label tick-label--minor" x="492" y="300" text-anchor="middle">FY22</text>
       <text class="tick-label tick-label--major" x="600" y="300" text-anchor="middle">FY26</text>
-
+      <text class="tick-label tick-label--minor" x="654" y="300" text-anchor="middle">FY28</text>
       <!-- Stoneham -->
-      <polyline class="data-line data-line--thin s-stoneham"
-                points="60,250 87,247 114,244 141,240 168,235 195,232 222,227 249,225 276,216 303,213 330,210 357,205 384,201 411,196 438,194 465,190 492,187 519,161 546,155 573,146 600,139"/>
-
+      <polyline class="data-line data-line--thin s-stoneham" points="60,250 87,247 114,244 141,240 168,235 195,232 222,227 249,225 276,216 303,213 330,210 357,205 384,201 411,196 438,194 465,190 492,187 519,161 546,155 573,146 600,139"/>
       <!-- Melrose -->
-      <polyline class="data-line data-line--bold s-melrose"
-                points="60,250 87,245 114,241 141,236 168,231 195,226 222,222 249,219 276,214 303,209 330,204 357,199 384,194 411,189 438,168 465,163 492,157 519,151 546,145 573,138 600,91"/>
-
+      <polyline class="data-line data-line--bold s-melrose" points="60,250 87,245 114,241 141,236 168,231 195,226 222,222 249,219 276,214 303,209 330,204 357,199 384,194 411,189 438,168 465,163 492,157 519,151 546,145 573,138 600,91"/>
       <!-- Marblehead -->
-      <polyline class="data-line data-line--bold s-marblehead"
-                points="60,202 87,199 114,194 141,189 168,181 195,178 222,170 249,166 276,159 303,150 330,142 357,133 384,124 411,118 438,111 465,102 492,87 519,77 546,64 573,57 600,56"/>
-
+      <polyline class="data-line data-line--bold s-marblehead" points="60,202 87,199 114,194 141,189 168,181 195,178 222,170 249,166 276,159 303,150 330,142 357,133 384,124 411,118 438,111 465,102 492,87 519,77 546,64 573,57 600,56"/>
       <!-- Swampscott -->
-      <polyline class="data-line data-line--thin s-swampscott"
-                points="60,186 87,171 114,161 141,154 168,145 195,144 222,131 249,126 276,125 303,114 330,112 357,107 384,111 411,113 438,113 465,113 492,110 519,95 546,77 573,68 600,44"/>
-
+      <polyline class="data-line data-line--thin s-swampscott" points="60,186 87,171 114,161 141,154 168,145 195,144 222,131 249,126 276,125 303,114 330,112 357,107 384,111 411,113 438,113 465,113 492,110 519,95 546,77 573,68 600,44"/>
       <!-- Melrose override spike annotation -->
       <circle class="data-dot s-melrose" cx="600" cy="91" r="3"/>
-
-      <!-- End labels -->
-      <text class="end-label s-swampscott" x="608" y="41">$11,478 Swampscott</text>
-      <text class="end-label s-marblehead" x="608" y="53">$11,055 Marblehead</text>
-      <text class="end-label s-melrose" x="608" y="88">$9,787 Melrose</text>
-      <text class="end-label s-stoneham" x="608" y="142">$8,059 Stoneham</text>
+      <!-- FY28 projections -->
+      <polyline class="data-line data-line--thin s-swampscott" points="600,44 654,27" stroke-dasharray="8 3" opacity="0.6"/>
+      <polyline class="data-line data-line--thin s-melrose" points="600,91 654,77" stroke-dasharray="8 3" opacity="0.6"/>
+      <polyline class="data-line data-line--thin s-stoneham" points="600,139 654,98" stroke-dasharray="8 3" opacity="0.6"/>
+      <polyline class="data-line data-line--thin s-marblehead" points="600,56 654,23" stroke-dasharray="8 3" opacity="0.6"/>
+      <polyline class="data-line data-line--thin s-marblehead" points="600,56 654,12" stroke-dasharray="8 3" opacity="0.6"/>
+      <polyline class="data-line data-line--thin s-marblehead" points="600,56 654,1" stroke-dasharray="8 3" opacity="0.6"/>
+      <!-- FY28 projection dots -->
+      <circle class="data-dot s-swampscott" cx="654" cy="27" r="3" opacity="0.6"/>
+      <circle class="data-dot s-melrose" cx="654" cy="77" r="3" opacity="0.6"/>
+      <circle class="data-dot s-stoneham" cx="654" cy="98" r="3" opacity="0.6"/>
+      <circle class="data-dot s-marblehead" cx="654" cy="23" r="3" opacity="0.6"/>
+      <circle class="data-dot s-marblehead" cx="654" cy="12" r="3" opacity="0.6"/>
+      <circle class="data-dot s-marblehead" cx="654" cy="1" r="3" opacity="0.6"/>
+      <!-- FY28 projection callout -->
+      <rect x="656" y="-18" width="172" height="118" rx="6" fill="var(--surface)" fill-opacity="0.95" stroke="var(--border)" stroke-width="0.75"/>
+      <text class="annotation" x="666" y="-2" font-weight="700" fill="var(--text-muted)">FY28 projected bills</text>
+      <text class="end-label s-marblehead" x="666" y="14">T3 ($15M): $12,991</text>
+      <text class="end-label s-marblehead" x="666" y="28">T2 ($12M): $12,604</text>
+      <text class="end-label s-marblehead" x="666" y="42">T1 ($9M): $12,217</text>
+      <text class="end-label s-swampscott" x="666" y="60">Swampscott: $12,061</text>
+      <text class="end-label s-melrose"    x="666" y="76">Melrose: $10,282</text>
+      <text class="end-label s-stoneham"   x="666" y="92">Stoneham: $9,542</text>
     </svg>
   </div>
 
-  <p class="caption">
-    Average single-family property tax bill for four North Shore towns, FY2006&ndash;FY2026. Marblehead's bill ($11,055) is the second-highest, behind Swampscott ($11,478), despite Marblehead having the lowest rate ($8.56) in the group. The difference is home values: Marblehead's median assessed value is $1,010,100 vs $853,264 in Melrose. The average bill reflects both the rate and the average home value, so towns with more expensive homes have higher bills even when their rates are lower.
-  </p>
+  <p class="caption">Average single-family property tax bill for four North Shore towns, FY2006&ndash;FY2026, with FY2028 projections (dashed). All projections assume 2.5% annual levy growth and constant assessed values. With any of the three proposed override tiers, Marblehead's projected average bill would surpass Swampscott's. Without an override, Marblehead ($11,055) remains the second-highest behind Swampscott ($11,478). The average bill reflects both the rate and the home value, so towns with more expensive homes have higher bills even when their rates are lower.</p>
+
+  <h2 class="h-center">Tax bill as share of household income</h2>
+
+  <p>The rate controls for property values but not for income. The bill shows what homeowners pay but not how that payment relates to what they earn. Dividing the average tax bill by median household income gives a rough measure of tax burden relative to ability to pay. It is the metric that is hardest to read in two directions.</p>
+
+  <div class="chart-wrapper">
+    <svg class="chart" viewBox="0 0 600 330" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar chart: tax bill as percentage of median household income. Swampscott 8.5%, Melrose 7.3%, Stoneham 7.1%, Marblehead 6.1% (lowest). With override, Marblehead reaches 6.7-7.1%, still below Swampscott.">
+      <!-- Grid -->
+      <line class="axis-base" x1="70" y1="280" x2="530" y2="280"/>
+      <line class="grid-minor" x1="70" y1="230" x2="530" y2="230"/>
+      <line class="grid-minor" x1="70" y1="180" x2="530" y2="180"/>
+      <line class="grid-minor" x1="70" y1="130" x2="530" y2="130"/>
+      <line class="grid-minor" x1="70" y1="80" x2="530" y2="80"/>
+      <!-- Y labels (0-10%, 25px per percentage point) -->
+      <text class="tick-label" x="63" y="283" text-anchor="end">0%</text>
+      <text class="tick-label" x="63" y="233" text-anchor="end">2%</text>
+      <text class="tick-label" x="63" y="183" text-anchor="end">4%</text>
+      <text class="tick-label" x="63" y="133" text-anchor="end">6%</text>
+      <text class="tick-label" x="63" y="83" text-anchor="end">8%</text>
+      <!-- Bars -->
+      <rect x="90"  y="67"  width="80" height="213" class="data-bar s-swampscott"/>
+      <rect x="200" y="97"  width="80" height="183" class="data-bar s-melrose"/>
+      <rect x="310" y="102" width="80" height="178" class="data-bar s-stoneham"/>
+      <rect x="420" y="127" width="80" height="153" class="data-bar s-marblehead"/>
+      <!-- Marblehead override range (T1-T3: 6.7%-7.1%) -->
+      <rect x="420" y="102" width="80" height="25" fill="var(--series-marblehead)" fill-opacity="0.15" stroke="var(--series-marblehead)" stroke-width="1" stroke-dasharray="4 2"/>
+      <!-- Value labels -->
+      <text class="value-label s-swampscott" x="130" y="59" text-anchor="middle">8.5%</text>
+      <text class="value-label s-melrose"    x="240" y="89" text-anchor="middle">7.3%</text>
+      <text class="value-label s-stoneham"   x="350" y="94" text-anchor="middle">7.1%</text>
+      <text class="value-label s-marblehead" x="460" y="119" text-anchor="middle">6.1%</text>
+      <!-- Override range annotation -->
+      <text class="annotation" x="506" y="110" font-size="10" fill="var(--series-marblehead)">T1-T3:</text>
+      <text class="annotation" x="506" y="122" font-size="10" fill="var(--series-marblehead)">6.7-7.1%</text>
+      <!-- Town labels -->
+      <text class="tick-label" x="130" y="298" text-anchor="middle">Swampscott</text>
+      <text class="tick-label" x="240" y="298" text-anchor="middle">Melrose</text>
+      <text class="tick-label" x="350" y="298" text-anchor="middle">Stoneham</text>
+      <text class="tick-label" x="460" y="298" text-anchor="middle">Marblehead</text>
+      <!-- Income context -->
+      <text class="annotation" x="130" y="312" text-anchor="middle" fill="var(--text-subtle)" font-size="9">$134K income</text>
+      <text class="annotation" x="240" y="312" text-anchor="middle" fill="var(--text-subtle)" font-size="9">$134K income</text>
+      <text class="annotation" x="350" y="312" text-anchor="middle" fill="var(--text-subtle)" font-size="9">$114K income</text>
+      <text class="annotation" x="460" y="312" text-anchor="middle" fill="var(--text-subtle)" font-size="9">$182K income</text>
+    </svg>
+  </div>
+
+  <p class="caption">Average single-family tax bill divided by median household income (<abbr class="g" title="American Community Survey">ACS</abbr> 2020&ndash;2024 5-year estimates) for four North Shore towns. Marblehead's bill is the second-highest, but its median income is the highest, making its tax-to-income ratio the lowest of the four at 6.1%. The dashed extension shows the projected range under override Tiers 1 through 3 (6.7% to 7.1%). Even at full Tier 3, Marblehead's ratio would remain below Swampscott's current 8.5%. Income estimates carry sampling uncertainty; Marblehead's margin of error is &plusmn;$28K. See notes below for methodology caveats.</p>
+
+  <h2 class="h-center">Reading the data</h2>
+
+  <p>Each metric on this page can support different conclusions depending on which question you start with. The table below lays out the strongest version of each side for each metric. This is by design: data shows what is true, but whether the result constitutes a problem depends on values and priorities that data alone cannot settle.</p>
+
+  <div class="table-wrap">
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Metric</th>
+          <th>Marblehead</th>
+          <th>Supports "undertaxed"</th>
+          <th>Supports "already paying enough"</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Tax rate</td>
+          <td>$8.56, lowest of four</td>
+          <td>Most room to raise; even at Tier 3, still lowest of the group</td>
+          <td>Rate is mechanically low because home values are high, not because the town chose to tax less</td>
+        </tr>
+        <tr>
+          <td>Avg SF bill</td>
+          <td>$11,055, 2nd highest</td>
+          <td>Bill tracks wealth, not tax effort; Swampscott pays more on lower incomes</td>
+          <td>Residents already pay more than Melrose and Stoneham; any override makes Marblehead the highest</td>
+        </tr>
+        <tr>
+          <td>Bill / income</td>
+          <td>6.1%, lowest of four</td>
+          <td>Clearest signal: even at Tier 3, Marblehead (7.1%) stays well below Swampscott (8.5%)</td>
+          <td><abbr class="g" title="American Community Survey">ACS</abbr> income has wide error margins (&plusmn;$28K for Marblehead); median income includes renters who don't pay property tax directly</td>
+        </tr>
+        <tr>
+          <td><a href="per_capita_levy.html">Per-capita levy</a></td>
+          <td>$4,144, 2nd highest</td>
+          <td>Per-capita counts everyone including children; property tax is per-property, not per-person</td>
+          <td>Town already collects nearly as much per resident as Swampscott despite a 29% lower rate</td>
+        </tr>
+        <tr>
+          <td><a href="/why-not-elsewhere.html">Override history</a></td>
+          <td>Last passed FY2006</td>
+          <td>Every structural peer has passed one more recently; Marblehead's levy limit has lagged as a result</td>
+          <td>Voters rejected overrides in 2023 and 2024; the gap reflects democratic choice, not undertaxation</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p>No single metric settles the question. The rate says Marblehead has capacity. The bill says residents already pay real money. The income ratio says the burden is lighter than it looks. The override history says Marblehead has made different choices than its peers. All of these are simultaneously true.</p>
 
   <div class="notes">
     <p>Rate chart source: MA Department of Revenue, Division of Local Services, Tax Rates by Class FY2003&ndash;FY2026.</p>
     <p>Bill chart source: MA Department of Revenue, Division of Local Services, "Average Single Family Tax Bill" report, FY2006&ndash;FY2026.</p>
     <p>All four towns use split tax rates (residential vs commercial) except Marblehead, which uses a single rate for all property classes.</p>
-    <p>Melrose FY26 rate and bill reflect a $13.5M override passed November 2025. Stoneham's $9.3M override (Dec 2025) not yet reflected.</p>
-    <p>Marblehead override tiers on the rate chart are estimates: current rate + (override amount / $9.89B assessed value). Tier 1 ($9M) ~$9.46, Tier 2 ($12M) ~$9.76, Tier 3 ($15M) ~$10.06.</p>
+    <p><strong>FY2028 projections.</strong> Dashed lines project each town's rate and bill assuming 2.5% annual levy growth (Proposition 2&frac12; ceiling) and assessed values held constant at FY2026 levels. Actual rates will differ due to new growth, changes in assessed values, and debt exclusions. These projections are illustrative, not forecasts.</p>
+    <p>Melrose FY26 rate and bill reflect a $13.5M override passed November 2025. Stoneham's $9.3M override (passed December 2025) is included in FY28 projections but not in FY26 actuals, since the override applies starting FY2027.</p>
+    <p>Marblehead override tiers are estimates: current rate + (override amount / $9.89B assessed value). Tier 1 ($9M) ~$9.46, Tier 2 ($12M) ~$9.76, Tier 3 ($15M) ~$10.06. Corresponding average bill estimates: ~$12,217, ~$12,604, ~$12,991.</p>
+    <p><strong>Income data.</strong> Median household income from US Census Bureau, American Community Survey 2020&ndash;2024 5-year estimates (table B19013), in 2024 inflation-adjusted dollars. Marblehead $182,132 (&plusmn;$27,872), Swampscott $134,386 (&plusmn;$22,662), Melrose $133,953 (&plusmn;$14,410), Stoneham $113,964 (&plusmn;$10,253). Margins of error are 90% confidence intervals. Marblehead's wide margin reflects its smaller household count (~8,300). Marblehead ranks 20th of 351 MA communities in per-capita income (<abbr class="g" title="Department of Revenue">DOR</abbr> Municipal Databank).</p>
+    <p><strong>On the income metric.</strong> The "bill as % of income" ratio divides the average single-family tax bill (from <abbr class="g" title="Department of Revenue">DOR</abbr>) by the <abbr class="g" title="American Community Survey">ACS</abbr> median household income. This is an approximation: the average bill describes a typical single-family homeowner, while the median income describes all households including renters. Renters pay property tax indirectly through rent, but the ratio is not a precise match of the same population. The metric is useful for relative comparisons across towns (all four use the same methodology) but should not be read as the exact percentage of a typical homeowner's income going to property tax.</p>
     <p>The rate and bill charts use different start years because the underlying <abbr class="g" title="Department of Revenue">DOR</abbr> reports have different coverage.</p>
   </div>
 
@@ -170,16 +265,16 @@ title: "Rate and Bill Comparison"
       <div class="read-next-title">Rate, value, and what you get &rarr;</div>
       <div class="read-next-desc">The same four towns compared on tax rates vs. home values, school staffing ratios, and employer health insurance contributions.</div>
     </a>
-    <a class="read-next-link" href="tax_comparison.html">
-      <div class="read-next-title">Marblehead vs. Swampscott, side by side &rarr;</div>
-      <div class="read-next-desc">A deeper look at the two towns with the highest bills: rate, home value, median bill, and what $750K buys in each.</div>
+    <a class="read-next-link" href="/why-not-elsewhere.html">
+      <div class="read-next-title">Why do some towns run overrides? &rarr;</div>
+      <div class="read-next-desc">Residential share, new growth, and override history for 21 peer towns. Marblehead is at the extreme end of both structural metrics.</div>
     </a>
     <a class="read-next-link" href="per_capita_levy.html">
       <div class="read-next-title">Per-capita property tax levy &rarr;</div>
       <div class="read-next-desc">Total property tax collected divided by population. Swampscott is the highest of the four; Marblehead is second.</div>
     </a>
-    <a class="read-next-link" href="levy_vs_bill.html">
-      <div class="read-next-title">Levy, median bill, and inflation &rarr;</div>
-      <div class="read-next-desc">Three indexed growth rates over FY2012 to FY2024. The levy and the median bill tracked each other closely; both grew faster than <abbr class="g" title="Consumer Price Index">CPI</abbr>.</div>
+    <a class="read-next-link" href="tax_comparison.html">
+      <div class="read-next-title">Marblehead vs. Swampscott, side by side &rarr;</div>
+      <div class="read-next-desc">A deeper look at the two towns with the highest bills: rate, home value, median bill, and what $750K buys in each.</div>
     </a>
   </div>


### PR DESCRIPTION
## Summary
- **Rate chart**: FY28 projections for all four towns (not just Marblehead). Lightly dashed lines (`stroke-dasharray="8 3"`). Even at Tier 3, Marblehead stays lowest rate.
- **Bill chart**: Same treatment. Any override tier puts Marblehead's avg bill above Swampscott's.
- **New: bill/income chart**: Tax bill as % of median household income (ACS 2020-2024). Marblehead lowest at 6.1%; even at Tier 3 (7.1%) still below Swampscott's 8.5%. Includes Nick Ward's stat: Marblehead ranks 20th of 351 MA communities in per-capita income.
- **New: "Reading the data" table**: Steelmans both "undertaxed" and "already paying enough" for five metrics (rate, bill, bill/income, per-capita levy, override history).
- Updated notes with projection methodology, ACS income sources, and caveats.

## Test plan
- [ ] Visual check of all three charts on desktop and mobile
- [ ] Verify dashed projection lines render correctly
- [ ] Verify bill chart callout box doesn't clip at top
- [ ] Check income bar chart bars and dashed override extension
- [ ] Check "Reading the data" table renders on mobile
- [ ] Run Playwright nav tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)