### PR TITLE
Style reading-the-data section, remove filler

### DIFF
--- a/charts/four_town_rates.html
+++ b/charts/four_town_rates.html
@@ -1,6 +1,20 @@
 ---
 title: "Rate and Bill Comparison"
 ---
+<style>
+  dl.defined-terms { margin: 0 0 20px; }
+  dl.defined-terms dt {
+    font-size: 14px; font-weight: 700; color: var(--text);
+    padding: 14px 0 6px;
+    border-top: 1px solid var(--divider);
+    margin-top: 4px;
+  }
+  dl.defined-terms dt:first-child { border-top: none; margin-top: 0; }
+  dl.defined-terms dd {
+    margin: 0 0 4px 0; padding: 0;
+    font-size: 13px; line-height: 1.55; color: var(--text-muted);
+  }
+</style>
 <h1 class="h-center">Rate and Bill: Four North Shore Towns</h1>
   <p class="subtitle h-center">Marblehead, Swampscott, Melrose, and Stoneham, FY2003&ndash;FY2026, with FY2028 projections.</p>
 
@@ -193,8 +207,6 @@ title: "Rate and Bill Comparison"
   <p class="caption">Even at full Tier 3, Marblehead's tax-to-income ratio (7.1%) stays well below Swampscott's current 8.5%. Rankings are <abbr class="g" title="Department of Revenue">DOR</abbr> per-capita income out of 351 MA communities. Income: <abbr class="g" title="American Community Survey">ACS</abbr> 2020&ndash;2024 median household (&plusmn;$28K for Marblehead).</p>
 
   <h2 class="h-center">Reading the data</h2>
-
-  <p>Every metric on this page can be read in two directions. That is the point.</p>
 
   <dl class="defined-terms">
     <dt>Tax rate: $8.56, lowest of four</dt>


### PR DESCRIPTION
## Summary
- Add CSS for `dl.defined-terms`: divider lines between metrics, proper sizing
- Remove "Every metric can be read in two directions. That is the point." filler

🤖 Generated with [Claude Code](https://claude.com/claude-code)