### PR TITLE
Sort unanswered explore questions to the top

### DIFF
--- a/index.html
+++ b/index.html
@@ -4024,6 +4024,16 @@ og_url: https://marbleheaddata.org/
     if (shareStripEl) {
       shareStripEl.classList.toggle('visible', hasAny);
     }
+    // Sort unanswered questions to the top
+    if (hasAny && listEl) {
+      var cards = Array.prototype.slice.call(listEl.children);
+      cards.sort(function (a, b) {
+        var aAnswered = a.classList.contains('has-pick') ? 1 : 0;
+        var bAnswered = b.classList.contains('has-pick') ? 1 : 0;
+        return aAnswered - bAnswered;
+      });
+      cards.forEach(function (c) { listEl.appendChild(c); });
+    }
   }
 
   /* ── Share button ── */


### PR DESCRIPTION
## Summary
- When a user has answered some explore questions, unanswered ones sort to the top of the landing list so they're easy to find on return visits
- Stable sort preserves relative order within answered/unanswered groups

## Test plan
- [ ] Answer 1-2 explore questions, return to landing -- unanswered should be above answered
- [ ] Answer all questions -- order unchanged (no unanswered to promote)
- [ ] Fresh visit with no answers -- order unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)