### PR TITLE
Replace landing card icons with proper Lucide SVGs

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,11 +133,11 @@ og_url: https://marbleheaddata.org/
     margin-top: 1px;
   }
   .explore-card-icon svg {
-    width: 18px;
-    height: 18px;
+    width: 20px;
+    height: 20px;
     fill: none;
     stroke: currentColor;
-    stroke-width: 1.8;
+    stroke-width: 2;
     stroke-linecap: round;
     stroke-linejoin: round;
   }
@@ -1118,7 +1118,7 @@ og_url: https://marbleheaddata.org/
     .explore-landing-head h1 { font-size: 24px; }
     .explore-question-card { padding: 14px 16px; grid-template-columns: 30px 1fr; gap: 0 10px; }
     .explore-card-icon { width: 30px; height: 30px; border-radius: 6px; }
-    .explore-card-icon svg { width: 15px; height: 15px; }
+    .explore-card-icon svg { width: 16px; height: 16px; }
     .explore-card-title { font-size: 15px; }
     .explore-card-context { font-size: 12px; }
     .question-block h1 { font-size: 22px; }
@@ -3921,17 +3921,18 @@ og_url: https://marbleheaddata.org/
   });
 
   /* ── Topic icons (inline SVG paths) ── */
+  /* Lucide-based icons, 24x24 viewBox */
   var topicIcons = {
-    override:     '<path d="M3 12h4l3-9 4 18 3-9h4"/>',                          /* pulse/budget */
-    voteno:       '<path d="M6 9l6 6m0-6l-6 6"/><rect x="2" y="4" width="14" height="14" rx="2"/>', /* cuts */
-    schools:      '<path d="M2 10l7-4 7 4-7 4z"/><path d="M4 11v4c0 1 3 3 5 3s5-2 5-3v-4"/>', /* school */
-    levy:         '<rect x="3" y="12" width="3" height="6"/><rect x="8" y="8" width="3" height="10"/><rect x="13" y="4" width="3" height="14"/>', /* bars */
-    taxrank:      '<path d="M3 9l4-5 4 5"/><path d="M5 9v7h6V9"/><path d="M2 18h14"/>',  /* house */
-    mycost:       '<rect x="3" y="2" width="12" height="16" rx="1"/><path d="M7 6h4m-4 3h4m-4 3h2"/>', /* calculator */
-    again:        '<path d="M3 10a6 6 0 1 1 1.5 4"/><path d="M3 14V10h4"/>',     /* cycle */
-    alternatives: '<path d="M9 3v5m0 0l-5 5m5-5l5 5"/><circle cx="4" cy="15" r="2"/><circle cx="14" cy="15" r="2"/>', /* fork */
-    trash:        '<path d="M4 5h10m-8 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1"/><path d="M5 5l1 11a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1l1-11"/>', /* trash can */
-    trust:        '<path d="M9 2l6 3v4c0 4-2.5 7.5-6 9-3.5-1.5-6-5-6-9V5z"/>'   /* shield */
+    override:     '<path d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83"/><circle cx="12" cy="12" r="4"/>',  /* sun – big-picture */
+    voteno:       '<path d="M6 18L18 6M6 6l12 12"/>',                             /* X – no vote */
+    schools:      '<path d="M22 10v6M2 10l10-5 10 5-10 5z"/><path d="M6 12v5c0 1.1 2.7 3 6 3s6-1.9 6-3v-5"/>', /* graduation cap */
+    levy:         '<path d="M3 3v18h18"/><path d="M7 16l4-4 4 4 5-7"/>',          /* trending up */
+    taxrank:      '<path d="M3 21l5-5m0 0V21m0-5h5"/><path d="M21 3l-5 5m0 0V3m0 5h-5"/>', /* arrow swap */
+    mycost:       '<line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>', /* dollar sign */
+    again:        '<path d="M21 2v6h-6"/><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M3 22v-6h6"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/>', /* refresh */
+    alternatives: '<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/>', /* question circle */
+    trash:        '<path d="M20 7l-1.2 12.5a2 2 0 0 1-2 1.5H7.2a2 2 0 0 1-2-1.5L4 7"/><path d="M10 11v6m4-6v6M1 7h22M8 7V3.5A1.5 1.5 0 0 1 9.5 2h5A1.5 1.5 0 0 1 16 3.5V7"/>', /* trash */
+    trust:        '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>'      /* shield */
   };
 
   /* ── Build landing question cards from actual h1s ── */
@@ -3953,7 +3954,7 @@ og_url: https://marbleheaddata.org/
     var iconWrap = document.createElement('span');
     iconWrap.className = 'explore-card-icon';
     var svgMarkup = topicIcons[topic] || '';
-    iconWrap.innerHTML = '<svg viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">' + svgMarkup + '</svg>';
+    iconWrap.innerHTML = '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">' + svgMarkup + '</svg>';
     btn.appendChild(iconWrap);
 
     /* Title */


### PR DESCRIPTION
## Summary
- Replaced hand-drawn 18x18 SVG paths with Lucide-based 24x24 icons that render cleanly at small sizes
- Updated viewBox from 18 to 24, icon display from 18px to 20px (16px mobile)
- Icon mapping: sun (override), X (vote-no), graduation cap (schools), trend line (levy), arrows (tax rank), dollar sign (cost), refresh (recurrence), question circle (alternatives), trash can, shield (trust)

## Test plan
- [ ] Verify all 10 icons render clearly at desktop and mobile sizes
- [ ] Check dark mode -- icons should inherit color from CSS variables
- [ ] Check picked state -- icons should shift from navy to teal

🤖 Generated with [Claude Code](https://claude.com/claude-code)