### PR TITLE
Use Libre Franklin for headings

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,6 +17,9 @@
   });
 </script>
 <!-- End PostHog Analytics -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@600;700&display=swap" rel="stylesheet">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="color-scheme" content="light dark">
 <meta name="theme-color" content="#F4F7FA" media="(prefers-color-scheme: light)">

--- a/assets/site.css
+++ b/assets/site.css
@@ -78,6 +78,7 @@
   --gutter:    16px;
 
   /* Typography */
+  --font-heading: "Libre Franklin", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 }
@@ -730,6 +731,7 @@ h2[id] { scroll-margin-top: 68px; }
    Typography
    ========================================================================== */
 
+h1, h2, h3 { font-family: var(--font-heading); }
 h1 {
   font-size: 1.375rem; font-weight: 700; color: var(--text);
   letter-spacing: -0.3px; line-height: 1.25; margin-bottom: 6px;


### PR DESCRIPTION
## Summary
- Loads Libre Franklin (600 + 700 weights only) from Google Fonts
- Applies it to h1, h2, h3 via a new `--font-heading` custom property
- Body text stays on the system font stack
- Falls back gracefully to system fonts if the web font fails to load

## Test plan
- [ ] Check headings on the-debate.html, index, and a chart page
- [ ] Verify body text is unchanged (still system font)
- [ ] Check dark mode
- [ ] Throttle network to Slow 3G in DevTools and confirm the page renders fine while the font loads (no layout shift thanks to `display=swap`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)