### PR TITLE
Add 12th question: Does the size of the override matter?

### DIFF
--- a/index.html
+++ b/index.html
@@ -2937,6 +2937,196 @@ og_url: https://marbleheaddata.org/
   </section>
 
   <!-- ═══════════════════════════════════════════════════
+       QUESTION: Does the size of the override matter?
+       ═══════════════════════════════════════════════════ -->
+  <section class="question-screen" data-topic="size">
+
+    <div class="question-block">
+      <h1>Does the size of the override matter?</h1>
+      <p class="question-context">
+        The ballot has three tiers: Tier 1 ($9M), Tier 2 ($12M), and
+        Tier 3 ($15M). Each passes or fails independently. Is the full
+        amount necessary, or would a smaller override be enough?
+      </p>
+    </div>
+
+    <div class="answers">
+      <div class="answer-card" data-answer="a" data-question="size">
+        <p class="answer-label">Answer A</p>
+        <h2>Fund the essentials, skip the rest</h2>
+        <p class="answer-summary">
+          Tier 1 restores cuts and avoids layoffs. Tiers 2 and 3 add
+          cushion and new spending that the town hasn't proven it needs.
+          A smaller override is easier to sustain long-term.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="b" data-question="size">
+        <p class="answer-label">Answer B</p>
+        <h2>The full amount is already the minimum</h2>
+        <p class="answer-summary">
+          Tier 1 barely closes the current gap. Without Tiers 2 and 3,
+          the deficit reopens within a year as health insurance, pensions,
+          and contracts keep growing. Passing only Tier 1 guarantees
+          another override vote soon.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="c" data-question="size">
+        <p class="answer-label">Answer C</p>
+        <h2>The size doesn't matter because the answer is no</h2>
+        <p class="answer-summary">
+          No override of any size should pass until the town demonstrates
+          structural reform. Voting yes at any tier rewards the spending
+          patterns that created the deficit.
+        </p>
+      </div>
+    </div>
+
+    <!-- Evidence A: smaller override -->
+    <div class="evidence" data-evidence="size-a">
+      <div class="evidence-header">
+        <h3>The case for a smaller override</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Tier 1 covers the immediate gap</h4>
+        <p>
+          The $8.47M structural deficit is what Tier 1 ($9M) was sized
+          to close. Tier 2 adds $3M for stabilization and Tier 3 adds
+          another $3M for investment, but neither is required to avoid
+          the published no-override cuts.
+        </p>
+        <a class="evidence-chart-link" href="what-is-the-override.html">
+          What each tier funds
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>A smaller levy is easier to sustain</h4>
+        <p>
+          At the average home, Tier 1 costs $1,187/year vs. $1,985/year
+          for Tier 3. The smaller permanent levy increase gives the town
+          time to pursue reforms before asking for more.
+        </p>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            Tier 1 closes the gap for one year. Health insurance rose 11%
+            for FY27 alone. Without the additional capacity from Tiers 2
+            and 3, the town will face the same deficit by FY29 and need
+            another override vote, as happened in Melrose and Stoneham.
+          </p>
+        </div>
+      </details>
+    </div>
+
+    <!-- Evidence B: full amount is minimum -->
+    <div class="evidence" data-evidence="size-b">
+      <div class="evidence-header">
+        <h3>The case for the full override</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Cost growth doesn't stop at the gap</h4>
+        <p>
+          The $8.47M deficit is FY27's number. Health insurance, pension
+          obligations, and contractual salary steps continue growing
+          3-7% per year. Tier 1 alone provides no runway for those
+          increases.
+        </p>
+        <a class="evidence-chart-link" href="how-we-got-here.html">
+          How we got here
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Towns that passed small overrides came back quickly</h4>
+        <p>
+          Stoneham rejected $14.6M, then passed $9.3M seven months later
+          after losing staff. Melrose rejected $7.7M, then passed $13.5M
+          (+75%) eighteen months later. A too-small override often leads
+          to a larger one.
+        </p>
+        <a class="evidence-chart-link" href="data/case_studies">
+          Override case studies
+        </a>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer A would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            The FinCom projections assume current spending patterns
+            continue. A Tier 1 override combined with genuine cost
+            controls could sustain services longer than the projections
+            suggest. Passing the full amount removes the pressure to
+            find savings.
+          </p>
+        </div>
+      </details>
+    </div>
+
+    <!-- Evidence C: no override until reform -->
+    <div class="evidence" data-evidence="size-c">
+      <div class="evidence-header">
+        <h3>The case for voting no at any size</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>An override without reform is a blank check</h4>
+        <p>
+          Marblehead has not consolidated departments, renegotiated
+          health plan design, or moved to
+          <abbr class="g" title="Group Insurance Commission">GIC</abbr>
+          since the early 2000s. Until structural changes are
+          implemented, any override amount will be absorbed by the same
+          cost drivers.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Voting no is the only real leverage</h4>
+        <p>
+          Once an override passes, the levy ceiling rises permanently.
+          There is no mechanism for voters to claw it back. Voting no
+          forces the conversation about which services the town can
+          actually afford at its current tax base.
+        </p>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            The leverage theory assumes cuts produce reform rather than
+            just degraded services. Melrose voted no and lost teachers
+            to neighboring towns before passing a larger override. The
+            cuts are real and some, like losing experienced staff, are
+            difficult to reverse even after a future override passes.
+          </p>
+        </div>
+      </details>
+    </div>
+
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════
        QUESTION: Will we be back here in 5 years?
        ═══════════════════════════════════════════════════ -->
   <section class="question-screen" data-topic="again">


### PR DESCRIPTION
## Summary
- Adds a new question card that directly separates three voter archetypes: smaller-override (Tier 1 only), full-override (all tiers), and no-override-at-any-size
- Includes three evidence panels with counter-arguments, following the existing pattern
- Placed between "How will this affect my taxes?" and "Will we be back in 5 years?" for natural thematic flow
- No JS changes needed — `topicOrder` is built dynamically from `data-topic` sections

## Test plan
- [ ] Verify the new question appears in the question list on the landing screen
- [ ] Confirm all three answer cards display and are selectable
- [ ] Confirm evidence panels open/close for each answer
- [ ] Test share URL includes `size:a/b/c` when a position is selected
- [ ] Verify progress dots show 12 instead of 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)