### PR TITLE
Point wrangler.toml migrations_dir at schema/

### DIFF
--- a/community-pulse/worker/wrangler.toml
+++ b/community-pulse/worker/wrangler.toml
@@ -6,6 +6,7 @@ compatibility_date = "2026-04-01"
 binding = "DB"
 database_name = "community-pulse"
 database_id = "e6c6e7ad-b93e-4d80-aeea-58e50e4ba43e"
+migrations_dir = "schema"
 
 [vars]
 ALLOWED_ORIGIN = "https://marbleheaddata.org"


### PR DESCRIPTION
## Summary

- Adds `migrations_dir = "schema"` to wrangler.toml so `wrangler d1 migrations apply` finds the SQL files

Without this, wrangler looks in the default `migrations/` folder and finds nothing.

## Test plan

- [x] Already verified: `wrangler d1 migrations apply community-pulse --remote` succeeded after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)