### PR TITLE
Add senior demographic data and Article 28 pool math

### DIFF
--- a/senior-tax-relief.html
+++ b/senior-tax-relief.html
@@ -356,6 +356,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     <ul>
       <li><strong>Circuit Breaker (state, available now):</strong> Refundable credit up to <strong>$2,820/year</strong> for homeowners 65+ with MA income below $75k (single), $94k (HoH), or $112k (joint), and home assessed at or below $1,298,000. Claimed on Schedule CB with your state tax return.</li>
       <li><strong>Means-tested exemption (local, pending):</strong> Article 28 / H.4225 stacks on top of the Circuit Breaker for longtime Marblehead seniors. Passed Town Meeting May 2025 with ~93% support. Passed the MA House March 30, 2026. Currently awaiting Senate action.</li>
+      <li><strong>How many claim it:</strong> 418 Marblehead seniors filed for the Circuit Breaker in TY2022, receiving an average of $1,054. With ~1,158 senior households under the $75k income limit, the credit is likely underclaimed.</li>
       <li><strong>Override twist:</strong> The Circuit Breaker formula is based on the <em>excess</em> of tax over 10% of income, so the credit grows when the tax bill grows. For seniors not yet at the $2,820 cap, the state absorbs part of an override hit automatically.</li>
       <li><strong>No operating-budget tradeoff:</strong> The local exemption is paid for from the tax overlay, not the operating budget. It does not compete with schools or services.</li>
       <li><strong>Also available:</strong> Veteran exemptions ($400 to full), senior tax deferral (Clause 41A), low-income senior exemption (Clause 41C), surviving spouse (Clause 17D), and the Council on Aging's Senior Tax Work-Off Program. Marblehead-specific amounts for 41C, 41A, and 17D are pending Assessor's Office confirmation.</li>
@@ -502,6 +503,37 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     <p>The median Marblehead single-family home is well under the $1,298,000 Circuit Breaker cap. The FY26 average is just under the cap, meaning well over half of single-family homes qualify on the value test. Waterfront and Peach's Point properties are more likely to exceed the cap and be excluded.</p>
     <p class="source">Sources: <a href="https://itemlive.com/2025/12/03/marblehead-fy26-valuations-rise/">Itemlive, "Marblehead valuations go high, taxes go low" (Dec 3, 2025)</a>, from the FY26 tax classification hearing.</p>
   </div>
+
+  <div class="card">
+    <h3>Who claims it in Marblehead</h3>
+    <p>Marblehead has roughly <strong>2,856 households</strong> headed by someone 65 or older, of which about <strong>2,392 are homeowners</strong> (83.8% homeownership rate). About 41% of those senior-headed households earn under $75,000 (the single-filer Circuit Breaker limit).</p>
+    <div class="cut-item">
+      <span class="cut-item-name">Senior households (householder 65+)</span>
+      <span class="cut-item-amount">2,856</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">Senior homeowners</span>
+      <span class="cut-item-amount">2,392</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">Senior households earning under $75,000</span>
+      <span class="cut-item-amount">1,158 (41%)</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">Senior households earning under $100,000</span>
+      <span class="cut-item-amount">1,390 (49%)</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">Circuit Breaker claims filed (TY2022)<span class="cut-item-note">Most recent year available from DOR. Average credit: $1,054, well below the $2,820 cap.</span></span>
+      <span class="cut-item-amount">418</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">Total Circuit Breaker credits paid (TY2022)</span>
+      <span class="cut-item-amount">$440,382</span>
+    </div>
+    <p>The 418 claims represent about 17% of senior homeowners, meaning the credit is likely underclaimed. An average credit of $1,054 (vs. the $2,820 cap) means most Marblehead claimants have room for the credit to grow if their tax bill increases.</p>
+    <p class="source">Demographics: US Census Bureau, ACS 2019-2023 5-year estimates, tables B19037 and B25007, Marblehead town, Essex County, MA. Circuit Breaker usage: <a href="https://www.mass.gov/doc/senior-circuit-breaker-credit-usage-by-town-2001-2022/download">MA DOR, Senior Circuit Breaker Credit Usage by Town, 2001-2022</a>.</p>
+  </div>
     </div>
   </details>
 
@@ -545,7 +577,8 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     <h3>Funding (important for the override debate)</h3>
     <p>The Finance Committee report states that the Select Board anticipates setting a first-year town-wide cap of <strong>$200,000</strong>, funded from the tax overlay, not the operating budget.</p>
     <p>The overlay is a pool the town sets aside each year specifically to cover abatements, exemptions, and uncollected taxes. FY2026 overlay is $657,722. Because the exemption is funded from overlay, it does not compete with school or town operating budgets and does not change the override math.</p>
-    <p class="source">Source: <a href="https://marbleheadma.gov/wp-content/uploads/2025/05/2026-Annual-Town-Meeting-Finance-Committee-Annual-Report.pdf">2025 Town Meeting <abbr class="g" title="Finance Committee">FinCom</abbr> Report</a>, Article 28 comment and FY2026 revenue table.</p>
+    <p><strong>How far does $200,000 go?</strong> In TY2022, 418 Marblehead seniors claimed the state Circuit Breaker. Article 28 requires Circuit Breaker eligibility plus 10-year residency and a home under the prior-year average ($1,217,000), so the eligible pool is smaller. If 300 seniors qualify and split the $200,000 pool evenly, each receives about $667. If 200 qualify, each receives $1,000. The formula amount for a qualifying senior can be substantially higher (the calculator above shows the theoretical maximum), but the actual exemption each household receives is limited by the annual pool and any per-household cap the Select Board sets. An override would increase each person's formula amount, putting more pressure on the pool.</p>
+    <p class="source">Source: <a href="https://marbleheadma.gov/wp-content/uploads/2025/05/2026-Annual-Town-Meeting-Finance-Committee-Annual-Report.pdf">2025 Town Meeting <abbr class="g" title="Finance Committee">FinCom</abbr> Report</a>, Article 28 comment and FY2026 revenue table. Circuit Breaker claim count: <a href="https://www.mass.gov/doc/senior-circuit-breaker-credit-usage-by-town-2001-2022/download">MA DOR, TY2022</a>.</p>
   </div>
 
   <div class="card">
@@ -711,6 +744,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
   <details class="notes">
     <summary>Sources and methodology</summary>
     <p>Circuit Breaker figures are for tax year 2025 (filed in 2026), per <a href="https://www.mass.gov/technical-information-release/tir-25-7-annual-update-of-real-estate-tax-credit-for-certain-persons-age-65-and-older">MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Technical Information Release">TIR</abbr> 25-7</a> and <a href="https://www.mass.gov/info-details/massachusetts-senior-circuit-breaker-tax-credit">Mass.gov Senior Circuit Breaker</a>. These amounts are indexed to inflation and change annually. Article 28 warrant text, veteran exemption amounts, and Marblehead FY2026 budget figures are from the <a href="https://marbleheadma.gov/wp-content/uploads/2025/05/2026-Annual-Town-Meeting-Finance-Committee-Annual-Report.pdf">2025 Annual Town Meeting Finance Committee Report</a>. H.4225 bill status snapshot from <a href="https://malegislature.gov/Bills/194/H4225">malegislature.gov</a> as of April 10, 2026. Town Meeting passage of Article 28 at ~93% per <a href="https://itemlive.com/2025/05/11/marblehead-town-meeting-passes-key-articles/">Itemlive, "Marblehead Town Meeting passes key articles" (May 11, 2025)</a>. FY2026 tax rate of $8.60/$1,000 per <a href="https://marbleheadcurrent.org/2025/12/02/town-lowers-tax-rate-average-bill-still-set-to-increase/">Marblehead Current (Dec 2, 2025)</a>. Median Marblehead single-family assessed value of roughly $1,010,000 per MA <abbr class="g" title="Division of Local Services">DLS</abbr>. Home rule constitutional reference: <a href="https://malegislature.gov/Laws/Constitution">MA Constitution, Article 89 of the Articles of Amendment</a>. Clause framework: <a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter59/Section5"><abbr class="g" title="Massachusetts General Laws">MGL</abbr> c. 59 s. 5</a>.</p>
+    <p>Senior demographic data (household counts, income distribution, homeownership rates) from US Census Bureau, American Community Survey 2019-2023 5-year estimates, tables B19037 (age of householder by income) and B25007 (tenure by age of householder), for Marblehead town, Essex County, MA. These are survey estimates with margins of error typical for a town of ~20,000. Circuit Breaker claim counts and total credits from <a href="https://www.mass.gov/doc/senior-circuit-breaker-credit-usage-by-town-2001-2022/download">MA DOR, Senior Circuit Breaker Credit Usage by Town, 2001-2022</a> (TY2022, preliminary).</p>
     <p>Clause 41C, 41A, and 17D current Marblehead amounts and limits are pending confirmation from the Board of Assessors. This page will be updated when those figures are verified from a primary source. In the meantime, residents should contact the Assessor's Office directly for eligibility determination.</p>
     <p>Nothing on this page is tax advice. It is a civic information resource. Talk to a tax professional, the Assessor's Office, or the Council on Aging (781-631-6240) for help with your individual situation.</p>
   </details>
@@ -932,7 +966,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     if (art28On && !renter) {
       if (base.art28Eligible && base.art28Amount > 0) {
         html += line('Article 28 exemption (pending, formula max)', '&minus;' + money(base.art28Amount), 'sr-line--credit');
-        html += '<div class="sr-warn" style="color: var(--text-subtle);">Not yet law. Subject to a per-household cap set by the Select Board and a $200,000 town-wide annual pool. Actual exemption may be lower.</div>';
+        html += '<div class="sr-warn" style="color: var(--text-subtle);">Not yet law. Subject to a per-household cap set by the Select Board and a $200,000 town-wide annual pool shared among an estimated 300-400 qualifying seniors. Actual exemption may be lower.</div>';
       } else {
         html += line('Article 28 exemption', '$0', '');
       }
@@ -1028,7 +1062,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
 
     var footNote = 'Year 3 (full phase-in) figures. The Circuit Breaker credit grows as your tax bill grows, so qualifying seniors below the $2,820 cap pay less of the override than the headline number suggests.';
     if (anyArt28Absorb) {
-      footNote += ' Article 28 amounts are formula maximums, subject to a per-household cap and $200,000 town-wide annual pool.';
+      footNote += ' Article 28 amounts are formula maximums, subject to a per-household cap and $200,000 town-wide pool shared among an estimated 300-400 qualifying seniors.';
     }
     ohtml += '<div class="sr-override-note">' + footNote + '</div>';
 


### PR DESCRIPTION
## Summary
- New "Who claims it in Marblehead" card in Circuit Breaker deep-dive: 2,856 senior households, 2,392 homeowners, 1,158 under $75k, 418 CB claims at $1,054 avg (DOR TY2022)
- Article 28 funding card: real pool math showing $200k shared among ~300-400 qualifying seniors
- TL;DR bullet: 418 claims, likely underclaimed
- Calculator caveats reference "300-400 qualifying seniors" instead of vague "$200k pool"
- Sources section updated with ACS and DOR citations

## Sources
- US Census Bureau, ACS 2019-2023 5-year estimates, tables B19037 (age of householder by income) and B25007 (tenure by age)
- MA DOR, Senior Circuit Breaker Credit Usage by Town, 2001-2022

## Test plan
- [ ] "Who claims it" card renders with proper cut-item layout
- [ ] Article 28 funding paragraph reads clearly with the pool math
- [ ] TL;DR bullet about 418 claims appears
- [ ] Calculator Art 28 caveat mentions "300-400 qualifying seniors"

🤖 Generated with [Claude Code](https://claude.com/claude-code)