### PR TITLE
Remove source-citation block from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -717,10 +717,6 @@ og_url: https://marbleheaddata.org/
     <div class="explore-share-strip" id="shareStrip">
       <button type="button" class="explore-share-btn" id="shareBtn">Share your positions</button>
     </div>
-    <div class="explore-trust">
-      Every claim cites a primary source. Every dollar traces to a town document.<br>
-      <a href="about.html">About this project</a>
-    </div>
   </div>
 
   <!-- Question nav (visible once inside a question) -->


### PR DESCRIPTION
## Summary
- Removes the "Every claim cites a primary source..." text and "About this project" link from the homepage landing section

## Test plan
- [ ] Verify homepage landing renders without the trust block
- [ ] Check no layout shift from the removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)