### PR TITLE
Add lighthouse beam animation on dark mode toggle

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -148,10 +148,41 @@
     navInner.scrollLeft = Math.max(0, target);
   })();
 
-  // Theme toggle
+  // Theme toggle + lighthouse beam sweep
   (function () {
     var btn = document.querySelector('.theme-toggle');
     if (!btn) return;
+
+    // Lighthouse lamp position: 50% x, 17.5% y of the watermark SVG.
+    // Watermark CSS: bottom: -150px; right: 0; height: 1260px; width: 840px.
+    function getLampPos() {
+      var h = 1260, w = 840, r = 0, b = -150;
+      var elBottomY = window.innerHeight - b;
+      var elTopY = elBottomY - h;
+      var elRightX = window.innerWidth - r;
+      var elLeftX = elRightX - w;
+      return { x: elLeftX + w * 0.50, y: elTopY + h * 0.175 };
+    }
+
+    var beamEl = null;
+    function fireBeam() {
+      if (beamEl && beamEl.parentNode) beamEl.parentNode.removeChild(beamEl);
+      var pos = getLampPos();
+      beamEl = document.createElement('div');
+      beamEl.className = 'beam-light';
+      beamEl.style.left = pos.x + 'px';
+      beamEl.style.top = pos.y + 'px';
+      beamEl.style.marginLeft = '-40vw';
+      beamEl.style.marginTop = '-5px';
+      document.body.appendChild(beamEl);
+      void beamEl.offsetWidth;
+      beamEl.classList.add('sweeping');
+      beamEl.addEventListener('animationend', function () {
+        if (beamEl && beamEl.parentNode) beamEl.parentNode.removeChild(beamEl);
+        beamEl = null;
+      });
+    }
+
     btn.addEventListener('click', function () {
       var current = document.documentElement.getAttribute('data-theme');
       var next = current === 'dark' ? 'light' : 'dark';
@@ -160,6 +191,7 @@
       if (typeof posthog !== 'undefined') {
         posthog.capture('theme_toggled', { theme: next });
       }
+      if (next === 'dark') fireBeam();
     });
   })();
 </script>

--- a/assets/site.css
+++ b/assets/site.css
@@ -419,6 +419,41 @@ html[data-theme="light"] .theme-icon--moon { display: block; }
 }
 
 /* ==========================================================================
+   Lighthouse beam (one-shot sweep on dark-mode entry)
+   A soft glow centered on the lighthouse lamp position, starts wide
+   (beam in profile) and compresses (beam rotating toward viewer).
+   Fired via JS -- a .beam-light div is appended to body, animated,
+   then removed.
+   ========================================================================== */
+
+.beam-light {
+  position: fixed;
+  pointer-events: none;
+  z-index: 1000;
+  border-radius: 50%;
+  width: 80vw;
+  height: 10px;
+  background: radial-gradient(
+    ellipse 35% 50% at 50% 50%,
+    rgba(255,232,170,0.9) 0%,
+    rgba(255,232,170,0.2) 40%,
+    rgba(255,232,170,0.04) 70%,
+    transparent 100%
+  );
+  filter: blur(5px);
+  opacity: 0;
+}
+.beam-light.sweeping {
+  animation: beam-rotate 4s ease-in-out forwards;
+}
+@keyframes beam-rotate {
+  0%   { opacity: 0;    transform: scaleX(1) scaleY(1); }
+  15%  { opacity: 0.70; }
+  60%  { opacity: 0.70; transform: scaleX(0.3) scaleY(2.5); }
+  100% { opacity: 0;    transform: scaleX(0.15) scaleY(3); }
+}
+
+/* ==========================================================================
    Read next CTA block (end-of-post continuation link)
    ========================================================================== */
 


### PR DESCRIPTION
## Summary
- When toggling to dark mode, a soft warm light beam fires from the lighthouse watermark's lamp position
- The beam starts wide (lighthouse beam in profile) and compresses horizontally as it "rotates toward the viewer," then fades out
- One-shot animation per dark mode entry, no looping
- Beam is a JS-created div positioned at the lamp coordinates (50% x, 17.5% y of the watermark SVG), animated via CSS, then removed from DOM

## Test plan
- [ ] Toggle to dark mode on desktop -- beam should sweep from the lighthouse area
- [ ] Toggle back to light -- no beam
- [ ] Toggle to dark again -- beam fires again
- [ ] Check mobile (<800px) -- beam still fires (from calculated position)
- [ ] Verify existing theme toggle still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)