### PR TITLE
Explore: add sustainability and alternatives questions

### DIFF
--- a/index.html
+++ b/index.html
@@ -637,6 +637,8 @@ og_url: https://marbleheaddata.org/
     <button class="topic-pill" data-topic="taxrank">Tax rank</button>
     <button class="topic-pill" data-topic="mycost">My cost</button>
     <button class="topic-pill" data-topic="schools">Schools</button>
+    <button class="topic-pill" data-topic="again">Again?</button>
+    <button class="topic-pill" data-topic="alternatives">Alternatives</button>
     <button class="topic-pill" data-topic="library">Library cuts</button>
     <button class="topic-pill" data-topic="trust">Trust</button>
   </nav>
@@ -1847,6 +1849,344 @@ og_url: https://marbleheaddata.org/
         </p>
         <a class="evidence-chart-link" href="data/case_studies">
           Override case studies
+        </a>
+      </div>
+    </div>
+
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════
+       QUESTION: Will we be back here in 5 years?
+       ═══════════════════════════════════════════════════ -->
+  <section class="question-screen" data-topic="again">
+
+    <div class="question-block">
+      <h1>Will we be back here in 5 years?</h1>
+      <p class="question-context">
+        If the override passes, does the problem go away or does the
+        same pressure rebuild?
+      </p>
+    </div>
+
+    <div class="answers">
+      <div class="answer-card" data-answer="a" data-question="again">
+        <p class="answer-label">Position A</p>
+        <h2>The override is sized to last several years</h2>
+        <p class="answer-summary">
+          The three tiers were designed as a multi-year correction.
+          Tier 2 and 3 build capacity to absorb future cost growth
+          without coming back to voters immediately.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="b" data-question="again">
+        <p class="answer-label">Position B</p>
+        <h2>The math says we will</h2>
+        <p class="answer-summary">
+          Health insurance and pensions don't stop growing when the
+          override passes. Even Tier 3 closes the gap for about one
+          year before expenses pull ahead again.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="c" data-question="again">
+        <p class="answer-label">Position C</p>
+        <h2>It depends on whether reform happens during the breathing room</h2>
+        <p class="answer-summary">
+          The override buys time. Whether that time gets used for
+          structural changes or just defers the problem is a choice,
+          not a certainty.
+        </p>
+      </div>
+    </div>
+
+    <!-- Evidence A: designed to last -->
+    <div class="evidence" data-evidence="again-a">
+      <div class="evidence-header">
+        <h3>The case for "designed to last"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Three tiers, three strategies</h4>
+        <p>
+          Tier 1 ($9M) restores what was cut. Tier 2 ($12M) stabilizes
+          recurring costs. Tier 3 ($15M) adds a cushion for future
+          growth. The tiers were scoped to match the Finance
+          Committee's three-year deficit forecast (FY26-FY28).
+        </p>
+        <a class="evidence-chart-link" href="what-is-the-override.html">
+          What is the override
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Deficits are projected only under the no-override scenario</h4>
+        <p>
+          The FinCom's three-year forecast shows structural deficits
+          only if the override fails. At Tier 2 or 3, the near-term
+          gap closes and the town doesn't need to come back to voters
+          for several years.
+        </p>
+        <a class="evidence-chart-link" href="how-we-got-here.html">
+          How we got here
+        </a>
+      </div>
+    </div>
+
+    <!-- Evidence B: math says yes -->
+    <div class="evidence" data-evidence="again-b">
+      <div class="evidence-header">
+        <h3>The case for "the math says we will"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The gap reopens even at Tier 3</h4>
+
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue vs expenses FY24-FY30, gap growing.">
+            <line class="axis-base" x1="60" y1="200" x2="500" y2="200"/>
+            <line class="grid-minor" x1="60" y1="160" x2="500" y2="160"/>
+            <line class="grid-minor" x1="60" y1="120" x2="500" y2="120"/>
+            <line class="grid-minor" x1="60" y1="80" x2="500" y2="80"/>
+            <text class="tick-label" x="53" y="204" text-anchor="end">$80M</text>
+            <text class="tick-label" x="53" y="164" text-anchor="end">$100M</text>
+            <text class="tick-label" x="53" y="124" text-anchor="end">$120M</text>
+            <text class="tick-label" x="53" y="84" text-anchor="end">$140M</text>
+            <text class="tick-label tick-label--major" x="94" y="220" text-anchor="middle">FY24</text>
+            <text class="tick-label tick-label--major" x="234" y="220" text-anchor="middle">FY27</text>
+            <text class="tick-label tick-label--major" x="444" y="220" text-anchor="middle">FY30</text>
+            <rect class="data-fill s-revenue" x="80" y="123" width="28" height="77"/>
+            <rect class="data-fill s-revenue" x="150" y="112" width="28" height="88" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="220" y="103" width="28" height="97" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="290" y="94" width="28" height="106" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="360" y="86" width="28" height="114" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="430" y="78" width="28" height="122" opacity="0.65"/>
+            <polyline class="data-line data-line--bold s-neutral" points="94,120 164,105 234,72 304,52 374,32 444,12"/>
+            <circle class="data-dot s-neutral" cx="94" cy="120" r="3"/>
+            <circle class="data-dot s-neutral" cx="444" cy="12" r="4"/>
+            <text class="annotation" x="460" y="18">expenses</text>
+            <text class="annotation" x="460" y="82">revenue</text>
+          </svg>
+        </div>
+
+        <p class="caption">
+          Expenses grow at ~5%/year. Revenue grows at ~2.5%. An
+          override adds a fixed amount that doesn't grow. By FY30
+          the gap reopens even at Tier 3. Tier 1 reopens sooner.
+        </p>
+        <a class="evidence-chart-link" href="charts/sustainability.html">
+          Sustainability projections
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Melrose is the preview</h4>
+        <p>
+          Melrose rejected $7.7M in 2024. Eighteen months later they
+          passed $13.5M, 75% more. Each delay makes the next ask bigger
+          because the underlying costs keep compounding.
+        </p>
+        <a class="evidence-chart-link" href="data/case_studies">
+          Override case studies
+        </a>
+      </div>
+    </div>
+
+    <!-- Evidence C: depends on reform -->
+    <div class="evidence" data-evidence="again-c">
+      <div class="evidence-header">
+        <h3>The case for "it depends on reform"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The override buys time. What you do with it matters.</h4>
+        <p>
+          Both sides agree costs will keep rising. The question is
+          whether the breathing room from the override gets used to
+          change the cost structure (insurance negotiations, staffing
+          model, budget transparency) or just delays the next ask.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Reform options that don't require an override</h4>
+        <p>
+          Premium split renegotiation (Marblehead pays 83%, peers
+          pay 50-80%). State budget review (free, never requested).
+          Detailed department-level reporting (format change, no vote
+          needed). None are fast, but none are impossible.
+        </p>
+        <a class="evidence-chart-link" href="what-you-can-do.html#better-oversight">
+          Reform options
+        </a>
+      </div>
+    </div>
+
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════
+       QUESTION: What else could we do instead?
+       ═══════════════════════════════════════════════════ -->
+  <section class="question-screen" data-topic="alternatives">
+
+    <div class="question-block">
+      <h1>What else could we do instead of an override?</h1>
+      <p class="question-context">
+        Is it really override-or-cuts, or are there other options
+        nobody is talking about?
+      </p>
+    </div>
+
+    <div class="answers">
+      <div class="answer-card" data-answer="a" data-question="alternatives">
+        <p class="answer-label">Position A</p>
+        <h2>There are no short-term alternatives that close an $8.47M gap</h2>
+        <p class="answer-summary">
+          The levers other towns use (commercial tax base, state aid,
+          CIP shift) either don't exist in Marblehead or don't scale.
+          Nothing else works in 12 weeks.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="b" data-question="alternatives">
+        <p class="answer-label">Position B</p>
+        <h2>There are alternatives the town has chosen not to pursue</h2>
+        <p class="answer-summary">
+          Benefits reform, economic development, and budget
+          transparency are all possible. They take longer, but that's
+          the point: the override is being asked for instead of the
+          harder work.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="c" data-question="alternatives">
+        <p class="answer-label">Position C</p>
+        <h2>12-week alternatives don't exist, but 5-year ones do</h2>
+        <p class="answer-summary">
+          Nothing closes $8.47M by June. But the override should come
+          with a commitment to the structural changes that prevent the
+          next one.
+        </p>
+      </div>
+    </div>
+
+    <!-- Evidence A: no short-term alternatives -->
+    <div class="evidence" data-evidence="alternatives-a">
+      <div class="evidence-header">
+        <h3>The case for "nothing else works in time"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Marblehead's tax base is almost entirely residential</h4>
+        <p>
+          95.5% of the tax levy comes from residential property, the
+          highest in a 21-town peer set. There's almost no commercial
+          base to shift burden onto. A CIP split on 4.5% commercial
+          property produces trivial revenue.
+        </p>
+        <a class="evidence-chart-link" href="why-not-elsewhere.html">
+          Why some towns don't need overrides
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>State aid excludes wealthy suburbs</h4>
+        <p>
+          State aid formulas are designed for lower-income communities.
+          Marblehead's property wealth means it gets less per capita
+          than most Massachusetts towns. This isn't changing.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>New growth is the lowest among peers</h4>
+        <p>
+          Marblehead's five-year average new growth rate is 0.54%,
+          the lowest in the peer set. Peninsula geography, historic
+          districts, and zoning constrain development. Rezoning
+          takes years.
+        </p>
+      </div>
+    </div>
+
+    <!-- Evidence B: alternatives exist -->
+    <div class="evidence" data-evidence="alternatives-b">
+      <div class="evidence-header">
+        <h3>The case for "alternatives exist"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The insurance split is a choice, not a law of nature</h4>
+        <p>
+          Marblehead pays 83% of health premiums. State law allows
+          anywhere from 50% to 99%. Hingham pays 50% and offsets it
+          with higher salaries. Moving to 75% would save roughly
+          $1M/year. It requires collective bargaining, not a ballot
+          question.
+        </p>
+        <a class="evidence-chart-link" href="charts/peer_compensation.html">
+          Peer compensation and premium splits
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Budget transparency is free</h4>
+        <p>
+          The state offers free independent budget reviews (DLS
+          Financial Management Review). The town has never requested
+          one. Publishing school-level budget detail is a format
+          choice, not a policy change.
+        </p>
+        <a class="evidence-chart-link" href="what-you-can-do.html#better-oversight">
+          Reform options
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Economic development is constrained but not impossible</h4>
+        <p>
+          Geography and zoning are real constraints. But zoning is a
+          town choice. The question is whether Marblehead wants to
+          diversify its tax base over the next decade or keep running
+          residential overrides.
+        </p>
+      </div>
+    </div>
+
+    <!-- Evidence C: both timelines -->
+    <div class="evidence" data-evidence="alternatives-c">
+      <div class="evidence-header">
+        <h3>The case for "12-week no, 5-year yes"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Both sides are answering different questions</h4>
+        <p>
+          "Are there alternatives?" means one thing on a 12-week budget
+          cycle and something else on a 5-year planning horizon.
+          Nothing replaces $8.47M by June. But benefits reform at the
+          next contract renewal, a state budget review, and zoning
+          conversations are all real options on a longer timeline.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The override and reform aren't mutually exclusive</h4>
+        <p>
+          You can vote yes and still push for structural changes. But
+          the history of overrides in Massachusetts is that once the
+          immediate pressure lifts, the longer-term work tends to stall.
+          Making reform an explicit condition of support is one way to
+          prevent that.
+        </p>
+        <a class="evidence-chart-link" href="what-you-can-do.html#pick-your-goal">
+          Pick your goal
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Fills the two gaps between the debate page's six dividing lines and the explore page:

**"Will we be back here in 5 years?"** (Again?)
- Designed to last / math says we will / depends on reform
- Inline sustainability chart, Melrose case study, reform options link

**"What else could we do instead?"** (Alternatives)
- Nothing works in 12 weeks / alternatives exist / both timelines
- 95.5% residential tax base, 83% insurance split, free state review

Explore now covers all 6 debate page dividing lines plus the additional questions (tax rank, my cost, 2.5% cap).

## Test plan
- [ ] "Again?" and "Alternatives" pills appear in topic bar
- [ ] Each question has three positions with evidence
- [ ] Sustainability chart renders in Again? Position B
- [ ] All evidence links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)