### PR TITLE
Explore: add trash collection question

### DIFF
--- a/index.html
+++ b/index.html
@@ -2289,6 +2289,160 @@ og_url: https://marbleheaddata.org/
   </section>
 
   <!-- ═══════════════════════════════════════════════════
+       QUESTION: Why is trash collection on the ballot?
+       ═══════════════════════════════════════════════════ -->
+  <section class="question-screen" data-topic="trash">
+
+    <div class="question-block">
+      <h1>Why is trash collection on the ballot?</h1>
+      <p class="question-context">
+        Question 2 asks for $2.3M to fund curbside trash through
+        property taxes. If it fails, a flat $281/household fee kicks
+        in instead. Either way, you pay for trash.
+      </p>
+    </div>
+
+    <div class="answers">
+      <div class="answer-card" data-answer="a" data-question="trash">
+        <p class="answer-label">Position A</p>
+        <h2>Vote yes: the levy scales with home value</h2>
+        <p class="answer-summary">
+          A $500K home pays less than a $2M home. The flat fee charges
+          the same $281 whether you're in a cottage or a waterfront
+          estate.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="b" data-question="trash">
+        <p class="answer-label">Position B</p>
+        <h2>Vote no: everyone uses the same service</h2>
+        <p class="answer-summary">
+          Every household gets one trash pickup. A flat fee means you
+          pay for what you use. The levy makes high-value homeowners
+          subsidize everyone else's trash.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="c" data-question="trash">
+        <p class="answer-label">Position C</p>
+        <h2>The real question is what happened to the money</h2>
+        <p class="answer-summary">
+          Trash was already in the budget. The Select Board carved it
+          out, freeing $1.15M for other spending. Question 2 is about
+          whether to backfill that with new taxes.
+        </p>
+      </div>
+    </div>
+
+    <!-- Evidence A: levy is fairer -->
+    <div class="evidence" data-evidence="trash-a">
+      <div class="evidence-header">
+        <h3>The case for "levy scales with value"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Below ~$1.21M, the levy costs you less than the fee</h4>
+        <p>
+          If your home is assessed under ~$1.21M, the levy is cheaper
+          than $281. Median home value is $1,010,100, so most
+          homeowners pay less under the levy.
+        </p>
+        <a class="evidence-chart-link" href="question-2-trash.html#levy-vs-fee">
+          Levy vs. fee at different home values
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The override is permanent</h4>
+        <p>
+          Like Question 1, this permanently raises the levy ceiling.
+          The trash portion grows at 2.5%/year. The flat fee would be
+          set annually by the Board of Health.
+        </p>
+      </div>
+    </div>
+
+    <!-- Evidence B: fee is fairer -->
+    <div class="evidence" data-evidence="trash-b">
+      <div class="evidence-header">
+        <h3>The case for "same service, same price"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>One barrel, one price</h4>
+        <p>
+          Every household gets the same pickup. A $500K condo and a
+          $2M house get the same truck. The fee matches the service.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Most peer towns use fees</h4>
+        <p>
+          Swampscott: $300/year. Melrose: $200/year (pay-as-you-throw
+          bags). Fee-based models are the norm. Marblehead has been
+          the outlier.
+        </p>
+        <a class="evidence-chart-link" href="question-2-trash.html#peer-towns">
+          How other towns fund trash
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The fee doesn't permanently raise taxes</h4>
+        <p>
+          A levy override is forever. The fee can be adjusted or
+          dropped if costs change.
+        </p>
+      </div>
+    </div>
+
+    <!-- Evidence C: follow the money -->
+    <div class="evidence" data-evidence="trash-c">
+      <div class="evidence-header">
+        <h3>The case for "follow the money"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Trash was already in the budget</h4>
+        <p>
+          FY26 Waste Collection: $2.94M, paid through general property
+          taxes. Nobody saw a separate trash charge. The new Republic
+          Services contract added roughly $1M to costs.
+        </p>
+        <a class="evidence-chart-link" href="question-2-trash.html#how-funded">
+          How trash has been funded
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The carve-out frees $1.15M regardless of your vote</h4>
+        <p>
+          The Select Board moved curbside service out of the general
+          fund before Question 2 existed. That freed $1.15M for other
+          spending. Yes or no, that capacity is already freed.
+        </p>
+        <a class="evidence-chart-link" href="question-2-trash.html#why-changed">
+          Why this changed
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>You're choosing who pays how much, not whether to pay</h4>
+        <p>
+          Yes = property taxes, scaled by home value. No = flat
+          $281/household. Total revenue is roughly the same either
+          way.
+        </p>
+      </div>
+    </div>
+
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════
        QUESTION 4: Library cuts (placeholder)
        ═══════════════════════════════════════════════════ -->
   <section class="question-screen" data-topic="library">


### PR DESCRIPTION
## Summary
New topic: "Why is trash collection on the ballot?" covering Question 2's $2.3M curbside trash override.

Three positions:
- **Levy scales with value**: break-even at ~$1.21M home value, most pay less than the fee
- **Same service, same price**: every household gets one pickup, peers use fees
- **Follow the money**: carve-out frees $1.15M either way, Q2 is about how to replace funding

All evidence from question-2-trash.html with section-specific anchor links.

## Test plan
- [ ] Trash question appears in topic list
- [ ] Three positions with evidence panels
- [ ] Links land on correct sections of question-2-trash.html
- [ ] Plain language throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)