### PR TITLE
Increase background lighthouse watermark size

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -840,8 +840,8 @@ details.notes[open] > summary {
 .page.page--home::before {
   content: "";
   position: absolute;
-  top: -20px; right: -40px;
-  width: 320px; height: 480px;
+  top: -40px; right: -60px;
+  width: 520px; height: 780px;
   background: url(lighthouse/lighthouse.svg) center / contain no-repeat;
   opacity: 0.05;
   pointer-events: none;

--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@ og_url: https://marbleheaddata.org/
   .explore-stage::before {
     content: "";
     position: absolute;
-    top: -20px; right: -40px;
-    width: 320px; height: 480px;
+    top: -40px; right: -60px;
+    width: 520px; height: 780px;
     background: url(assets/lighthouse/lighthouse.svg) center / contain no-repeat;
     opacity: 0.05;
     pointer-events: none;


### PR DESCRIPTION
## Summary
- Bumps lighthouse watermark from 320×480px to 520×780px in both `site.css` and `index.html`
- Adjusts offset (`top: -40px; right: -60px`) so it doesn't crowd content at the larger size

🤖 Generated with [Claude Code](https://claude.com/claude-code)