### PR TITLE
Link meeting video IDs to Vimeo/YouTube

### DIFF
--- a/data/meeting-tracker.html
+++ b/data/meeting-tracker.html
@@ -11,7 +11,7 @@ body_class: doc-page
   <p>This is not a meeting recap. It is a data audit trail: a way to see how the numbers on this site have shifted over time and why. Entries are sourced from public video, official presentations, and primary documents. Where auto-generated captions were the initial source, claims are cross-referenced against primary documents before appearing on topic pages.</p>
 
   <h2 id="apr-8-2026">April 8, 2026</h2>
-  <p>Select Board (Vimeo 1181632658) and School Committee (YouTube VFf_HUGS1o0)</p>
+  <p>Select Board (<a href="https://vimeo.com/1181632658">Vimeo</a>) and School Committee (<a href="https://www.youtube.com/watch?v=VFf_HUGS1o0">YouTube</a>)</p>
 
   <table>
     <thead>


### PR DESCRIPTION
## Summary
- Converts plain-text video IDs on the meeting changelog to clickable links (Vimeo for Select Board, YouTube for School Committee)

## Test plan
- [ ] Verify links open correct videos on /data/meeting-tracker.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)