### PR TITLE
Load JS only on pages that need it

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,12 +24,13 @@
 <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
 <link rel="icon" href="{{ '/' | relative_url }}favicon.svg" type="image/svg+xml">
 <link rel="stylesheet" href="{{ '/' | relative_url }}assets/site.css">
-<script defer src="{{ '/' | relative_url }}assets/citations.js"></script>
-<script defer src="{{ '/' | relative_url }}assets/ballot.js"></script>
-<script defer src="{{ '/' | relative_url }}assets/deep-dive.js"></script>
 <script defer src="{{ '/' | relative_url }}assets/analytics.js"></script>
-<script defer src="{{ '/' | relative_url }}assets/lens.js"></script>
-<script defer src="{{ '/' | relative_url }}assets/chart-tooltip.js"></script>
+{% if page.scripts contains "citations" %}<script defer src="{{ '/' | relative_url }}assets/citations.js"></script>
+{% endif %}{% if page.scripts contains "ballot" %}<script defer src="{{ '/' | relative_url }}assets/ballot.js"></script>
+{% endif %}{% if page.scripts contains "deep-dive" %}<script defer src="{{ '/' | relative_url }}assets/deep-dive.js"></script>
+{% endif %}{% if page.scripts contains "lens" %}<script defer src="{{ '/' | relative_url }}assets/lens.js"></script>
+{% endif %}{% if page.scripts contains "chart-tooltip" %}<script defer src="{{ '/' | relative_url }}assets/chart-tooltip.js"></script>
+{% endif %}
 {% unless page.community_pulse == "off-sections" %}
 <link rel="stylesheet" href="{{ '/' | relative_url }}assets/community-pulse/widget.css">
 <script type="module" src="{{ '/' | relative_url }}assets/community-pulse/widget.js" data-api-base="https://marblehead-community-pulse.agbaber.workers.dev"></script>

--- a/charts/enrollment_vs_staffing.html
+++ b/charts/enrollment_vs_staffing.html
@@ -1,5 +1,6 @@
 ---
 title: "Enrollment vs. Staffing"
+scripts: [chart-tooltip]
 ---
 <style>
 .chart-label {

--- a/charts/four_town_rates.html
+++ b/charts/four_town_rates.html
@@ -1,5 +1,6 @@
 ---
 title: "Rate and Bill Comparison"
+scripts: [chart-tooltip]
 ---
 <style>
   dl.defined-terms { margin: 0 0 20px; }

--- a/charts/healthcare_costs.html
+++ b/charts/healthcare_costs.html
@@ -1,5 +1,6 @@
 ---
 title: "Why Health Insurance Keeps Rising"
+scripts: [chart-tooltip]
 og_title: "Why health insurance keeps rising"
 og_description: "Tax levy vs health insurance indexed, spending vs FTE, and the GIC family plan premium. Three views of the same question in Marblehead's budget."
 og_url: https://marbleheaddata.org/charts/healthcare_costs.html

--- a/charts/levy_vs_bill.html
+++ b/charts/levy_vs_bill.html
@@ -1,5 +1,6 @@
 ---
 title: "Tax Levy, Median Bill, and Inflation"
+scripts: [chart-tooltip]
 ---
 <h1 class="h-center">Marblehead Tax Levy, Median Single-Family Bill, and Inflation, FY2012&ndash;FY2024</h1>
 <p class="subtitle h-center">Three indexed growth rates over a twelve-year window. Source: Marblehead <abbr class="g" title="Annual Comprehensive Financial Reports">ACFRs</abbr>, MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr>, US <abbr class="g" title="Bureau of Labor Statistics">BLS</abbr>.</p>

--- a/charts/sustainability.html
+++ b/charts/sustainability.html
@@ -1,5 +1,6 @@
 ---
 title: "General Fund Revenue, Free Cash, and Expenses"
+scripts: [chart-tooltip]
 ---
 <style>
   .chart-view { display: none; }

--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -1,5 +1,6 @@
 ---
 title: "How did we get here?"
+scripts: [citations]
 ---
 <h1>How did we get here?</h1>
   <p>The FY27 override vote is not a surprise. It was forecast, warned about, and predicted in writing by Marblehead's Finance Committee for years. Reading <abbr class="g" title="Finance Committee">FinCom</abbr>'s own annual transmittal letters to Town Meeting, there is a clean arc from "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025. This page traces that arc in <abbr class="g" title="Finance Committee">FinCom</abbr>'s own words.</p>

--- a/inside-school-staffing.html
+++ b/inside-school-staffing.html
@@ -1,5 +1,6 @@
 ---
 title: "Inside school staffing"
+scripts: [citations, deep-dive]
 og_title: "Inside school staffing"
 og_description: "What 430 school positions actually are, how many are legally mandated, how Marblehead compares to peer towns by role, and what options exist."
 og_url: https://marbleheaddata.org/inside-school-staffing.html

--- a/marblehead-voting-record.html
+++ b/marblehead-voting-record.html
@@ -1,5 +1,6 @@
 ---
 title: "Marblehead's Prop 2½ voting record"
+scripts: [citations]
 og_title: "Marblehead's Prop 2½ voting record"
 og_description: "Every Proposition 2½ vote since 1988: what passed, what failed, and how much. Operating overrides and debt exclusions with vote counts and primary sources."
 og_url: https://marbleheaddata.org/marblehead-voting-record.html

--- a/no-override-budget.html
+++ b/no-override-budget.html
@@ -1,5 +1,6 @@
 ---
 title: "What's in the no-override budget?"
+scripts: [citations]
 og_title: "What's in the no-override budget?"
 og_description: "The line-item changes in the town's FY27 No-Override Balanced Budget: 22 town positions, 18 school FTEs, the library reduced 43 percent, and what comparable Massachusetts towns did after similar votes."
 og_url: https://marbleheaddata.org/no-override-budget.html

--- a/question-2-trash.html
+++ b/question-2-trash.html
@@ -1,5 +1,6 @@
 ---
 title: "Trash: levy or fee?"
+scripts: [citations, deep-dive, ballot]
 og_title: "Trash: levy or fee? (Question 2)"
 og_description: The $2.3 million Question 2 trash ask, in plain English. What is actually being decided, what has already been decided, what it costs at different home values, how other Massachusetts towns handle curbside trash, and the long-term options Marblehead has considered (or hasn't).
 og_url: https://marbleheaddata.org/question-2-trash.html

--- a/senior-tax-relief.html
+++ b/senior-tax-relief.html
@@ -1,5 +1,6 @@
 ---
 title: "What relief can seniors claim?"
+scripts: [citations, deep-dive]
 og_title: "What relief can seniors claim? (Marblehead)"
 og_description: "Calculator: enter your home value and income to see your Circuit Breaker credit, how the override affects you after relief, and what Article 28 would add. 418 Marblehead seniors claimed the credit in 2022, likely underclaimed."
 og_url: https://marbleheaddata.org/senior-tax-relief.html

--- a/the-debate.html
+++ b/the-debate.html
@@ -1,5 +1,6 @@
 ---
 title: "Both sides of the override debate"
+scripts: [citations, lens]
 og_title: "Both sides of the override debate"
 og_description: The six dividing lines in the FY27 override debate, presented as the strongest version of each side's case. A map of where the real disagreements are, for readers still working through their vote.
 og_url: https://marbleheaddata.org/the-debate.html

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -1,5 +1,6 @@
 ---
 title: "What is the override?"
+scripts: [citations, deep-dive, ballot]
 og_title: What is the override?
 og_description: The three-tier structure of the proposed Marblehead override, what each tier funds, key terms, and historical context.
 og_url: https://marbleheaddata.org/what-is-the-override.html

--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -1,5 +1,6 @@
 ---
 title: "What can you do?"
+scripts: [citations]
 og_title: "What can you do?"
 og_description: "How to engage with Marblehead budget decisions beyond voting yes or no on the override: who decides what, when residents can input, and what longer-term oversight looks like."
 og_url: https://marbleheaddata.org/what-you-can-do.html

--- a/whats-on-the-ballot.html
+++ b/whats-on-the-ballot.html
@@ -1,5 +1,6 @@
 ---
 title: "What else is on the June 9 ballot?"
+scripts: [citations]
 og_title: "What else is on the June 9 ballot?"
 og_description: "Beyond the override questions, Marblehead voters will fill 24 seats across 11 elected bodies on June 9, 2026. Here is every office up for election, the seats available, and how to confirm the final candidate list."
 og_url: https://marbleheaddata.org/whats-on-the-ballot.html

--- a/where-has-the-money-gone.html
+++ b/where-has-the-money-gone.html
@@ -1,5 +1,6 @@
 ---
 title: "Where has Marblehead's money gone?"
+scripts: [citations, deep-dive, chart-tooltip]
 og_title: "Where has Marblehead's money gone?"
 og_description: Marblehead's general fund grew from $70.5M to $106.2M between FY2015 and FY2026. Here's where the $35.7M went, who has been checking the books, and which lines grew faster than enrollment, inflation, or headcount would explain.
 og_url: https://marbleheaddata.org/where-has-the-money-gone.html

--- a/why-not-elsewhere.html
+++ b/why-not-elsewhere.html
@@ -1,5 +1,6 @@
 ---
 title: "Why do some MA towns run overrides and others don't?"
+scripts: [citations]
 og_title: "Why do some MA towns run overrides and others don't?"
 og_description: A neutral walkthrough of the revenue alternatives the town has considered or rejected, with the concrete fiscal tradeoffs for each.
 og_url: https://marbleheaddata.org/why-not-elsewhere.html


### PR DESCRIPTION
## Summary
- Scripts (citations, ballot, deep-dive, lens, chart-tooltip) now load conditionally via a `scripts` frontmatter array instead of globally on every page
- Pages that don't use a script no longer download, parse, or execute it
- analytics.js stays global; community-pulse already had its own conditional

**Before:** Every page loaded all 6 optional scripts regardless of whether it had matching DOM elements.

**After:** Pages declare what they need. The 6 "Poor" pages from Lighthouse (about, per_capita_levy, override_calculator, healthcare_costs, the-debate, where-has-the-money-gone) each drop 3-5 unnecessary script loads.

| Page | Scripts before | Scripts after |
|------|---------------|--------------|
| /about.html (1.48s) | 6 | 0 |
| /charts/override_calculator.html (2.04s) | 6 | 0 |
| /charts/per_capita_levy.html (1.56s) | 6 | 0 |
| /charts/healthcare_costs.html (1.00s) | 6 | 1 (chart-tooltip) |
| /the-debate.html (1.60s) | 6 | 2 (citations, lens) |
| /where-has-the-money-gone.html (509ms) | 6 | 3 (citations, deep-dive, chart-tooltip) |

## Test plan
- [ ] Verify charts with tooltips still work (healthcare_costs, levy_vs_bill, four_town_rates, sustainability, enrollment_vs_staffing, where-has-the-money-gone)
- [ ] Verify citations render on pages that have them (the-debate, how-we-got-here, etc.)
- [ ] Verify ballot widget works on what-is-the-override and question-2-trash
- [ ] Verify lens toggle works on the-debate
- [ ] Verify deep-dive collapsibles work on where-has-the-money-gone, senior-tax-relief, etc.
- [ ] Verify pages without scripts (about, override_calculator, per_capita_levy) load cleanly with no console errors
- [ ] Re-run Lighthouse/PageSpeed to measure improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)