### PR TITLE
Surface underclaimed CB finding, add Calculator tag

### DIFF
--- a/browse.html
+++ b/browse.html
@@ -169,8 +169,9 @@ og_url: https://marbleheaddata.org/browse.html
     </a>
 
     <a class="question" href="senior-tax-relief.html">
+      <span class="tag tag-charts">Calculator</span>
       <h2>What relief can seniors claim?</h2>
-      <p>The state Circuit Breaker (up to $2,820), Marblehead's pending means-tested exemption (H.4225), and how both interact with the override.</p>
+      <p>Enter your home value and income to see your Circuit Breaker credit and how each override tier affects you after relief. Only 418 of an estimated 1,158 eligible seniors claimed the credit in 2022.</p>
     </a>
   </div>
 

--- a/charts/override_calculator.html
+++ b/charts/override_calculator.html
@@ -134,7 +134,7 @@ title: "What the Override Costs You"
     </a>
     <a class="read-next-link" href="../senior-tax-relief.html">
       <div class="read-next-title">What relief can seniors claim? &rarr;</div>
-      <div class="read-next-desc">The state Circuit Breaker, Marblehead's pending means-tested exemption, and how both interact with the override.</div>
+      <div class="read-next-desc">Calculator: see your Circuit Breaker credit and how each override tier affects you after relief. Only 418 of ~1,158 eligible seniors claimed the credit in 2022.</div>
     </a>
   </div>
 

--- a/senior-tax-relief.html
+++ b/senior-tax-relief.html
@@ -1,7 +1,7 @@
 ---
 title: "What relief can seniors claim?"
 og_title: "What relief can seniors claim? (Marblehead)"
-og_description: "How Marblehead's senior tax-relief programs actually work: the Clause 41C exemption, the tax deferral, verified examples, and the formulas."
+og_description: "Calculator: enter your home value and income to see your Circuit Breaker credit, how the override affects you after relief, and what Article 28 would add. 418 Marblehead seniors claimed the credit in 2022, likely underclaimed."
 og_url: https://marbleheaddata.org/senior-tax-relief.html
 ---
 <style>
@@ -364,7 +364,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
   </div>
 
   <div class="takeaway takeaway--neutral">
-    For a qualifying senior, the state Senior Circuit Breaker formula refunds <em>more</em>, not less, as the property tax bill goes up. The override increases the credit for seniors who are not yet at the $2,820 cap, but it also increases the tax bill that created the need for the credit.
+    Only 418 Marblehead seniors claimed the Circuit Breaker in 2022, out of roughly 1,158 senior households under the income limit. The average credit was $1,054. If you are 65 or older and your household income is under $75,000 (single), $94,000 (head of household), or $112,000 (joint), you may be leaving money on the table.
   </div>
 
   <nav class="page-toc" aria-label="On this page">
@@ -656,6 +656,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
   <div class="card">
     <h3>The Circuit Breaker formula absorbs part of the override</h3>
     <p>Because the credit equals the excess of your property tax over 10% of your income, every dollar the override adds to a qualifying senior's tax bill is a dollar added to the Circuit Breaker credit, up to the $2,820 cap. Seniors not yet at the cap are partially insulated from the override by the state formula itself.</p>
+    <p>In TY2022, the average Marblehead Circuit Breaker credit was $1,054, well below the $2,820 cap. Most claimants have room for the credit to grow if the override passes. But only 418 out of an estimated 1,158 eligible senior households actually claimed it. The insulation only works if you file.</p>
   </div>
 
   <div class="card">


### PR DESCRIPTION
## Summary
- Browse page: Calculator tag on senior relief card, updated desc with "418 of 1,158" hook
- og_description: mentions calculator and underclaimed stat for social sharing
- Takeaway box: swapped to the underclaimed finding as a direct call to action ("you may be leaving money on the table")
- Override connection section: new paragraph noting insulation only works if you file
- Override calculator read-next: updated link desc

## Test plan
- [ ] Browse page shows Calculator pill on senior relief card
- [ ] Takeaway box reads as a call to action, not a formula explanation
- [ ] Override connection section has the "only works if you file" paragraph
- [ ] Override calculator read-next desc mentions calculator and 418 stat

🤖 Generated with [Claude Code](https://claude.com/claude-code)