### PR TITLE
Distinguish Tier 2 restore items with Restore+ tag

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -3109,6 +3109,11 @@ blockquote.quote--mixed p {
   color: var(--c-teal);
   background: color-mix(in srgb, var(--c-teal) 12%, transparent);
 }
+.tier-tag--restore-plus {
+  color: var(--c-teal);
+  background: color-mix(in srgb, var(--c-teal) 6%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--c-teal) 35%, transparent);
+}
 .tier-tag--new {
   color: var(--c-navy);
   background: color-mix(in srgb, var(--c-navy) 12%, transparent);

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -233,11 +233,11 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
 
       <div class="tier-group-heading">Recreation, Library &amp; Parks</div>
       <div class="tier-line">
-        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Library staffing</span>
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore-plus">Restore+</span> Library staffing</span>
         <span class="tier-line-amount">$218,980</span>
       </div>
       <div class="tier-line">
-        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Library materials</span>
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore-plus">Restore+</span> Library materials</span>
         <span class="tier-line-amount">$168,400</span>
       </div>
       <div class="tier-line">
@@ -263,11 +263,11 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
         <span class="tier-line-amount">$70,000</span>
       </div>
       <div class="tier-line">
-        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Community Development staffing</span>
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore-plus">Restore+</span> Community Development staffing</span>
         <span class="tier-line-amount">$170,552</span>
       </div>
       <div class="tier-line">
-        <span class="tier-line-name"><span class="tier-tag tier-tag--restore">Restore</span> Town Clerk staffing</span>
+        <span class="tier-line-name"><span class="tier-tag tier-tag--restore-plus">Restore+</span> Town Clerk staffing</span>
         <span class="tier-line-amount">$66,125</span>
       </div>
       <div class="tier-line">


### PR DESCRIPTION
## Summary
- Tier 2 has incremental restore line items (Library staffing, Library materials, Community Development staffing, Town Clerk staffing) that share names with Tier 1 items, making them look duplicated
- New `Restore+` tag with dashed border and lighter background visually distinguishes these from Tier 1 `Restore` tags, signaling "additional restoration beyond Tier 1"
- Tier 3 checked and is clean (all "New" items, no restore overlap)

## Test plan
- [ ] Verify Tier 1 `Restore` tags still render with solid teal background
- [ ] Verify Tier 2 `Restore+` tags render with dashed border and lighter fill
- [ ] Confirm the four updated items: Library staffing, Library materials, Community Development staffing, Town Clerk staffing

🤖 Generated with [Claude Code](https://claude.com/claude-code)