### PR TITLE
Make picked question cards unmistakable on the landing

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@ og_url: https://marbleheaddata.org/
   }
   .explore-question-card {
     display: block;
+    position: relative;
     background: var(--surface);
     border: 1.5px solid var(--border);
     border-radius: var(--radius-md);
@@ -95,14 +96,43 @@ og_url: https://marbleheaddata.org/
   }
   .explore-question-card.has-pick {
     border-color: var(--c-teal);
+    background: color-mix(in srgb, var(--c-teal) 7%, var(--surface));
+  }
+  .explore-question-card.has-pick::after {
+    content: "\2713";
+    position: absolute;
+    top: -10px;
+    right: -10px;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: var(--c-teal);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    font-weight: 700;
+    box-shadow: var(--shadow-sm);
+    border: 2px solid var(--bg);
   }
   .explore-card-pick {
     display: block;
     font-size: 13px;
-    font-weight: 400;
+    font-weight: 500;
     color: var(--c-teal);
-    margin-top: 4px;
+    margin-top: 6px;
     line-height: 1.4;
+  }
+  .explore-question-card.has-pick .explore-card-pick::before {
+    content: "Your view";
+    display: block;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-subtle);
+    margin-bottom: 2px;
   }
 
   /* Share strip on landing */
@@ -160,9 +190,8 @@ og_url: https://marbleheaddata.org/
     padding: 4px 0 0;
   }
   .explore-shared-fresh:hover { text-decoration: underline; }
-  .shared-mode .explore-card-pick::before {
-    content: "Their view: ";
-    font-weight: 600;
+  .shared-mode .explore-question-card.has-pick .explore-card-pick::before {
+    content: "Their view";
   }
 
   /* Hide landing once a topic is active */


### PR DESCRIPTION
## Summary

Follow-up to #322. User feedback: *"its not super clear that you've chosen 1 of 3 positions imo"* — on the homepage list of questions, a picked card only got a 1.5px border color change and a small teal line of text below the question. That reads as a caption, not "your view," so the committed state is barely distinguishable from unpicked siblings at a glance.

## Changes

`has-pick` now stacks four reinforcing cues on landing question cards:

1. **Background tint** — `color-mix(in srgb, var(--c-teal) 7%, var(--surface))` so the card visibly separates from unpicked siblings instead of only differing by a thin border.
2. **Teal border** — unchanged, kept for consistency with the selected-card state inside a topic.
3. **Check badge** — a 26px circular teal `✓` pinned at `top: -10px; right: -10px` with a background-colored `border: 2px solid var(--bg)` so it reads as a sticker layered on top of the card. No layout shift on unpicked cards because it's absolutely positioned.
4. **"YOUR VIEW" overline** — a small uppercase label added via `.has-pick .explore-card-pick::before` so the teal line below is unambiguously the user's chosen answer, not a card subtitle.

Shared-mode override is preserved: `.shared-mode .explore-question-card.has-pick .explore-card-pick::before` swaps the overline to `Their view` so someone arriving on a `?positions=...` shared URL sees "THEIR VIEW" instead of "YOUR VIEW".

## Test plan

- [ ] Pick an answer on any topic, return to the landing. The corresponding question card should have a tinted background, teal border, check badge in the top-right corner, and a "YOUR VIEW" overline above the answer text.
- [ ] Unpicked cards should be unchanged.
- [ ] Load a `?positions=override:a,schools:c` shared URL. The overline on each picked card should read "THEIR VIEW" and the heading should say "Someone shared their positions".
- [ ] Click "Start fresh with your own answers" in shared mode — picks clear and the cards return to unpicked state.
- [ ] Check mobile: the check badge should still sit cleanly on the corner without being clipped.