### PR TITLE
Always show landing, stop auto-redirecting to last topic

### DIFF
--- a/index.html
+++ b/index.html
@@ -2254,7 +2254,6 @@ og_url: https://marbleheaddata.org/
   });
 
   var stageEl = document.querySelector('.explore-stage');
-  var TOPIC_KEY = 'explore-topic';
 
   /* ── URL state ── */
   // URL format: ?q=schools&pos=b
@@ -2288,8 +2287,6 @@ og_url: https://marbleheaddata.org/
     document.querySelectorAll('.question-screen').forEach(function (s) {
       s.style.display = s.dataset.topic === topic ? 'block' : 'none';
     });
-    // Remember for next visit
-    try { localStorage.setItem(TOPIC_KEY, topic); } catch (e) {}
     // Update URL, preserve pos if same topic has a selection
     writeURL(topic, selections[topic] || null);
   }
@@ -2317,7 +2314,6 @@ og_url: https://marbleheaddata.org/
   var startOverBtn = document.getElementById('startOver');
   if (startOverBtn) {
     startOverBtn.addEventListener('click', function () {
-      try { localStorage.removeItem(TOPIC_KEY); } catch (e) {}
       showLanding();
       window.scrollTo(0, 0);
     });
@@ -2639,8 +2635,6 @@ og_url: https://marbleheaddata.org/
   /* ── Restore state on load ── */
   // Priority: URL positions param > URL q param > localStorage > landing
   var initial = readURL();
-  var savedTopic = null;
-  try { savedTopic = localStorage.getItem(TOPIC_KEY); } catch (e) {}
 
   // Check for shared positions URL: ?positions=override:a,schools:c
   var positionsParam = new URLSearchParams(window.location.search).get('positions');
@@ -2662,10 +2656,8 @@ og_url: https://marbleheaddata.org/
       selectAnswer(initial.topic, initial.pos);
     }
     updateNotesPill();
-  } else if (savedTopic) {
-    switchTopic(savedTopic);
-    updateNotesPill();
   } else {
+    // Always show landing -- positions are visible on the cards
     showLanding();
     updateNotesPill();
   }


### PR DESCRIPTION
## Summary
- Homepage always shows the question card landing -- no more auto-redirect into last topic
- Logo click takes you home to your position cards
- Direct links (`?q=schools`) and shared links (`?positions=...`) still bypass the landing
- Removed `explore-topic` localStorage key (no longer needed)

## Test plan
- [ ] Visit `/` -- should see landing with question cards (not redirected)
- [ ] Pick positions, navigate away, come back to `/` -- landing shows with your picks visible
- [ ] Click logo from any page -- goes to landing
- [ ] `/?q=schools&pos=b` -- still goes directly to that question

🤖 Generated with [Claude Code](https://claude.com/claude-code)