### PR TITLE
Move meeting changelog from Budget to Data nav dropdown

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -21,7 +21,6 @@
       <button class="nav-dropdown-toggle" aria-expanded="false">Budget <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <div class="nav-dropdown-menu">
         <a href="{{ '/' | relative_url }}where-has-the-money-gone.html"{% if page.url == '/where-has-the-money-gone.html' %} aria-current="page"{% endif %}>Where the money went</a>
-        <a href="{{ '/' | relative_url }}data/meeting-tracker.html"{% if page.url == '/data/meeting-tracker.html' %} aria-current="page"{% endif %}>Meeting changelog</a>
       </div>
     </div>
 
@@ -68,6 +67,7 @@
       <button class="nav-dropdown-toggle" aria-expanded="false">Data <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <div class="nav-dropdown-menu">
         <a href="{{ '/' | relative_url }}data/master-data.html"{% if page.url == '/data/master-data.html' %} aria-current="page"{% endif %}>Annual rollup (FY01-FY27)</a>
+        <a href="{{ '/' | relative_url }}data/meeting-tracker.html"{% if page.url == '/data/meeting-tracker.html' %} aria-current="page"{% endif %}>Meeting changelog</a>
         <a href="{{ '/' | relative_url }}data/DATA_CATALOG.html"{% if page.url == '/data/DATA_CATALOG.html' %} aria-current="page"{% endif %}>Data catalog</a>
         <a href="{{ '/' | relative_url }}data/SOURCE_LOOKUP.html"{% if page.url == '/data/SOURCE_LOOKUP.html' %} aria-current="page"{% endif %}>Source lookup</a>
         <a href="{{ '/' | relative_url }}about.html"{% if page.url == '/about.html' %} aria-current="page"{% endif %}>About this project</a>


### PR DESCRIPTION
## Summary

- The "Meeting changelog" link was nested under the **Budget** nav dropdown, but it lives at `/data/meeting-tracker.html` and is reference/log material rather than a budget chart.
- Moves it into the **Data** dropdown alongside the annual rollup, data catalog, and source lookup so the nav grouping matches the URL and content type.
- Budget dropdown now only contains "Where the money went".

## Test plan

- [ ] `bundle exec jekyll serve` and verify Meeting changelog appears under Data, not Budget
- [ ] Confirm the active-page highlight still works when visiting `/data/meeting-tracker.html`
- [ ] Check the mobile nav panel still scrolls the active dropdown into view
