### PR TITLE
Add hover/tap tooltips to line charts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,6 +24,7 @@
 <script defer src="{{ '/' | relative_url }}assets/deep-dive.js"></script>
 <script defer src="{{ '/' | relative_url }}assets/analytics.js"></script>
 <script defer src="{{ '/' | relative_url }}assets/lens.js"></script>
+<script defer src="{{ '/' | relative_url }}assets/chart-tooltip.js"></script>
 {% unless page.community_pulse == "off-sections" %}
 <link rel="stylesheet" href="{{ '/' | relative_url }}assets/community-pulse/widget.css">
 <script type="module" src="{{ '/' | relative_url }}assets/community-pulse/widget.js" data-api-base="https://marblehead-community-pulse.agbaber.workers.dev"></script>

--- a/assets/chart-tooltip.js
+++ b/assets/chart-tooltip.js
@@ -1,0 +1,327 @@
+/*
+  chart-tooltip.js
+  ----------------
+  Universal line-chart tooltip. Opt in on a .chart-wrapper by adding
+  `data-chart-tooltip`. Series + year data lives in a JSON
+  <script type="application/json" class="chart-tooltip-data"> inside
+  the wrapper. Data shape:
+
+    {
+      "xLabels":      ["FY06","FY07",...],   // strings shown in tooltip
+      "xPositions":   [60,87,...],           // SVG x coords, same length
+      "valuePrefix":  "$",                   // optional, default ""
+      "valueSuffix":  "M",                   // optional, default ""
+      "valueDecimals": 1,                    // optional, default auto
+      "projectedFromIndex": 18,              // optional, marks years >= this
+      "series": [
+        {
+          "name":      "Total tax levy",
+          "className": "s-revenue",          // color class for swatch
+          "values":    [50.1, 51.6, ..., null],
+          "yPositions":[246,242, ...]        // optional per-year SVG y; if
+                                             // omitted, we auto-detect from
+                                             // polylines in the SVG
+        },
+        ...
+      ]
+    }
+
+  Interaction model matches charts/statewide_tax_burden.html:
+  - Mouse move anywhere over the SVG finds the nearest x in xPositions,
+    snaps a vertical crosshair to it, drops colored dots on each series,
+    and renders an HTML tooltip above the snap point.
+  - On touch devices (no mouseleave), tapping the chart snaps to the
+    nearest point; tapping outside the chart dismisses.
+*/
+(function () {
+  'use strict';
+
+  var SVG_NS = 'http://www.w3.org/2000/svg';
+
+  function parseJSON(el) {
+    try { return JSON.parse(el.textContent); }
+    catch (e) { return null; }
+  }
+
+  // Parse a polyline "points" attribute (e.g. "60,246 87,242 ...") into
+  // an array of {x, y} objects.
+  function parsePoints(str) {
+    if (!str) return [];
+    var out = [];
+    var pairs = str.trim().split(/\s+/);
+    for (var i = 0; i < pairs.length; i++) {
+      var xy = pairs[i].split(',');
+      if (xy.length !== 2) continue;
+      var x = parseFloat(xy[0]);
+      var y = parseFloat(xy[1]);
+      if (!isFinite(x) || !isFinite(y)) continue;
+      out.push({ x: x, y: y });
+    }
+    return out;
+  }
+
+  // For a given series, collect all (x,y) pairs from any polyline in
+  // the SVG that carries the series' className. Multiple polylines are
+  // merged (handles split solid/dashed projections). Duplicates on the
+  // same x are deduped, keeping the first one encountered.
+  function collectSeriesPoints(svg, className) {
+    var polylines = svg.querySelectorAll('polyline.' + className);
+    var seen = {};
+    var out = [];
+    for (var i = 0; i < polylines.length; i++) {
+      var pts = parsePoints(polylines[i].getAttribute('points'));
+      for (var j = 0; j < pts.length; j++) {
+        var key = pts[j].x.toFixed(2);
+        if (seen[key]) continue;
+        seen[key] = true;
+        out.push(pts[j]);
+      }
+    }
+    return out;
+  }
+
+  // Given the series points and a target x, return the y at the
+  // closest-matching x (within 2px), or null if no match.
+  function yAtX(points, targetX) {
+    var best = null, bestD = Infinity;
+    for (var i = 0; i < points.length; i++) {
+      var d = Math.abs(points[i].x - targetX);
+      if (d < bestD) { bestD = d; best = points[i]; }
+    }
+    if (best && bestD <= 2.5) return best.y;
+    return null;
+  }
+
+  // Format a raw value using chart-level prefix/suffix/decimals.
+  function formatValue(raw, cfg) {
+    if (raw === null || raw === undefined) return '\u2014'; // em dash placeholder
+    var num = Number(raw);
+    if (!isFinite(num)) return String(raw);
+    var decimals;
+    if (typeof cfg.valueDecimals === 'number') {
+      decimals = cfg.valueDecimals;
+    } else {
+      // Auto: 0 if integer-looking, else 1
+      decimals = (Math.abs(num - Math.round(num)) < 0.05) ? 0 : 1;
+    }
+    var s = num.toLocaleString('en-US', {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals
+    });
+    return (cfg.valuePrefix || '') + s + (cfg.valueSuffix || '');
+  }
+
+  function initChart(wrap) {
+    var svg = wrap.querySelector('svg.chart');
+    if (!svg) return;
+    var dataEl = wrap.querySelector('script.chart-tooltip-data');
+    if (!dataEl) return;
+    var cfg = parseJSON(dataEl);
+    if (!cfg || !cfg.xPositions || !cfg.xLabels || !cfg.series) return;
+    if (cfg.xPositions.length !== cfg.xLabels.length) return;
+
+    // Auto-harvest y positions for any series that didn't supply them.
+    var series = cfg.series.map(function (s) {
+      var yPositions = s.yPositions;
+      if (!yPositions && s.className) {
+        var pts = collectSeriesPoints(svg, s.className);
+        yPositions = cfg.xPositions.map(function (x) {
+          return yAtX(pts, x);
+        });
+      }
+      return {
+        name: s.name,
+        className: s.className || 's-neutral',
+        values: s.values || [],
+        yPositions: yPositions || []
+      };
+    });
+
+    // Build SVG overlay elements: vertical crosshair line + one dot per
+    // series. They live in the same SVG so they scale with the chart.
+    var hoverLine = document.createElementNS(SVG_NS, 'line');
+    hoverLine.setAttribute('class', 'chart-tooltip-hover-line');
+    hoverLine.setAttribute('x1', '0');
+    hoverLine.setAttribute('x2', '0');
+    hoverLine.setAttribute('y1', '0');
+    hoverLine.setAttribute('y2', '0');
+    svg.appendChild(hoverLine);
+
+    var dots = series.map(function (s) {
+      var dot = document.createElementNS(SVG_NS, 'circle');
+      dot.setAttribute('class', 'chart-tooltip-dot ' + s.className);
+      dot.setAttribute('r', '4');
+      dot.setAttribute('cx', '0');
+      dot.setAttribute('cy', '0');
+      svg.appendChild(dot);
+      return dot;
+    });
+
+    // Figure out the vertical extent of the plot area. Use the first
+    // .axis-base line for the bottom; use the smallest y among all
+    // harvested series points for the top. Fall back to viewBox.
+    var vb = svg.viewBox.baseVal;
+    var topY = vb ? vb.y + 4 : 0;
+    var bottomY;
+    var axisBase = svg.querySelector('.axis-base');
+    if (axisBase && axisBase.getAttribute('y1') !== null) {
+      bottomY = parseFloat(axisBase.getAttribute('y1'));
+    } else if (vb) {
+      bottomY = vb.y + vb.height - 20;
+    } else {
+      bottomY = 300;
+    }
+    // Expand topY to cover series highs if available.
+    var dataTop = Infinity;
+    series.forEach(function (s) {
+      s.yPositions.forEach(function (y) {
+        if (y !== null && y !== undefined && y < dataTop) dataTop = y;
+      });
+    });
+    if (isFinite(dataTop)) topY = Math.max(topY, dataTop - 6);
+
+    // Tooltip HTML div (absolutely positioned relative to wrapper).
+    var tip = document.createElement('div');
+    tip.className = 'chart-tooltip';
+    wrap.appendChild(tip);
+
+    var lastIdx = -1;
+
+    function hide() {
+      tip.classList.remove('visible');
+      hoverLine.classList.remove('visible');
+      dots.forEach(function (d) { d.classList.remove('visible'); });
+      lastIdx = -1;
+    }
+
+    function svgXFromClient(clientX) {
+      var pt = svg.createSVGPoint();
+      pt.x = clientX;
+      pt.y = 0;
+      var ctm = svg.getScreenCTM();
+      if (!ctm) return null;
+      return pt.matrixTransform(ctm.inverse()).x;
+    }
+
+    function showAtClient(clientX) {
+      var mx = svgXFromClient(clientX);
+      if (mx === null) return;
+      var xs = cfg.xPositions;
+      // Guard against being well outside the plot horizontally.
+      var first = xs[0], last = xs[xs.length - 1];
+      if (mx < first - 10 || mx > last + 10) { hide(); return; }
+      // Find nearest index.
+      var idx = 0;
+      var bestD = Math.abs(mx - xs[0]);
+      for (var i = 1; i < xs.length; i++) {
+        var d = Math.abs(mx - xs[i]);
+        if (d < bestD) { bestD = d; idx = i; }
+      }
+      if (idx === lastIdx) return;
+      lastIdx = idx;
+
+      var snappedX = xs[idx];
+      hoverLine.setAttribute('x1', snappedX);
+      hoverLine.setAttribute('x2', snappedX);
+      hoverLine.setAttribute('y1', topY);
+      hoverLine.setAttribute('y2', bottomY);
+      hoverLine.classList.add('visible');
+
+      // Position dots on the snapped x at each series' y.
+      series.forEach(function (s, k) {
+        var y = s.yPositions[idx];
+        var v = s.values[idx];
+        if (y === null || y === undefined || v === null || v === undefined) {
+          dots[k].classList.remove('visible');
+          return;
+        }
+        dots[k].setAttribute('cx', snappedX);
+        dots[k].setAttribute('cy', y);
+        dots[k].classList.add('visible');
+      });
+
+      // Build tooltip HTML.
+      var isProjected = (typeof cfg.projectedFromIndex === 'number')
+        && idx >= cfg.projectedFromIndex;
+      var html = '<div class="chart-tooltip-year">' + escapeHtml(cfg.xLabels[idx]);
+      if (isProjected) {
+        html += '<span class="chart-tooltip-projected">projected</span>';
+      }
+      html += '</div>';
+      series.forEach(function (s) {
+        var v = s.values[idx];
+        if (v === null || v === undefined) return;
+        html += '<div class="chart-tooltip-row ' + escapeHtml(s.className) + '">' +
+          '<span class="chart-tooltip-swatch"></span>' +
+          '<span class="chart-tooltip-label">' + escapeHtml(s.name) + '</span>' +
+          '<span class="chart-tooltip-value">' + escapeHtml(formatValue(v, cfg)) + '</span>' +
+          '</div>';
+      });
+      tip.innerHTML = html;
+      tip.classList.add('visible');
+
+      // Position tooltip above the snapped point.
+      var wrapRect = wrap.getBoundingClientRect();
+      var ctm = svg.getScreenCTM();
+      if (!ctm) return;
+      // Convert (snappedX, topY) from SVG to client coords, then to
+      // wrapper-relative coords.
+      var pt = svg.createSVGPoint();
+      pt.x = snappedX;
+      pt.y = topY;
+      var clientPoint = pt.matrixTransform(ctm);
+      var px = clientPoint.x - wrapRect.left;
+      var py = clientPoint.y - wrapRect.top;
+
+      var tw = tip.offsetWidth;
+      var th = tip.offsetHeight;
+      var tx = px - tw / 2;
+      var ty = py - th - 10;
+      if (tx < 4) tx = 4;
+      if (tx + tw > wrapRect.width - 4) tx = wrapRect.width - tw - 4;
+      if (ty < 4) {
+        // Flip below the snapped x (use bottomY instead).
+        var pt2 = svg.createSVGPoint();
+        pt2.x = snappedX;
+        pt2.y = bottomY;
+        var cb = pt2.matrixTransform(ctm);
+        ty = (cb.y - wrapRect.top) + 10;
+      }
+      tip.style.left = tx + 'px';
+      tip.style.top = ty + 'px';
+    }
+
+    function escapeHtml(s) {
+      if (s === null || s === undefined) return '';
+      return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    }
+
+    svg.addEventListener('mousemove', function (e) { showAtClient(e.clientX); });
+    svg.addEventListener('mouseleave', hide);
+
+    // Touch / tap: snap to the tapped x, dismiss on a tap outside.
+    svg.addEventListener('click', function (e) { showAtClient(e.clientX); });
+    document.addEventListener('click', function (e) {
+      if (!wrap.contains(e.target)) hide();
+    });
+    // On touch devices, touchstart beats click latency.
+    svg.addEventListener('touchstart', function (e) {
+      if (e.touches && e.touches.length) showAtClient(e.touches[0].clientX);
+    }, { passive: true });
+  }
+
+  function initAll() {
+    var wraps = document.querySelectorAll('.chart-wrapper[data-chart-tooltip]');
+    for (var i = 0; i < wraps.length; i++) initChart(wraps[i]);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAll);
+  } else {
+    initAll();
+  }
+})();

--- a/assets/site.css
+++ b/assets/site.css
@@ -1378,6 +1378,92 @@ body.doc-page .page table:not(.data) th {
    ========================================================================== */
 
 .chart-wrapper { margin: 8px 0 16px; }
+.chart-wrapper[data-chart-tooltip] { position: relative; }
+.chart-wrapper[data-chart-tooltip] svg.chart { cursor: crosshair; }
+.chart-wrapper[data-chart-tooltip] svg.chart .chart-tooltip-hover-line {
+  stroke: var(--text-subtle);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s;
+}
+.chart-wrapper[data-chart-tooltip] svg.chart .chart-tooltip-hover-line.visible {
+  opacity: 0.55;
+}
+.chart-wrapper[data-chart-tooltip] svg.chart .chart-tooltip-dot {
+  fill: currentColor;
+  stroke: var(--surface);
+  stroke-width: 1.75;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s;
+}
+.chart-wrapper[data-chart-tooltip] svg.chart .chart-tooltip-dot.visible {
+  opacity: 1;
+}
+.chart-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text);
+  box-shadow: var(--shadow-sm);
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.12s;
+  z-index: 10;
+  max-width: calc(100% - 16px);
+}
+.chart-tooltip.visible { opacity: 1; }
+.chart-tooltip-year {
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+.chart-tooltip-year .chart-tooltip-projected {
+  font-weight: 500;
+  color: var(--text-subtle);
+  font-size: 11px;
+  margin-left: 4px;
+}
+.chart-tooltip-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.chart-tooltip-row .chart-tooltip-swatch {
+  display: inline-block;
+  width: 10px; height: 3px;
+  border-radius: 2px;
+  background: currentColor;
+  flex-shrink: 0;
+}
+.chart-tooltip-row .chart-tooltip-label {
+  color: var(--text-muted);
+  margin-right: auto;
+}
+.chart-tooltip-row .chart-tooltip-value {
+  color: var(--text);
+  font-weight: 600;
+}
+.chart-tooltip-row.s-marblehead { color: var(--series-marblehead); }
+.chart-tooltip-row.s-swampscott { color: var(--series-swampscott); }
+.chart-tooltip-row.s-melrose    { color: var(--series-melrose); }
+.chart-tooltip-row.s-stoneham   { color: var(--series-stoneham); }
+.chart-tooltip-row.s-revenue    { color: var(--series-revenue); }
+.chart-tooltip-row.s-cost       { color: var(--series-cost); }
+.chart-tooltip-row.s-neutral    { color: var(--series-neutral); }
+.chart-tooltip-row.s-everything { color: var(--series-everything); }
+.chart-tooltip-row.s-tier-1     { color: var(--series-tier-1); }
+.chart-tooltip-row.s-tier-2     { color: var(--series-tier-2); }
+.chart-tooltip-row.s-tier-3     { color: var(--series-tier-3); }
 svg.chart {
   width: 100%; height: auto; display: block;
   font-family: var(--font-sans);

--- a/charts/enrollment_vs_staffing.html
+++ b/charts/enrollment_vs_staffing.html
@@ -12,7 +12,21 @@ title: "Enrollment vs. Staffing"
   <p class="subtitle h-center">Marblehead Public Schools, FY2001&ndash;FY2024. From audited Annual Comprehensive Financial Reports.</p>
 
   <p class="chart-label">Student enrollment</p>
-  <div class="chart-wrapper">
+  <div class="chart-wrapper" data-chart-tooltip>
+    <script type="application/json" class="chart-tooltip-data">
+    {
+      "xLabels": ["FY01","FY02","FY03","FY04","FY05","FY06","FY07","FY08","FY09","FY10","FY11","FY12","FY13","FY14","FY15","FY16","FY17","FY18","FY19","FY20","FY21","FY22","FY23","FY24"],
+      "xPositions": [70,93,117,140,164,187,211,234,258,281,305,328,352,375,399,422,446,469,493,516,540,563,587,610],
+      "valueDecimals": 0,
+      "series": [
+        {
+          "name": "Student enrollment",
+          "className": "s-neutral",
+          "values": [2792,2875,2970,3003,3067,3133,3242,3212,3262,3232,3206,3172,3269,3327,3245,3208,3264,3185,3051,2963,2703,2602,2622,2617]
+        }
+      ]
+    }
+    </script>
     <svg class="chart" viewBox="0 0 740 185" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart showing Marblehead student enrollment from FY2001 to FY2024, peaking at 3,327 in FY2014 and declining to 2,617.">
       <!-- Baseline -->
       <line class="axis-base" x1="70" y1="170" x2="610" y2="170"/>
@@ -35,7 +49,21 @@ title: "Enrollment vs. Staffing"
   </div>
 
   <p class="chart-label">Education full-time equivalent employees</p>
-  <div class="chart-wrapper">
+  <div class="chart-wrapper" data-chart-tooltip>
+    <script type="application/json" class="chart-tooltip-data">
+    {
+      "xLabels": ["FY01","FY02","FY03","FY04","FY05","FY06","FY07","FY08","FY09","FY10","FY11","FY12","FY13","FY14","FY15","FY16","FY17","FY18","FY19","FY20","FY21","FY22","FY23","FY24"],
+      "xPositions": [70,93,117,140,164,187,211,234,258,281,305,328,352,375,399,422,446,469,493,516,540,563,587,610],
+      "valueDecimals": 0,
+      "series": [
+        {
+          "name": "Education FTE",
+          "className": "s-marblehead",
+          "values": [400,414,424,426,448,466,475,480,488,488,488,480,490,492,490,489,493,504,484,480,484,483,537,537]
+        }
+      ]
+    }
+    </script>
     <svg class="chart" viewBox="0 0 740 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart showing Marblehead education FTE from FY2001 to FY2024, rising from 400 to 537.">
       <!-- Baseline -->
       <line class="axis-base" x1="70" y1="140" x2="610" y2="140"/>
@@ -81,7 +109,36 @@ title: "Enrollment vs. Staffing"
     <span class="legend-item s-stoneham"><span class="legend-swatch"></span><span class="legend-text">Stoneham</span></span>
   </div>
 
-  <div class="chart-wrapper">
+  <div class="chart-wrapper" data-chart-tooltip>
+    <script type="application/json" class="chart-tooltip-data">
+    {
+      "xLabels": ["FY15","FY16","FY17","FY18","FY19","FY20","FY21","FY22","FY23","FY24"],
+      "xPositions": [70,130,190,250,310,370,430,490,550,610],
+      "valueDecimals": 1,
+      "series": [
+        {
+          "name": "Marblehead",
+          "className": "s-marblehead",
+          "values": [12.6,12.2,11.9,11.9,11.8,11.5,10.5,10.3,10.5,10.7]
+        },
+        {
+          "name": "Swampscott",
+          "className": "s-swampscott",
+          "values": [12.3,12.0,11.5,11.6,12.0,12.0,11.5,10.8,10.7,11.1]
+        },
+        {
+          "name": "Melrose",
+          "className": "s-melrose",
+          "values": [14.5,14.4,14.5,14.6,14.7,14.5,13.3,14.0,14.6,13.7]
+        },
+        {
+          "name": "Stoneham",
+          "className": "s-stoneham",
+          "values": [12.4,12.6,12.7,12.4,12.3,12.0,10.9,11.4,11.4,10.8]
+        }
+      ]
+    }
+    </script>
     <svg class="chart" viewBox="0 0 740 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart comparing students per teacher FTE for Marblehead, Swampscott, Melrose, and Stoneham from FY2015 to FY2024. All four towns show declining ratios. Marblehead drops from 12.6 to 10.7, the steepest decline. Melrose remains highest at 13.7 in FY24.">
       <!-- Baseline -->
       <line class="axis-base" x1="70" y1="160" x2="610" y2="160"/>

--- a/charts/four_town_rates.html
+++ b/charts/four_town_rates.html
@@ -43,7 +43,37 @@ title: "Rate and Bill Comparison"
     <div class="legend-item s-stoneham"><span class="legend-swatch"></span><span class="legend-text">Stoneham</span></div>
   </div>
 
-  <div class="chart-wrapper">
+  <div class="chart-wrapper" data-chart-tooltip>
+    <script type="application/json" class="chart-tooltip-data">
+    {
+      "xLabels": ["FY03","FY04","FY05","FY06","FY07","FY08","FY09","FY10","FY11","FY12","FY13","FY14","FY15","FY16","FY17","FY18","FY19","FY20","FY21","FY22","FY23","FY24","FY25","FY26"],
+      "xPositions": [55,83,111,138,166,194,222,250,277,305,333,361,389,416,444,472,500,528,555,583,611,639,667,694],
+      "valuePrefix": "$",
+      "valueDecimals": 2,
+      "series": [
+        {
+          "name": "Marblehead",
+          "className": "s-marblehead",
+          "values": [8.42,8.48,8.26,8.43,7.76,8.34,8.99,9.57,10.21,10.52,10.85,11.09,11.08,11.10,11.01,11.02,10.74,10.39,10.42,10.52,10.00,8.96,9.05,8.56]
+        },
+        {
+          "name": "Swampscott",
+          "className": "s-swampscott",
+          "values": [13.50,12.10,11.30,12.20,12.85,13.65,14.35,16.50,16.60,18.00,18.85,18.70,17.15,17.35,17.45,16.00,15.20,14.30,13.80,12.85,11.75,11.50,11.45,12.00]
+        },
+        {
+          "name": "Melrose",
+          "className": "s-melrose",
+          "values": [12.25,11.50,9.75,9.65,9.85,10.45,11.35,12.05,12.45,12.75,13.05,13.30,12.95,12.35,11.80,11.35,10.80,11.05,10.95,10.55,10.40,9.95,9.90,11.45]
+        },
+        {
+          "name": "Stoneham",
+          "className": "s-stoneham",
+          "values": [11.70,12.15,10.45,9.65,9.75,10.20,10.90,11.50,12.20,12.60,13.05,13.50,12.95,12.70,12.40,11.70,11.20,10.80,10.80,10.40,11.10,10.60,10.25,10.05]
+        }
+      ]
+    }
+    </script>
     <svg class="chart" viewBox="0 0 880 400" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart: residential tax rates for Marblehead, Swampscott, Melrose, and Stoneham, FY2003 to FY2026, with FY2028 projections for all four towns.">
       <!-- Grid -->
       <line class="axis-base" x1="55" y1="310" x2="750" y2="310"/>
@@ -114,7 +144,37 @@ title: "Rate and Bill Comparison"
 
   <h2 class="h-center">Average single-family tax bill</h2>
 
-  <div class="chart-wrapper">
+  <div class="chart-wrapper" data-chart-tooltip>
+    <script type="application/json" class="chart-tooltip-data">
+    {
+      "xLabels": ["FY06","FY07","FY08","FY09","FY10","FY11","FY12","FY13","FY14","FY15","FY16","FY17","FY18","FY19","FY20","FY21","FY22","FY23","FY24","FY25","FY26"],
+      "xPositions": [60,87,114,141,168,195,222,249,276,303,330,357,384,411,438,465,492,519,546,573,600],
+      "valuePrefix": "$",
+      "valueDecimals": 0,
+      "series": [
+        {
+          "name": "Marblehead",
+          "className": "s-marblehead",
+          "values": [5800,5900,6100,6250,6550,6650,6950,7100,7350,7700,7950,8300,8600,8850,9100,9400,9950,10300,10800,11050,11055]
+        },
+        {
+          "name": "Swampscott",
+          "className": "s-swampscott",
+          "values": [6400,6900,7300,7550,7850,7900,8350,8550,8600,8950,9050,9200,9100,9000,9000,9000,9100,9650,10300,10650,11478]
+        },
+        {
+          "name": "Melrose",
+          "className": "s-melrose",
+          "values": [4100,4250,4400,4550,4750,4950,5100,5200,5350,5550,5750,5900,6100,6250,7050,7200,7400,7650,7850,8100,9800]
+        },
+        {
+          "name": "Stoneham",
+          "className": "s-stoneham",
+          "values": [4050,4200,4300,4450,4600,4700,4900,5000,5300,5400,5500,5700,5850,6000,6100,6250,6350,7300,7500,7800,8050]
+        }
+      ]
+    }
+    </script>
     <svg class="chart" viewBox="0 -20 840 350" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart showing average single-family tax bills for four North Shore towns, FY2006 to FY2028.">
       <!-- Grid -->
       <line class="axis-base" x1="60" y1="280" x2="654" y2="280"/>

--- a/charts/healthcare_costs.html
+++ b/charts/healthcare_costs.html
@@ -16,7 +16,27 @@ og_url: https://marbleheaddata.org/charts/healthcare_costs.html
     <div class="legend-item s-neutral"><span class="legend-swatch"></span><span class="legend-text">Health insurance spending</span></div>
   </div>
 
-  <div class="chart-wrapper">
+  <div class="chart-wrapper" data-chart-tooltip>
+    <script type="application/json" class="chart-tooltip-data">
+    {
+      "xLabels": ["FY06","FY07","FY08","FY09","FY10","FY11","FY12","FY13","FY14","FY15","FY16","FY17","FY18","FY19","FY20","FY21","FY22","FY23","FY24","FY25","FY26","FY27"],
+      "xPositions": [60,87,113,140,167,193,220,247,273,300,327,353,380,407,433,460,487,513,540,567,593,620],
+      "valueDecimals": 1,
+      "projectedFromIndex": 19,
+      "series": [
+        {
+          "name": "Tax levy",
+          "className": "s-revenue",
+          "values": [100.0,102.6,105.8,108.8,113.7,116.2,121.4,124.0,128.4,133.5,138.8,144.7,150.0,153.5,157.9,163.3,172.6,178.9,185.9,191.5,197.2,203.1]
+        },
+        {
+          "name": "Health insurance",
+          "className": "s-neutral",
+          "values": [100.0,106.7,117.2,134.6,126.3,132.0,147.4,135.9,145.4,152.1,159.0,163.9,164.7,169.2,null,173.4,181.8,191.4,174.7,172.0,189.6,210.4]
+        }
+      ]
+    }
+    </script>
     <svg class="chart" viewBox="0 0 760 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart comparing tax levy growth and health insurance spending growth from FY2006 to FY2027, both indexed to FY2006 equals 100. Health insurance grew faster for most of the period, with both converging near 200 by FY2027.">
       <line class="axis-base" x1="60" y1="246" x2="620" y2="246"/>
 
@@ -122,7 +142,22 @@ og_url: https://marbleheaddata.org/charts/healthcare_costs.html
 
   <p>If it is not headcount, it is price per employee. Here is the actual price of one Harvard Pilgrim family plan through the state Group Insurance Commission, taken directly from the <abbr class="g" title="Group Insurance Commission">GIC</abbr>'s published rate sheets. This is the full premium before the 83/17 employer-employee split; the town pays 83% of the figures below under the Public Employee Committee agreement.</p>
 
-  <div class="chart-wrapper">
+  <div class="chart-wrapper" data-chart-tooltip>
+    <script type="application/json" class="chart-tooltip-data">
+    {
+      "xLabels": ["FY19","FY20","FY23","FY24","FY25","FY26"],
+      "xPositions": [80,157,389,466,543,620],
+      "valuePrefix": "$",
+      "valueDecimals": 0,
+      "series": [
+        {
+          "name": "Family plan premium",
+          "className": "s-cost",
+          "values": [24107,26045,28251,31530,33687,38562]
+        }
+      ]
+    }
+    </script>
     <svg class="chart" viewBox="0 0 760 310" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart: annual Harvard Pilgrim family plan premium rose from $24,107 in FY19 to $38,562 in FY26.">
       <line class="axis-base" x1="80" y1="270" x2="620" y2="270"/>
 

--- a/charts/levy_vs_bill.html
+++ b/charts/levy_vs_bill.html
@@ -12,7 +12,31 @@ title: "Tax Levy, Median Bill, and Inflation"
   <div class="legend-item s-neutral"><span class="legend-swatch"></span><span class="legend-text">CPI-U (inflation)</span></div>
 </div>
 
-<div class="chart-wrapper">
+<div class="chart-wrapper" data-chart-tooltip>
+  <script type="application/json" class="chart-tooltip-data">
+  {
+    "xLabels": ["FY12","FY13","FY14","FY15","FY16","FY17","FY18","FY19","FY20","FY21","FY22","FY23","FY24"],
+    "xPositions": [70,116,162,208,254,299,345,391,437,483,528,574,620],
+    "valueDecimals": 1,
+    "series": [
+      {
+        "name": "Collected tax levy",
+        "className": "s-revenue",
+        "values": [100.0,102.1,105.8,110.0,114.3,119.2,123.6,126.4,130.1,134.5,142.2,147.4,153.2]
+      },
+      {
+        "name": "Median single-family bill",
+        "className": "s-cost",
+        "values": [100.0,102.0,105.8,110.3,114.5,119.5,123.8,126.8,130.3,135.5,142.8,148.0,154.9]
+      },
+      {
+        "name": "CPI-U",
+        "className": "s-neutral",
+        "values": [100.0,101.5,103.1,103.2,104.5,106.8,109.4,111.4,112.7,118.0,127.5,132.7,136.6]
+      }
+    ]
+  }
+  </script>
   <svg class="chart" viewBox="0 0 840 330" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart: three indexed growth rates from FY2012 to FY2024, each starting at 100 at FY2012. Marblehead's collected property tax levy reaches 153 by FY2024. The median single-family tax bill reaches 155. CPI-U reaches 137. Levy and bill track each other closely; both grow faster than CPI-U.">
     <line class="axis-base" x1="70" y1="300" x2="620" y2="300"/>
     <line class="grid-minor" x1="70" y1="260" x2="620" y2="260"/>


### PR DESCRIPTION
## Summary

Adds a universal tooltip system so readers can see the exact value for any year on a line chart, on both desktop (hover) and mobile (tap). The interaction model is lifted from `charts/statewide_tax_burden.html`, which was the one chart that already had a working tooltip.

## How it works

- **`assets/chart-tooltip.js`** (new): shared runtime. Finds every `.chart-wrapper[data-chart-tooltip]`, reads its data from an inline `<script type="application/json" class="chart-tooltip-data">`, injects a vertical crosshair line and a colored dot per series into the SVG, and renders an HTML tooltip listing each series' value for the snapped year. It auto-harvests each dot's y-position from the existing polyline `points` attributes, so split solid/dashed projection lines just work.
- **`assets/site.css`**: styles for `.chart-tooltip`, the hover line, and the per-series dots. Dots and rows pick up series colors via the existing `s-marblehead` / `s-revenue` / etc. classes so themes stay consistent.
- **`_includes/head.html`**: defer-loads `chart-tooltip.js` site-wide.

Each chart opts in by adding `data-chart-tooltip` to its wrapper and a small JSON block describing xLabels, xPositions, series values, value prefix/suffix, and an optional `projectedFromIndex` so projected years get a subtle "projected" label in the tooltip.

## Charts converted in this pass

- `charts/healthcare_costs.html`: chart 1 (levy vs. health insurance, indexed, FY06-FY27) and chart 3 (Harvard Pilgrim family plan premium, FY19-FY26).
- `charts/levy_vs_bill.html`: collected levy, median single-family bill, and CPI-U, all indexed FY12-FY24.
- `charts/enrollment_vs_staffing.html`: all three charts (enrollment, education FTE, and students-per-teacher peer comparison).
- `charts/four_town_rates.html`: both line charts (residential tax rate and average single-family bill for the four peer towns).

Values are sourced from the existing repo CSVs where available (`tax_levy_FY01-24.csv`, `group_insurance_FY06-27.csv`, `cpi_us.csv`, `demographics_FY01-24.csv`, `gic_premium_rates_FY19-26.csv`, `dese_peer_teachers_enrollment.csv`, `MASTER_DATA.csv`). For the four-town rate and bill charts, peer-town values match the existing SVG positions (originally sourced from MA DOR DLS per the chart notes) at chart precision.

## Not yet converted (follow-ups)

- The two-panel healthcare spending vs. FTE chart: requires per-series unit formatting and the two panels share an x-axis but have different y scales.
- `charts/sustainability.html`: stacked bars + expense line with three override tier views. Needs a different interaction model for the bars.
- Homepage teaser thumbnails: intentional. They're visual appetizers that link to the full chart pages where the tooltip lives.

## Test plan

- [ ] Load `/charts/healthcare_costs.html` on desktop and hover across the levy / health-insurance chart. Crosshair line snaps to years, dots follow both series, tooltip shows both values and marks FY25-FY27 as projected.
- [ ] FY20 health insurance shows an em-dash (no data) while the levy line still shows its value.
- [ ] Load `/charts/levy_vs_bill.html` on desktop and confirm all three indexed series show values.
- [ ] Load `/charts/enrollment_vs_staffing.html` on desktop. All three charts show tooltips; the peer-comparison chart shows all four towns' values at once.
- [ ] Load `/charts/four_town_rates.html` on desktop. Rate chart shows `$X.XX`, bill chart shows `$X,XXX`, both with all four towns.
- [ ] On mobile (or a phone-sized viewport), tap the chart. Tooltip appears; tap outside the chart dismisses.
- [ ] Toggle dark mode. Tooltip background and borders adapt. Series colors still match the lines.
- [ ] `charts/statewide_tax_burden.html` still works as before (its own scatter tooltip is untouched).

https://claude.ai/code/session_01Ppz6YgSKVJtdSWLgjDpAnt