### PR TITLE
Drop directional "both have to pass" framing on the two-vote strip

### DIFF
--- a/index.html
+++ b/index.html
@@ -944,9 +944,9 @@ og_url: https://marbleheaddata.org/
       <p>Work through the questions below. For each one, see the strongest case for every answer, then mark your view. Your picks collect into a set of positions you can review or share.</p>
     </div>
 
-    <!-- Procedural strip: explains the two-step voting process. Both votes have to pass. -->
+    <!-- Procedural strip: explains the two-step voting process. Either vote can end the override. -->
     <div class="votes-strip">
-      <p class="votes-strip-label">Two votes. Both have to pass.</p>
+      <p class="votes-strip-label">Two votes decide the override</p>
       <div class="votes-strip-steps">
         <div class="votes-strip-step">
           <div class="votes-strip-step-when">Mon, May 4</div>

--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -227,14 +227,14 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
 
 <h1>What can you do?</h1>
 
-<p>This year's override needs to pass <strong>two separate votes</strong>: one at Annual Town Meeting on May 4, and one at the ballot on June 9. Both have to pass for any tier to take effect. The first section below walks through those two votes. Structural reforms that could affect future budgets are real, but they are slow, and none of them change what is on this year's ballot. Everything else is about influencing what comes next.</p>
+<p>This year's override goes through <strong>two separate votes</strong>: one at Annual Town Meeting on May 4, and one at the ballot on June 9. Either vote can end it. The first section below walks through how those two votes work. Structural reforms that could affect future budgets are real, but they are slow, and none of them change what is on this year's ballot. Everything else is about influencing what comes next.</p>
 
 <p>Still deciding how to vote? See <a href="what-is-the-override.html">what is the override</a> and <a href="no-override-budget.html">what is in the no-override budget</a>.</p>
 
 <div class="tldr">
   <p class="tldr-label">The short version</p>
   <ul>
-    <li><strong>Two votes, both have to pass.</strong> Annual Town Meeting on May 4 decides whether the override goes to the ballot. The June 9 ballot picks the tier. A no at either vote ends the override. See <a href="#your-two-votes">the two votes</a> below.</li>
+    <li><strong>Two votes decide the override.</strong> Annual Town Meeting on May 4 decides whether it goes to the ballot. The June 9 ballot picks the tier. Either vote can end the override. See <a href="#your-two-votes">the two votes</a> below.</li>
     <li><strong>Town Meeting is the lever</strong> for the overall size of the town budget. The Select Board handles operations and policy. The Finance Committee reviews and recommends. The School Committee sets priorities within the school budget.</li>
     <li><strong>Two reform ideas with precedent elsewhere:</strong> a state <abbr class="g" title="Division of Local Services">DLS</abbr> Financial Management Review (free, independent, requested by the Select Board) and more detailed department-level budget reporting (a format choice, no warrant article needed).</li>
     <li><strong>Every body listed below is public.</strong> Meetings are hybrid. Agendas are posted on the <a href="https://marbleheadma.gov/">town calendar</a> at least 48 hours ahead.</li>
@@ -253,7 +253,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
 </nav>
 
 <h2 id="your-two-votes">The two votes</h2>
-<p>The override on this year's warrant has to clear two separate votes to take effect. The first is at Annual Town Meeting, where residents decide whether to send the override to the ballot at all. If Town Meeting votes no, there is no second vote on this question and the no-override budget takes effect. If Town Meeting votes yes, the override moves to the June ballot, where voters pick the tier. A no at either vote ends the override.</p>
+<p>The override on this year's warrant faces two separate votes. The first is at Annual Town Meeting, where residents decide whether to send the override to the ballot at all. If Town Meeting votes no, there is no second vote on this question and the no-override budget takes effect. If Town Meeting votes yes, the override moves to the June ballot, where voters pick the tier. A no at either vote ends the override.</p>
 
 <div class="vote-steps">
   <div class="vote-step">


### PR DESCRIPTION
## Summary

You pointed out that "Two votes. Both have to pass." is still directionally pro-override — "have to pass" only reads as a requirement if you assume override passage is the reader's goal. An anti-override reader doesn't need both votes to pass; they just need one to fail. Same issue with "needs to pass" and "has to clear" elsewhere in the same content.

This PR replaces the directional framing with language that's symmetric between readers.

### Changes

- **`index.html`** — homepage explore strip:
  - Label: "Two votes. Both have to pass." → "Two votes decide the override"
- **`what-you-can-do.html`**:
  - Intro paragraph: "needs to pass two separate votes... Both have to pass for any tier to take effect" → "goes through two separate votes... Either vote can end it"
  - TL;DR first bullet: "Two votes, both have to pass" → "Two votes decide the override... Either vote can end the override"
  - Section intro (under `#your-two-votes`): "has to clear two separate votes to take effect" → "faces two separate votes"

"Decide" and "faces" are directionally neutral — they don't imply a preferred outcome. "Either can end" is symmetric: both pro- and anti-override readers get the same fact from it.

### Editorial stance

This is the neutrality fix I should have made in #324 but didn't catch all the way through. The takeaway block on the 2023 precedent ("Clearing one bar does not mean the override passes") is untouched — that one is factual narration of what happened in 2023, not a directional framing of the reader's preferred outcome.

## Test plan

- [ ] Load the homepage and confirm the strip label reads "Two votes decide the override"
- [ ] Load `what-you-can-do.html` and confirm the TL;DR bullet, intro paragraph, and section intro all read with the new neutral framing
- [ ] No "both have to pass" / "needs to pass" / "has to clear" language remains in either file (verified via grep)

https://claude.ai/code/session_01D44eyweFwkbnB6eVHwHdWd