### PR TITLE
Explore: hoverable abbreviation tooltips

### DIFF
--- a/explore.html
+++ b/explore.html
@@ -413,7 +413,7 @@ og_url: https://marbleheaddata.org/explore.html
         <h4>Health insurance grew 2.5x faster than revenue</h4>
         <p>
           Town health insurance spending rose from $8.6M in FY14 to $15.1M in
-          FY25. GIC premiums are set at the state level; the town cannot
+          FY25. <abbr class="g" title="Group Insurance Commission">GIC</abbr> premiums are set at the state level; the town cannot
           negotiate rates directly, though it can bargain over the
           employer/employee premium split.
         </p>
@@ -421,7 +421,7 @@ og_url: https://marbleheaddata.org/explore.html
           Healthcare cost chart
         </a>
         <p class="evidence-caveat">
-          FY25 figure is from the FY25 adopted budget, not the ACFR (not yet published).
+          FY25 figure is from the FY25 adopted budget, not the <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> (not yet published).
         </p>
       </div>
 
@@ -440,7 +440,7 @@ og_url: https://marbleheaddata.org/explore.html
       <div class="evidence-point">
         <h4>Contractual obligations account for most of the budget</h4>
         <p>
-          The largest line items -- schools, police, fire, DPW, pensions,
+          The largest line items -- schools, police, fire, <abbr class="g" title="Department of Public Works">DPW</abbr>, pensions,
           debt service, and health insurance -- are governed by union
           contracts, state mandates, or fixed obligations. What remains
           for discretionary spending is a small share of the total, which
@@ -469,7 +469,7 @@ og_url: https://marbleheaddata.org/explore.html
           Enrollment vs. staffing chart
         </a>
         <p class="evidence-caveat">
-          The FY23 jump from 483 to 537 education FTE is unexplained in
+          The FY23 jump from 483 to 537 education <abbr class="g" title="Full-Time Equivalent">FTE</abbr> is unexplained in
           public records and may reflect ESSER-funded positions or a
           reporting change. This inflates the trend line.
         </p>
@@ -489,8 +489,8 @@ og_url: https://marbleheaddata.org/explore.html
           Peer compensation chart
         </a>
         <p class="evidence-caveat">
-          Salary from DESE 2023-24 reports. Total compensation estimate
-          uses the GIC Harvard Pilgrim family plan at each town's modal
+          Salary from <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> 2023-24 reports. Total compensation estimate
+          uses the <abbr class="g" title="Group Insurance Commission">GIC</abbr> Harvard Pilgrim family plan at each town's modal
           employer share.
         </p>
       </div>
@@ -498,7 +498,7 @@ og_url: https://marbleheaddata.org/explore.html
       <div class="evidence-point">
         <h4>Budget process lacks independent scrutiny</h4>
         <p>
-          FinCom reviews proposed budgets but does not conduct zero-based
+          <abbr class="g" title="Finance Committee">FinCom</abbr> reviews proposed budgets but does not conduct zero-based
           reviews. Some residents argue line-item audits would surface
           cuts the current process misses.
         </p>
@@ -516,8 +516,8 @@ og_url: https://marbleheaddata.org/explore.html
         <h4>Even aggressive cuts would not close the gap</h4>
         <p>
           The no-override budget cuts the library 43% (-$636K), eliminates
-          the OPEB trust contribution, and cuts 22 town positions and
-          18.25 school FTEs. Even with those cuts, without an override
+          the <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr> trust contribution, and cuts 22 town positions and
+          18.25 school <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>. Even with those cuts, without an override
           the gap between projected expenses and revenue grows to roughly
           $18M by FY30.
         </p>
@@ -566,7 +566,7 @@ og_url: https://marbleheaddata.org/explore.html
       <h1>What will happen if we vote no?</h1>
       <p class="question-context">
         The town has published a no-override balanced budget. It cuts
-        22 town positions, 18.25 school FTEs, and reduces the library 43%.
+        22 town positions, 18.25 school <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>, and reduces the library 43%.
         What does that actually look like?
       </p>
     </div>
@@ -614,7 +614,7 @@ og_url: https://marbleheaddata.org/explore.html
         <p>
           The town published a line-by-line FY27 Proposed Balanced Budget
           With No Override. It uses $5M in free cash, staffing reductions,
-          and elimination of the OPEB trust contribution. It is a legal,
+          and elimination of the <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr> trust contribution. It is a legal,
           balanced budget that can operate.
         </p>
         <a class="evidence-chart-link" href="no-override-budget.html">
@@ -684,9 +684,9 @@ og_url: https://marbleheaddata.org/explore.html
       </div>
 
       <div class="evidence-point">
-        <h4>School FTE cuts in Marblehead's no-override budget</h4>
+        <h4>School <abbr class="g" title="Full-Time Equivalent">FTE</abbr> cuts in Marblehead's no-override budget</h4>
         <p>
-          The superintendent identifies 18.25 FTEs eliminated: roughly 9.3
+          The superintendent identifies 18.25 <abbr class="g" title="Full-Time Equivalents">FTEs</abbr> eliminated: roughly 9.3
           currently filled positions and 8.95 vacant. The school
           appropriation drops from $49.1M to $47.6M (-3.1%), with the
           reduction absorbed by the out-of-district special education line
@@ -725,7 +725,7 @@ og_url: https://marbleheaddata.org/explore.html
       <div class="evidence-point">
         <h4>Reform options exist but have not been pursued</h4>
         <p>
-          A state DLS Financial Management Review is free, independent,
+          A state <abbr class="g" title="Division of Local Services">DLS</abbr> Financial Management Review is free, independent,
           and requested by the Select Board. More detailed department-level
           budget reporting is a format choice that requires no warrant
           article. Neither has been implemented.
@@ -776,8 +776,8 @@ og_url: https://marbleheaddata.org/explore.html
         <p class="answer-label">Position B</p>
         <h2>Most of the growth is legally mandated</h2>
         <p class="answer-summary">
-          Special education, ELL, and compliance requirements drove
-          60-65% of the staffing increase. You cannot cut an IEP-required
+          Special education, <abbr class="g" title="English Language Learner">ELL</abbr>, and compliance requirements drove
+          60-65% of the staffing increase. You cannot cut an <abbr class="g" title="Individualized Education Program">IEP</abbr>-required
           aide without violating federal law.
         </p>
       </div>
@@ -786,7 +786,7 @@ og_url: https://marbleheaddata.org/explore.html
         <p class="answer-label">Position C</p>
         <h2>The mandates are real, but not every position is mandated</h2>
         <p class="answer-summary">
-          SPED and ELL growth are required. Instructional coaches,
+          <abbr class="g" title="Special Education">SPED</abbr> and <abbr class="g" title="English Language Learner">ELL</abbr> growth are required. Instructional coaches,
           additional administrators, and co-teachers are district
           choices. Both things are true.
         </p>
@@ -835,7 +835,7 @@ og_url: https://marbleheaddata.org/explore.html
 
         <p class="caption">
           Look at these together: enrollment drops 21% while staffing rises.
-          Students per FTE fell from 6.8 to 4.9. If staffing had tracked
+          Students per <abbr class="g" title="Full-Time Equivalent">FTE</abbr> fell from 6.8 to 4.9. If staffing had tracked
           enrollment, we would have fewer positions and lower costs.
         </p>
         <p class="evidence-caveat">
@@ -848,8 +848,8 @@ og_url: https://marbleheaddata.org/explore.html
       <div class="evidence-point">
         <h4>Marblehead has the most staff per student among peers</h4>
         <p>
-          DESE data for SY2025-26 shows Marblehead at 5.6 students per
-          total school FTE. Stoneham is at 5.8, Swampscott at 6.6,
+          <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> data for SY2025-26 shows Marblehead at 5.6 students per
+          total school <abbr class="g" title="Full-Time Equivalent">FTE</abbr>. Stoneham is at 5.8, Swampscott at 6.6,
           Melrose at 7.8. If Marblehead staffed at Melrose's ratio, the
           district would have roughly 307 FTE instead of 430.
         </p>
@@ -861,7 +861,7 @@ og_url: https://marbleheaddata.org/explore.html
       <div class="evidence-point">
         <h4>Total compensation compounds the staffing cost</h4>
         <p>
-          Marblehead pays 83% of GIC health premiums, the highest employer
+          Marblehead pays 83% of <abbr class="g" title="Group Insurance Commission">GIC</abbr> health premiums, the highest employer
           share among peer towns. Estimated total compensation per teacher
           is $122,702 (salary + employer health insurance), above Melrose
           ($116,532) and Stoneham ($112,143). More staff at higher per-person
@@ -871,7 +871,7 @@ og_url: https://marbleheaddata.org/explore.html
           Peer compensation chart
         </a>
         <p class="evidence-caveat">
-          Salary from DESE 2023-24 reports. Total comp estimate uses GIC
+          Salary from <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> 2023-24 reports. Total comp estimate uses <abbr class="g" title="Group Insurance Commission">GIC</abbr>
           Harvard Pilgrim family plan at each town's modal employer share.
         </p>
       </div>
@@ -887,8 +887,8 @@ og_url: https://marbleheaddata.org/explore.html
       <div class="evidence-point">
         <h4>60-65% of positions are mandate-driven</h4>
         <p>
-          Federal IDEA and Massachusetts 603 CMR 28 require the district
-          to staff every service written into an IEP. ELL instruction is
+          Federal <abbr class="g" title="Individuals with Disabilities Education Act">IDEA</abbr> and Massachusetts 603 <abbr class="g" title="Code of Massachusetts Regulations">CMR</abbr> 28 require the district
+          to staff every service written into an <abbr class="g" title="Individualized Education Program">IEP</abbr>. <abbr class="g" title="English Language Learner">ELL</abbr> instruction is
           mandated under MGL 71A and the LOOK Act. Title IX and Section
           504 compliance coordinators are federally required. These are
           not optional.
@@ -935,11 +935,11 @@ og_url: https://marbleheaddata.org/explore.html
           Same chart, different reading: enrollment fell but the students
           who remained have higher needs. High-needs students grew from
           27% to 32% of enrollment. Students with autism increased 34%,
-          neurological disabilities 48%. Each IEP requiring a 1:1 aide
-          generates a full FTE the district must provide under IDEA.
+          neurological disabilities 48%. Each <abbr class="g" title="Individualized Education Program">IEP</abbr> requiring a 1:1 aide
+          generates a full <abbr class="g" title="Full-Time Equivalent">FTE</abbr> the district must provide under <abbr class="g" title="Individuals with Disabilities Education Act">IDEA</abbr>.
         </p>
         <p class="evidence-caveat">
-          SPED percentages from DESE data cited in a Marblehead Current
+          <abbr class="g" title="Special Education">SPED</abbr> percentages from <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> data cited in a Marblehead Current
           guest column (Feb 2026). Primary DESE enrollment reports are
           the authoritative source.
         </p>
@@ -948,7 +948,7 @@ og_url: https://marbleheaddata.org/explore.html
       <div class="evidence-point">
         <h4>Paras and tutors are the second-largest staff category</h4>
         <p>
-          Marblehead employs 87.6 FTE in the combined paraprofessional
+          Marblehead employs 87.6 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> in the combined paraprofessional
           and tutor category, most of whom support special education
           classrooms. This is 3.67 per 100 students, comparable to
           Melrose (3.47) and Stoneham (3.08).
@@ -970,10 +970,10 @@ og_url: https://marbleheaddata.org/explore.html
         <h4>The discretionary growth is real but smaller than the headline suggests</h4>
         <p>
           Of the roughly 58 non-teaching positions added between FY2015
-          and FY2024, an estimated 7-13 FTE are fully discretionary:
+          and FY2024, an estimated 7-13 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> are fully discretionary:
           technology staff, curriculum and instructional coaches, and
           additional administrators beyond the legally required minimum.
-          The rest are driven by SPED, ELL, counseling, and compliance
+          The rest are driven by <abbr class="g" title="Special Education">SPED</abbr>, <abbr class="g" title="English Language Learner">ELL</abbr>, counseling, and compliance
           mandates.
         </p>
         <a class="evidence-chart-link" href="inside-school-staffing.html">
@@ -985,7 +985,7 @@ og_url: https://marbleheaddata.org/explore.html
         <h4>Mandated does not mean beyond scrutiny</h4>
         <p>
           IEPs are developed with district participation. The mandate is
-          to deliver the services in the IEP, but the service delivery
+          to deliver the services in the <abbr class="g" title="Individualized Education Program">IEP</abbr>, but the service delivery
           model (inclusion vs. substantially separate, in-district vs.
           out-of-district) is a district decision that affects both
           staffing levels and cost. Massachusetts is a "maximum feasible
@@ -1038,7 +1038,7 @@ og_url: https://marbleheaddata.org/explore.html
         <p class="answer-label">Position B</p>
         <h2>Contracts protect everything else</h2>
         <p class="answer-summary">
-          Police, fire, schools, and DPW are covered by union contracts
+          Police, fire, schools, and <abbr class="g" title="Department of Public Works">DPW</abbr> are covered by union contracts
           and state mandates. The library is one of the few large
           discretionary line items.
         </p>
@@ -1062,7 +1062,7 @@ og_url: https://marbleheaddata.org/explore.html
       <div class="evidence-point">
         <h4>Proportional cuts across departments</h4>
         <p>
-          The no-override budget cuts DPW road maintenance by a comparable
+          The no-override budget cuts <abbr class="g" title="Department of Public Works">DPW</abbr> road maintenance by a comparable
           percentage, delays vehicle replacements, and freezes open positions
           town-wide. These are less visible because they happen gradually.
         </p>
@@ -1189,8 +1189,8 @@ og_url: https://marbleheaddata.org/explore.html
         <h4>Independent audits and state oversight</h4>
         <p>
           The town publishes an Annual Comprehensive Financial Report
-          (ACFR) audited by an independent firm. The MA Department of
-          Revenue reviews tax rates and certifies free cash. PERAC
+          (<abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>) audited by an independent firm. The MA Department of
+          Revenue reviews tax rates and certifies free cash. <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>
           audits the pension fund. These are not self-reported numbers.
         </p>
       </div>
@@ -1219,7 +1219,7 @@ og_url: https://marbleheaddata.org/explore.html
         <h4>Participation is very low</h4>
         <p>
           Town Meeting attendance is typically a small fraction of
-          registered voters. FinCom hearings draw single-digit audiences.
+          registered voters. <abbr class="g" title="Finance Committee">FinCom</abbr> hearings draw single-digit audiences.
           Most residents learn about the budget from social media, not
           from primary documents or public meetings.
         </p>
@@ -1233,7 +1233,7 @@ og_url: https://marbleheaddata.org/explore.html
           30-minute slideshows. The data exists but requires significant
           time and expertise to interpret. A resident who wants to fact-check
           a claim about health insurance costs would need to find the right
-          ACFR schedule, adjust for GASB reporting rules, and compare across
+          <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> schedule, adjust for <abbr class="g" title="Governmental Accounting Standards Board">GASB</abbr> reporting rules, and compare across
           fiscal years.
         </p>
       </div>
@@ -1244,7 +1244,7 @@ og_url: https://marbleheaddata.org/explore.html
           The FY27 Proposed Budget presents the school department as a
           single line item ($47.6M). The breakdown of where cuts fall
           within the district comes from the School Committee, not the
-          budget document itself. A state DLS Financial Management Review
+          budget document itself. A state <abbr class="g" title="Division of Local Services">DLS</abbr> Financial Management Review
           could provide independent, department-level analysis, but one
           has not been requested.
         </p>
@@ -1274,7 +1274,7 @@ og_url: https://marbleheaddata.org/explore.html
       <div class="evidence-point">
         <h4>Two concrete reforms that do not require an override</h4>
         <p>
-          A state DLS Financial Management Review is free, independent, and
+          A state <abbr class="g" title="Division of Local Services">DLS</abbr> Financial Management Review is free, independent, and
           requested by the Select Board. More detailed department-level
           budget reporting is a format choice that requires no warrant
           article. Neither costs money. Both would make verification easier


### PR DESCRIPTION
## Summary
- Wrap all acronyms in `<abbr class="g" title="...">` tags so readers can hover/tap for definitions
- Covers 15 abbreviations: FTE, GIC, ACFR, DPW, DESE, OPEB, FinCom, DLS, PERAC, GASB, IDEA, IEP, SPED, ELL, CMR
- First occurrence per evidence section is tagged to keep text clean

## Test plan
- [ ] Hover over FTE, GIC, IDEA etc. in evidence panels -- tooltip shows full name
- [ ] Mobile: tap and hold shows tooltip
- [ ] Existing `abbr.g` styling from site.css applies (dotted underline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)