### PR TITLE
Remove +1 reaction buttons from explore cards

### DIFF
--- a/explore.html
+++ b/explore.html
@@ -138,49 +138,6 @@ og_url: https://marbleheaddata.org/explore.html
     pointer-events: none;
   }
 
-  /* +1 reaction button inside answer cards */
-  .answer-react {
-    position: absolute;
-    top: 12px;
-    right: 14px;
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--text-muted);
-    background: var(--surface);
-    border: 1.5px solid var(--border);
-    border-radius: 8px;
-    padding: 4px 10px;
-    min-width: 44px;
-    justify-content: center;
-    cursor: pointer;
-    transition: all 0.15s;
-    z-index: 1;
-  }
-  .answer-react:hover {
-    border-color: var(--text-muted);
-    color: var(--text);
-    background: color-mix(in srgb, var(--text) 4%, var(--surface));
-  }
-  .answer-react.voted {
-    border-color: var(--c-teal);
-    color: var(--c-teal);
-    background: color-mix(in srgb, var(--c-teal) 8%, var(--surface));
-  }
-  .answer-react.voted:hover {
-    background: color-mix(in srgb, var(--c-teal) 14%, var(--surface));
-  }
-  .answer-react-glyph {
-    font-size: 13px;
-    line-height: 1;
-  }
-  .answer-react-count {
-    font-variant-numeric: tabular-nums;
-    font-size: 12px;
-  }
-
   .answer-label {
     font-size: 10px;
     font-weight: 700;
@@ -2228,85 +2185,6 @@ og_url: https://marbleheaddata.org/explore.html
     }
   });
 
-  /* ── +1 reactions on answer cards ── */
-  var API_BASE = 'https://marblehead-community-pulse.agbaber.workers.dev';
-  var pagePath = 'explore.html';
-
-  // Build section IDs for each answer card
-  var reactCards = document.querySelectorAll('.answer-card[data-question][data-answer]');
-  var sectionIds = [];
-  var cardMap = {};
-
-  reactCards.forEach(function (card) {
-    var id = pagePath + '#' + card.dataset.question + '-' + card.dataset.answer;
-    sectionIds.push(id);
-    cardMap[id] = card;
-
-    // Inject the +1 button
-    var btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'answer-react';
-    btn.innerHTML = '<span class="answer-react-glyph">+1</span><span class="answer-react-count">0</span>';
-    btn.dataset.sectionId = id;
-
-    // Check if already voted
-    var isVoted = !!localStorage.getItem('explore-voted-' + id);
-    if (isVoted) {
-      btn.classList.add('voted');
-      btn.querySelector('.answer-react-glyph').textContent = '\u2713';
-    }
-
-    btn.addEventListener('click', function (e) {
-      e.stopPropagation(); // Don't trigger card selection
-      var currentlyVoted = !!localStorage.getItem('explore-voted-' + id);
-
-      if (currentlyVoted) {
-        // Unvote
-        localStorage.removeItem('explore-voted-' + id);
-        btn.classList.remove('voted');
-        btn.querySelector('.answer-react-glyph').textContent = '+1';
-        var countEl = btn.querySelector('.answer-react-count');
-        var cur = parseInt(countEl.textContent) || 0;
-        countEl.textContent = Math.max(0, cur - 1);
-      } else {
-        // Vote
-        localStorage.setItem('explore-voted-' + id, '1');
-        btn.classList.add('voted');
-        btn.querySelector('.answer-react-glyph').textContent = '\u2713';
-
-        // Increment via API
-        fetch(API_BASE + '/api/reactions', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ section_id: id })
-        })
-          .then(function (r) { return r.ok ? r.json() : null; })
-          .then(function (data) {
-            if (data) btn.querySelector('.answer-react-count').textContent = data.total;
-          })
-          .catch(function () {});
-      }
-    });
-
-    card.appendChild(btn);
-  });
-
-  // Fetch initial counts
-  if (sectionIds.length) {
-    fetch(API_BASE + '/api/reactions?section_ids=' + sectionIds.map(encodeURIComponent).join(','))
-      .then(function (r) { return r.ok ? r.json() : {}; })
-      .then(function (data) {
-        Object.keys(data).forEach(function (id) {
-          var card = cardMap[id];
-          if (!card) return;
-          var btn = card.querySelector('.answer-react');
-          if (btn) {
-            btn.querySelector('.answer-react-count').textContent = data[id].total || 0;
-          }
-        });
-      })
-      .catch(function () {});
-  }
 })();
 </script>
 


### PR DESCRIPTION
## Summary
- Remove the +1 reaction button from answer cards
- Picking an answer and seeing the evidence IS the response
- The "+1 0" display on fresh loads signaled emptiness
- Removes CSS, JS injection, localStorage tracking, and API calls

## Test plan
- [ ] No +1 button visible on answer cards
- [ ] Cards still clickable, evidence still expands
- [ ] No console errors from removed API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)