### PR TITLE
Spell out Tier 1/2/3, single-family, and assessed value on rate pages

### DIFF
--- a/charts/four_town_rates.html
+++ b/charts/four_town_rates.html
@@ -103,9 +103,9 @@ title: "Rate and Bill Comparison"
       <rect x="540" y="30" width="200" height="108" rx="6" fill="var(--surface)" fill-opacity="0.95" stroke="var(--border)" stroke-width="0.75"/>
       <text class="annotation" x="552" y="48" font-weight="700" fill="var(--text-muted)">FY28 projections</text>
       <text class="annotation" x="552" y="62" fill="var(--text-subtle)" font-size="9">2.5% levy growth, assessed values constant</text>
-      <text class="end-label s-marblehead" x="552" y="80">Marblehead T1 ($9M): $9.46</text>
-      <text class="end-label s-marblehead" x="552" y="96">Marblehead T2 ($12M): $9.76</text>
-      <text class="end-label s-marblehead" x="552" y="112">Marblehead T3 ($15M): $10.06</text>
+      <text class="end-label s-marblehead" x="552" y="80">Tier 1 ($9M): $9.46</text>
+      <text class="end-label s-marblehead" x="552" y="96">Tier 2 ($12M): $9.76</text>
+      <text class="end-label s-marblehead" x="552" y="112">Tier 3 ($15M): $10.06</text>
       <text class="annotation" x="552" y="130" fill="var(--text-subtle)" font-size="9">Stoneham incl. $9.3M override (FY27)</text>
     </svg>
   </div>
@@ -163,9 +163,9 @@ title: "Rate and Bill Comparison"
       <!-- FY28 projection callout -->
       <rect x="656" y="-18" width="172" height="118" rx="6" fill="var(--surface)" fill-opacity="0.95" stroke="var(--border)" stroke-width="0.75"/>
       <text class="annotation" x="666" y="-2" font-weight="700" fill="var(--text-muted)">FY28 projected bills</text>
-      <text class="end-label s-marblehead" x="666" y="14">T3 ($15M): $12,991</text>
-      <text class="end-label s-marblehead" x="666" y="28">T2 ($12M): $12,604</text>
-      <text class="end-label s-marblehead" x="666" y="42">T1 ($9M): $12,217</text>
+      <text class="end-label s-marblehead" x="666" y="14">Tier 3 ($15M): $12,991</text>
+      <text class="end-label s-marblehead" x="666" y="28">Tier 2 ($12M): $12,604</text>
+      <text class="end-label s-marblehead" x="666" y="42">Tier 1 ($9M): $12,217</text>
       <text class="end-label s-swampscott" x="666" y="60">Swampscott: $12,061</text>
       <text class="end-label s-melrose"    x="666" y="76">Melrose: $10,282</text>
       <text class="end-label s-stoneham"   x="666" y="92">Stoneham: $9,542</text>
@@ -195,7 +195,7 @@ title: "Rate and Bill Comparison"
       <rect x="200" y="97"  width="80" height="183" class="data-bar s-melrose"/>
       <rect x="310" y="102" width="80" height="178" class="data-bar s-stoneham"/>
       <rect x="420" y="127" width="80" height="153" class="data-bar s-marblehead"/>
-      <!-- Marblehead override range (T1-T3: 6.7%-7.1%) -->
+      <!-- Marblehead override range (Tier 1-3: 6.7%-7.1%) -->
       <rect x="420" y="102" width="80" height="25" fill="var(--series-marblehead)" fill-opacity="0.15" stroke="var(--series-marblehead)" stroke-width="1" stroke-dasharray="4 2"/>
       <!-- Value labels -->
       <text class="value-label s-swampscott" x="130" y="59" text-anchor="middle">8.5%</text>
@@ -203,7 +203,7 @@ title: "Rate and Bill Comparison"
       <text class="value-label s-stoneham"   x="350" y="94" text-anchor="middle">7.1%</text>
       <text class="value-label s-marblehead" x="460" y="119" text-anchor="middle">6.1%</text>
       <!-- Override range annotation -->
-      <text class="annotation" x="506" y="110" font-size="10" fill="var(--series-marblehead)">T1-T3:</text>
+      <text class="annotation" x="506" y="110" font-size="10" fill="var(--series-marblehead)">Tier 1-3:</text>
       <text class="annotation" x="506" y="122" font-size="10" fill="var(--series-marblehead)">6.7-7.1%</text>
       <!-- Town labels -->
       <text class="tick-label" x="130" y="298" text-anchor="middle">Swampscott</text>
@@ -227,7 +227,7 @@ title: "Rate and Bill Comparison"
     <dd><strong>Undertaxed:</strong> Most room to raise; even at Tier 3, still lowest of the group.</dd>
     <dd><strong>Paying enough:</strong> Rate is mechanically low because home values are high, not because the town chose to tax less.</dd>
 
-    <dt>Avg SF bill: $11,055, 2nd highest</dt>
+    <dt>Average single-family bill: $11,055, 2nd highest</dt>
     <dd><strong>Undertaxed:</strong> Bill tracks wealth, not tax effort; Swampscott pays more on lower incomes.</dd>
     <dd><strong>Paying enough:</strong> Residents already pay more than Melrose and Stoneham; any override makes Marblehead the highest.</dd>
 
@@ -249,9 +249,9 @@ title: "Rate and Bill Comparison"
   <details class="notes">
     <summary>Sources and methodology</summary>
     <p>Rate chart: MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr>, Tax Rates by Class FY2003&ndash;FY2026. Bill chart: <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr>, "Average Single Family Tax Bill" report, FY2006&ndash;FY2026. All four towns use split tax rates except Marblehead, which uses a single rate.</p>
-    <p><strong>FY2028 projections.</strong> Dashed lines assume 2.5% annual levy growth (Proposition 2&frac12; ceiling) and assessed values held constant at FY2026 levels. Actual rates will differ due to new growth, value changes, and debt exclusions. Melrose FY26 includes its $13.5M override (November 2025). Stoneham's $9.3M override (December 2025) is in FY28 projections but not FY26 actuals. Marblehead tiers: rate + (override / $9.89B AV). T1 ~$9.46, T2 ~$9.76, T3 ~$10.06. Bills: ~$12,217, ~$12,604, ~$12,991.</p>
+    <p><strong>FY2028 projections.</strong> Dashed lines assume 2.5% annual levy growth (Proposition 2&frac12; ceiling) and assessed values held constant at FY2026 levels. Actual rates will differ due to new growth, value changes, and debt exclusions. Melrose FY26 includes its $13.5M override (November 2025). Stoneham's $9.3M override (December 2025) is in FY28 projections but not FY26 actuals. Marblehead tiers: rate + (override / $9.89B assessed value). Tier 1 ~$9.46, Tier 2 ~$9.76, Tier 3 ~$10.06. Bills: ~$12,217, ~$12,604, ~$12,991.</p>
     <p><strong>Income data (two sources).</strong> (1) <abbr class="g" title="American Community Survey">ACS</abbr> 2020&ndash;2024 5-year estimates (table B19013), 2024 dollars. Marblehead $182,132 (&plusmn;$27,872), Swampscott $134,386 (&plusmn;$22,662), Melrose $133,953 (&plusmn;$14,410), Stoneham $113,964 (&plusmn;$10,253). (2) <abbr class="g" title="Department of Revenue">DOR</abbr> per-capita income FY2027 (<a href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=dor_income_eqv_per_capita">Municipal Databank</a>): Marblehead $115,422 (20th of 351), Swampscott $76,071 (64th), Melrose $69,170 (85th), Stoneham $58,058 (115th). Full dataset: <a href="/data/dor_per_capita_income_FY27.csv">dor_per_capita_income_FY27.csv</a>.</p>
-    <p><strong>On the income metric.</strong> Bill / income divides the <abbr class="g" title="Department of Revenue">DOR</abbr> average SF bill by the <abbr class="g" title="American Community Survey">ACS</abbr> median household income. The bill describes homeowners; the income describes all households including renters. The ratio is useful for relative comparisons across towns (same methodology) but is not a precise measure of any individual homeowner's burden.</p>
+    <p><strong>On the income metric.</strong> Bill / income divides the <abbr class="g" title="Department of Revenue">DOR</abbr> average single-family bill by the <abbr class="g" title="American Community Survey">ACS</abbr> median household income. The bill describes homeowners; the income describes all households including renters. The ratio is useful for relative comparisons across towns (same methodology) but is not a precise measure of any individual homeowner's burden.</p>
   </details>
 
   <div class="read-next">

--- a/charts/rate_value_schools.html
+++ b/charts/rate_value_schools.html
@@ -122,8 +122,8 @@ title: "Rate, Value, and What You Get"
         <th>Town</th>
         <th>FY26 Rate</th>
         <th>Median Home</th>
-        <th>Avg SF Bill</th>
-        <th>Res. Share</th>
+        <th>Avg. single-family bill</th>
+        <th>Residential share</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## Summary

The four-town rates page had unexplained abbreviations that had no reason to be abbreviations:

- **`charts/four_town_rates.html`**
  - Both FY28 projection callouts used `T1`/`T2`/`T3`, while the page captions already say "Tier 3" in prose &ndash; now consistently "Tier 1/2/3" everywhere (SVG callouts, bar-chart annotation, notes)
  - "Avg SF bill: $11,055, 2nd highest" in the **Reading the data** heading &rarr; "Average single-family bill: ..." (the H2 right above it already says "Average single-family tax bill")
  - Notes: `$9.89B AV` &rarr; `$9.89B assessed value`; `average SF bill` &rarr; `average single-family bill`
- **`charts/rate_value_schools.html`** (directly linked as "Read next" from the rates page, same table uses the same data)
  - `Avg SF Bill` column header &rarr; `Avg. single-family bill`
  - `Res. Share` column header &rarr; `Residential share`

Everyday acronyms on the allowlist in `STYLE_GUIDE.md` (FY, MA) are left alone, and the municipal-finance acronyms that were already wrapped in `<abbr class="g">` (ACS, DOR, DLS) are untouched.

## Test plan

- [ ] Load `/charts/four_town_rates.html` and verify the FY28 projection callout on the rate chart still fits inside the rounded-rect background (the longest label is now "Tier 3 ($15M): $10.06")
- [ ] Verify the FY28 projection callout on the bill chart fits ("Tier 3 ($15M): $12,991")
- [ ] Verify the "Tier 1-3: 6.7-7.1%" annotation on the bar chart doesn't collide with the chart edge
- [ ] Load `/charts/rate_value_schools.html` and verify the comparison table header row still lays out cleanly on desktop and mobile
- [ ] Skim both pages for any remaining `T1`/`T2`/`T3`/`SF`/`AV` usage I missed

https://claude.ai/code/session_0182UD27ucmNb2YhVzLtBrCD