### PR TITLE
Lighthouse as background watermark behind homepage

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -832,30 +832,26 @@ details.notes[open] > summary {
    ========================================================================== */
 
 .hero { text-align: center; margin-bottom: 36px; }
-.hero-lighthouse {
-  display: block; margin: 0 auto 12px; width: 80px; height: 120px;
-  opacity: 0.35;
-}
-@media (prefers-color-scheme: dark) {
-  html:not([data-theme="light"]) .hero-lighthouse { filter: invert(1); opacity: 0.5; }
-}
-html[data-theme="dark"] .hero-lighthouse { filter: invert(1); opacity: 0.5; }
 .hero h1 { font-size: 28px; margin-bottom: 10px; }
 .hero p  { font-size: 16px; color: var(--text-subtle); max-width: 520px; margin: 0 auto; }
-@media (min-width: 600px) {
-  .hero {
-    position: relative; text-align: left;
-    padding-left: 120px; min-height: 80px;
-    margin-bottom: 0;
-  }
-  .hero-lighthouse {
-    position: absolute; left: 0; top: 0;
-    width: 90px; height: 320px; margin: 0;
-    opacity: 0.25;
-  }
-  html[data-theme="dark"] .hero-lighthouse { opacity: 0.35; }
-  .hero p { margin: 0; }
+
+/* Lighthouse watermark behind homepage content */
+.page.page--home { position: relative; }
+.page.page--home::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 50%; transform: translateX(-50%);
+  width: 280px; height: 420px;
+  background: url(lighthouse/lighthouse.svg) center / contain no-repeat;
+  opacity: 0.06;
+  pointer-events: none;
+  z-index: 0;
 }
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) .page.page--home::before { filter: invert(1); opacity: 0.08; }
+}
+html[data-theme="dark"] .page.page--home::before { filter: invert(1); opacity: 0.08; }
+.page.page--home > * { position: relative; z-index: 1; }
 
 .question-list {
   display: flex; flex-direction: column; gap: 12px;

--- a/index.html
+++ b/index.html
@@ -7,11 +7,8 @@ og_type: website
 og_url: https://marbleheaddata.org/
 ---
 <div class="hero">
-    <img class="hero-lighthouse" src="{{ '/' | relative_url }}assets/lighthouse/lighthouse.svg" alt="Marblehead lighthouse" width="90" height="135">
-    <div class="hero-text">
-      <h1>Weighing the FY2027 override?</h1>
-      <p>Every claim on this site cites a primary source. Every dollar traces to a town document. Make your own call. <a href="#data-sources">See all sources.</a></p>
-    </div>
+    <h1>Weighing the FY2027 override?</h1>
+    <p>Every claim on this site cites a primary source. Every dollar traces to a town document. Make your own call. <a href="#data-sources">See all sources.</a></p>
   </div>
 
   <a class="featured-card" href="super-summary.html">


### PR DESCRIPTION
## Summary
- Remove `<img>` hero-lighthouse element and all its positioning CSS
- Add `::before` pseudo-element on `.page--home` with the lighthouse as a centered background image at low opacity
- Cards and text sit on top via `z-index: 1`
- No more positioning conflicts across breakpoints

## Test plan
- [x] Playwright: desktop light -- lighthouse watermark behind hero + cards
- [x] Playwright: desktop dark -- inverted, visible
- [x] Playwright: mobile light -- watermark behind content
- [x] Playwright: mobile dark -- inverted, visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)