### PR TITLE
Add book icon for library question

### DIFF
--- a/index.html
+++ b/index.html
@@ -4419,6 +4419,7 @@ og_url: https://marbleheaddata.org/
     again:        '<path d="M21 2v6h-6"/><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M3 22v-6h6"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/>', /* refresh */
     alternatives: '<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/>', /* question circle */
     trash:        '<path d="M20 7l-1.2 12.5a2 2 0 0 1-2 1.5H7.2a2 2 0 0 1-2-1.5L4 7"/><path d="M10 11v6m4-6v6M1 7h22M8 7V3.5A1.5 1.5 0 0 1 9.5 2h5A1.5 1.5 0 0 1 16 3.5V7"/>', /* trash */
+    library:      '<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>', /* book */
     trust:        '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>'      /* shield */
   };
 


### PR DESCRIPTION
## Summary
- Adds a book SVG icon to the `topicIcons` map for the library question card
- Without this, the library card rendered with a blank icon slot

## Test plan
- [ ] Verify book icon appears on the library question card on the landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)