### PR TITLE
Simplify the explore-page landing instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ title: "Marblehead Budget Data"
 body_class: explore-page
 community_pulse: off-sections
 og_title: "Marblehead Budget Data"
-og_description: Work through the questions one at a time. See the strongest case for each answer, mark your view, and build up a set of positions you can share.
+og_description: Each question shows the strongest case for every answer. Pick the one you agree with. Your picks build into a set of positions you can review or share.
 og_url: https://marbleheaddata.org/
 ---
 {% include nav.html %}
@@ -1067,7 +1067,7 @@ og_url: https://marbleheaddata.org/
   <div class="explore-landing">
     <div class="explore-landing-head">
       <h1>Weighing the FY2027 override?</h1>
-      <p>Work through the questions below. For each one, see the strongest case for every answer, then mark your view. Your picks collect into a set of positions you can review or share.</p>
+      <p>Each question shows the strongest case for every answer. Pick the one you agree with. Your picks build into a set of positions you can review or share.</p>
     </div>
 
     <!-- Procedural strip: explains the two-step voting process. Either vote can end the override. -->
@@ -4381,7 +4381,7 @@ og_url: https://marbleheaddata.org/
       Object.keys(selections).forEach(function (k) { delete selections[k]; });
       isSharedView = false;
       if (headingEl) headingEl.textContent = 'Weighing the FY2027 override?';
-      if (subEl) subEl.textContent = 'Work through the questions below. For each one, see the strongest case for every answer, then mark your view. Your picks collect into a set of positions you can review or share.';
+      if (subEl) subEl.textContent = 'Each question shows the strongest case for every answer. Pick the one you agree with. Your picks build into a set of positions you can review or share.';
       sharedBanner.classList.remove('visible');
       document.querySelector('.explore-landing').classList.remove('shared-mode');
       if (shareStripEl) shareStripEl.style.display = '';


### PR DESCRIPTION
## Summary

The landing copy on `/` read:

> Work through the questions below. For each one, see the strongest case for every answer, then mark your view. Your picks collect into a set of positions you can review or share.

That's 42 words across one long sentence plus two more, and "mark your view" is opaque. Rewrite as three short imperative sentences:

> Each question shows the strongest case for every answer. Pick the one you agree with. Your picks build into a set of positions you can review or share.

Updated in all three places the copy lives:
- The visible `<p>` in the explore landing head
- The `og_description` frontmatter (social share preview)
- The "Start fresh" reset path in JS that restores the landing subtitle after leaving shared view

## Test plan

- [ ] Load `/` and confirm the new subtitle renders under "Weighing the FY2027 override?"
- [ ] Visit a shared-positions URL, click "Start fresh", and confirm the subtitle resets to the new copy
- [ ] Spot-check the og meta tag in view-source