### PR TITLE
Add statewide income ranking, tighten page

### DIFF
--- a/charts/four_town_rates.html
+++ b/charts/four_town_rates.html
@@ -200,50 +200,27 @@ title: "Rate and Bill Comparison"
 
   <p>Each metric on this page can support different conclusions depending on which question you start with. The table below lays out the strongest version of each side for each metric. This is by design: data shows what is true, but whether the result constitutes a problem depends on values and priorities that data alone cannot settle.</p>
 
-  <div class="table-wrap">
-    <table class="data">
-      <thead>
-        <tr>
-          <th>Metric</th>
-          <th>Marblehead</th>
-          <th>Supports "undertaxed"</th>
-          <th>Supports "already paying enough"</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Tax rate</td>
-          <td>$8.56, lowest of four</td>
-          <td>Most room to raise; even at Tier 3, still lowest of the group</td>
-          <td>Rate is mechanically low because home values are high, not because the town chose to tax less</td>
-        </tr>
-        <tr>
-          <td>Avg SF bill</td>
-          <td>$11,055, 2nd highest</td>
-          <td>Bill tracks wealth, not tax effort; Swampscott pays more on lower incomes</td>
-          <td>Residents already pay more than Melrose and Stoneham; any override makes Marblehead the highest</td>
-        </tr>
-        <tr>
-          <td>Bill / income</td>
-          <td>6.1%, lowest of four</td>
-          <td>Clearest signal: even at Tier 3, Marblehead (7.1%) stays well below Swampscott (8.5%)</td>
-          <td><abbr class="g" title="American Community Survey">ACS</abbr> income has wide error margins (&plusmn;$28K for Marblehead); median income includes renters who don't pay property tax directly</td>
-        </tr>
-        <tr>
-          <td><a href="per_capita_levy.html">Per-capita levy</a></td>
-          <td>$4,144, 2nd highest</td>
-          <td>Per-capita counts everyone including children; property tax is per-property, not per-person</td>
-          <td>Town already collects nearly as much per resident as Swampscott despite a 29% lower rate</td>
-        </tr>
-        <tr>
-          <td><a href="/why-not-elsewhere.html">Override history</a></td>
-          <td>Last passed FY2006</td>
-          <td>Every structural peer has passed one more recently; Marblehead's levy limit has lagged as a result</td>
-          <td>Voters rejected overrides in 2023 and 2024; the gap reflects democratic choice, not undertaxation</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+  <dl class="defined-terms">
+    <dt>Tax rate: $8.56, lowest of four</dt>
+    <dd><strong>Undertaxed:</strong> Most room to raise; even at Tier 3, still lowest of the group.</dd>
+    <dd><strong>Paying enough:</strong> Rate is mechanically low because home values are high, not because the town chose to tax less.</dd>
+
+    <dt>Avg SF bill: $11,055, 2nd highest</dt>
+    <dd><strong>Undertaxed:</strong> Bill tracks wealth, not tax effort; Swampscott pays more on lower incomes.</dd>
+    <dd><strong>Paying enough:</strong> Residents already pay more than Melrose and Stoneham; any override makes Marblehead the highest.</dd>
+
+    <dt>Bill / income: 6.1%, lowest of four</dt>
+    <dd><strong>Undertaxed:</strong> Clearest signal: even at Tier 3, Marblehead (7.1%) stays well below Swampscott (8.5%).</dd>
+    <dd><strong>Paying enough:</strong> <abbr class="g" title="American Community Survey">ACS</abbr> income has wide error margins (&plusmn;$28K for Marblehead); median income includes renters who don't pay property tax directly.</dd>
+
+    <dt><a href="per_capita_levy.html">Per-capita levy</a>: $4,144, 2nd highest</dt>
+    <dd><strong>Undertaxed:</strong> Per-capita counts everyone including children; property tax is per-property, not per-person.</dd>
+    <dd><strong>Paying enough:</strong> Town already collects nearly as much per resident as Swampscott despite a 29% lower rate.</dd>
+
+    <dt><a href="/why-not-elsewhere.html">Override history</a>: last passed FY2006</dt>
+    <dd><strong>Undertaxed:</strong> Every structural peer has passed one more recently; Marblehead's levy limit has lagged as a result.</dd>
+    <dd><strong>Paying enough:</strong> Voters rejected overrides in 2023 and 2024; the gap reflects democratic choice, not undertaxation.</dd>
+  </dl>
 
   <p>No single metric settles the question. The rate says Marblehead has capacity. The bill says residents already pay real money. The income ratio says the burden is lighter than it looks. The override history says Marblehead has made different choices than its peers. All of these are simultaneously true.</p>
 

--- a/charts/four_town_rates.html
+++ b/charts/four_town_rates.html
@@ -2,11 +2,9 @@
 title: "Rate and Bill Comparison"
 ---
 <h1 class="h-center">Rate and Bill: Four North Shore Towns</h1>
-  <p class="subtitle h-center">Three views of the same question. Marblehead, Swampscott, Melrose, and Stoneham, FY2003&ndash;FY2026, with FY2028 projections. Source: MA Department of Revenue, US Census Bureau.</p>
+  <p class="subtitle h-center">Marblehead, Swampscott, Melrose, and Stoneham, FY2003&ndash;FY2026, with FY2028 projections.</p>
 
-  <p>Tax rate and tax bill answer different questions. The <strong>rate</strong> is the price per $1,000 of assessed value, set by the town each year after the levy is certified by the state. The <strong>bill</strong> is what a homeowner actually pays, which depends on both the rate and the home's value. Two towns with the same tax rate can have very different average bills if their home values differ. Neither metric alone answers the question "who pays more relative to what they can afford?" A third metric, the tax bill as a share of household income, gets closer.</p>
-
-  <p>Marblehead has the lowest rate of the four towns and the second-highest average bill. The gap is explained by home values: Marblehead's median assessed home value ($1,010,100 in FY2026) is materially higher than Melrose ($853,264) or Stoneham.</p>
+  <p>Marblehead has the lowest tax rate, the second-highest average bill, and the lowest tax burden relative to household income. These three facts are all true at the same time. The rate is low because home values are high. The bill is high for the same reason. And the income ratio is low because Marblehead is the 20th wealthiest of 351 Massachusetts communities. Each metric answers a different question; no single one settles "is Marblehead undertaxed?"</p>
 
   <h2 class="h-center">Tax rate, per $1,000 assessed value</h2>
 
@@ -84,7 +82,7 @@ title: "Rate and Bill Comparison"
     </svg>
   </div>
 
-  <p class="caption">Residential tax rates for four North Shore towns, FY2003&ndash;FY2026, with FY2028 projections (dashed). All projections assume 2.5% annual levy growth and constant assessed values. Stoneham's projection includes its $9.3M override (passed December 2025). Melrose's FY26 spike reflects its $13.5M override (passed November 2025). Marblehead shows three proposed override tiers. Even at full Tier 3 ($15M), Marblehead's projected rate ($10.06) would remain the lowest of the four towns. Tax rates move inversely with property values and do not directly indicate total tax burden or spending efficiency.</p>
+  <p class="caption">Even at full Tier 3 ($15M), Marblehead's rate ($10.06) would remain the lowest of the four. The Melrose FY26 spike reflects its $13.5M override (November 2025). Dashed lines assume 2.5% levy growth and constant assessed values.</p>
 
   <h2 class="h-center">Average single-family tax bill</h2>
 
@@ -146,11 +144,9 @@ title: "Rate and Bill Comparison"
     </svg>
   </div>
 
-  <p class="caption">Average single-family property tax bill for four North Shore towns, FY2006&ndash;FY2026, with FY2028 projections (dashed). All projections assume 2.5% annual levy growth and constant assessed values. With any of the three proposed override tiers, Marblehead's projected average bill would surpass Swampscott's. Without an override, Marblehead ($11,055) remains the second-highest behind Swampscott ($11,478). The average bill reflects both the rate and the home value, so towns with more expensive homes have higher bills even when their rates are lower.</p>
+  <p class="caption">With any override tier, Marblehead's average bill would surpass Swampscott's. Without an override, Marblehead ($11,055) remains second behind Swampscott ($11,478). The difference is home values: Marblehead's median assessed value is $1,010,100.</p>
 
   <h2 class="h-center">Tax bill as share of household income</h2>
-
-  <p>The rate controls for property values but not for income. The bill shows what homeowners pay but not how that payment relates to what they earn. Dividing the average tax bill by median household income gives a rough measure of tax burden relative to ability to pay. It is the metric that is hardest to read in two directions. Two independent sources confirm the income gap: Marblehead ranks 20th of 351 Massachusetts communities in <abbr class="g" title="Department of Revenue">DOR</abbr> per-capita income ($115,422), while Swampscott ranks 64th ($76,071), Melrose 85th ($69,170), and Stoneham 115th ($58,058).</p>
 
   <div class="chart-wrapper">
     <svg class="chart" viewBox="0 0 600 330" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar chart: tax bill as percentage of median household income. Swampscott 8.5%, Melrose 7.3%, Stoneham 7.1%, Marblehead 6.1% (lowest). With override, Marblehead reaches 6.7-7.1%, still below Swampscott.">
@@ -194,11 +190,11 @@ title: "Rate and Bill Comparison"
     </svg>
   </div>
 
-  <p class="caption">Average single-family tax bill divided by median household income (<abbr class="g" title="American Community Survey">ACS</abbr> 2020&ndash;2024 5-year estimates) for four North Shore towns. Marblehead's bill is the second-highest, but its median income is the highest, making its tax-to-income ratio the lowest of the four at 6.1%. The dashed extension shows the projected range under override Tiers 1 through 3 (6.7% to 7.1%). Even at full Tier 3, Marblehead's ratio would remain below Swampscott's current 8.5%. Income estimates carry sampling uncertainty; Marblehead's margin of error is &plusmn;$28K. See notes below for methodology caveats.</p>
+  <p class="caption">Even at full Tier 3, Marblehead's tax-to-income ratio (7.1%) stays well below Swampscott's current 8.5%. Rankings are <abbr class="g" title="Department of Revenue">DOR</abbr> per-capita income out of 351 MA communities. Income: <abbr class="g" title="American Community Survey">ACS</abbr> 2020&ndash;2024 median household (&plusmn;$28K for Marblehead).</p>
 
   <h2 class="h-center">Reading the data</h2>
 
-  <p>Each metric on this page can support different conclusions depending on which question you start with. The table below lays out the strongest version of each side for each metric. This is by design: data shows what is true, but whether the result constitutes a problem depends on values and priorities that data alone cannot settle.</p>
+  <p>Every metric on this page can be read in two directions. That is the point.</p>
 
   <dl class="defined-terms">
     <dt>Tax rate: $8.56, lowest of four</dt>
@@ -222,19 +218,15 @@ title: "Rate and Bill Comparison"
     <dd><strong>Paying enough:</strong> Voters rejected overrides in 2023 and 2024; the gap reflects democratic choice, not undertaxation.</dd>
   </dl>
 
-  <p>No single metric settles the question. The rate says Marblehead has capacity. The bill says residents already pay real money. The income ratio says the burden is lighter than it looks. The override history says Marblehead has made different choices than its peers. All of these are simultaneously true.</p>
+  <p>No single metric settles the question. The rate says Marblehead has capacity. The bill says residents already pay real money. The income ratio says the burden is lighter than it looks. All of these are simultaneously true.</p>
 
-  <div class="notes">
-    <p>Rate chart source: MA Department of Revenue, Division of Local Services, Tax Rates by Class FY2003&ndash;FY2026.</p>
-    <p>Bill chart source: MA Department of Revenue, Division of Local Services, "Average Single Family Tax Bill" report, FY2006&ndash;FY2026.</p>
-    <p>All four towns use split tax rates (residential vs commercial) except Marblehead, which uses a single rate for all property classes.</p>
-    <p><strong>FY2028 projections.</strong> Dashed lines project each town's rate and bill assuming 2.5% annual levy growth (Proposition 2&frac12; ceiling) and assessed values held constant at FY2026 levels. Actual rates will differ due to new growth, changes in assessed values, and debt exclusions. These projections are illustrative, not forecasts.</p>
-    <p>Melrose FY26 rate and bill reflect a $13.5M override passed November 2025. Stoneham's $9.3M override (passed December 2025) is included in FY28 projections but not in FY26 actuals, since the override applies starting FY2027.</p>
-    <p>Marblehead override tiers are estimates: current rate + (override amount / $9.89B assessed value). Tier 1 ($9M) ~$9.46, Tier 2 ($12M) ~$9.76, Tier 3 ($15M) ~$10.06. Corresponding average bill estimates: ~$12,217, ~$12,604, ~$12,991.</p>
-    <p><strong>Income data (two sources).</strong> (1) Median household income from US Census Bureau, American Community Survey 2020&ndash;2024 5-year estimates (table B19013), in 2024 inflation-adjusted dollars. Marblehead $182,132 (&plusmn;$27,872), Swampscott $134,386 (&plusmn;$22,662), Melrose $133,953 (&plusmn;$14,410), Stoneham $113,964 (&plusmn;$10,253). Margins of error are 90% confidence intervals. Marblehead's wide margin reflects its smaller household count (~8,300). (2) <abbr class="g" title="Department of Revenue">DOR</abbr> per-capita income (FY2027, from the <a href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=dor_income_eqv_per_capita">Municipal Databank</a>, all 351 communities): Marblehead $115,422 (20th), Swampscott $76,071, Melrose $69,170, Stoneham $58,058. Full dataset: <a href="data/dor_per_capita_income_FY27.csv">dor_per_capita_income_FY27.csv</a>. The two measures use different methodologies (household vs per-capita, Census vs state formula) but both confirm the same relative ranking: Marblehead's income is materially higher than the other three towns.</p>
-    <p><strong>On the income metric.</strong> The "bill as % of income" ratio divides the average single-family tax bill (from <abbr class="g" title="Department of Revenue">DOR</abbr>) by the <abbr class="g" title="American Community Survey">ACS</abbr> median household income. This is an approximation: the average bill describes a typical single-family homeowner, while the median income describes all households including renters. Renters pay property tax indirectly through rent, but the ratio is not a precise match of the same population. The metric is useful for relative comparisons across towns (all four use the same methodology) but should not be read as the exact percentage of a typical homeowner's income going to property tax.</p>
-    <p>The rate and bill charts use different start years because the underlying <abbr class="g" title="Department of Revenue">DOR</abbr> reports have different coverage.</p>
-  </div>
+  <details class="notes">
+    <summary>Sources and methodology</summary>
+    <p>Rate chart: MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr>, Tax Rates by Class FY2003&ndash;FY2026. Bill chart: <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr>, "Average Single Family Tax Bill" report, FY2006&ndash;FY2026. All four towns use split tax rates except Marblehead, which uses a single rate.</p>
+    <p><strong>FY2028 projections.</strong> Dashed lines assume 2.5% annual levy growth (Proposition 2&frac12; ceiling) and assessed values held constant at FY2026 levels. Actual rates will differ due to new growth, value changes, and debt exclusions. Melrose FY26 includes its $13.5M override (November 2025). Stoneham's $9.3M override (December 2025) is in FY28 projections but not FY26 actuals. Marblehead tiers: rate + (override / $9.89B AV). T1 ~$9.46, T2 ~$9.76, T3 ~$10.06. Bills: ~$12,217, ~$12,604, ~$12,991.</p>
+    <p><strong>Income data (two sources).</strong> (1) <abbr class="g" title="American Community Survey">ACS</abbr> 2020&ndash;2024 5-year estimates (table B19013), 2024 dollars. Marblehead $182,132 (&plusmn;$27,872), Swampscott $134,386 (&plusmn;$22,662), Melrose $133,953 (&plusmn;$14,410), Stoneham $113,964 (&plusmn;$10,253). (2) <abbr class="g" title="Department of Revenue">DOR</abbr> per-capita income FY2027 (<a href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=dor_income_eqv_per_capita">Municipal Databank</a>): Marblehead $115,422 (20th of 351), Swampscott $76,071 (64th), Melrose $69,170 (85th), Stoneham $58,058 (115th). Full dataset: <a href="data/dor_per_capita_income_FY27.csv">dor_per_capita_income_FY27.csv</a>.</p>
+    <p><strong>On the income metric.</strong> Bill / income divides the <abbr class="g" title="Department of Revenue">DOR</abbr> average SF bill by the <abbr class="g" title="American Community Survey">ACS</abbr> median household income. The bill describes homeowners; the income describes all households including renters. The ratio is useful for relative comparisons across towns (same methodology) but is not a precise measure of any individual homeowner's burden.</p>
+  </details>
 
   <div class="read-next">
     <div class="read-next-label">Read next</div>


### PR DESCRIPTION
## Summary
- Add `dor_per_capita_income_FY27.csv` (all 351 MA communities)
- Add DOR ranks to income chart labels (Marblehead 20th, Swampscott 64th, Melrose 85th, Stoneham 115th)
- Tighten page: lead with three-fact summary, short captions, notes in collapsible `<details>`
- Replace wide table with stacked `<dl>` for "Reading the data"

## Test plan
- [ ] Visual check all three charts
- [ ] Verify `<details>` collapses/expands
- [ ] Check mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)