### PR TITLE
Fullscreen lighthouse watermark fixed to viewport bottom

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -840,16 +840,16 @@ details.notes[open] > summary {
 .page.page--home { position: relative; }
 .page.page--home::before {
   content: "";
-  position: absolute;
-  top: 40px; right: -360px;
-  width: 520px; height: 780px;
+  position: fixed;
+  bottom: -150px; right: 0;
+  width: 840px; height: 1260px;
   background: url(lighthouse/lighthouse.svg) center / contain no-repeat;
   opacity: 0.05;
   pointer-events: none;
   z-index: 0;
 }
 @media (max-width: 600px) {
-  .page.page--home::before { right: -200px; top: 60px; }
+  .page.page--home::before { right: -380px; }
 }
 @media (prefers-color-scheme: dark) {
   html:not([data-theme="light"]) .page.page--home::before { filter: invert(1); opacity: 0.07; }

--- a/index.html
+++ b/index.html
@@ -24,16 +24,16 @@ og_url: https://marbleheaddata.org/
   }
   .explore-stage::before {
     content: "";
-    position: absolute;
-    top: 40px; right: -360px;
-    width: 520px; height: 780px;
+    position: fixed;
+    bottom: -150px; right: 0;
+    width: 840px; height: 1260px;
     background: url(assets/lighthouse/lighthouse.svg) center / contain no-repeat;
     opacity: 0.05;
     pointer-events: none;
     z-index: 0;
   }
   @media (max-width: 600px) {
-    .explore-stage::before { right: -200px; top: 60px; }
+    .explore-stage::before { right: -380px; }
   }
   html[data-theme="dark"] .explore-stage::before { filter: invert(1); opacity: 0.07; }
   @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- Lighthouse is now 840x1260px (was 520x780), nearly full-viewport scale
- `position: fixed` pins it to viewport bottom-right so content scrolls over it without extra scroll height
- `bottom: -150px` lets it extend below the fold naturally
- Desktop: `right: 0` (lighthouse in right gutter, bleeding behind content)
- Mobile (<=600px): `right: -380px` (roughly right third visible)

## Test plan
- [ ] Desktop: lighthouse visible bottom-right, no extra scroll, content readable over it
- [ ] Mobile: right third of lighthouse visible, no horizontal scroll
- [ ] Dark mode: invert filter still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)