### PR TITLE
Trim filler from super summary

### DIFF
--- a/super-summary.html
+++ b/super-summary.html
@@ -9,14 +9,6 @@ og_url: https://marbleheaddata.org/super-summary.html
     text-align: center;
     margin-bottom: 28px;
   }
-  .ss-header h1 {
-    margin-bottom: 6px;
-  }
-  .ss-header p {
-    font-size: 14px;
-    color: var(--text-muted);
-    margin: 0;
-  }
 
   .ss-block {
     background: var(--surface);
@@ -196,7 +188,7 @@ og_url: https://marbleheaddata.org/super-summary.html
 
 <div class="ss-block">
   <h2>What it costs at the average home ($1.29M)</h2>
-  <p style="font-size: 13px; color: var(--text-muted); margin-bottom: 14px;">Monthly cost at full phase-in (Year 3). <a href="charts/override_calculator.html">Enter your home value &rarr;</a></p>
+  <p style="font-size: 13px; color: var(--text-muted); margin-bottom: 14px;"><a href="charts/override_calculator.html">Enter your home value &rarr;</a></p>
   <div class="ss-cost-grid">
     <div class="ss-cost-item">
       <div class="ss-cost-label">Tier 1</div>
@@ -221,7 +213,6 @@ og_url: https://marbleheaddata.org/super-summary.html
 <div class="ss-block">
   <h2>When</h2>
   <div class="ss-vote-date">June 9, 2026</div>
-  <p style="text-align: center;">Annual Town Election ballot. Requires a majority on each question.</p>
 </div>
 
 <div class="ss-block">


### PR DESCRIPTION
## Summary
- Remove dead CSS rules left from old header wrapper
- Drop "Monthly cost at full phase-in (Year 3)" subtitle
- Drop "Annual Town Election ballot" line under the date

🤖 Generated with [Claude Code](https://claude.com/claude-code)