### PR TITLE
Scroll to top when selecting a question from the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -3564,6 +3564,7 @@ og_url: https://marbleheaddata.org/
 
     btn.addEventListener('click', function () {
       switchTopic(topic);
+      window.scrollTo(0, 0);
     });
     listEl.appendChild(btn);
     landingCards[topic] = { el: btn, pick: pickSpan };

--- a/index.html
+++ b/index.html
@@ -3402,6 +3402,7 @@ og_url: https://marbleheaddata.org/
     dot.title = topicLabels[topic] || topic;
     dot.addEventListener('click', function () {
       switchTopic(topic);
+      window.scrollTo(0, 0);
     });
     dotsEl.appendChild(dot);
   });


### PR DESCRIPTION
## Summary

On mobile, tapping a question card from the landing list kept the existing page scroll position. Users who had scrolled down the card list ended up partway (or at the bottom) of the revealed question screen instead of at its title.

The landing card click handler in `index.html` was the only `switchTopic()` entry point missing a `window.scrollTo(0, 0)` call &mdash; the next/back/related handlers all already do this. Added the matching scroll.

## Test plan

- [ ] On mobile (or a narrow viewport), scroll the homepage question list so the lower cards are in view
- [ ] Tap a lower card and confirm the resulting question screen opens at the top, with the question title visible
- [ ] Regression: confirm the "Next question", "All questions" back button, and related-question links still scroll to top as before