### PR TITLE
Extend chart tooltips to 2-panel and mixed-unit charts

### DIFF
--- a/assets/chart-tooltip.js
+++ b/assets/chart-tooltip.js
@@ -92,13 +92,22 @@
     return null;
   }
 
-  // Format a raw value using chart-level prefix/suffix/decimals.
-  function formatValue(raw, cfg) {
+  // Format a raw value. Per-series prefix/suffix/decimals override the
+  // chart-level defaults; otherwise fall back to cfg's values.
+  function formatValue(raw, cfg, series) {
     if (raw === null || raw === undefined) return '\u2014'; // em dash placeholder
     var num = Number(raw);
     if (!isFinite(num)) return String(raw);
+    var prefix = (series && series.valuePrefix !== undefined)
+      ? series.valuePrefix
+      : (cfg.valuePrefix || '');
+    var suffix = (series && series.valueSuffix !== undefined)
+      ? series.valueSuffix
+      : (cfg.valueSuffix || '');
     var decimals;
-    if (typeof cfg.valueDecimals === 'number') {
+    if (series && typeof series.valueDecimals === 'number') {
+      decimals = series.valueDecimals;
+    } else if (typeof cfg.valueDecimals === 'number') {
       decimals = cfg.valueDecimals;
     } else {
       // Auto: 0 if integer-looking, else 1
@@ -108,7 +117,7 @@
       minimumFractionDigits: decimals,
       maximumFractionDigits: decimals
     });
-    return (cfg.valuePrefix || '') + s + (cfg.valueSuffix || '');
+    return prefix + s + suffix;
   }
 
   function initChart(wrap) {
@@ -133,7 +142,10 @@
         name: s.name,
         className: s.className || 's-neutral',
         values: s.values || [],
-        yPositions: yPositions || []
+        yPositions: yPositions || [],
+        valuePrefix: s.valuePrefix,
+        valueSuffix: s.valueSuffix,
+        valueDecimals: s.valueDecimals
       };
     });
 
@@ -157,28 +169,47 @@
       return dot;
     });
 
-    // Figure out the vertical extent of the plot area. Use the first
-    // .axis-base line for the bottom; use the smallest y among all
-    // harvested series points for the top. Fall back to viewBox.
+    // Figure out the vertical extent of the crosshair line. Explicit
+    // plotTop / plotBottom in the JSON wins (needed for multi-panel
+    // charts where there's more than one .axis-base). Otherwise:
+    //   - bottomY = the LAST .axis-base y1 (covers multi-panel charts
+    //     where the full plot area runs from the top panel to the
+    //     bottom panel's baseline)
+    //   - topY   = the smallest y among harvested series points, minus
+    //     a small margin, clamped to the viewBox.
     var vb = svg.viewBox.baseVal;
-    var topY = vb ? vb.y + 4 : 0;
-    var bottomY;
-    var axisBase = svg.querySelector('.axis-base');
-    if (axisBase && axisBase.getAttribute('y1') !== null) {
-      bottomY = parseFloat(axisBase.getAttribute('y1'));
-    } else if (vb) {
-      bottomY = vb.y + vb.height - 20;
+    var topY, bottomY;
+    if (typeof cfg.plotTop === 'number') {
+      topY = cfg.plotTop;
     } else {
-      bottomY = 300;
+      topY = vb ? vb.y + 4 : 0;
     }
-    // Expand topY to cover series highs if available.
-    var dataTop = Infinity;
-    series.forEach(function (s) {
-      s.yPositions.forEach(function (y) {
-        if (y !== null && y !== undefined && y < dataTop) dataTop = y;
+    if (typeof cfg.plotBottom === 'number') {
+      bottomY = cfg.plotBottom;
+    } else {
+      var axisBases = svg.querySelectorAll('.axis-base');
+      var lastBase = null;
+      for (var bi = 0; bi < axisBases.length; bi++) {
+        if (axisBases[bi].getAttribute('y1') !== null) lastBase = axisBases[bi];
+      }
+      if (lastBase) {
+        bottomY = parseFloat(lastBase.getAttribute('y1'));
+      } else if (vb) {
+        bottomY = vb.y + vb.height - 20;
+      } else {
+        bottomY = 300;
+      }
+    }
+    if (typeof cfg.plotTop !== 'number') {
+      // Expand topY to cover series highs if available.
+      var dataTop = Infinity;
+      series.forEach(function (s) {
+        s.yPositions.forEach(function (y) {
+          if (y !== null && y !== undefined && y < dataTop) dataTop = y;
+        });
       });
-    });
-    if (isFinite(dataTop)) topY = Math.max(topY, dataTop - 6);
+      if (isFinite(dataTop)) topY = Math.max(topY, dataTop - 6);
+    }
 
     // Tooltip HTML div (absolutely positioned relative to wrapper).
     var tip = document.createElement('div');
@@ -254,7 +285,7 @@
         html += '<div class="chart-tooltip-row ' + escapeHtml(s.className) + '">' +
           '<span class="chart-tooltip-swatch"></span>' +
           '<span class="chart-tooltip-label">' + escapeHtml(s.name) + '</span>' +
-          '<span class="chart-tooltip-value">' + escapeHtml(formatValue(v, cfg)) + '</span>' +
+          '<span class="chart-tooltip-value">' + escapeHtml(formatValue(v, cfg, s)) + '</span>' +
           '</div>';
       });
       tip.innerHTML = html;

--- a/charts/healthcare_costs.html
+++ b/charts/healthcare_costs.html
@@ -90,7 +90,30 @@ og_url: https://marbleheaddata.org/charts/healthcare_costs.html
 
   <p>The flat total line hides a composition shift underneath it. <a href="enrollment_vs_staffing.html">Education <abbr class="g" title="Full-Time Equivalent">FTE</abbr> grew from 466 to 537</a> (+15%) over the same period, while non-education departments (police, fire, <abbr class="g" title="Department of Public Works">DPW</abbr>, library, administration) shrank from 188 to 169 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> (&minus;10%). Schools added staff; the rest of town government cut. For insurance costs, what matters is the total number of employees on plans, and that number barely moved. But a reader who knows schools have been hiring will reasonably question a flat-line chart that does not show where the offsetting cuts came from.</p>
 
-  <div class="chart-wrapper">
+  <div class="chart-wrapper" data-chart-tooltip>
+    <script type="application/json" class="chart-tooltip-data">
+    {
+      "xLabels": ["FY06","FY07","FY08","FY09","FY10","FY11","FY12","FY13","FY14","FY15","FY16","FY17","FY18","FY19","FY20","FY21","FY22","FY23","FY24","FY25","FY26","FY27"],
+      "xPositions": [70,97,124,151,178,205,232,260,287,314,341,368,395,422,449,476,503,530,557,584,611,640],
+      "projectedFromIndex": 20,
+      "series": [
+        {
+          "name": "Health insurance",
+          "className": "s-cost",
+          "valuePrefix": "$",
+          "valueSuffix": "M",
+          "valueDecimals": 2,
+          "values": [7.96,8.50,9.33,10.72,10.06,10.52,11.74,10.82,11.58,12.11,12.66,13.06,13.12,13.48,null,13.81,14.48,15.24,13.92,13.70,15.10,16.75]
+        },
+        {
+          "name": "Employees (FTE)",
+          "className": "s-neutral",
+          "valueDecimals": 0,
+          "values": [655,667,673,680,682,683,675,686,687,687,675,676,691,671,668,667,669,709,706,null,null,null]
+        }
+      ]
+    }
+    </script>
     <svg class="chart" viewBox="0 0 800 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Two-panel chart. Top: health insurance spending FY06-FY27. Bottom: full-time equivalent employees FY06-FY24. Spending roughly doubled while FTE stayed near 700.">
       <line class="axis-base" x1="70" y1="180" x2="640" y2="180"/>
 

--- a/charts/sustainability.html
+++ b/charts/sustainability.html
@@ -28,7 +28,26 @@ title: "General Fund Revenue, Free Cash, and Expenses"
     <div class="legend-item s-neutral"><span class="legend-swatch"></span><span class="legend-text">Total expenditures</span></div>
   </div>
 
-  <div class="chart-wrapper">
+  <div class="chart-wrapper" data-chart-tooltip>
+    <script type="application/json" class="chart-tooltip-data">
+    {
+      "xLabels": ["FY15","FY16","FY17","FY18","FY19","FY20","FY21","FY22","FY23","FY24","FY25","FY26","FY27","FY28","FY29","FY30"],
+      "xPositions": [94,134,174,214,254,294,334,374,414,454,494,534,574,614,654,694],
+      "plotTop": 48,
+      "plotBottom": 380,
+      "projectedFromIndex": 10,
+      "series": [
+        {
+          "name": "Total expenditures",
+          "className": "s-neutral",
+          "valuePrefix": "$",
+          "valueSuffix": "M",
+          "valueDecimals": 1,
+          "values": [70.5,73.2,76.9,81.8,83.3,85.2,85.8,93.6,96.8,100.1,105.0,112.5,120.5,126.5,133.0,139.5]
+        }
+      ]
+    }
+    </script>
     <svg class="chart" viewBox="0 0 800 430" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stacked bar chart from FY15 to FY30 showing general fund base revenue plus free cash compared to an expense line. Tabs switch between no-override and three override tier scenarios.">
 
       <!-- Grid: $60M at y=380, scale 4px/$1M, up to $140M at y=60 -->


### PR DESCRIPTION
## Summary

Follow-up to #337. Extends the line-chart tooltip infrastructure to handle two charts the first pass intentionally skipped, and fixes the specific gap you pointed out on `charts/healthcare_costs.html` (the middle 2-panel chart).

## What gets a tooltip now

- **`healthcare_costs.html` chart 2** (health insurance spending + FTE). The top panel is `$M` and the bottom panel is an FTE count - two different units in the same SVG, which is why the original PR skipped it. The crosshair line spans both panels so hovering any year shows both values at once.
- **`sustainability.html` expense line**. The expense line is the same across all four override tier views, so a single static tooltip works regardless of which tab is active. Bar values (base revenue, free cash, tier override overlay) are not tooltipped yet - that would need per-view logic and the bars already use the same `$M` space as the line, so it's easy to add later once we decide how much we want to cram into one hover.

## Infrastructure changes in `chart-tooltip.js`

- **Per-series value formatting.** `valuePrefix`, `valueSuffix`, and `valueDecimals` can now live on each series entry in the JSON and override the chart-level defaults. This is the fix that unblocks 2-panel charts.
- **Explicit `plotTop` / `plotBottom`** in the JSON to override the auto-detected crosshair extent. The auto-detect also now uses the **last** `.axis-base` line in the SVG, so 2-panel charts automatically get the bottom panel's baseline without needing an override. `sustainability.html` uses the explicit fields to keep the crosshair inside the grid rather than the full viewBox (the viewBox extends up to the annotation area above the plot).

## Test plan

- [ ] `/charts/healthcare_costs.html` middle chart: hover across FY06-FY27. Crosshair spans both panels, top dot sits on the spending polyline, bottom dot sits on the FTE polyline, tooltip shows both values with correct units (`$M` vs plain count). FY20 spending shows an em-dash (no data); FY25-FY27 FTE show em-dashes (data only goes through FY24). FY26 and FY27 get the "projected" label.
- [ ] `/charts/sustainability.html`: hover the expense line from FY15-FY30. Tooltip shows the expense value at each year. FY25-FY30 get the "projected" label. Crosshair line is confined to the plot grid, not the annotation area above. Switching between the four tabs doesn't break the tooltip.
- [ ] Regression: charts from #337 (other `healthcare_costs` charts, `levy_vs_bill`, `enrollment_vs_staffing`, `four_town_rates`) still behave identically.
- [ ] Dark mode: tooltip still readable, crosshair still visible.
- [ ] Mobile tap works on both charts.

https://claude.ai/code/session_01Ppz6YgSKVJtdSWLgjDpAnt