### PR TITLE
Fix mycost framing: median context, MOU commitment, FY29 dollars

### DIFF
--- a/index.html
+++ b/index.html
@@ -2279,6 +2279,9 @@ og_url: https://marbleheaddata.org/
         <p class="caption">
           Tiers are nested: Tier 2 includes Tier 1, Tier 3 includes
           both. Your cost scales linearly with your assessed value.
+          Half of Marblehead single-family homes are below the
+          median ($1,010,100), where the tiers cost $928, $1,241,
+          and $1,553 per year.
         </p>
         <a class="evidence-chart-link" href="charts/override_calculator.html">
           Calculate your exact cost
@@ -2299,9 +2302,9 @@ og_url: https://marbleheaddata.org/
             The monthly framing understates the total cost. $165/mo
             is $1,985/year, and because an override permanently
             raises the levy ceiling, that's roughly $19,850 over ten
-            years at the average home value (and growing at 2.5%/yr
-            thereafter). "Monthly" is a reading lens, not a
-            description of the underlying commitment.
+            years at the average home value, in FY29 dollars.
+            "Monthly" is a reading lens, not a description of the
+            underlying commitment.
           </p>
         </div>
       </details>
@@ -2332,6 +2335,29 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="charts/override_calculator.html">
           Calculator with cumulative totals
         </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Three-board commitment on new overrides</h4>
+        <p>
+          On April 8, 2026, the Select Board, School Committee, and
+          Finance Committee began voting on a Memorandum of
+          Understanding. One operative term: if any tier passes, no
+          new general override would appear on the ballot until at
+          least FY30 (July 1, 2029), regardless of which tier voters
+          chose. That is roughly three years after full phase-in.
+        </p>
+        <a class="evidence-chart-link" href="what-is-the-override.html#mou-commitments">
+          Full MOU terms
+        </a>
+        <p class="evidence-caveat">
+          The MOU is a public statement of intent, not a binding
+          contract; a two-thirds vote of all three boards could
+          deviate. It covers general operating overrides only, not
+          debt exclusions. At the April 8, 2026 meeting the School
+          Committee voted 4-0 subject to final numbers; the Select
+          Board deferred pending school approval.
+        </p>
       </div>
 
       <details class="counter-argument">


### PR DESCRIPTION
## Summary

Three small corrections to the "How will this affect my taxes?" question on the homepage, surfaced by a reader who thought the $1,985/yr Tier 3 figure felt high and asked whether the town had committed to a no-override window.

- **mycost-a chart caption**: add a median-home context line. The $1,985 is anchored to the *average* single-family home ($1,291,507), which is skewed upward by a smaller number of high-end properties. Half of Marblehead single-family homes are below the median ($1,010,100), where the tiers cost $928, $1,241, and $1,553 per year. (Source: FY26 tax classification hearing, already cited elsewhere on the site.)
- **mycost-a counter-argument**: remove the misleading `(and growing at 2.5%/yr thereafter)` parenthetical. Prop 2½'s 2.5% cap applies every year, not starting after year ten, so "thereafter" was wrong. Replaced with "in FY29 dollars" to make the denomination explicit without overreaching.
- **mycost-b**: add a new "Three-board commitment on new overrides" evidence point. The April 8, 2026 MOU between the Select Board, School Committee, and FinCom includes an operative term: if any tier passes, no new general override on the ballot until at least FY30. Caveats included inline: non-binding intent, 2/3-of-three-boards could deviate, general overrides only (not debt exclusions), School Committee 4-0 subject to final numbers, Select Board deferred pending school approval. Links to the full MOU terms on `what-is-the-override.html#mou-commitments`.

All three changes are on the homepage's `mycost` question section only. No new data files, no CSS changes, no JS changes.

## Test plan

- [ ] Homepage renders — open `/?q=mycost&pos=a`, confirm chart caption shows the new median sentence on one line and that nothing else in the caption or the SVG shifted
- [ ] Open `/?q=mycost&pos=a`, expand the counter-argument, confirm the "in FY29 dollars" replacement reads cleanly and no orphaned parenthesis remains
- [ ] Open `/?q=mycost&pos=b`, confirm the new "Three-board commitment on new overrides" evidence point renders between "Over 10 years" and the Position C counter-argument, with the italicized `.evidence-caveat` block for the caveats
- [ ] Click "Full MOU terms" link — confirm it jumps to `what-is-the-override.html#mou-commitments`
- [ ] Mobile layout: confirm the extended caption and new evidence point don't overflow on narrow widths
- [ ] Spot-check that no em-dashes or inline SVG styles were introduced (STYLE_GUIDE "What Not To Do")

https://claude.ai/code/session_01UKjBiAhq7vfoBh2UdjqJUp