### PR TITLE
Fix mouseover tooltip landing in top-left on statewide tax burden chart

### DIFF
--- a/charts/statewide_tax_burden.html
+++ b/charts/statewide_tax_burden.html
@@ -2,6 +2,7 @@
 title: "Statewide Tax Burden"
 ---
 <style>
+  #scatter-wrap { position: relative; }
   .scatter-tip {
     position: absolute; pointer-events: none;
     background: var(--surface); border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- On `/charts/statewide_tax_burden.html`, the hover tooltip showed up in the viewport's top-left instead of above the bar under the cursor.
- Root cause: `.scatter-tip` is `position: absolute`, and the JS computes `left`/`top` as pixel offsets from `#scatter-wrap.getBoundingClientRect()`. But `#scatter-wrap` (which inherits only `.chart-wrapper { margin: 8px 0 16px; }` from `assets/site.css`) had no `position` set, so the tooltip's containing block was a far ancestor and the small offsets landed near 0,0 of that ancestor.
- Fix: add `#scatter-wrap { position: relative; }` scoped inline to this chart, so the already-correct offset math resolves against the chart wrapper as intended. No other chart uses a positioned descendant of `.chart-wrapper`, so this stays targeted and doesn't touch global CSS.

## Test plan
- [ ] Load `/charts/statewide_tax_burden.html` and move the cursor across the 351 bars; tooltip should track the bar under the cursor and sit just above it (flipping below when near the top).
- [ ] Confirm tooltip dismisses on `mouseleave` and on tap-outside (touch path).
- [ ] Spot-check other chart pages (`where-has-the-money-gone.html`, `inside-school-staffing.html`) to confirm nothing visually changed; they share `.chart-wrapper` but don't use tooltips.