### PR TITLE
Fix shared link resetting viewer's own selections to zero

### DIFF
--- a/index.html
+++ b/index.html
@@ -5168,6 +5168,13 @@ og_url: https://marbleheaddata.org/
     if (typeof posthog !== 'undefined') {
       posthog.capture('explore_shared_viewed', { position_count: pairs.length });
     }
+
+    // Save the viewer's own selections so we can restore them later.
+    var savedOwnSelections = {};
+    Object.keys(selections).forEach(function (k) { savedOwnSelections[k] = selections[k]; });
+
+    // Temporarily overwrite selections with the shared picks for display.
+    Object.keys(selections).forEach(function (k) { delete selections[k]; });
     pairs.forEach(function (pair) {
       var parts = pair.split(':');
       if (parts.length === 2) {
@@ -5190,12 +5197,14 @@ og_url: https://marbleheaddata.org/
     // Hide "Share your positions" button in shared view
     if (shareStripEl) shareStripEl.style.display = 'none';
 
-    // "Start fresh" clears shared picks and restores normal landing
+    // "Start fresh" restores the viewer's own picks (not blank)
     document.getElementById('sharedFresh').addEventListener('click', function () {
       if (typeof posthog !== 'undefined') {
         posthog.capture('explore_shared_start_fresh');
       }
+      // Restore viewer's own selections
       Object.keys(selections).forEach(function (k) { delete selections[k]; });
+      Object.keys(savedOwnSelections).forEach(function (k) { selections[k] = savedOwnSelections[k]; });
       isSharedView = false;
       if (headingEl) headingEl.textContent = 'Do we need an override?';
       if (subEl) subEl.textContent = 'Each question shows the strongest case for every answer. Pick the one you agree with. Your picks build into a set of positions you can review or share.';


### PR DESCRIPTION
## Summary
- Opening a `?positions=` share link was overwriting the viewer's own saved picks with the shared ones
- Clicking "Start fresh" then deleted everything, leaving the viewer with 0 decided
- Now the viewer's own picks are saved aside before shared picks are loaded, and "Start fresh" restores them

## Test plan
- [ ] Pick answers on several questions, copy share link
- [ ] Open that share link in the same browser -- should show shared picks, not wipe yours
- [ ] Click "Start fresh" -- your own picks should reappear, not reset to zero
- [ ] Stats strip should show your correct decided count after "Start fresh"

Generated with [Claude Code](https://claude.com/claude-code)