### PR TITLE
Move override node above Property Tax in Sankey

### DIFF
--- a/charts/budget_flow.html
+++ b/charts/budget_flow.html
@@ -350,12 +350,15 @@ title: "Where the Money Goes"
     var rest = tier !== 'none' ? restorations[tier] : null;
 
     /* ── Build left nodes ── */
-    var leftNodes = revSources.map(function (s) {
-      return { id: s.id, label: s.label, value: s.value, type: 'rev' };
-    });
+    /* Override goes first (top), above Property Tax, since it IS
+       additional property tax levy. */
+    var leftNodes = [];
     if (ov) {
       leftNodes.push({ id: 'override', label: tierLabels[tier], value: ov.total, type: 'override' });
     }
+    revSources.forEach(function (s) {
+      leftNodes.push({ id: s.id, label: s.label, value: s.value, type: 'rev' });
+    });
 
     /* ── Build right nodes ── */
     var rightNodes = spendCats.map(function (c) {


### PR DESCRIPTION
## Summary
The override is additional property tax levy, so it now appears at the top of the left column, above Property Tax, instead of at the bottom. This visually communicates that it adds to the tax base.

## Test plan
- [ ] No Override: left column unchanged (no override node)
- [ ] Tier 1/2/3: override node appears at top, Property Tax below it
- [ ] Ribbons flow correctly from new position

🤖 Generated with [Claude Code](https://claude.com/claude-code)