### PR TITLE
Verify three open research items from April 8 meetings

### DIFF
--- a/charts/levy_vs_bill.html
+++ b/charts/levy_vs_bill.html
@@ -99,6 +99,12 @@ title: "Tax Levy, Median Bill, and Inflation"
 
 <p>Individual tax bills vary based on each property's assessment history. A home whose value rose faster than the town median over this window saw a bill increase larger than the 55 percent median figure. A home whose value rose slower saw a smaller increase. The chart's median line is a summary statistic, not a prediction of any individual homeowner's experience.</p>
 
+<h2>Home values grew faster than tax bills after COVID</h2>
+
+<p>A related question came up at the April 8, 2026 Select Board meeting: have home values and tax bills diverged? They have. From FY2016 to FY2020 (pre-COVID), total assessed value rose roughly 21% while the levy rose 14%, a modest gap. From FY2020 to FY2026, total assessed value rose roughly 48% while the levy rose only 22%. The average single-family assessed value is up about 80% over the full FY2016&ndash;FY2026 window; the average single-family tax bill is up about 39%.</p>
+
+<p>The mechanism is Proposition 2&frac12;. The levy can grow at most 2.5% per year (plus new growth and debt exclusions). When COVID-era demand pushed assessed values up sharply, the tax rate dropped from $10.39 (FY2020) to $8.59 (FY2026) to keep total collections within the cap. Individual bills still rose, but at the levy's pace, not the valuation pace. A homeowner whose property doubled in value did not see their tax bill double.</p>
+
 <h2>Why is FY27 tight despite this revenue growth?</h2>
 
 <p>Marblehead's levy has grown faster than headline inflation over the past decade, but the FY27 budget gap is a specific acute cliff rather than a long-run drift. Health insurance rates jumped 11 percent for FY27, pension obligations rose 9 percent, a new curbside trash contract added costs, and the Free Cash reserves that balanced the FY26 budget are not available again at the same level. For the full reconciliation of where the $8.47M FY27 gap comes from, see <a href="no-override-budget.html#fy27-gap-calculated">how the $8.47M FY27 gap is calculated</a>.</p>

--- a/data/meeting-tracker.html
+++ b/data/meeting-tracker.html
@@ -62,9 +62,9 @@ body_class: doc-page
     </tbody>
   </table>
 
-  <h2 id="open-research">Open research items</h2>
+  <h2 id="verified-research">Verified research items</h2>
 
-  <p>Some meetings surface claims that are not yet verified against primary sources. These are listed here as open items, not as site content.</p>
+  <p>Claims from meetings that have been checked against primary sources.</p>
 
   <table>
     <thead>
@@ -78,17 +78,17 @@ body_class: doc-page
       <tr>
         <td>Marblehead ranks 20th of 351 MA communities in per-capita income</td>
         <td>Nick Ward, Select Board 4/8</td>
-        <td>Unverified. Checkable via DOR Municipal Databank or Census ACS.</td>
+        <td>Confirmed (approximately). DOR per-capita income FY2027 ranks Marblehead 20th of 351 at $115,422. Census ACS 2020&ndash;2024 per-capita income ($103,980) ranks Marblehead 14th. Ward's "20th" matches the DOR dataset, which is standard for MA municipal comparisons. See <a href="/charts/four_town_rates.html">four-town tax rates</a>.</td>
       </tr>
       <tr>
         <td>Essex North Shore Aggie Tech costs: $468K (FY25) to $750K (FY27), driven by lottery enrollment change</td>
         <td>CFO Benjamin / Select Board members, 4/8</td>
-        <td>Unverified. Checkable via FY25-FY27 budgets and Essex North Shore assessment records.</td>
+        <td>Confirmed. FY25 assessment $468,057 (25 students), FY26 $627,323 (35 students), FY27 $749,920 (~55 students projected, Town Meeting Article 21). DESE required vocational schools to switch from selective admissions to lottery, with minimum seat allocations per community. Marblehead's minimum is 39 incoming 9th-graders per year. Sources: <a href="https://itemlive.com/2026/03/25/in-marblehead-essex-tech-enrollment-increases-as-do-costs/">Itemlive 3/25/26</a>; <a href="https://marbleheadweeklynews.com/finance-committee-advances-most-warrant-articles-as-budget-tightens/">Marblehead Weekly News (FinCom report)</a>; 2026 Annual Town Meeting Article 21. See <a href="/no-override-budget.html#what-stays-or-grows">no-override budget</a>.</td>
       </tr>
       <tr>
         <td>Home values and tax bills tracked together until COVID, then diverged</td>
         <td>Kezer presentation, Select Board 4/8</td>
-        <td>Unverified. Checkable via DOR tax rate and assessor data.</td>
+        <td>Confirmed. FY2016&ndash;FY2020: total assessed value +21%, total levy +14% (rough parity). FY2020&ndash;FY2026: total assessed value +48%, total levy +22% (sharp divergence). Average SF assessed value up ~80% over the full period, average SF tax bill up ~39%. Mechanism: Proposition 2&frac12; caps levy growth at ~2.5%/year; when COVID-era values surged the rate dropped from $10.39 to $8.59 to keep the levy within cap. Bills still rose, but at the levy's pace, not the valuation pace. Sources: MA DOR DLS tax rate reports; Oliver Reports; Marblehead Weekly News; ACFRs. See <a href="/charts/levy_vs_bill.html">levy vs. bill chart</a>.</td>
       </tr>
     </tbody>
   </table>

--- a/no-override-budget.html
+++ b/no-override-budget.html
@@ -210,10 +210,14 @@ og_url: https://marbleheaddata.org/no-override-budget.html
       <span class="cut-item-name">Town Counsel</span>
       <span class="cut-item-amount">+$163K (+142%)</span>
     </div>
-    <p class="source">Source: <a href="https://marbleheadma.gov/wp-content/uploads/2026/04/PROPOSED-FY27-BALANCED-BUDGET-WITH-NO-OVERRIDE.pdf">FY27 Proposed Budget</a>, pages 1-4</p>
+    <div class="cut-item">
+      <span class="cut-item-name">Essex North Shore Aggie Tech<span class="cut-item-note">Marblehead's assessment for students attending Essex North Shore Agricultural and Technical School. The state required vocational schools to switch from selective admissions to a lottery system with minimum seat allocations per community. Marblehead's minimum is 39 incoming 9th-graders per year, up from roughly 6&ndash;8 under the old system. At ~$18,768 per pupil, steady-state enrollment of 150+ students could push assessments past $2M.</span></span>
+      <span class="cut-item-amount">+$282K (+60% over 2 yrs)</span>
+    </div>
+    <p class="source">Source: <a href="https://marbleheadma.gov/wp-content/uploads/2026/04/PROPOSED-FY27-BALANCED-BUDGET-WITH-NO-OVERRIDE.pdf">FY27 Proposed Budget</a>, pages 1-4; Essex Tech assessment: 2026 Annual Town Meeting Article 21 ($749,920), <a href="https://itemlive.com/2026/03/25/in-marblehead-essex-tech-enrollment-increases-as-do-costs/">Itemlive 3/25/26</a>, <a href="https://marbleheadweeklynews.com/finance-committee-advances-most-warrant-articles-as-budget-tightens/">Marblehead Weekly News (FinCom report)</a></p>
   </div>
 
-  <p>Health insurance, pensions, and contracted salary increases continue to grow regardless of the override outcome. The reductions above are what the town finance team determined would be required to balance the budget around these fixed-cost increases. Excluded debt service, shown separately in the list, also grows each year but is paid through a different mechanism and is not part of the $8.47M operating gap.</p>
+  <p>Health insurance, pensions, contracted salary increases, and vocational school assessments continue to grow regardless of the override outcome. The reductions above are what the town finance team determined would be required to balance the budget around these fixed-cost increases. Excluded debt service, shown separately in the list, also grows each year but is paid through a different mechanism and is not part of the $8.47M operating gap.</p>
 
   <h2 data-stance-section="what-other-towns-did" id="what-other-towns-did">What other MA towns did after similar votes</h2>
 


### PR DESCRIPTION
## Summary
- **Per-capita income rank**: Ward's "20th of 351" confirmed via DOR per-capita income FY2027 ($115,422). ACS 2020-2024 per-capita puts Marblehead at 14th ($103,980); different metric, both correct. Meeting tracker updated with nuance.
- **Essex Aggie Tech costs**: Confirmed $468K (FY25) to $750K (FY27) via Town Meeting Article 21, Itemlive, and FinCom report. Added as a line item to the no-override budget "costs that increase" section with the lottery enrollment mechanism explained.
- **Home value vs tax bill divergence**: Confirmed. Assessed values +48% post-COVID vs levy +22%. Added new section to levy_vs_bill.html explaining the Prop 2 1/2 mechanism.

All three items moved from "Open research" to "Verified research" on the meeting tracker.

## Test plan
- [ ] Meeting tracker renders verified table correctly
- [ ] No-override budget Essex Tech line item displays with tooltip
- [ ] Levy vs bill page new section reads correctly between existing sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)