### PR TITLE
Change hero headline to "Do we need an override?"

### DIFF
--- a/browse.html
+++ b/browse.html
@@ -8,7 +8,7 @@ og_type: website
 og_url: https://marbleheaddata.org/browse.html
 ---
 <div class="hero">
-    <h1>Weighing the FY2027 override?</h1>
+    <h1>Do we need an override?</h1>
     <p>Every claim on this site cites a primary source. Every dollar traces to a town document. Make your own call. <a href="#data-sources">See all sources.</a></p>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -1066,7 +1066,7 @@ og_url: https://marbleheaddata.org/
   <!-- Landing (shown until a topic is picked; JS populates question cards) -->
   <div class="explore-landing">
     <div class="explore-landing-head">
-      <h1>Weighing the FY2027 override?</h1>
+      <h1>Do we need an override?</h1>
       <p>Each question shows the strongest case for every answer. Pick the one you agree with. Your picks build into a set of positions you can review or share.</p>
     </div>
 
@@ -4416,7 +4416,7 @@ og_url: https://marbleheaddata.org/
       }
       Object.keys(selections).forEach(function (k) { delete selections[k]; });
       isSharedView = false;
-      if (headingEl) headingEl.textContent = 'Weighing the FY2027 override?';
+      if (headingEl) headingEl.textContent = 'Do we need an override?';
       if (subEl) subEl.textContent = 'Each question shows the strongest case for every answer. Pick the one you agree with. Your picks build into a set of positions you can review or share.';
       sharedBanner.classList.remove('visible');
       document.querySelector('.explore-landing').classList.remove('shared-mode');


### PR DESCRIPTION
## Summary

Replaces the hero headline "Weighing the FY2027 override?" with "Do we need an override?" on `browse.html` and the `index.html` Explore landing (plus the JS reset that restores the heading after clearing a shared view).

## Why

- **"FY2027" added friction without orientation.** Most residents don't think in fiscal-year terms, and the label goes stale the day after Town Meeting.
- **"Weighing" presumed the reader was already mid-process.** It didn't meet people who hadn't started thinking about it yet.
- **"Do we need an override?" names the question the whole site exists to help you answer.** The charts, sources, FinCom history, and no-override budget breakdown all ladder into it.
- **Neutral by design.** No presupposition yes or no. "We" is community framing, not "you vs. the town." Consistent with the README / STYLE_GUIDE editorial stance: state the question, let residents make their own call.
- Sets up the existing subtitles cleanly on both pages ("Make your own call" on browse; the question-walker intro on the Explore tool).

## Test plan

- [ ] Load `browse.html` and confirm the hero `<h1>` reads "Do we need an override?"
- [ ] Load `index.html` Explore landing and confirm the heading reads "Do we need an override?"
- [ ] Enter a shared Explore view, then click "Start fresh" and confirm the heading resets to "Do we need an override?" (exercises the JS on index.html:4419)
- [ ] Spot-check that no other page still references the old "Weighing the FY2027 override?" string