### PR TITLE
Fix browser back button leaving the site from a question page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3416,15 +3416,29 @@ og_url: https://marbleheaddata.org/
     };
   }
 
-  function writeURL(topic, pos) {
+  // When true, writeURL is a no-op. Used during initial load and popstate
+  // handling so that restoring state from the URL doesn't itself create
+  // new history entries.
+  var suppressURLWrite = false;
+
+  function writeURL(topic, pos, replace) {
+    if (suppressURLWrite) return;
+    var newUrl;
     if (!topic) {
-      history.replaceState(null, '', window.location.pathname);
-      return;
+      newUrl = window.location.pathname;
+    } else {
+      var params = new URLSearchParams();
+      params.set('q', topic);
+      if (pos) params.set('pos', pos);
+      newUrl = window.location.pathname + '?' + params.toString();
     }
-    var params = new URLSearchParams();
-    params.set('q', topic);
-    if (pos) params.set('pos', pos);
-    history.replaceState(null, '', window.location.pathname + '?' + params.toString());
+    // No-op if the URL isn't actually changing -- avoids duplicate entries.
+    if (newUrl === window.location.pathname + window.location.search) return;
+    if (replace) {
+      history.replaceState(null, '', newUrl);
+    } else {
+      history.pushState(null, '', newUrl);
+    }
   }
 
   /* ── Update question header elements ── */
@@ -3623,7 +3637,9 @@ og_url: https://marbleheaddata.org/
     });
 
     selections[question] = answer;
-    writeURL(question, answer);
+    // Selecting an answer is an in-place state change on the current topic,
+    // so replace the current history entry rather than pushing a new one.
+    writeURL(question, answer, true);
     persistSelections();
     updateQuestionHeader(question);
 
@@ -3668,7 +3684,7 @@ og_url: https://marbleheaddata.org/
       }
     });
     delete selections[question];
-    writeURL(question, null);
+    writeURL(question, null, true);
     persistSelections();
     updateQuestionHeader(question);
 
@@ -3922,20 +3938,29 @@ og_url: https://marbleheaddata.org/
       updateNotesPanel();
     });
   } else if (initial.topic) {
+    // Restoring from URL: don't create a second history entry for what
+    // the browser is already showing.
+    suppressURLWrite = true;
     switchTopic(initial.topic);
     if (initial.pos) {
       selectAnswer(initial.topic, initial.pos);
     }
+    suppressURLWrite = false;
     updateNotesPill();
   } else {
     // Always show landing -- positions are visible on the cards
+    suppressURLWrite = true;
     showLanding();
+    suppressURLWrite = false;
     updateNotesPill();
   }
 
   // Handle back/forward navigation
   window.addEventListener('popstate', function () {
     var state = readURL();
+    // The browser already moved the history pointer; just sync the UI
+    // without touching history again.
+    suppressURLWrite = true;
     if (state.topic) {
       switchTopic(state.topic);
       if (state.pos) {
@@ -3944,6 +3969,7 @@ og_url: https://marbleheaddata.org/
     } else {
       showLanding();
     }
+    suppressURLWrite = false;
   });
 
 })();


### PR DESCRIPTION
## Summary

Clicking a question card on the homepage and then hitting the browser back button was kicking people off the site instead of returning them to the question grid.

The explore-index SPA in `index.html` was calling `history.replaceState()` for every URL update, so clicking a question overwrote the landing page's history entry rather than pushing a new one. With nothing behind it in history, the browser back button walked right out of the site.

## Fix

- `writeURL()` now uses `pushState` by default and `replaceState` only when an optional `replace` flag is passed.
- Switching topics (`switchTopic`) and returning to the landing grid (`showLanding`) push new history entries, so back/forward walk the topic trail naturally.
- Picking or unpicking an answer within the current topic still uses `replaceState` — it's an in-place state change, not a new page.
- A `suppressURLWrite` guard wraps the initial-load branch and the `popstate` handler so that restoring UI state from the URL doesn't itself push new history entries (which would fight the browser's own history navigation).
- `writeURL()` also no-ops when the target URL equals the current URL, avoiding duplicate entries.

## Test plan

- [ ] Visit `/`, click a question card, hit browser back → lands back on the question grid (not off-site).
- [ ] Visit `/`, click a question, pick an answer, click "Next question", hit back → returns to previous topic with the chosen answer still highlighted.
- [ ] Deep-link to `/?q=levy&pos=yes` → page opens on that topic with the answer selected; history isn't polluted with a duplicate entry.
- [ ] Use "Share your positions" → copied link still opens the shared view; "Start fresh" still clears it.
- [ ] Forward button works after going back from a topic to the landing grid.