### PR TITLE
Explore: fix schools title, embed charts across questions

### DIFF
--- a/explore.html
+++ b/explore.html
@@ -485,15 +485,33 @@ og_url: https://marbleheaddata.org/explore.html
       </div>
 
       <div class="evidence-point">
-        <h4>Health insurance grew 2.5x faster than revenue</h4>
-        <p>
-          Town health insurance spending rose from $8.6M in FY14 to $15.1M in
-          FY25. <abbr class="g" title="Group Insurance Commission">GIC</abbr> premiums are set at the state level; the town cannot
-          negotiate rates directly, though it can bargain over the
-          employer/employee premium split.
+        <h4>Health insurance grew faster than the levy</h4>
+
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 760 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Tax levy growth vs health insurance growth, FY06 to FY27, both indexed to 100.">
+            <line class="axis-base" x1="60" y1="200" x2="620" y2="200"/>
+            <text class="tick-label" x="53" y="204" text-anchor="end">100</text>
+            <text class="tick-label" x="53" y="136" text-anchor="end">150</text>
+            <text class="tick-label" x="53" y="68" text-anchor="end">200</text>
+            <line class="grid-minor" x1="60" y1="132" x2="620" y2="132"/>
+            <line class="grid-minor" x1="60" y1="64" x2="620" y2="64"/>
+            <text class="tick-label tick-label--major" x="60" y="224" text-anchor="middle">FY06</text>
+            <text class="tick-label tick-label--major" x="340" y="224" text-anchor="middle">FY16</text>
+            <text class="tick-label tick-label--major" x="620" y="224" text-anchor="middle">FY27</text>
+            <polyline class="data-line s-revenue" points="60,200 87,197 113,193 140,189 167,183 193,179 220,172 247,169 273,163 300,156 327,149 353,142 380,135 407,130 433,124 460,118 487,106 513,98 540,88 567,82 593,74 620,66"/>
+            <polyline class="data-line s-neutral" points="60,200 87,191 113,178 140,157 167,168 193,160 220,141 247,156 273,144 300,135 327,127 353,120 380,119 407,113 460,108 487,97 513,85 540,104 567,108 593,86 620,60"/>
+            <text class="end-label s-neutral" x="628" y="57">+110% health ins.</text>
+            <text class="end-label s-revenue" x="628" y="74">+103% levy</text>
+          </svg>
+        </div>
+
+        <p class="caption">
+          Both indexed to FY06 = 100. Health insurance outpaced levy growth
+          for most of the period. The town joined the state <abbr class="g" title="Group Insurance Commission">GIC</abbr> insurance
+          pool in FY12; premiums are set at the state level.
         </p>
         <a class="evidence-chart-link" href="charts/healthcare_costs.html">
-          Healthcare cost chart
+          Full healthcare cost chart
         </a>
         <p class="evidence-caveat">
           FY25 figure is from the FY25 adopted budget, not the <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> (not yet published).
@@ -502,13 +520,36 @@ og_url: https://marbleheaddata.org/explore.html
 
       <div class="evidence-point">
         <h4>Levy growth has been nearly flat in real terms</h4>
-        <p>
-          Prop 2&frac12; limits annual levy growth to 2.5%. Inflation averaged
-          3.4% over the same period. In real dollars, Marblehead's tax capacity
-          has been shrinking.
+
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 740 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Tax levy, median bill, and CPI-U indexed FY12 to FY24.">
+            <line class="axis-base" x1="70" y1="220" x2="620" y2="220"/>
+            <line class="grid-minor" x1="70" y1="180" x2="620" y2="180"/>
+            <line class="grid-minor" x1="70" y1="140" x2="620" y2="140"/>
+            <line class="grid-minor" x1="70" y1="100" x2="620" y2="100"/>
+            <text class="tick-label" x="60" y="224" text-anchor="end">100</text>
+            <text class="tick-label" x="60" y="184" text-anchor="end">110</text>
+            <text class="tick-label" x="60" y="144" text-anchor="end">120</text>
+            <text class="tick-label" x="60" y="104" text-anchor="end">130</text>
+            <text class="tick-label tick-label--major" x="70" y="242" text-anchor="middle">FY12</text>
+            <text class="tick-label tick-label--major" x="345" y="242" text-anchor="middle">FY18</text>
+            <text class="tick-label tick-label--major" x="620" y="242" text-anchor="middle">FY24</text>
+            <polyline class="data-line data-line--thin s-neutral" points="70,220 116,217 162,214 208,213 254,211 299,207 345,201 391,197 437,193 483,184 528,167 574,160 620,152"/>
+            <polyline class="data-line data-line--bold s-revenue" points="70,220 116,216 162,209 208,200 254,191 299,183 345,175 391,170 437,164 483,155 528,141 574,134 620,124"/>
+            <polyline class="data-line data-line--bold s-cost" points="70,220 116,216 162,209 208,199 254,190 299,182 345,174 391,169 437,163 483,153 528,139 574,132 620,120"/>
+            <text class="end-label s-cost" x="630" y="120">+55% bill</text>
+            <text class="end-label s-revenue" x="630" y="132">+53% levy</text>
+            <text class="end-label s-neutral" x="630" y="152">+37% CPI</text>
+          </svg>
+        </div>
+
+        <p class="caption">
+          All three indexed to FY12 = 100. The levy and median tax bill grew
+          53-55% while inflation (CPI-U) grew 37%. In real terms, the levy
+          barely kept pace. Prop 2&frac12; caps annual growth at 2.5%.
         </p>
         <a class="evidence-chart-link" href="charts/levy_vs_bill.html">
-          Levy, bill, and inflation chart
+          Full levy, bill, and inflation chart
         </a>
       </div>
 
@@ -613,15 +654,45 @@ og_url: https://marbleheaddata.org/explore.html
 
       <div class="evidence-point">
         <h4>The sustainability question remains either way</h4>
-        <p>
-          An override closes the current gap but does not change the
-          underlying math: costs will continue to outpace 2.5% levy
-          growth. Even Tier 3 ($15M) briefly closes the gap in FY29
-          but reopens to roughly $4M by FY30 as expenses outpace the
-          fixed override levy.
+
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue bars vs expense line, FY24 to FY30. Gap grows from $1M to $18M without an override.">
+            <line class="axis-base" x1="60" y1="200" x2="500" y2="200"/>
+            <line class="grid-minor" x1="60" y1="160" x2="500" y2="160"/>
+            <line class="grid-minor" x1="60" y1="120" x2="500" y2="120"/>
+            <line class="grid-minor" x1="60" y1="80" x2="500" y2="80"/>
+            <text class="tick-label" x="53" y="204" text-anchor="end">$80M</text>
+            <text class="tick-label" x="53" y="164" text-anchor="end">$100M</text>
+            <text class="tick-label" x="53" y="124" text-anchor="end">$120M</text>
+            <text class="tick-label" x="53" y="84" text-anchor="end">$140M</text>
+            <text class="tick-label tick-label--major" x="94" y="220" text-anchor="middle">FY24</text>
+            <text class="tick-label tick-label--major" x="234" y="220" text-anchor="middle">FY27</text>
+            <text class="tick-label tick-label--major" x="374" y="220" text-anchor="middle">FY29</text>
+            <text class="tick-label tick-label--major" x="444" y="220" text-anchor="middle">FY30</text>
+            <rect class="data-fill s-revenue" x="80" y="123" width="28" height="77"/>
+            <rect class="data-fill s-revenue" x="150" y="112" width="28" height="88" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="220" y="103" width="28" height="97" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="290" y="94" width="28" height="106" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="360" y="86" width="28" height="114" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="430" y="78" width="28" height="122" opacity="0.65"/>
+            <polyline class="data-line data-line--bold s-neutral" points="94,120 164,105 234,72 304,52 374,32 444,12"/>
+            <circle class="data-dot s-neutral" cx="94" cy="120" r="3"/>
+            <circle class="data-dot s-neutral" cx="234" cy="72" r="3"/>
+            <circle class="data-dot s-neutral" cx="444" cy="12" r="4"/>
+            <text class="annotation" x="460" y="18">$140M expenses</text>
+            <text class="annotation" x="460" y="82">$121M revenue</text>
+            <text class="annotation" x="390" y="58" text-anchor="middle">$18M gap</text>
+          </svg>
+        </div>
+
+        <p class="caption">
+          Without an override, the gap between expenses and revenue grows
+          from roughly $1M (FY24) to $18M by FY30. Even Tier 3 ($15M)
+          briefly closes the gap in FY29 but reopens to roughly $4M by FY30
+          as expenses outpace the fixed override levy.
         </p>
         <a class="evidence-chart-link" href="charts/sustainability.html">
-          Sustainability projections
+          Full sustainability projections
         </a>
         <p class="evidence-caveat">
           FY28-FY30 are illustrative projections (3% revenue growth,
@@ -782,14 +853,44 @@ og_url: https://marbleheaddata.org/explore.html
 
       <div class="evidence-point">
         <h4>The override does not fix the underlying math</h4>
-        <p>
-          Even Tier 3 ($15M) briefly closes the gap in FY29 but reopens to
-          roughly $4M by FY30 as expenses outpace the fixed override levy.
-          Without structural change, the town will face another override
-          request within a few years.
+
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue bars vs expense line, FY24 to FY30. Gap grows even with override.">
+            <line class="axis-base" x1="60" y1="200" x2="500" y2="200"/>
+            <line class="grid-minor" x1="60" y1="160" x2="500" y2="160"/>
+            <line class="grid-minor" x1="60" y1="120" x2="500" y2="120"/>
+            <line class="grid-minor" x1="60" y1="80" x2="500" y2="80"/>
+            <text class="tick-label" x="53" y="204" text-anchor="end">$80M</text>
+            <text class="tick-label" x="53" y="164" text-anchor="end">$100M</text>
+            <text class="tick-label" x="53" y="124" text-anchor="end">$120M</text>
+            <text class="tick-label" x="53" y="84" text-anchor="end">$140M</text>
+            <text class="tick-label tick-label--major" x="94" y="220" text-anchor="middle">FY24</text>
+            <text class="tick-label tick-label--major" x="234" y="220" text-anchor="middle">FY27</text>
+            <text class="tick-label tick-label--major" x="374" y="220" text-anchor="middle">FY29</text>
+            <text class="tick-label tick-label--major" x="444" y="220" text-anchor="middle">FY30</text>
+            <rect class="data-fill s-revenue" x="80" y="123" width="28" height="77"/>
+            <rect class="data-fill s-revenue" x="150" y="112" width="28" height="88" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="220" y="103" width="28" height="97" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="290" y="94" width="28" height="106" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="360" y="86" width="28" height="114" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="430" y="78" width="28" height="122" opacity="0.65"/>
+            <polyline class="data-line data-line--bold s-neutral" points="94,120 164,105 234,72 304,52 374,32 444,12"/>
+            <circle class="data-dot s-neutral" cx="94" cy="120" r="3"/>
+            <circle class="data-dot s-neutral" cx="234" cy="72" r="3"/>
+            <circle class="data-dot s-neutral" cx="444" cy="12" r="4"/>
+            <text class="annotation" x="460" y="18">$140M expenses</text>
+            <text class="annotation" x="460" y="82">$121M revenue</text>
+          </svg>
+        </div>
+
+        <p class="caption">
+          Same chart, different reading: even Tier 3 ($15M) briefly closes
+          the gap in FY29 but reopens to roughly $4M by FY30. The override
+          buys time but does not change the underlying cost trajectory.
+          Without structural change, the town will face another override.
         </p>
         <a class="evidence-chart-link" href="charts/sustainability.html">
-          Sustainability projections
+          Full sustainability projections
         </a>
         <p class="evidence-caveat">
           FY28-FY30 are illustrative projections (3% revenue growth,
@@ -828,7 +929,7 @@ og_url: https://marbleheaddata.org/explore.html
   <section class="question-screen" data-topic="schools" style="display:none">
 
     <div class="question-block">
-      <h1>Are our schools overstaffed?</h1>
+      <h1>Why did school staffing grow while enrollment fell?</h1>
       <p class="question-context">
         Marblehead employs 430 school staff for 2,389 students, a ratio
         of 5.6 students per staff member. Enrollment fell 21% since


### PR DESCRIPTION
## Summary
- Schools question renamed: "Are our schools overstaffed?" -> "Why did school staffing grow while enrollment fell?"
- Inline charts added to override and vote-no questions:
  - Override A: healthcare cost chart (levy vs health ins, indexed FY06-FY27)
  - Override A: levy/bill/CPI chart (three indexed lines, FY12-FY24)
  - Override C: sustainability chart (revenue bars vs expense line, gap to $18M)
  - Vote-no C: same sustainability chart, different caption ("buys time, doesn't fix trajectory")

## Chart coverage now
- Override: 3 inline charts across positions A and C
- Vote no: 1 inline chart in position C
- Schools: 2 inline charts in positions A and B (from prior PR)
- Library: no charts (stub, needs peer data)
- Trust: no charts (governance evidence is text-based)

## Test plan
- [ ] Schools pill shows new question title
- [ ] Override Position A shows healthcare and levy/bill charts inline
- [ ] Override Position C shows sustainability chart
- [ ] Vote-no Position C shows sustainability chart with different caption
- [ ] Charts render in dark mode
- [ ] Charts scale on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)