### PR TITLE
Clarify the position-collection model on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ title: "Marblehead Budget Data"
 body_class: explore-page
 community_pulse: off-sections
 og_title: "Marblehead Budget Data"
-og_description: Pick the question that's on your mind, see the strongest case for each answer, and make your own call.
+og_description: Work through the questions one at a time. See the strongest case for each answer, mark your view, and build up a set of positions you can share.
 og_url: https://marbleheaddata.org/
 ---
 {% include nav.html %}
@@ -833,7 +833,7 @@ og_url: https://marbleheaddata.org/
   <div class="explore-landing">
     <div class="explore-landing-head">
       <h1>Weighing the FY2027 override?</h1>
-      <p>Pick the question on your mind. See the strongest case for each answer. Make your own call.</p>
+      <p>Work through the questions below. For each one, see the strongest case for every answer, then mark your view. Your picks collect into a set of positions you can review or share.</p>
     </div>
     <div class="explore-shared-banner" id="sharedBanner">
       Tap any question to see the evidence behind their pick.
@@ -878,7 +878,7 @@ og_url: https://marbleheaddata.org/
 
       <!-- Answer A -->
       <div class="answer-card" data-answer="a" data-question="override">
-        <p class="answer-label">Position A</p>
+        <p class="answer-label">Answer A</p>
         <h2>Years of underfunding made this inevitable</h2>
         <p class="answer-summary">
           Costs grew faster than revenue for over a decade. Health insurance,
@@ -888,7 +888,7 @@ og_url: https://marbleheaddata.org/
 
       <!-- Answer B -->
       <div class="answer-card" data-answer="b" data-question="override">
-        <p class="answer-label">Position B</p>
+        <p class="answer-label">Answer B</p>
         <h2>There is real waste they could cut first</h2>
         <p class="answer-summary">
           Staffing held steady while enrollment fell 21%, total compensation
@@ -899,7 +899,7 @@ og_url: https://marbleheaddata.org/
 
       <!-- Answer C -->
       <div class="answer-card" data-answer="c" data-question="override">
-        <p class="answer-label">Position C</p>
+        <p class="answer-label">Answer C</p>
         <h2>Both are true, but the gap is too large to close with cuts alone</h2>
         <p class="answer-summary">
           Some spending was avoidable. But even aggressive cuts would not
@@ -999,7 +999,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -1059,7 +1059,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position A would push back</span>
+          <span class="counter-argument-teaser">Answer A would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -1157,7 +1157,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Positions A and B would push back</span>
+          <span class="counter-argument-teaser">Answers A and B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -1190,7 +1190,7 @@ og_url: https://marbleheaddata.org/
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="voteno">
-        <p class="answer-label">Position A</p>
+        <p class="answer-label">Answer A</p>
         <h2>Services get cut, but the town adjusts</h2>
         <p class="answer-summary">
           The no-override budget is painful but balanced. Marblehead has
@@ -1199,7 +1199,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="b" data-question="voteno">
-        <p class="answer-label">Position B</p>
+        <p class="answer-label">Answer B</p>
         <h2>The cuts trigger losses that are hard to reverse</h2>
         <p class="answer-summary">
           Staff leave for higher-paying districts, institutional knowledge
@@ -1209,7 +1209,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="c" data-question="voteno">
-        <p class="answer-label">Position C</p>
+        <p class="answer-label">Answer C</p>
         <h2>Voting no is the only way to force structural reform</h2>
         <p class="answer-summary">
           Approving the override removes the pressure to fix the spending
@@ -1264,7 +1264,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -1328,7 +1328,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position A would push back</span>
+          <span class="counter-argument-teaser">Answer A would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -1424,7 +1424,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -1460,7 +1460,7 @@ og_url: https://marbleheaddata.org/
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="schools">
-        <p class="answer-label">Position A</p>
+        <p class="answer-label">Answer A</p>
         <h2>Yes, staffing should have tracked enrollment down</h2>
         <p class="answer-summary">
           Enrollment fell 21% but FTEs grew. The student-to-staff ratio
@@ -1470,7 +1470,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="b" data-question="schools">
-        <p class="answer-label">Position B</p>
+        <p class="answer-label">Answer B</p>
         <h2>Most of the growth is legally mandated</h2>
         <p class="answer-summary">
           Special education, <abbr class="g" title="English Language Learner">ELL</abbr>, and compliance requirements drove
@@ -1480,7 +1480,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="c" data-question="schools">
-        <p class="answer-label">Position C</p>
+        <p class="answer-label">Answer C</p>
         <h2>The mandates are real, but not every position is mandated</h2>
         <p class="answer-summary">
           <abbr class="g" title="Special Education">SPED</abbr> and <abbr class="g" title="English Language Learner">ELL</abbr> growth are required. Instructional coaches,
@@ -1564,7 +1564,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -1659,7 +1659,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position A would push back</span>
+          <span class="counter-argument-teaser">Answer A would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -1721,7 +1721,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Positions A and B would push back</span>
+          <span class="counter-argument-teaser">Answers A and B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -1756,7 +1756,7 @@ og_url: https://marbleheaddata.org/
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="levy">
-        <p class="answer-label">Position A</p>
+        <p class="answer-label">Answer A</p>
         <h2>The cap was never designed for the cost structure towns face today</h2>
         <p class="answer-summary">
           Health insurance grows 7-11% per year. Pensions grow 9%. A 2.5%
@@ -1765,7 +1765,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="b" data-question="levy">
-        <p class="answer-label">Position B</p>
+        <p class="answer-label">Answer B</p>
         <h2>The cap is the only check on spending growth</h2>
         <p class="answer-summary">
           Without the cap, spending would grow unchecked. The pressure it
@@ -1774,7 +1774,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="c" data-question="levy">
-        <p class="answer-label">Position C</p>
+        <p class="answer-label">Answer C</p>
         <h2>The math is real, but so is the need for reform</h2>
         <p class="answer-summary">
           The structural gap is not the town's fault. But closing it with
@@ -1834,7 +1834,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -1894,7 +1894,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position A would push back</span>
+          <span class="counter-argument-teaser">Answer A would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -1962,7 +1962,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Positions A and B would push back</span>
+          <span class="counter-argument-teaser">Answers A and B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -1973,7 +1973,7 @@ og_url: https://marbleheaddata.org/
             take longer still. If the deficit is now and reform is
             slow, "both" tends to resolve in practice as "override
             now, reform eventually" &ndash; which is the outcome
-            Position A says is required and Position B says repeats
+            Answer A says is required and Answer B says repeats
             the pattern.
           </p>
         </div>
@@ -1998,7 +1998,7 @@ og_url: https://marbleheaddata.org/
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="taxrank">
-        <p class="answer-label">Position A</p>
+        <p class="answer-label">Answer A</p>
         <h2>The rate is what matters, and ours is the lowest</h2>
         <p class="answer-summary">
           At $8.59 per $1,000, Marblehead's tax rate is lower than
@@ -2008,7 +2008,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="b" data-question="taxrank">
-        <p class="answer-label">Position B</p>
+        <p class="answer-label">Answer B</p>
         <h2>The bill is what you pay, and ours is high</h2>
         <p class="answer-summary">
           The median Marblehead tax bill is ~$8,677. That is more than
@@ -2018,7 +2018,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="c" data-question="taxrank">
-        <p class="answer-label">Position C</p>
+        <p class="answer-label">Answer C</p>
         <h2>Per-capita levy is the fairest comparison</h2>
         <p class="answer-summary">
           Total tax collected per resident: Swampscott $4,207, Marblehead
@@ -2085,7 +2085,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -2135,7 +2135,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Positions A and C would push back</span>
+          <span class="counter-argument-teaser">Answers A and C would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -2183,7 +2183,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -2217,7 +2217,7 @@ og_url: https://marbleheaddata.org/
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="mycost">
-        <p class="answer-label">Position A</p>
+        <p class="answer-label">Answer A</p>
         <h2>At the average home value, Tier 3 adds ~$166/month at full phase-in</h2>
         <p class="answer-summary">
           The average assessed value in Marblehead is $1,291,507.
@@ -2227,7 +2227,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="b" data-question="mycost">
-        <p class="answer-label">Position B</p>
+        <p class="answer-label">Answer B</p>
         <h2>It compounds: $20K-$24K over ten years</h2>
         <p class="answer-summary">
           An override permanently raises the levy. Tier 3 at the average
@@ -2237,7 +2237,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="c" data-question="mycost">
-        <p class="answer-label">Position C</p>
+        <p class="answer-label">Answer C</p>
         <h2>Compare it to what you lose without it</h2>
         <p class="answer-summary">
           The no-override budget cuts 22 town positions, 18.25 school
@@ -2292,7 +2292,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -2337,7 +2337,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position C would push back</span>
+          <span class="counter-argument-teaser">Answer C would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -2388,7 +2388,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -2421,7 +2421,7 @@ og_url: https://marbleheaddata.org/
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="again">
-        <p class="answer-label">Position A</p>
+        <p class="answer-label">Answer A</p>
         <h2>The override is sized to last several years</h2>
         <p class="answer-summary">
           The three tiers were designed as a multi-year correction.
@@ -2431,7 +2431,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="b" data-question="again">
-        <p class="answer-label">Position B</p>
+        <p class="answer-label">Answer B</p>
         <h2>The math says we will</h2>
         <p class="answer-summary">
           Health insurance and pensions don't stop growing when the
@@ -2441,7 +2441,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="c" data-question="again">
-        <p class="answer-label">Position C</p>
+        <p class="answer-label">Answer C</p>
         <h2>It depends on whether reform happens during the breathing room</h2>
         <p class="answer-summary">
           The override buys time. Whether that time gets used for
@@ -2487,7 +2487,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -2566,7 +2566,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Positions A and C would push back</span>
+          <span class="counter-argument-teaser">Answers A and C would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -2616,7 +2616,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -2628,7 +2628,7 @@ og_url: https://marbleheaddata.org/
             review has to be requested. Budget-format changes need
             someone inside the process to prioritize them. Betting on
             reform after an override is betting that politics does
-            something it hasn't yet, which is exactly what Position B
+            something it hasn't yet, which is exactly what Answer B
             says cannot be counted on.
           </p>
         </div>
@@ -2652,7 +2652,7 @@ og_url: https://marbleheaddata.org/
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="alternatives">
-        <p class="answer-label">Position A</p>
+        <p class="answer-label">Answer A</p>
         <h2>There are no short-term alternatives that close an $8.47M gap</h2>
         <p class="answer-summary">
           The levers other towns use (commercial tax base, state aid,
@@ -2662,7 +2662,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="b" data-question="alternatives">
-        <p class="answer-label">Position B</p>
+        <p class="answer-label">Answer B</p>
         <h2>There are alternatives the town has chosen not to pursue</h2>
         <p class="answer-summary">
           Benefits reform, economic development, and budget
@@ -2673,7 +2673,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="c" data-question="alternatives">
-        <p class="answer-label">Position C</p>
+        <p class="answer-label">Answer C</p>
         <h2>12-week alternatives don't exist, but 5-year ones do</h2>
         <p class="answer-summary">
           Nothing closes $8.47M by June. But the override should come
@@ -2725,7 +2725,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -2790,7 +2790,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position A would push back</span>
+          <span class="counter-argument-teaser">Answer A would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -2841,7 +2841,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -2875,7 +2875,7 @@ og_url: https://marbleheaddata.org/
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="trash">
-        <p class="answer-label">Position A</p>
+        <p class="answer-label">Answer A</p>
         <h2>Vote yes: the levy scales with home value</h2>
         <p class="answer-summary">
           If your home is assessed below the ~$1.21M break-even, you
@@ -2885,7 +2885,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="b" data-question="trash">
-        <p class="answer-label">Position B</p>
+        <p class="answer-label">Answer B</p>
         <h2>Vote no: everyone uses the same service</h2>
         <p class="answer-summary">
           If your home is assessed above the ~$1.21M break-even, you
@@ -2895,7 +2895,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="c" data-question="trash">
-        <p class="answer-label">Position C</p>
+        <p class="answer-label">Answer C</p>
         <h2>The real question is what happened to the money</h2>
         <p class="answer-summary">
           Trash was already in the budget. The Select Board carved it
@@ -2936,7 +2936,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -2990,7 +2990,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position A would push back</span>
+          <span class="counter-argument-teaser">Answer A would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -3049,7 +3049,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Positions A and B would push back</span>
+          <span class="counter-argument-teaser">Answers A and B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -3089,7 +3089,7 @@ og_url: https://marbleheaddata.org/
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="trust">
-        <p class="answer-label">Position A</p>
+        <p class="answer-label">Answer A</p>
         <h2>The system has real checks and transparency</h2>
         <p class="answer-summary">
           Elected boards, public meetings, independent audits, state
@@ -3099,7 +3099,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="b" data-question="trust">
-        <p class="answer-label">Position B</p>
+        <p class="answer-label">Answer B</p>
         <h2>Transparency exists on paper but not in practice</h2>
         <p class="answer-summary">
           Meetings are poorly attended, budgets are presented as
@@ -3109,7 +3109,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="answer-card" data-answer="c" data-question="trust">
-        <p class="answer-label">Position C</p>
+        <p class="answer-label">Answer C</p>
         <h2>Trust is earned by showing the work, not asking for faith</h2>
         <p class="answer-summary">
           The question is not whether officials are honest but whether
@@ -3166,7 +3166,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position B would push back</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -3226,7 +3226,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Position A would push back</span>
+          <span class="counter-argument-teaser">Answer A would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -3286,7 +3286,7 @@ og_url: https://marbleheaddata.org/
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Positions A and B would push back</span>
+          <span class="counter-argument-teaser">Answers A and B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
@@ -3365,7 +3365,7 @@ og_url: https://marbleheaddata.org/
 
     var hint = document.createElement('span');
     hint.className = 'answer-hint';
-    hint.textContent = 'See the data \u2192';
+    hint.textContent = 'Pick this answer \u2192';
     card.appendChild(hint);
   });
 
@@ -3925,7 +3925,7 @@ og_url: https://marbleheaddata.org/
       Object.keys(selections).forEach(function (k) { delete selections[k]; });
       isSharedView = false;
       if (headingEl) headingEl.textContent = 'Weighing the FY2027 override?';
-      if (subEl) subEl.textContent = 'Pick the question on your mind. See the strongest case for each answer. Make your own call.';
+      if (subEl) subEl.textContent = 'Work through the questions below. For each one, see the strongest case for every answer, then mark your view. Your picks collect into a set of positions you can review or share.';
       sharedBanner.classList.remove('visible');
       document.querySelector('.explore-landing').classList.remove('shared-mode');
       if (shareStripEl) shareStripEl.style.display = '';


### PR DESCRIPTION
## Summary

User feedback on the new homepage flow: *"I find the position taking model a bit hard to grok. Might just be that the caffeine hasn't kicked in yet but it took me a while to understand that I could 'collect' positions by topic."*

Root cause: the word "position" was overloaded. Every answer card was labeled `Position A/B/C` while the collection pill was called `My positions`, so picking an answer didn't read as adding to a set. The landing copy also framed the flow as a single-question pick rather than a multi-topic walkthrough.

## Changes

- **Landing subhead** now explicitly describes the collect-by-topic flow and tells the reader their picks accumulate into a shareable set of positions, instead of "Pick the question on your mind. See the strongest case for each answer. Make your own call." (which implied a single pick).
- **Answer card labels** renamed `Position A/B/C` to `Answer A/B/C` (and counter-argument teasers updated to match, e.g. "Answer B would push back") so "position" unambiguously refers to the collected view, not a single option on one question.
- **Card hint text** changed from "See the data" to "Pick this answer" so the commit action is explicit rather than a side effect of browsing the evidence.
- `og_description` and the "Start fresh" reset path updated so link previews and shared-mode reset land on the same reframed copy.

No JS behavior changes, no CSS changes. Pure copy and label work, same styling hooks (`.answer-label`, `.counter-argument-teaser`, `.answer-hint`).

## Test plan

- [ ] Homepage landing renders the new subhead and the question list still builds from question `<h1>`s.
- [ ] Clicking an answer card still selects it, opens the evidence panel, updates the "My positions" pill count, and marks the landing card as picked.
- [ ] Counter-argument details on each evidence panel still open and read naturally with "Answer X would push back".
- [ ] Loading a `?positions=...` shared URL swaps the heading to "Someone shared their positions" and the "Start fresh" button restores the new subhead (not the old one).
- [ ] Link previews / `og_description` reflect the new copy.