### PR TITLE
Add lighthouse watermark to explore homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,23 @@ og_url: https://marbleheaddata.org/
     min-height: 100dvh;
     display: flex;
     flex-direction: column;
+    position: relative;
   }
+  .explore-stage::before {
+    content: "";
+    position: absolute;
+    top: -20px; right: -40px;
+    width: 320px; height: 480px;
+    background: url(assets/lighthouse/lighthouse.svg) center / contain no-repeat;
+    opacity: 0.05;
+    pointer-events: none;
+    z-index: 0;
+  }
+  html[data-theme="dark"] .explore-stage::before { filter: invert(1); opacity: 0.07; }
+  @media (prefers-color-scheme: dark) {
+    html:not([data-theme="light"]) .explore-stage::before { filter: invert(1); opacity: 0.07; }
+  }
+  .explore-stage > * { position: relative; z-index: 1; }
 
 
   /* ── Landing hero (first visit) ── */


### PR DESCRIPTION
## Summary
- Add right-aligned lighthouse watermark to the new explore homepage
- Same `::before` pseudo-element approach, scoped to `.explore-stage`
- Dark mode: `filter: invert(1)` with slightly higher opacity

## Test plan
- [x] Playwright: desktop light -- lighthouse visible on right
- [x] Playwright: mobile light -- visible, doesn't obstruct content

🤖 Generated with [Claude Code](https://claude.com/claude-code)