### PR TITLE
Position lighthouse in right gutter (desktop) and right third (mobile)

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -198,6 +198,7 @@ body {
   font-variant-numeric: tabular-nums;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  overflow-x: hidden;
 }
 
 /* Paper texture + warm gradient on background */
@@ -836,16 +837,19 @@ details.notes[open] > summary {
 .hero p  { font-size: 16px; color: var(--text-subtle); max-width: 520px; margin: 0 auto; }
 
 /* Lighthouse watermark behind homepage content */
-.page.page--home { position: relative; overflow: hidden; }
+.page.page--home { position: relative; }
 .page.page--home::before {
   content: "";
   position: absolute;
-  top: -40px; right: -200px;
+  top: 40px; right: -360px;
   width: 520px; height: 780px;
   background: url(lighthouse/lighthouse.svg) center / contain no-repeat;
   opacity: 0.05;
   pointer-events: none;
   z-index: 0;
+}
+@media (max-width: 600px) {
+  .page.page--home::before { right: -200px; top: 60px; }
 }
 @media (prefers-color-scheme: dark) {
   html:not([data-theme="light"]) .page.page--home::before { filter: invert(1); opacity: 0.07; }

--- a/index.html
+++ b/index.html
@@ -21,17 +21,19 @@ og_url: https://marbleheaddata.org/
     display: flex;
     flex-direction: column;
     position: relative;
-    overflow: hidden;
   }
   .explore-stage::before {
     content: "";
     position: absolute;
-    top: -40px; right: -200px;
+    top: 40px; right: -360px;
     width: 520px; height: 780px;
     background: url(assets/lighthouse/lighthouse.svg) center / contain no-repeat;
     opacity: 0.05;
     pointer-events: none;
     z-index: 0;
+  }
+  @media (max-width: 600px) {
+    .explore-stage::before { right: -200px; top: 60px; }
   }
   html[data-theme="dark"] .explore-stage::before { filter: invert(1); opacity: 0.07; }
   @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- Desktop: `right: -360px` places the 520px lighthouse mostly in the viewport gutter right of the 920px content, with some bleed behind the questions
- Mobile (<=600px): `right: -200px` pulls it in to roughly the right third of the screen
- Added `overflow-x: hidden` on `body` to prevent horizontal scrollbar
- Removed `overflow: hidden` from `.page--home` and `.explore-stage` so the lighthouse can extend into the gutter

## Test plan
- [ ] Desktop wide viewport: lighthouse visible in right gutter, bleeding slightly behind content
- [ ] Mobile: lighthouse in right third, no horizontal scroll
- [ ] Dark mode: lighthouse still inverts properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)