### PR TITLE
Enrich landing cards with topic icons, context, and perspectives count

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,10 @@ og_url: https://marbleheaddata.org/
     gap: 8px;
   }
   .explore-question-card {
-    display: block;
+    display: grid;
+    grid-template-columns: 36px 1fr;
+    grid-template-rows: auto auto auto;
+    gap: 0 12px;
     position: relative;
     background: var(--surface);
     border: 1.5px solid var(--border);
@@ -85,10 +88,6 @@ og_url: https://marbleheaddata.org/
     text-align: left;
     font: inherit;
     color: var(--text);
-    font-size: 16px;
-    font-weight: 600;
-    line-height: 1.4;
-    letter-spacing: -0.1px;
   }
   .explore-question-card:hover {
     border-color: var(--c-navy);
@@ -116,16 +115,82 @@ og_url: https://marbleheaddata.org/
     box-shadow: var(--shadow-sm);
     border: 2px solid var(--bg);
   }
+
+  /* Icon */
+  .explore-card-icon {
+    grid-column: 1;
+    grid-row: 1 / -1;
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--c-navy) 10%, transparent);
+    color: var(--c-navy);
+    flex-shrink: 0;
+    align-self: start;
+    margin-top: 1px;
+  }
+  .explore-card-icon svg {
+    width: 18px;
+    height: 18px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.8;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .explore-question-card.has-pick .explore-card-icon {
+    background: color-mix(in srgb, var(--c-teal) 12%, transparent);
+    color: var(--c-teal);
+  }
+
+  /* Title */
+  .explore-card-title {
+    grid-column: 2;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.4;
+    letter-spacing: -0.1px;
+  }
+
+  /* Context subtitle */
+  .explore-card-context {
+    grid-column: 2;
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--text-muted);
+    line-height: 1.45;
+    margin-top: 3px;
+  }
+
+  /* Perspectives count */
+  .explore-card-meta {
+    grid-column: 2;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-subtle);
+    margin-top: 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  /* Pick display */
   .explore-card-pick {
-    display: block;
+    display: none;
+    grid-column: 2;
     font-size: 13px;
     font-weight: 500;
     color: var(--c-teal);
-    margin-top: 6px;
+    margin-top: 8px;
     line-height: 1.4;
+    padding-top: 8px;
+    border-top: 1px solid color-mix(in srgb, var(--c-teal) 20%, transparent);
   }
-  .explore-question-card.has-pick .explore-card-pick::before {
-    content: "Your view";
+  .explore-question-card.has-pick .explore-card-pick { display: block; }
+  .explore-question-card.has-pick .explore-card-meta { display: none; }
+  .explore-card-pick-label {
     display: block;
     font-size: 10px;
     font-weight: 700;
@@ -190,9 +255,6 @@ og_url: https://marbleheaddata.org/
     padding: 4px 0 0;
   }
   .explore-shared-fresh:hover { text-decoration: underline; }
-  .shared-mode .explore-question-card.has-pick .explore-card-pick::before {
-    content: "Their view";
-  }
 
   /* Hide landing once a topic is active */
   .explore-stage.has-topic .explore-landing { display: none; }
@@ -1061,7 +1123,8 @@ og_url: https://marbleheaddata.org/
   /* ── Responsive ── */
   @media (min-width: 600px) {
     .explore-landing-head h1 { font-size: 34px; }
-    .explore-question-card { font-size: 17px; padding: 18px 24px; }
+    .explore-question-card { padding: 18px 24px; }
+    .explore-card-title { font-size: 17px; }
     .question-block h1 { font-size: 32px; }
     .answers {
       flex-direction: row;
@@ -1073,7 +1136,11 @@ og_url: https://marbleheaddata.org/
     .explore-stage { padding-top: 20px; }
     .explore-landing-head { padding: 24px 0 20px; }
     .explore-landing-head h1 { font-size: 24px; }
-    .explore-question-card { font-size: 15px; padding: 14px 16px; }
+    .explore-question-card { padding: 14px 16px; grid-template-columns: 30px 1fr; gap: 0 10px; }
+    .explore-card-icon { width: 30px; height: 30px; border-radius: 6px; }
+    .explore-card-icon svg { width: 15px; height: 15px; }
+    .explore-card-title { font-size: 15px; }
+    .explore-card-context { font-size: 12px; }
     .question-block h1 { font-size: 22px; }
     .answer-card { padding: 14px 16px; }
     .question-nav { gap: 8px; }
@@ -3870,26 +3937,73 @@ og_url: https://marbleheaddata.org/
     screen.appendChild(wrap);
   });
 
+  /* ── Topic icons (inline SVG paths) ── */
+  var topicIcons = {
+    override:     '<path d="M3 12h4l3-9 4 18 3-9h4"/>',                          /* pulse/budget */
+    voteno:       '<path d="M6 9l6 6m0-6l-6 6"/><rect x="2" y="4" width="14" height="14" rx="2"/>', /* cuts */
+    schools:      '<path d="M2 10l7-4 7 4-7 4z"/><path d="M4 11v4c0 1 3 3 5 3s5-2 5-3v-4"/>', /* school */
+    levy:         '<rect x="3" y="12" width="3" height="6"/><rect x="8" y="8" width="3" height="10"/><rect x="13" y="4" width="3" height="14"/>', /* bars */
+    taxrank:      '<path d="M3 9l4-5 4 5"/><path d="M5 9v7h6V9"/><path d="M2 18h14"/>',  /* house */
+    mycost:       '<rect x="3" y="2" width="12" height="16" rx="1"/><path d="M7 6h4m-4 3h4m-4 3h2"/>', /* calculator */
+    again:        '<path d="M3 10a6 6 0 1 1 1.5 4"/><path d="M3 14V10h4"/>',     /* cycle */
+    alternatives: '<path d="M9 3v5m0 0l-5 5m5-5l5 5"/><circle cx="4" cy="15" r="2"/><circle cx="14" cy="15" r="2"/>', /* fork */
+    trash:        '<path d="M4 5h10m-8 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1"/><path d="M5 5l1 11a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1l1-11"/>', /* trash can */
+    trust:        '<path d="M9 2l6 3v4c0 4-2.5 7.5-6 9-3.5-1.5-6-5-6-9V5z"/>'   /* shield */
+  };
+
   /* ── Build landing question cards from actual h1s ── */
   var listEl = document.getElementById('questionList');
   var shareStripEl = document.getElementById('shareStrip');
-  var landingCards = {};  // topic -> card element
+  var landingCards = {};  // topic -> { el, pick, pickLabel, pickText }
 
   document.querySelectorAll('.question-screen').forEach(function (screen) {
     var topic = screen.dataset.topic;
     var h1 = screen.querySelector('.question-block h1');
     if (!h1 || !listEl) return;
+
     var btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'explore-question-card';
     btn.dataset.topic = topic;
 
+    /* Icon */
+    var iconWrap = document.createElement('span');
+    iconWrap.className = 'explore-card-icon';
+    var svgMarkup = topicIcons[topic] || '';
+    iconWrap.innerHTML = '<svg viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">' + svgMarkup + '</svg>';
+    btn.appendChild(iconWrap);
+
+    /* Title */
     var titleSpan = document.createElement('span');
+    titleSpan.className = 'explore-card-title';
     titleSpan.textContent = h1.textContent;
     btn.appendChild(titleSpan);
 
+    /* Context subtitle */
+    var ctxP = screen.querySelector('.question-context');
+    if (ctxP) {
+      var ctxSpan = document.createElement('span');
+      ctxSpan.className = 'explore-card-context';
+      ctxSpan.textContent = ctxP.textContent.trim();
+      btn.appendChild(ctxSpan);
+    }
+
+    /* Perspectives count */
+    var answerCount = screen.querySelectorAll('.answer-card').length;
+    var metaSpan = document.createElement('span');
+    metaSpan.className = 'explore-card-meta';
+    metaSpan.textContent = answerCount + ' perspectives';
+    btn.appendChild(metaSpan);
+
+    /* Pick display */
     var pickSpan = document.createElement('span');
     pickSpan.className = 'explore-card-pick';
+    var pickLabel = document.createElement('span');
+    pickLabel.className = 'explore-card-pick-label';
+    pickLabel.textContent = 'Your view';
+    pickSpan.appendChild(pickLabel);
+    var pickText = document.createElement('span');
+    pickSpan.appendChild(pickText);
     btn.appendChild(pickSpan);
 
     btn.addEventListener('click', function () {
@@ -3897,24 +4011,29 @@ og_url: https://marbleheaddata.org/
       window.scrollTo(0, 0);
     });
     listEl.appendChild(btn);
-    landingCards[topic] = { el: btn, pick: pickSpan };
+    landingCards[topic] = { el: btn, pick: pickSpan, pickLabel: pickLabel, pickText: pickText };
   });
 
   /* Update landing cards to reflect current selections */
   function updateLandingCards() {
     var hasAny = false;
+    var landingEl = document.querySelector('.explore-landing');
+    var isShared = landingEl && landingEl.classList.contains('shared-mode');
+    var labelText = isShared ? 'Their view' : 'Your view';
     Object.keys(landingCards).forEach(function (topic) {
       var card = landingCards[topic];
       var answer = selections[topic];
       if (answer) {
         hasAny = true;
-        var answerCard = document.querySelector(
-          '.answer-card[data-question="' + topic + '"][data-answer="' + answer + '"] h2'
+        var answerEl = document.querySelector(
+          '.answer-card[data-question="' + topic + '"][data-answer="' + answer + '"]'
         );
-        card.pick.textContent = answerCard ? answerCard.textContent : '';
+        var h2 = answerEl ? answerEl.querySelector('h2') : null;
+        card.pickText.textContent = h2 ? h2.textContent : '';
+        card.pickLabel.textContent = labelText;
         card.el.classList.add('has-pick');
       } else {
-        card.pick.textContent = '';
+        card.pickText.textContent = '';
         card.el.classList.remove('has-pick');
       }
     });


### PR DESCRIPTION
## Summary
- Adds a small inline SVG icon per topic (pulse for override, scissors for cuts, school cap, bar chart, house, calculator, cycle, fork, trash can, shield) for quick visual identification
- Shows the question-context paragraph as a subtitle on each card so users get the framing without drilling in
- Displays "3 perspectives" count on unanswered cards; replaced by "Your view" + answer heading once picked
- Shared-mode links show "Their view" instead of "Your view"

## Test plan
- [ ] Verify all 10 question cards render with icons, context text, and "3 perspectives" label
- [ ] Pick an answer, return to landing -- card should show checkmark, teal border, "Your view" + answer heading, no perspectives count
- [ ] Open a shared positions link -- cards should say "Their view" instead of "Your view"
- [ ] Test mobile (< 600px) -- icons should shrink to 30px, text should remain readable
- [ ] Test dark mode -- icons should adapt via CSS variable inheritance

🤖 Generated with [Claude Code](https://claude.com/claude-code)