### PR TITLE
Add tab-aware bar tooltip to sustainability chart

### DIFF
--- a/assets/chart-tooltip.js
+++ b/assets/chart-tooltip.js
@@ -18,9 +18,18 @@
           "name":      "Total tax levy",
           "className": "s-revenue",          // color class for swatch
           "values":    [50.1, 51.6, ..., null],
-          "yPositions":[246,242, ...]        // optional per-year SVG y; if
+          "yPositions":[246,242, ...],       // optional per-year SVG y; if
                                              // omitted, we auto-detect from
                                              // polylines in the SVG
+          "valuePrefix": "$",                // optional, per-series override
+          "valueSuffix": "M",                // optional, per-series override
+          "valueDecimals": 2,                // optional, per-series override
+          "visibleWhen": "#view-tier1.active"// optional, CSS selector. The
+                                             // series is only rendered when
+                                             // the selector currently matches
+                                             // something in the document.
+                                             // Used by tabbed charts to show
+                                             // different series per view.
         },
         ...
       ]
@@ -145,7 +154,8 @@
         yPositions: yPositions || [],
         valuePrefix: s.valuePrefix,
         valueSuffix: s.valueSuffix,
-        valueDecimals: s.valueDecimals
+        valueDecimals: s.valueDecimals,
+        visibleWhen: s.visibleWhen
       };
     });
 
@@ -258,11 +268,22 @@
       hoverLine.setAttribute('y2', bottomY);
       hoverLine.classList.add('visible');
 
+      // Resolve per-series visibility. A series with `visibleWhen` set
+      // to a CSS selector is only shown if that selector currently
+      // matches something in the document. This lets tabbed charts
+      // (e.g. sustainability.html) show override tiers only for the
+      // active tab without any other runtime plumbing.
+      var visibleFlags = series.map(function (s) {
+        if (!s.visibleWhen) return true;
+        try { return !!document.querySelector(s.visibleWhen); }
+        catch (e) { return true; }
+      });
+
       // Position dots on the snapped x at each series' y.
       series.forEach(function (s, k) {
         var y = s.yPositions[idx];
         var v = s.values[idx];
-        if (y === null || y === undefined || v === null || v === undefined) {
+        if (!visibleFlags[k] || y === null || y === undefined || v === null || v === undefined) {
           dots[k].classList.remove('visible');
           return;
         }
@@ -279,9 +300,10 @@
         html += '<span class="chart-tooltip-projected">projected</span>';
       }
       html += '</div>';
-      series.forEach(function (s) {
+      series.forEach(function (s, k) {
         var v = s.values[idx];
         if (v === null || v === undefined) return;
+        if (!visibleFlags[k]) return;
         html += '<div class="chart-tooltip-row ' + escapeHtml(s.className) + '">' +
           '<span class="chart-tooltip-swatch"></span>' +
           '<span class="chart-tooltip-label">' + escapeHtml(s.name) + '</span>' +

--- a/charts/sustainability.html
+++ b/charts/sustainability.html
@@ -36,14 +36,47 @@ title: "General Fund Revenue, Free Cash, and Expenses"
       "plotTop": 48,
       "plotBottom": 380,
       "projectedFromIndex": 10,
+      "valuePrefix": "$",
+      "valueSuffix": "M",
+      "valueDecimals": 2,
       "series": [
+        {
+          "name": "Base revenue",
+          "className": "s-revenue",
+          "yPositions": [338,327,313,301,290,281,278,254,239,225,222,198,191,180,168,156],
+          "values": [71.32,74.06,77.06,79.73,82.54,84.77,85.39,91.45,95.13,98.79,99.60,105.42,107.12,110.00,113.00,116.00]
+        },
+        {
+          "name": "Free cash drawn",
+          "className": "s-swampscott",
+          "yPositions": [null,null,null,293,287,279,277,246,233,220,200,170,171,160,148,136],
+          "values": [null,null,null,2.03,0.73,0.44,0.41,2.13,1.70,1.31,5.50,7.00,5.00,5.00,5.00,5.00]
+        },
+        {
+          "name": "Tier 1 override",
+          "className": "s-tier-1",
+          "visibleWhen": "#view-tier1.active",
+          "yPositions": [null,null,null,null,null,null,null,null,null,null,null,null,166,135,112,100],
+          "values": [null,null,null,null,null,null,null,null,null,null,null,null,1.27,6.30,9.00,9.00]
+        },
+        {
+          "name": "Tier 2 override",
+          "className": "s-tier-2",
+          "visibleWhen": "#view-tier2.active",
+          "yPositions": [null,null,null,null,null,null,null,null,null,null,null,null,160,125,100,88],
+          "values": [null,null,null,null,null,null,null,null,null,null,null,null,2.81,8.71,12.00,12.00]
+        },
+        {
+          "name": "Tier 3 override",
+          "className": "s-tier-3",
+          "visibleWhen": "#view-tier3.active",
+          "yPositions": [null,null,null,null,null,null,null,null,null,null,null,null,154,118,88,76],
+          "values": [null,null,null,null,null,null,null,null,null,null,null,null,4.30,10.54,15.00,15.00]
+        },
         {
           "name": "Total expenditures",
           "className": "s-neutral",
-          "valuePrefix": "$",
-          "valueSuffix": "M",
-          "valueDecimals": 1,
-          "values": [70.5,73.2,76.9,81.8,83.3,85.2,85.8,93.6,96.8,100.1,105.0,112.5,120.5,126.5,133.0,139.5]
+          "values": [70.50,73.20,76.86,81.76,83.27,85.21,85.80,93.58,96.83,100.10,105.00,112.50,120.50,126.50,133.00,139.50]
         }
       ]
     }


### PR DESCRIPTION
## Summary

Follow-up to #339. Extends the existing `sustainability.html` tooltip (which was expense-line-only) to cover the stacked bars and the active override tier. Hover any year and the tooltip now shows:

- **Base revenue** (green bar)
- **Free cash drawn** (brass bar, when the chart draws one)
- **Tier 1 / 2 / 3 override** - only the one whose view tab is active, matching the visible bars on the chart
- **Total expenditures** (the line)

## Infrastructure change in `chart-tooltip.js`

New per-series field **`visibleWhen`**: if set, it holds a CSS selector, and the series is only rendered when the selector currently matches something in the document. For sustainability, the three tier series use `#view-tier1.active`, `#view-tier2.active`, `#view-tier3.active`, which already mirrors the existing tab-switch pattern in `sustainability.html` (the page's own JS toggles `.active` on `#view-tierN` when you click a tab).

No tab-switch plumbing was added to the runtime. The existing click-outside-wrap logic already hides the tooltip when a tab button is clicked (the tabs live outside the chart wrapper), so the next hover naturally re-renders with the new active view. Verified by simulating all four views against the JSON.

## Data sources

- **Base revenue** from `data/general_fund_budgetary_FY15-24.csv` for FY15-FY24 (the ACFR general fund schedule), and from the chart's FY25-FY30 projection comments for the remaining years. Note: the chart visually caps the green bar at the expense level in years where revenue exceeded expenses (FY15-FY17), but the tooltip shows the actual ACFR revenue, which is the primary-source number. Expected minor discrepancy: the bar is drawn to $70.50M for FY15 while the tooltip row says $71.32M.
- **Free cash drawn** is the amount needed to bridge the rev/exp gap, so it's `null` for years where revenue exceeded expenses (FY15-FY17) and the row is omitted.
- **Tier override phase-in** from the draw-schedule comments on the chart (FY27 $1.27M / $2.81M / $4.30M → full at FY29).
- **Total expenditures** unchanged from #339, bumped to 2dp for consistency with the other rows.

## Test plan

- [ ] Default "No override" view: hover FY15-FY30. Tooltip shows Base revenue / (Free cash drawn, from FY18 on) / Total expenditures. FY15-FY17 skip the free-cash row.
- [ ] Click Tier 1 ($9M). Tooltip now has a fourth row "Tier 1 override" for years FY27-FY30, and the green/brass dots land on their respective bar tops.
- [ ] Same for Tier 2 and Tier 3 - only the active tier row appears.
- [ ] Mobile tap: tap the chart, tap a tab, tap the chart again. Tooltip refreshes to the new view's content.
- [ ] Regression: other tooltip-enabled charts still behave the same (they have no `visibleWhen` on their series, so the runtime path is identical).
- [ ] Dark mode readable.

https://claude.ai/code/session_01Ppz6YgSKVJtdSWLgjDpAnt