### PR TITLE
Add 350-community tax bill / income dataset

### DIFF
--- a/charts/four_town_rates.html
+++ b/charts/four_town_rates.html
@@ -18,7 +18,11 @@ title: "Rate and Bill Comparison"
 <h1 class="h-center">Rate and Bill: Four North Shore Towns</h1>
   <p class="subtitle h-center">Marblehead, Swampscott, Melrose, and Stoneham, FY2003&ndash;FY2026, with FY2028 projections.</p>
 
-  <p>Marblehead has the lowest tax rate, the second-highest average bill, and the lowest tax burden relative to household income. These three facts are all true at the same time. The rate is low because home values are high. The bill is high for the same reason. And the income ratio is low because Marblehead is the 20th wealthiest of 351 Massachusetts communities. Each metric answers a different question; no single one settles "is Marblehead undertaxed?"</p>
+  <ul class="tldr">
+    <li><strong>Lowest tax rate</strong> of the four towns, because home values are high</li>
+    <li><strong>Second-highest average bill</strong>, for the same reason</li>
+    <li><strong>Lowest tax burden relative to income</strong> (20th wealthiest of 351 MA communities)</li>
+  </ul>
 
   <h2 class="h-center">Tax rate, per $1,000 assessed value</h2>
 


### PR DESCRIPTION
## Summary
- `tax_bill_as_pct_of_income_351.csv`: avg SF bill / DOR per-capita income for 350 matched communities, ranked
- `ma_avg_sf_tax_bill_fy2026.csv`: raw DOR avg SF tax bills for all 351 communities
- Marblehead ranks **326th of 350** (9.6%): only 24 communities have a lighter ratio
- Swampscott 125th (15.1%), Melrose 172nd (14.1%), Stoneham 185th (13.9%)
- Updated income chart caption with statewide rank and CSV link

🤖 Generated with [Claude Code](https://claude.com/claude-code)