### PR TITLE
Personal stats on question pages, reset text fix, 23 Playwright tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -4473,7 +4473,8 @@ og_url: https://marbleheaddata.org/
     })
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (data) {
-        if (data && socialCounts[topic]) {
+        if (data) {
+          if (!socialCounts[topic]) socialCounts[topic] = { decided: 0, views: 0, shares: 0 };
           var field = prefix === 'q' ? 'decided' : prefix === 'v' ? 'views' : 'shares';
           socialCounts[topic][field] = data.total;
           updateSocialDisplays();
@@ -4495,7 +4496,8 @@ og_url: https://marbleheaddata.org/
     })
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (data) {
-        if (data && socialCounts[topic]) {
+        if (data) {
+          if (!socialCounts[topic]) socialCounts[topic] = { decided: 0, views: 0, shares: 0 };
           socialCounts[topic].shares = data.total;
           updateSocialDisplays();
         }
@@ -4529,14 +4531,22 @@ og_url: https://marbleheaddata.org/
     // Your row
     var yourDecided = bar.querySelector('.qsocial-your-decided');
     var yourViews = bar.querySelector('.qsocial-your-views');
+    var yourShares = bar.querySelector('.qsocial-your-shares');
+    var tv = getTopicViews();
+    var ts = getTopicShares();
     if (yourDecided) {
-      yourDecided.textContent = selections[topic] ? 'Decided' : 'Undecided';
-      yourDecided.style.color = selections[topic] ? 'var(--c-teal)' : '';
-      yourDecided.style.fontWeight = selections[topic] ? '700' : '';
+      var d = selections[topic] ? 'Decided' : 'Not yet';
+      yourDecided.innerHTML = d === 'Decided'
+        ? '<span class="question-social-num">&#10003;</span> decided'
+        : 'undecided';
     }
     if (yourViews) {
-      var viewedThis = counted['v-' + topic] ? 'Viewed' : '';
-      yourViews.textContent = viewedThis;
+      var myViews = tv[topic] || 0;
+      yourViews.innerHTML = '<span class="question-social-num">' + myViews + '</span> views';
+    }
+    if (yourShares) {
+      var myShares = ts[topic] || 0;
+      yourShares.innerHTML = '<span class="question-social-num">' + myShares + '</span> shares';
     }
   }
 
@@ -4578,15 +4588,33 @@ og_url: https://marbleheaddata.org/
       '</div>';
   }
 
-  // Personal counters (localStorage)
+  // Personal counters (localStorage) -- per-topic + totals
   var VIEWS_KEY = 'explore-your-views';
   var SHARES_KEY = 'explore-your-shares';
+  var TOPIC_VIEWS_KEY = 'explore-topic-views';    // { topic: count }
+  var TOPIC_SHARES_KEY = 'explore-topic-shares';  // { topic: count }
+
   function getYourViews() { return parseInt(localStorage.getItem(VIEWS_KEY), 10) || 0; }
   function getYourShares() { return parseInt(localStorage.getItem(SHARES_KEY), 10) || 0; }
   function bumpYourViews() { var v = getYourViews() + 1; localStorage.setItem(VIEWS_KEY, v); return v; }
   function bumpYourShares() { var v = getYourShares() + 1; localStorage.setItem(SHARES_KEY, v); return v; }
 
-  // Increment personal view count on page load
+  function getTopicViews() { try { return JSON.parse(localStorage.getItem(TOPIC_VIEWS_KEY)) || {}; } catch (e) { return {}; } }
+  function getTopicShares() { try { return JSON.parse(localStorage.getItem(TOPIC_SHARES_KEY)) || {}; } catch (e) { return {}; } }
+  function bumpTopicView(topic) {
+    var tv = getTopicViews();
+    tv[topic] = (tv[topic] || 0) + 1;
+    localStorage.setItem(TOPIC_VIEWS_KEY, JSON.stringify(tv));
+    return tv[topic];
+  }
+  function bumpTopicShare(topic) {
+    var ts = getTopicShares();
+    ts[topic] = (ts[topic] || 0) + 1;
+    localStorage.setItem(TOPIC_SHARES_KEY, JSON.stringify(ts));
+    return ts[topic];
+  }
+
+  // Increment personal page-level view count on load
   bumpYourViews();
 
   function updateStatsStrip() {
@@ -4638,6 +4666,8 @@ og_url: https://marbleheaddata.org/
     // Clear personal counters
     localStorage.removeItem(VIEWS_KEY);
     localStorage.removeItem(SHARES_KEY);
+    localStorage.removeItem(TOPIC_VIEWS_KEY);
+    localStorage.removeItem(TOPIC_SHARES_KEY);
     // Clear decided-counted flags
     localStorage.removeItem('explore-counted');
     counted = {};
@@ -4827,8 +4857,9 @@ og_url: https://marbleheaddata.org/
     currentTopic = topic;
     stageEl.classList.add('has-topic');
 
-    // Server-side view increment (once per topic per browser)
+    // Server-side view increment (once per topic per browser) + personal counter
     incrementSocial('v', topic);
+    bumpTopicView(topic);
     updateQuestionSocialBar(topic);
     document.querySelectorAll('.question-screen').forEach(function (s) {
       s.style.display = s.dataset.topic === topic ? 'block' : 'none';
@@ -4944,6 +4975,7 @@ og_url: https://marbleheaddata.org/
         '<span class="question-social-label">You</span>' +
         '<span class="question-social-stat qsocial-your-decided"></span>' +
         '<span class="question-social-stat qsocial-your-views"></span>' +
+        '<span class="question-social-stat qsocial-your-shares"></span>' +
       '</div>';
 
     var shareBtn = document.createElement('button');
@@ -4960,6 +4992,7 @@ og_url: https://marbleheaddata.org/
         shareBtn.textContent = 'Copied';
         setTimeout(function () { shareBtn.textContent = 'Share'; }, 2000);
         bumpYourShares();
+        bumpTopicShare(topic);
         incrementShareCount(topic);
         updateStatsStrip();
         updateQuestionSocialBar(topic);

--- a/index.html
+++ b/index.html
@@ -4465,6 +4465,13 @@ og_url: https://marbleheaddata.org/
     if (counted[key]) return;
     counted[key] = true;
     saveCounted();
+
+    // Optimistically bump the local count so the UI updates immediately
+    if (!socialCounts[topic]) socialCounts[topic] = { decided: 0, views: 0, shares: 0 };
+    var field = prefix === 'q' ? 'decided' : prefix === 'v' ? 'views' : 'shares';
+    socialCounts[topic][field]++;
+    updateSocialDisplays();
+
     var sid = sectionId(prefix, topic);
     fetch(API_BASE + '/api/reactions', {
       method: 'POST',
@@ -4474,20 +4481,27 @@ og_url: https://marbleheaddata.org/
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (data) {
         if (data) {
-          if (!socialCounts[topic]) socialCounts[topic] = { decided: 0, views: 0, shares: 0 };
-          var field = prefix === 'q' ? 'decided' : prefix === 'v' ? 'views' : 'shares';
+          // Server response is authoritative; correct the optimistic value
           socialCounts[topic][field] = data.total;
           updateSocialDisplays();
         }
       })
       .catch(function () {
+        // Revert optimistic bump and counted flag
+        socialCounts[topic][field]--;
         delete counted[key];
         saveCounted();
+        updateSocialDisplays();
       });
   }
 
   // Increment share counter (cumulative, not once-per-browser)
   function incrementShareCount(topic) {
+    // Optimistic bump
+    if (!socialCounts[topic]) socialCounts[topic] = { decided: 0, views: 0, shares: 0 };
+    socialCounts[topic].shares++;
+    updateSocialDisplays();
+
     var sid = sectionId('s', topic);
     fetch(API_BASE + '/api/reactions', {
       method: 'POST',
@@ -4497,12 +4511,14 @@ og_url: https://marbleheaddata.org/
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (data) {
         if (data) {
-          if (!socialCounts[topic]) socialCounts[topic] = { decided: 0, views: 0, shares: 0 };
           socialCounts[topic].shares = data.total;
           updateSocialDisplays();
         }
       })
-      .catch(function () {});
+      .catch(function () {
+        socialCounts[topic].shares--;
+        updateSocialDisplays();
+      });
   }
 
   // Update all social proof displays (question bars only; landing cards use position pips)

--- a/index.html
+++ b/index.html
@@ -1269,17 +1269,28 @@ og_url: https://marbleheaddata.org/
   /* ── Question social proof bar ── */
   .question-social {
     display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 16px;
-    flex-wrap: wrap;
-    padding: 8px 16px;
+    flex-direction: column;
+    gap: 0;
     margin: -12px 0 20px;
-    font-size: 12px;
-    color: var(--text-muted);
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius-md);
+    overflow: hidden;
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+  .question-social-row {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 8px 16px;
+    flex-wrap: wrap;
+  }
+  .question-social-row + .question-social-row {
+    border-top: 1px solid var(--divider);
+    padding: 6px 16px;
+    font-size: 11px;
+    color: var(--text-subtle);
   }
   .question-social-stat {
     display: inline-flex;
@@ -1290,6 +1301,13 @@ og_url: https://marbleheaddata.org/
   .question-social-num {
     font-weight: 700;
     color: var(--c-teal);
+  }
+  .question-social-label {
+    font-weight: 600;
+    color: var(--text-faint);
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.5px;
   }
   .question-social-share {
     display: inline-flex;
@@ -1312,7 +1330,8 @@ og_url: https://marbleheaddata.org/
     box-shadow: var(--shadow-sm);
   }
   @media (max-width: 599px) {
-    .question-social { gap: 10px; font-size: 11px; padding: 6px 12px; }
+    .question-social-row { gap: 10px; padding: 6px 12px; }
+    .question-social-row + .question-social-row { font-size: 10px; }
     .question-social-share { font-size: 11px; padding: 5px 12px; }
   }
 
@@ -4500,12 +4519,25 @@ og_url: https://marbleheaddata.org/
     var bar = document.getElementById('qsocial-' + topic);
     if (!bar) return;
     var c = socialCounts[topic] || {};
+    // Community row
     var decidedEl = bar.querySelector('.qsocial-decided');
     var viewsEl = bar.querySelector('.qsocial-views');
     var sharesEl = bar.querySelector('.qsocial-shares');
     if (decidedEl) decidedEl.textContent = c.decided || 0;
     if (viewsEl) viewsEl.textContent = c.views || 0;
     if (sharesEl) sharesEl.textContent = c.shares || 0;
+    // Your row
+    var yourDecided = bar.querySelector('.qsocial-your-decided');
+    var yourViews = bar.querySelector('.qsocial-your-views');
+    if (yourDecided) {
+      yourDecided.textContent = selections[topic] ? 'Decided' : 'Undecided';
+      yourDecided.style.color = selections[topic] ? 'var(--c-teal)' : '';
+      yourDecided.style.fontWeight = selections[topic] ? '700' : '';
+    }
+    if (yourViews) {
+      var viewedThis = counted['v-' + topic] ? 'Viewed' : '';
+      yourViews.textContent = viewedThis;
+    }
   }
 
   // Show answer distribution bar below the answers container for a topic
@@ -4902,14 +4934,22 @@ og_url: https://marbleheaddata.org/
     bar.id = 'qsocial-' + topic;
 
     bar.innerHTML =
-      '<span class="question-social-stat"><span class="question-social-num qsocial-decided">0</span> decided</span>' +
-      '<span class="question-social-stat"><span class="question-social-num qsocial-views">0</span> views</span>' +
-      '<span class="question-social-stat"><span class="question-social-num qsocial-shares">0</span> shares</span>';
+      '<div class="question-social-row">' +
+        '<span class="question-social-label">Community</span>' +
+        '<span class="question-social-stat"><span class="question-social-num qsocial-decided">0</span> decided</span>' +
+        '<span class="question-social-stat"><span class="question-social-num qsocial-views">0</span> views</span>' +
+        '<span class="question-social-stat"><span class="question-social-num qsocial-shares">0</span> shares</span>' +
+      '</div>' +
+      '<div class="question-social-row">' +
+        '<span class="question-social-label">You</span>' +
+        '<span class="question-social-stat qsocial-your-decided"></span>' +
+        '<span class="question-social-stat qsocial-your-views"></span>' +
+      '</div>';
 
     var shareBtn = document.createElement('button');
     shareBtn.type = 'button';
     shareBtn.className = 'question-social-share';
-    shareBtn.textContent = 'Share this question';
+    shareBtn.textContent = 'Share';
     shareBtn.addEventListener('click', function () {
       var pick = selections[topic] || null;
       var params = new URLSearchParams();
@@ -4917,17 +4957,20 @@ og_url: https://marbleheaddata.org/
       if (pick) params.set('pos', pick);
       var url = window.location.origin + window.location.pathname + '?' + params.toString();
       navigator.clipboard.writeText(url).then(function () {
-        shareBtn.textContent = 'Link copied';
-        setTimeout(function () { shareBtn.textContent = 'Share this question'; }, 2000);
+        shareBtn.textContent = 'Copied';
+        setTimeout(function () { shareBtn.textContent = 'Share'; }, 2000);
         bumpYourShares();
         incrementShareCount(topic);
         updateStatsStrip();
+        updateQuestionSocialBar(topic);
         if (typeof posthog !== 'undefined') {
           posthog.capture('explore_question_shared', { topic: topic, has_pick: !!pick });
         }
       });
     });
-    bar.appendChild(shareBtn);
+    // Append share button to the "You" row
+    var yourRow = bar.querySelector('.question-social-row + .question-social-row');
+    if (yourRow) yourRow.appendChild(shareBtn);
 
     // Insert bar between question-block and answers
     screen.insertBefore(bar, answersEl);

--- a/index.html
+++ b/index.html
@@ -5144,8 +5144,9 @@ og_url: https://marbleheaddata.org/
     // Show browse hint (after tutorial is seen)
     updateBrowseHint(question);
 
-    // Update stats strip
+    // Update stats strip and question social bar
     updateStatsStrip();
+    updateQuestionSocialBar(question);
 
     // Hide prompt, show next button
     var screen = document.querySelector('.question-screen[data-topic="' + question + '"]');

--- a/index.html
+++ b/index.html
@@ -4597,7 +4597,7 @@ og_url: https://marbleheaddata.org/
 
   // Reset button: clears all local data (selections, notes, counters, tutorial)
   document.getElementById('statsReset').addEventListener('click', function () {
-    if (!confirm('Erase all your picks and notes? Nothing about you is stored on our server.')) return;
+    if (!confirm('Erase all your picks and notes? Nothing about you is stored anywhere except your browser.')) return;
     // Clear selections
     Object.keys(selections).forEach(function (k) { delete selections[k]; });
     persistSelections();

--- a/tests/explore-test.mjs
+++ b/tests/explore-test.mjs
@@ -1,0 +1,284 @@
+import { chromium } from 'playwright';
+
+const SITE = 'https://marbleheaddata.org';
+const DESKTOP = { width: 1280, height: 800 };
+
+let passed = 0;
+let failed = 0;
+function ok(name) { passed++; console.log(`  PASS: ${name}`); }
+function fail(name, detail) { failed++; console.log(`  FAIL: ${name} — ${detail}`); }
+
+async function run() {
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ viewport: DESKTOP });
+
+  // ── Fresh page (clear storage first) ──
+  console.log('\n── Explore flow tests ──');
+
+  const page = await context.newPage();
+  await page.goto(SITE, { waitUntil: 'networkidle' });
+
+  // Clear all localStorage to start fresh
+  await page.evaluate(() => localStorage.clear());
+  await page.reload({ waitUntil: 'networkidle' });
+
+  // 1. Landing page loads with question cards
+  const cards = await page.$$('.explore-question-card');
+  if (cards.length >= 10) {
+    ok(`Landing shows ${cards.length} question cards`);
+  } else {
+    fail('Landing question cards', `expected >= 10, got ${cards.length}`);
+  }
+
+  // 2. Stats strip shows 0 decided
+  const decided = await page.$eval('#statDecided', el => el.textContent);
+  if (decided === '0') {
+    ok('Stats strip starts at 0 decided');
+  } else {
+    fail('Stats strip initial decided', `expected "0", got "${decided}"`);
+  }
+
+  // 3. Progress bar at 0%
+  const barWidth = await page.$eval('#statBar', el => el.style.width);
+  if (barWidth === '0%') {
+    ok('Progress bar starts at 0%');
+  } else {
+    fail('Progress bar initial', `expected "0%", got "${barWidth}"`);
+  }
+
+  // 4. Progress message shows "Pick your first answer"
+  const msg = await page.$eval('#statMsg', el => el.textContent);
+  if (msg === 'Pick your first answer') {
+    ok('Progress message: "Pick your first answer"');
+  } else {
+    fail('Progress message initial', `expected "Pick your first answer", got "${msg}"`);
+  }
+
+  // 5. Click first question card to open it
+  await cards[0].click();
+  await page.waitForTimeout(300);
+  const hasTopicClass = await page.$eval('.explore-stage', el => el.classList.contains('has-topic'));
+  if (hasTopicClass) {
+    ok('Clicking question card opens question screen');
+  } else {
+    fail('Question screen open', 'explore-stage missing has-topic class');
+  }
+
+  // 6. Question social proof bar is visible
+  const socialBar = await page.$('.question-social');
+  if (socialBar) {
+    ok('Question social proof bar present');
+  } else {
+    fail('Question social proof bar', 'not found');
+  }
+
+  // 7. Share button on question screen exists
+  const shareBtn = await page.$('.question-social-share');
+  if (shareBtn) {
+    ok('Per-question share button present');
+  } else {
+    fail('Per-question share button', 'not found');
+  }
+
+  // 8. Click an answer card to select it
+  const answerCards = await page.$$('.answer-card:not(.selected)');
+  if (answerCards.length > 0) {
+    await answerCards[0].click();
+    await page.waitForTimeout(500);
+    const selected = await page.$('.answer-card.selected');
+    if (selected) {
+      ok('Clicking answer card selects it');
+    } else {
+      fail('Answer selection', 'no card has .selected class');
+    }
+  } else {
+    fail('Answer cards', 'no unselected answer cards found');
+  }
+
+  // 9. Tutorial shows on first pick
+  const tutorialVisible = await page.$eval('#exploreTutorial', el =>
+    el.classList.contains('visible')
+  );
+  if (tutorialVisible) {
+    ok('First-time tutorial shows on first pick');
+  } else {
+    fail('First-time tutorial', 'not visible after first pick');
+  }
+
+  // 10. Dismiss tutorial
+  await page.click('#tutorialDismiss');
+  await page.waitForTimeout(200);
+  const tutorialHidden = await page.$eval('#exploreTutorial', el =>
+    !el.classList.contains('visible')
+  );
+  if (tutorialHidden) {
+    ok('Tutorial dismisses on click');
+  } else {
+    fail('Tutorial dismiss', 'still visible after click');
+  }
+
+  // 11. Browse hint shows after tutorial
+  const hintVisible = await page.$eval('#browseHint', el =>
+    el.classList.contains('visible')
+  );
+  if (hintVisible) {
+    ok('Browse hint shows after tutorial dismissed');
+  } else {
+    fail('Browse hint', 'not visible');
+  }
+
+  // 12. Navigate back to landing
+  await page.click('#navBack');
+  await page.waitForTimeout(300);
+
+  // 13. Stats strip now shows 1 decided
+  const decided2 = await page.$eval('#statDecided', el => el.textContent);
+  if (decided2 === '1') {
+    ok('Stats strip shows 1 decided after first pick');
+  } else {
+    fail('Stats strip after pick', `expected "1", got "${decided2}"`);
+  }
+
+  // 14. Progress bar no longer 0%
+  const barWidth2 = await page.$eval('#statBar', el => el.style.width);
+  if (barWidth2 !== '0%' && parseInt(barWidth2) > 0) {
+    ok(`Progress bar filled to ${barWidth2}`);
+  } else {
+    fail('Progress bar after pick', `still at ${barWidth2}`);
+  }
+
+  // 15. First question card shows "has-pick" class
+  await page.waitForTimeout(200);
+  const firstCard = await page.$('.explore-question-card.has-pick');
+  if (firstCard) {
+    ok('Landing card shows has-pick after selection');
+  } else {
+    fail('Landing card has-pick', 'class not present');
+  }
+
+  // 16. Selections persist in localStorage
+  const stored = await page.evaluate(() => {
+    try { return JSON.parse(localStorage.getItem('explore-selections')); }
+    catch { return null; }
+  });
+  if (stored && Object.keys(stored).length === 1) {
+    ok('Selection persisted to localStorage');
+  } else {
+    fail('localStorage persistence', `got ${JSON.stringify(stored)}`);
+  }
+
+  // 17. Personal view count incremented
+  const views = await page.evaluate(() =>
+    parseInt(localStorage.getItem('explore-your-views'), 10) || 0
+  );
+  if (views >= 1) {
+    ok(`Personal view counter: ${views}`);
+  } else {
+    fail('Personal view counter', `expected >= 1, got ${views}`);
+  }
+
+  // 18. Share positions and check share counter
+  // First need to have the share strip visible
+  const shareStripVisible = await page.$eval('#shareStrip', el =>
+    el.classList.contains('visible')
+  );
+  if (shareStripVisible) {
+    // Mock clipboard to avoid permission errors
+    await page.evaluate(() => {
+      navigator.clipboard.writeText = async (text) => {
+        window.__lastClipboard = text;
+      };
+    });
+    await page.click('#shareBtn');
+    await page.waitForTimeout(500);
+    const shares = await page.evaluate(() =>
+      parseInt(localStorage.getItem('explore-your-shares'), 10) || 0
+    );
+    if (shares >= 1) {
+      ok(`Share counter incremented: ${shares}`);
+    } else {
+      fail('Share counter', `expected >= 1, got ${shares}`);
+    }
+
+    // 19. Share URL contains positions param
+    const clipUrl = await page.evaluate(() => window.__lastClipboard || '');
+    if (clipUrl.includes('positions=')) {
+      ok('Share URL includes positions param');
+    } else {
+      fail('Share URL format', `got "${clipUrl}"`);
+    }
+  } else {
+    fail('Share strip', 'not visible with 1 pick');
+  }
+
+  // 20. Shared link loads correctly
+  const shareUrl = await page.evaluate(() => window.__lastClipboard || '');
+  if (shareUrl) {
+    const page2 = await context.newPage();
+    await page2.goto(shareUrl, { waitUntil: 'networkidle' });
+    const banner = await page2.$eval('#sharedBanner', el =>
+      el.classList.contains('visible')
+    );
+    if (banner) {
+      ok('Shared link shows "someone shared" banner');
+    } else {
+      fail('Shared link banner', 'not visible');
+    }
+
+    // 21. "Start fresh" restores own picks (not blank)
+    await page2.click('#sharedFresh');
+    await page2.waitForTimeout(300);
+    const bannerGone = await page2.$eval('#sharedBanner', el =>
+      !el.classList.contains('visible')
+    );
+    if (bannerGone) {
+      ok('"Start fresh" hides shared banner');
+    } else {
+      fail('Start fresh', 'banner still visible');
+    }
+    await page2.close();
+  }
+
+  // 22. Reset clears everything
+  // Override confirm to auto-accept
+  await page.evaluate(() => { window.confirm = () => true; });
+  await page.click('#statsReset');
+  await page.waitForTimeout(300);
+  const decidedAfterReset = await page.$eval('#statDecided', el => el.textContent);
+  if (decidedAfterReset === '0') {
+    ok('Reset clears decided count to 0');
+  } else {
+    fail('Reset decided', `expected "0", got "${decidedAfterReset}"`);
+  }
+
+  const selectionsAfterReset = await page.evaluate(() => {
+    try { return JSON.parse(localStorage.getItem('explore-selections')); }
+    catch { return null; }
+  });
+  const isEmpty = !selectionsAfterReset || Object.keys(selectionsAfterReset).length === 0;
+  if (isEmpty) {
+    ok('Reset clears localStorage selections');
+  } else {
+    fail('Reset localStorage', `still has: ${JSON.stringify(selectionsAfterReset)}`);
+  }
+
+  // 23. Tutorial flag cleared (will show again on next pick)
+  const tutorialFlag = await page.evaluate(() =>
+    localStorage.getItem('explore-tutorial-seen')
+  );
+  if (!tutorialFlag) {
+    ok('Reset clears tutorial flag');
+  } else {
+    fail('Reset tutorial flag', `still set: ${tutorialFlag}`);
+  }
+
+  await browser.close();
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- **Question social proof bar now two rows**: Community row (decided/views/shares totals) + You row (decided status, viewed, share button)
- **Reset confirm text**: "Erase all your picks and notes? Nothing about you is stored anywhere except your browser."
- **23 Playwright tests** covering the full explore flow: landing, stats, progress bar, answer selection, tutorial, browse hint, localStorage, sharing, shared links, reset

## Test plan
- [ ] Open a question -- see two-row social bar (Community + You)
- [ ] Pick an answer -- "You" row shows "Decided"
- [ ] Share from question page -- share button in You row works
- [ ] Reset -- confirm text is clear, no "our server"
- [ ] `node tests/explore-test.mjs` -- 23/23 pass

Generated with [Claude Code](https://claude.com/claude-code)