### PR TITLE
Push lighthouse watermark further right

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -836,11 +836,11 @@ details.notes[open] > summary {
 .hero p  { font-size: 16px; color: var(--text-subtle); max-width: 520px; margin: 0 auto; }
 
 /* Lighthouse watermark behind homepage content */
-.page.page--home { position: relative; }
+.page.page--home { position: relative; overflow: hidden; }
 .page.page--home::before {
   content: "";
   position: absolute;
-  top: -40px; right: -60px;
+  top: -40px; right: -200px;
   width: 520px; height: 780px;
   background: url(lighthouse/lighthouse.svg) center / contain no-repeat;
   opacity: 0.05;

--- a/index.html
+++ b/index.html
@@ -21,11 +21,12 @@ og_url: https://marbleheaddata.org/
     display: flex;
     flex-direction: column;
     position: relative;
+    overflow: hidden;
   }
   .explore-stage::before {
     content: "";
     position: absolute;
-    top: -40px; right: -60px;
+    top: -40px; right: -200px;
     width: 520px; height: 780px;
     background: url(assets/lighthouse/lighthouse.svg) center / contain no-repeat;
     opacity: 0.05;


### PR DESCRIPTION
## Summary
- Move `right` offset from `-60px` to `-200px` so the lighthouse hugs the right edge
- Add `overflow: hidden` on both containers to prevent horizontal scroll

## Test plan
- [ ] Check desktop: lighthouse visible as a subtle watermark on the right, no horizontal scrollbar
- [ ] Check mobile: same behavior, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)