### PR TITLE
Nav icon: use favicon img instead of broken CSS mask

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,6 +1,6 @@
 <nav class="site-nav">
   <div class="nav-inner">
-    <a class="nav-brand" href="{{ '/' | relative_url }}"><span class="nav-logo" role="img" aria-label="Lighthouse"></span> MHD Data</a>
+    <a class="nav-brand" href="{{ '/' | relative_url }}"><img class="nav-logo" src="{{ '/' | relative_url }}favicon.svg" alt="" width="22" height="22"> MHD Data</a>
 
     <a href="{{ '/' | relative_url }}the-debate.html"{% if page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Debate</a>
 

--- a/assets/site.css
+++ b/assets/site.css
@@ -282,12 +282,7 @@ nav.site-nav .nav-brand {
   white-space: nowrap; margin-right: 4px;
   display: inline-flex; align-items: center; gap: 6px;
 }
-.nav-logo {
-  display: inline-block; width: 16px; height: 24px;
-  background: currentColor;
-  -webkit-mask: url(lighthouse/lighthouse.svg) center / contain no-repeat;
-          mask: url(lighthouse/lighthouse.svg) center / contain no-repeat;
-}
+.nav-logo { width: 22px; height: 22px; border-radius: 5px; }
 nav.site-nav .nav-inner > a,
 nav.site-nav .nav-dropdown-toggle {
   font-size: 13px; line-height: 1; color: var(--text-subtle);


### PR DESCRIPTION
## Summary
- The lighthouse SVG is an outline drawing -- thin lines vanish when used as a CSS mask at 22px
- Reverts to favicon.svg as an `<img>` (white lighthouse on navy, 5px border-radius) which reads clearly at icon size
- Verified in Playwright: visible in both light and dark mode

## Test plan
- [x] Playwright: light mode nav
- [x] Playwright: dark mode nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)