### PR TITLE
Add library question to homepage explore flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -3418,11 +3418,236 @@ og_url: https://marbleheaddata.org/
 
   </section>
 
-  <!-- Library cuts question hidden until peer library funding data is available
+  <!-- ═══════════════════════════════════════════════════
+       QUESTION: Library
+       ═══════════════════════════════════════════════════ -->
   <section class="question-screen" data-topic="library">
-    ...
+
+    <div class="question-block">
+      <h1>Why would the library be the heaviest cut without an override?</h1>
+      <p class="question-context">
+        Marblehead approved $8.5M to renovate Abbot Library in 2021.
+        Now the no-override budget cuts library operations 43%, the
+        deepest reduction of any department. What explains that?
+      </p>
+    </div>
+
+    <div class="answers">
+      <div class="answer-card" data-answer="a" data-question="library">
+        <p class="answer-label">Answer A</p>
+        <h2>The building and the operating budget are different things</h2>
+        <p class="answer-summary">
+          The $8.5M was a debt exclusion for construction. Staff,
+          materials, and hours come from the general fund. A new
+          building doesn't change what it costs to keep it open.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="b" data-question="library">
+        <p class="answer-label">Answer B</p>
+        <h2>Law and contracts leave almost nowhere else to cut</h2>
+        <p class="answer-summary">
+          Pensions are state-mandated. Police, fire, and teacher pay
+          are locked by union contracts. Health insurance rates are
+          set by the GIC. The library has no union, no state funding
+          floor, and voluntary accreditation. The 43% isn't a
+          preference. It's what's left.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="c" data-question="library">
+        <p class="answer-label">Answer C</p>
+        <h2>The town is cutting the library to pressure a yes vote</h2>
+        <p class="answer-summary">
+          The library is visible and sympathetic. Officials could
+          spread the pain differently but are concentrating it where
+          residents will feel it most, to make the no-override
+          outcome feel unacceptable.
+        </p>
+      </div>
+    </div>
+
+    <!-- Evidence A: building vs. operating -->
+    <div class="evidence" data-evidence="library-a">
+      <div class="evidence-header">
+        <h3>The case for "different budgets"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Debt exclusion vs. general fund</h4>
+        <p>
+          The 2021 vote authorized $8.5M in borrowing specifically for
+          the Abbot Library renovation. That debt is repaid through a
+          separate line on your tax bill, outside the Proposition 2.5
+          levy cap. It cannot be used for salaries, book purchases, or
+          operating hours.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Operating costs didn't shrink with the renovation</h4>
+        <p>
+          A renovated building still needs librarians, custodians,
+          materials, and utilities. The FY26 library operating budget
+          was roughly $1.48M. The no-override budget reduces it by
+          $636K, to about $840K.
+        </p>
+        <a class="evidence-chart-link" href="no-override-budget.html">
+          Full no-override budget breakdown
+        </a>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer C would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            The building-vs.-operating distinction is real, but it
+            doesn't explain why the library takes a 43% cut while
+            other general fund departments take much less. The debt
+            exclusion explains why the renovation doesn't help; it
+            doesn't explain why the operating cut is concentrated
+            here.
+          </p>
+        </div>
+      </details>
+    </div>
+
+    <!-- Evidence B: legal and contractual locks -->
+    <div class="evidence" data-evidence="library-b">
+      <div class="evidence-header">
+        <h3>The case for "everything else is locked"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>What the town legally cannot cut</h4>
+        <p>
+          Contributory Retirement: set by <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>
+          on a state-mandated amortization schedule (+$463K in FY27).
+          Debt service: contractual bond payments. Essex Tech
+          assessment: set by the regional district, not the town.
+          These lines go up regardless of the override outcome.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>What contracts prevent cutting</h4>
+        <p>
+          Police, fire, and teacher salaries are set by collective
+          bargaining agreements. Step increases and cost-of-living
+          adjustments are locked for the contract term. Laying off
+          unionized staff triggers seniority rules, bumping, and
+          potential arbitration. Group health insurance rates are set
+          by the <abbr class="g" title="Group Insurance Commission">GIC</abbr>
+          (+$1.65M in FY27, +11%). The town cannot negotiate a lower
+          rate.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The library has none of these protections</h4>
+        <p>
+          Library staff are non-union and at-will. There is no state
+          law requiring a minimum level of library funding. State
+          accreditation (which provides roughly $57,000 in state aid
+          and reciprocal borrowing across the library network) is
+          voluntary, not mandated. That makes the library one of the
+          few departments where deep cuts are even legally possible.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The other unprotected departments got cut too</h4>
+        <p>
+          Community development: -59%. Council on Aging: staffing
+          reductions. Recreation: groundskeeper eliminated. Cemetery:
+          laborer eliminated. The library's 43% is the largest dollar
+          amount because it has the largest unprotected budget.
+        </p>
+        <a class="evidence-chart-link" href="no-override-budget.html">
+          Department-by-department cuts
+        </a>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer C would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            The legal constraints are real, but budget-building
+            involves judgment calls within those constraints. The
+            town chose to restore the stabilization transfer
+            ($250K) and workers' comp reserve ($98K) in Tier 1
+            alongside the library. A different set of priorities
+            could have shifted some of that toward library staffing.
+            "Legally constrained" and "no discretion at all" are not
+            the same thing.
+          </p>
+        </div>
+      </details>
+    </div>
+
+    <!-- Evidence C: strategic pressure -->
+    <div class="evidence" data-evidence="library-c">
+      <div class="evidence-header">
+        <h3>The case for "pressure a yes vote"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The library is the most visible cut</h4>
+        <p>
+          Every Marblehead household uses or sees the library. Cutting
+          it 43% produces a reaction in a way that cutting a planning
+          position or a DPW laborer does not. If your goal is to make
+          the no-override scenario feel painful, the library is the
+          most effective place to concentrate cuts.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The pattern exists in other towns</h4>
+        <p>
+          Stoneham's Finance Committee initially proposed eliminating
+          all library funding before the Town Administrator proposed
+          a 35% cut instead. Libraries are a common target in
+          override debates because they are popular enough to
+          generate public pressure.
+        </p>
+        <a class="evidence-chart-link" href="data/case_studies">
+          Override case studies
+        </a>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            The strategic argument requires that officials had
+            realistic alternatives and chose not to use them. But
+            the list of departments without union contracts or state
+            mandates is short: the library, community development,
+            COA, recreation, and cemetery. Community development is
+            already cut 59%. Spreading $636K evenly across those
+            departments would cripple all of them instead of deeply
+            cutting one. The skeptic's challenge is to name a
+            specific, large, unprotected line item that could have
+            absorbed this cut instead.
+          </p>
+        </div>
+      </details>
+    </div>
+
   </section>
-  -->
 
   <!-- ═══════════════════════════════════════════════════
        QUESTION: Trust


### PR DESCRIPTION
## Summary
- Adds the library question: "Why would the library be the heaviest cut without an override?"
- Three answers: building vs. operating budget distinction, legal/contractual locks on other departments, and the skeptic's case that the cut is strategic pressure
- Each answer has evidence cards with sourced data points and counter-arguments
- Replaces the commented-out library placeholder that was waiting for data

## Test plan
- [ ] Verify the library question card appears on the homepage landing
- [ ] Click each answer (A, B, C) and confirm evidence panels expand
- [ ] Verify counter-argument details expand/collapse
- [ ] Check evidence-chart-links point to correct pages (no-override-budget.html, data/case_studies)
- [ ] Mobile layout renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)