### PR TITLE
Reframe two-vote messaging to be neutral on override outcome

### DIFF
--- a/index.html
+++ b/index.html
@@ -917,21 +917,21 @@ og_url: https://marbleheaddata.org/
 
     <!-- Procedural strip: explains the two-step voting process. Both votes have to pass. -->
     <div class="votes-strip">
-      <p class="votes-strip-label">You'll vote on this twice</p>
+      <p class="votes-strip-label">Two votes. Both have to pass.</p>
       <div class="votes-strip-steps">
         <div class="votes-strip-step">
           <div class="votes-strip-step-when">Mon, May 4</div>
           <div class="votes-strip-step-what">Annual Town Meeting</div>
-          <p class="votes-strip-step-desc">Residents vote yes or no on sending the override to the ballot as three tiers, ceiling $15M.</p>
+          <p class="votes-strip-step-desc">Residents vote yes or no on sending the override to the ballot as three tiers, ceiling $15M. A no ends the override here.</p>
         </div>
         <div class="votes-strip-arrow" aria-hidden="true">&rarr;</div>
         <div class="votes-strip-step">
           <div class="votes-strip-step-when">Tue, Jun 9</div>
           <div class="votes-strip-step-what">Annual Town Election</div>
-          <p class="votes-strip-step-desc">Voters pick the tier at the ballot. The highest tier with a majority sets the amount.</p>
+          <p class="votes-strip-step-desc">If Town Meeting sends it forward, voters pick the tier at the ballot. The highest tier with a majority sets the amount.</p>
         </div>
       </div>
-      <p class="votes-strip-note">Both votes have to pass for any tier to take effect. <a class="votes-strip-link" href="what-you-can-do.html#your-two-votes">How the two votes work together &rarr;</a></p>
+      <p class="votes-strip-note">Either vote can end the override. <a class="votes-strip-link" href="what-you-can-do.html#your-two-votes">How the two votes work together &rarr;</a></p>
     </div>
 
     <div class="explore-shared-banner" id="sharedBanner">

--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -234,7 +234,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
 <div class="tldr">
   <p class="tldr-label">The short version</p>
   <ul>
-    <li><strong>You'll vote twice.</strong> Annual Town Meeting on May 4 authorizes the ballot question. The June 9 ballot picks the tier. Both have to pass. See <a href="#your-two-votes">your two votes</a> below.</li>
+    <li><strong>Two votes, both have to pass.</strong> Annual Town Meeting on May 4 decides whether the override goes to the ballot. The June 9 ballot picks the tier. A no at either vote ends the override. See <a href="#your-two-votes">the two votes</a> below.</li>
     <li><strong>Town Meeting is the lever</strong> for the overall size of the town budget. The Select Board handles operations and policy. The Finance Committee reviews and recommends. The School Committee sets priorities within the school budget.</li>
     <li><strong>Two reform ideas with precedent elsewhere:</strong> a state <abbr class="g" title="Division of Local Services">DLS</abbr> Financial Management Review (free, independent, requested by the Select Board) and more detailed department-level budget reporting (a format choice, no warrant article needed).</li>
     <li><strong>Every body listed below is public.</strong> Meetings are hybrid. Agendas are posted on the <a href="https://marbleheadma.gov/">town calendar</a> at least 48 hours ahead.</li>
@@ -243,7 +243,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
 
 <nav class="page-toc" aria-label="On this page">
   <span class="page-toc-label">On this page</span>
-  <a href="#your-two-votes">Your two votes</a>
+  <a href="#your-two-votes">The two votes</a>
   <a href="#pick-your-goal">Pick your goal</a>
   <a href="#better-oversight">Better oversight</a>
   <a href="#who-decides-what">Who decides what</a>
@@ -252,8 +252,8 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
   <a href="#petitioning-an-article">Petitioning an article</a>
 </nav>
 
-<h2 id="your-two-votes">Your two votes</h2>
-<p>The override on this year's warrant goes through two separate votes in sequence. The first is at Annual Town Meeting, where residents authorize the Select Board to put the override on the June ballot. The second is at the ballot, where voters pick the tier. If either vote fails, the override does not take effect.</p>
+<h2 id="your-two-votes">The two votes</h2>
+<p>The override on this year's warrant has to clear two separate votes to take effect. The first is at Annual Town Meeting, where residents decide whether to send the override to the ballot at all. If Town Meeting votes no, there is no second vote on this question and the no-override budget takes effect. If Town Meeting votes yes, the override moves to the June ballot, where voters pick the tier. A no at either vote ends the override.</p>
 
 <div class="vote-steps">
   <div class="vote-step">


### PR DESCRIPTION
## Summary

Recovers an orphaned commit I pushed to the merged `claude/civic-duty-override-research-OZBWL` branch after #321 was already merged. My mistake — I skipped the `git log origin/main..HEAD` staleness check that CLAUDE.md explicitly warns about.

The content of this PR is the neutrality reframing of the two-vote strip that came up in conversation after #321 merged. The original "You'll vote on this twice" / "Voters pick the tier at the ballot" language implicitly assumes Town Meeting passes the override to the ballot, which is the pro-override expected path. If Town Meeting rejects it, residents vote once and the override is done. This PR treats both votes as gates the override has to clear rather than as an experience the reader will definitely have.

### Changes

- **`index.html`** — homepage explore strip:
  - Label: "You'll vote on this twice" → "Two votes. Both have to pass."
  - Step 1 desc: adds "A no ends the override here."
  - Step 2 desc: prefixed with "If Town Meeting sends it forward,"
  - Note: "Both votes have to pass for any tier to take effect." → "Either vote can end the override."
- **`what-you-can-do.html`**:
  - TL;DR first bullet: "You'll vote twice." → "Two votes, both have to pass." + "A no at either vote ends the override."
  - Section H2: "Your two votes" → "The two votes" (anchor ID `#your-two-votes` kept for link stability, including the strip link from index.html)
  - Section intro paragraph: rewritten to explicitly describe the Town Meeting "no" path (no second vote, no-override budget takes effect) alongside the "yes" path.

### Editorial stance

Neutral. The fix is specifically *about* neutrality — avoiding language that implicitly assumes the override clears Town Meeting. "Either vote can end the override" is symmetric between pro- and anti-override readers.

## Test plan

- [ ] Load the homepage and confirm the strip label reads "Two votes. Both have to pass." and step 2 is prefixed with "If Town Meeting sends it forward,"
- [ ] Load `what-you-can-do.html` and confirm the H2 reads "The two votes" and the TL;DR first bullet matches
- [ ] Confirm the strip link from `index.html` still resolves to `#your-two-votes` (the ID was intentionally kept)

https://claude.ai/code/session_01D44eyweFwkbnB6eVHwHdWd