### PR TITLE
Add "What else is on the June 9 ballot?" page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,20 @@ When styling doc-page markdown content, always scope selectors with
 `body.doc-page .page` so bespoke HTML pages that already use `.page` with
 their own `.tier-list`, `.tldr ul`, etc. are not affected.
 
+## Don't read your own branch name back as user intent
+
+You (Claude) usually pick the branch name for a new task, often before the
+user has said anything beyond a question. That means the branch name
+reflects *your* early interpretation, not the user's stated request. Don't
+then turn around mid-conversation and cite the branch name as evidence of
+what the user wants ("the branch is called `claude/add-ballot-info-XXXX`
+so I assume you want a ballot info page added"). The user didn't name it;
+you did. If you're unsure what the user wants, ask them directly, or act
+on the words they actually said in the conversation.
+
+Branch names are scratch paper for where commits will land. They are not
+a user requirements document.
+
 ## Always open a PR after pushing
 
 When you push a branch, always open a pull request for it as the next

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -9,6 +9,7 @@
       <div class="nav-dropdown-menu">
         <a href="{{ '/' | relative_url }}what-is-the-override.html"{% if page.url == '/what-is-the-override.html' %} aria-current="page"{% endif %}>What is the override?</a>
         <a href="{{ '/' | relative_url }}question-2-trash.html"{% if page.url == '/question-2-trash.html' %} aria-current="page"{% endif %}>Trash: levy or fee?</a>
+        <a href="{{ '/' | relative_url }}whats-on-the-ballot.html"{% if page.url == '/whats-on-the-ballot.html' %} aria-current="page"{% endif %}>What else is on the ballot?</a>
         <a href="{{ '/' | relative_url }}how-we-got-here.html"{% if page.url == '/how-we-got-here.html' %} aria-current="page"{% endif %}>How we got here</a>
         <a href="{{ '/' | relative_url }}marblehead-voting-record.html"{% if page.url == '/marblehead-voting-record.html' %} aria-current="page"{% endif %}>Voting record</a>
         <a href="{{ '/' | relative_url }}no-override-budget.html"{% if page.url == '/no-override-budget.html' %} aria-current="page"{% endif %}>No-override budget</a>

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -496,6 +496,8 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
   </div>
   <p>Question 2 is independent of Question 1. Either way, residents pay for trash: the override spreads the cost by home value, while the Board of Health's fallback is a flat fee of roughly $281 per household.</p>
   <a class="btn-link" href="question-2-trash.html">Trash: levy or fee?</a>
+
+  <p>The same June 9 ballot also fills 24 seats across 11 elected town bodies, including the Select Board, School Committee, and Board of Health. See <a href="whats-on-the-ballot.html">what else is on the ballot</a> for the full rundown.</p>
     </div>
   </details>
 

--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -273,6 +273,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
       <h3>Voters pick the tier at the ballot</h3>
       <p>All registered Marblehead voters can vote at their precinct polling place. The ballot has three tier questions (<strong>1A: $15M "Invest"</strong>, <strong>1B: $12M "Stabilize"</strong>, <strong>1C: $9M "Restore"</strong>), and you may vote yes on more than one. The highest tier with a majority yes sets the override amount. If none of the three get a majority, no override takes effect.<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2026/03/2026-03-25-Override-Presentation.pdf" data-source="Town Administrator's March 25, 2026 override presentation, sample ballot language for three tiers"></sup></p>
       <p>See the <a href="what-is-the-override.html#how-youll-vote">sample ballot walkthrough</a> on the what-is-the-override page, and the <a href="charts/override_calculator.html">override cost calculator</a> for what each tier costs at different home values.</p>
+      <p>The same ballot fills 24 seats across 11 elected town bodies, from Select Board to Cemetery Commission. See <a href="whats-on-the-ballot.html">what else is on the ballot</a> for the office races.</p>
     </div>
   </div>
 </div>

--- a/whats-on-the-ballot.html
+++ b/whats-on-the-ballot.html
@@ -1,0 +1,158 @@
+---
+title: "What else is on the June 9 ballot?"
+og_title: "What else is on the June 9 ballot?"
+og_description: "Beyond the override questions, Marblehead voters will fill 24 seats across 11 elected bodies on June 9, 2026. Here is every office up for election, the seats available, and how to confirm the final candidate list."
+og_url: https://marbleheaddata.org/whats-on-the-ballot.html
+---
+<style>
+  /* Page-scoped: office list for ballot rundown */
+  .office-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 14px;
+    margin: 18px 0 24px;
+  }
+  @media (min-width: 600px) {
+    .office-grid { grid-template-columns: 1fr 1fr; }
+  }
+  .office {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: 16px 18px 14px;
+  }
+  .office h3 {
+    font-size: 16px;
+    margin: 0 0 6px;
+    line-height: 1.3;
+  }
+  .office-meta {
+    font-size: 12px;
+    color: var(--text-subtle);
+    font-variant-numeric: tabular-nums;
+    margin: 0 0 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    font-weight: 700;
+  }
+  .office p {
+    font-size: 14px;
+    line-height: 1.55;
+    margin: 0 0 6px;
+    color: var(--text-muted);
+  }
+  .office p:last-child { margin-bottom: 0; }
+  .office p strong { color: var(--text); }
+</style>
+
+<h1>What else is on the June 9 ballot?</h1>
+
+<p class="page-lead">The override questions share a ballot with the rest of the Annual Town Election. Marblehead voters will fill <strong>24 seats across 11 elected bodies</strong> on June 9, 2026, making this year's ballot one of the broadest in recent memory.<sup class="cite" data-href="https://www.marbleheadindependent.com/a-big-ballot-for-marblehead-24-seats-open-in-june-town-election/" data-source="Marblehead Independent, &quot;A big ballot for Marblehead: 24 seats open in June town election&quot; (March 2026): 24 seats across 11 elected bodies"></sup></p>
+
+<div class="takeaway takeaway--neutral">
+  <p><strong>The candidate list is not final until after April 21, 2026.</strong> Nomination papers became available March 16 and are due back to the town clerk by 5pm on April 21. Individual candidates named below reflect reporting from late March and early April; some races had drawn no candidates at that point. For the official certified ballot, check with the <a href="https://www.marbleheadma.gov/elections-registration-office/pages/elections-voting">Marblehead Elections &amp; Registration Office</a>.<sup class="cite" data-href="https://www.marbleheadindependent.com/a-big-ballot-for-marblehead-24-seats-open-in-june-town-election/" data-source="Marblehead Independent, &quot;A big ballot for Marblehead: 24 seats open in June town election&quot; (March 2026): nomination papers available March 16, due April 21 at 5pm"></sup></p>
+</div>
+
+<h2 id="ballot-questions">Ballot questions</h2>
+
+<p>Two ballot questions appear alongside the office races. Both are covered in depth elsewhere on this site:</p>
+
+<div class="card">
+  <h3>Question 1: Proposition 2&frac12; operating override</h3>
+  <p>Three nested tier options (1A: $15M, 1B: $12M, 1C: $9M). You may vote yes on more than one; the highest tier with a majority yes sets the override amount. See <a href="what-is-the-override.html">what is the override</a> for the tier breakdown and <a href="what-is-the-override.html#how-youll-vote">how you'll vote</a> for a sample-ballot walkthrough.</p>
+</div>
+
+<div class="card">
+  <h3>Question 2: Curbside trash funding</h3>
+  <p>A separate $2,298,575 levy to fund curbside trash and recycling. Question 2 passes or fails on its own, independent of Question 1. If it fails, the Board of Health implements a flat fee of roughly $281 per household instead. See <a href="question-2-trash.html">trash: levy or fee?</a> for the details.</p>
+</div>
+
+<h2 id="offices">Offices up for election</h2>
+
+<p>The 11 elected bodies on the June 9 ballot:<sup class="cite" data-href="https://www.marbleheadindependent.com/a-big-ballot-for-marblehead-24-seats-open-in-june-town-election/" data-source="Marblehead Independent, &quot;A big ballot for Marblehead: 24 seats open in June town election&quot; (March 2026): list of 11 elected bodies with seats on the June ballot"></sup><sup class="cite" data-href="https://www.marbleheadindependent.com/ferrante-pulls-for-select-board-as-marbleheads-24-seat-june-ballot-opens/" data-source="Marblehead Independent, &quot;Ferrante pulls for Select Board as Marblehead's 24-seat June ballot opens&quot; (late March 2026): early candidate filings and incumbent status across boards"></sup></p>
+
+<div class="office-grid">
+  <div class="office">
+    <h3>Select Board</h3>
+    <p class="office-meta">2 seats &middot; 3-year terms</p>
+    <p>The Select Board is the town's principal executive body. Both incumbents, Erin M. Noonan and Alexa J. Singer, had terms expiring in 2026. As of late March, Rossana Ferrante (chair of the Recreation &amp; Park Commission and a long-serving Planning Board member) had pulled nomination papers. Confirmed candidacies were still in flux.</p>
+  </div>
+
+  <div class="office">
+    <h3>School Committee</h3>
+    <p class="office-meta">2 seats</p>
+    <p>One seat is held by Jennifer Schaeffner, who has said she is not seeking re-election. The second is the seat Brian Scott Ota left when he resigned in August 2025. Early reporting noted no candidates had pulled papers for either seat as of late March.</p>
+  </div>
+
+  <div class="office">
+    <h3>Town Moderator</h3>
+    <p class="office-meta">1 seat &middot; 1-year term</p>
+    <p>The moderator presides over Town Meeting. Incumbent John G. Attridge was reported to be running for re-election.</p>
+  </div>
+
+  <div class="office">
+    <h3>Board of Health</h3>
+    <p class="office-meta">3 seats</p>
+    <p>The Board of Health has three seats on this year's ballot: one regular expiring term held by Thomas R. McMahon (who said he will seek re-election), plus two newly created seats as the board expands from three members to five.</p>
+  </div>
+
+  <div class="office">
+    <h3>Planning Board</h3>
+    <p class="office-meta">2 seats &middot; 5-year terms</p>
+    <p>Incumbents Marc J. Liebman and Robert J. Schaeffner Jr. told the Marblehead Independent they planned to seek re-election.</p>
+  </div>
+
+  <div class="office">
+    <h3>Abbot Public Library Trustees</h3>
+    <p class="office-meta">2 seats</p>
+    <p>As of late March, Katherine H. Barker was the only resident to have pulled papers for either of the two open seats.</p>
+  </div>
+
+  <div class="office">
+    <h3>Water &amp; Sewer Commission</h3>
+    <p class="office-meta">2 seats &middot; 3-year terms</p>
+    <p>The seats are currently held by Gregory W. Burt and Barton Hyte.</p>
+  </div>
+
+  <div class="office">
+    <h3>Municipal Light Commission</h3>
+    <p class="office-meta">Seats up</p>
+    <p>The Municipal Light Commission oversees the town's electric utility. The commission had drawn no candidates as of late March reporting.</p>
+  </div>
+
+  <div class="office">
+    <h3>Housing Authority</h3>
+    <p class="office-meta">Seats up</p>
+    <p>The Housing Authority manages state-subsidized housing in Marblehead. The body had drawn no candidates as of late March reporting.</p>
+  </div>
+
+  <div class="office">
+    <h3>Board of Assessors</h3>
+    <p class="office-meta">1 seat</p>
+    <p>The seat is held by John P. Kelley, who told the Marblehead Independent he was still deciding whether to run.</p>
+  </div>
+
+  <div class="office">
+    <h3>Cemetery Commission</h3>
+    <p class="office-meta">2 seats &middot; regular 3-year and 2-year unexpired</p>
+    <p>Incumbent David J. Meyer pulled papers for the regular three-year term. Sally Bull Sands, appointed in December 2025 to fill a vacancy, pulled for the two-year unexpired term.</p>
+  </div>
+
+  <div class="office">
+    <h3>Recreation &amp; Park Commission</h3>
+    <p class="office-meta">5 seats &middot; 1-year terms</p>
+    <p>All five of the commission's one-year seats are on the ballot each year. The current chair, Rossana Ferrante, has pulled papers for Select Board instead.</p>
+  </div>
+</div>
+
+<h2 id="why-this-matters">Why this also matters</h2>
+
+<p>The override questions are the reason many residents will show up on June 9, but the same trip to the polls sets 24 seats on bodies that will run the town for the next one to five years. The Select Board decides what goes on a future warrant. The School Committee sets priorities inside the school budget. The Planning Board decides zoning and subdivision applications. The Board of Health sets the fallback flat fee if Question 2 fails. If you care about how the override money is spent after the vote, or how the no-override budget would be implemented, these are the offices that make those calls.</p>
+
+<p>For a fuller walkthrough of which body handles which decision, see <a href="what-you-can-do.html#who-decides-what">who decides what</a> on the civic engagement page.</p>
+
+<h2 id="how-to-confirm">How to confirm the final ballot</h2>
+
+<p>The authoritative list of certified candidates is posted by the <a href="https://www.marbleheadma.gov/elections-registration-office/pages/elections-voting">Marblehead Elections &amp; Registration Office</a> after the April 21 filing deadline. The town clerk can be reached at (781) 631-0528. Sample ballots are typically posted on the town website a few weeks before election day.</p>
+
+<p class="source">Reporting on seat counts, incumbents, and early nomination filings is drawn from the Marblehead Independent's March and early April 2026 coverage of the nomination-papers window. Candidate status in this page reflects that reporting and may have changed by the April 21 filing deadline.</p>


### PR DESCRIPTION
## Summary

- New page `whats-on-the-ballot.html` covering the 24 seats across 11 elected bodies that share the June 9 ballot with the override questions. Neutral rundown by office (Select Board, School Committee, Board of Health, Planning Board, Library Trustees, Water & Sewer, Municipal Light, Housing Authority, Board of Assessors, Cemetery Commission, Recreation & Park Commission, Town Moderator), sourced to Marblehead Independent reporting.
- Added to the Vote nav dropdown and linked from `what-is-the-override.html` (end of "How You'll Vote") and `what-you-can-do.html` (June 9 step of the two-votes walkthrough).
- Flags that the candidate list isn't final until after the April 21 filing deadline and points readers at the town elections office for the certified list.
- Adds a short CLAUDE.md rule: don't read your own Claude-chosen branch name back as user intent — it's just your own earlier guess reflected back at you.

## Why it's here

Motivated by a reader question: *"what else is on the ballot? are we voting for new select board members or other town positions too?"* The site had been override-only on ballot coverage.

## Test plan

- [ ] Jekyll build succeeds locally (no local Jekyll installed in this env)
- [ ] Nav dropdown shows "What else is on the ballot?" on desktop and mobile
- [ ] `.office-grid` stacks single-column below 600px and goes two-column above
- [ ] Citation footnotes (`<sup class="cite">`) render via `assets/citations.js` and collect into the auto-generated Sources section
- [ ] Internal links from override and civic pages resolve correctly
- [ ] No em-dashes, no inline `style=""`, no unfootnoted external links in the reading flow (skimmed, should confirm)

https://claude.ai/code/session_01TL6ZkbrEG9jyH9RpSZTqra