### PR TITLE
Ground Q2 trash position cards in the $1.21M break-even

### DIFF
--- a/index.html
+++ b/index.html
@@ -2331,9 +2331,9 @@ og_url: https://marbleheaddata.org/
         <p class="answer-label">Position A</p>
         <h2>Vote yes: the levy scales with home value</h2>
         <p class="answer-summary">
-          A $500K home pays less than a $2M home. The flat fee charges
-          the same $281 whether you're in a cottage or a waterfront
-          estate.
+          If your home is assessed below the ~$1.21M break-even, you
+          save by voting yes. The median home ($1.01M) saves $46/yr;
+          a $500K home saves $165/yr.
         </p>
       </div>
 
@@ -2341,9 +2341,9 @@ og_url: https://marbleheaddata.org/
         <p class="answer-label">Position B</p>
         <h2>Vote no: everyone uses the same service</h2>
         <p class="answer-summary">
-          Every household gets one trash pickup. A flat fee means you
-          pay for what you use. The levy makes high-value homeowners
-          subsidize everyone else's trash.
+          If your home is assessed above the ~$1.21M break-even, you
+          save by voting no. A $2M home saves $184/yr; a $3M home
+          saves $417/yr.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

The Position A / Position B summary cards on the home-page "Why is trash collection on the ballot?" question screen (`index.html:2330-2348`) previously framed the yes/no choice as a philosophical pitch — progressive vs. flat. That left out the thing a voter actually needs to know: does my home sit above or below the ~$1.21M break-even?

It also contained a factual error. Position B claimed a flat fee "means you pay for what you use," but the $281 fee is the same whether a household puts out one bag or five — it is not usage-based. The rest of the site is careful about this; `question-2-trash.html:600` explicitly calls the flat fee regressive.

This PR rewrites both summaries to lead with the concrete self-interest calculation:

- **Position A (Vote yes):** If your home is assessed below the ~$1.21M break-even, you save by voting yes. Median home ($1.01M) saves $46/yr; a $500K home saves $165/yr.
- **Position B (Vote no):** If your home is assessed above the ~$1.21M break-even, you save by voting no. A $2M home saves $184/yr; a $3M home saves $417/yr.

Position C is unchanged — it's about the budget carve-out, which is orthogonal to personal finance.

## Sources

All four dollar figures trace to the Q2 scrolly walkthrough on `question-2-trash.html`:

- `:568` — a $500K home saves $165/yr under the levy
- `:574` — median single-family home ($1.01M) saves $46/yr under the levy
- `:586` — a $2M home saves $184/yr under the flat fee
- `:592` — a $3M home saves $417/yr under the flat fee
- `:580` — break-even point at approximately $1,210,000

## Test plan

- [ ] Load `/` locally and scroll to the "Why is trash collection on the ballot?" question screen
- [ ] Confirm Position A and Position B cards render the new copy without layout regression
- [ ] Confirm Position C is unchanged
- [ ] Confirm the cards still fit in the existing `.answer-card` grid on mobile

https://claude.ai/code/session_01Qv25zgJoLbWXmXR2WcXe93