### PR TITLE
Move next-question button to right after answer cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,7 +297,7 @@ og_url: https://marbleheaddata.org/
   /* ── Next question button ── */
   .next-question {
     display: none;
-    margin: 24px 0 12px;
+    margin: 14px 0 4px;
     text-align: center;
   }
   .next-question.visible { display: block; }
@@ -4868,7 +4868,13 @@ og_url: https://marbleheaddata.org/
       wrap.appendChild(btn);
     }
 
-    screen.appendChild(wrap);
+    // Insert right after .answers so it sits above the pick distribution bar
+    var answersEl = screen.querySelector('.answers');
+    if (answersEl) {
+      answersEl.parentNode.insertBefore(wrap, answersEl.nextSibling);
+    } else {
+      screen.appendChild(wrap);
+    }
   });
 
   /* ── Inject social proof bar + share button into each question screen ── */


### PR DESCRIPTION
## Summary

- Repositions the "Next question" button from the bottom of the question screen to directly after the `.answers` container
- Now sits above the pick distribution bar: answers -> next question -> distribution
- Tightened top margin (24px -> 14px) since it's no longer floating at the bottom

## Test plan

- [ ] Pick an answer: next-question button and distribution bar both appear, in that order
- [ ] Navigate between questions: button still works correctly
- [ ] Last question shows "Back to all questions" in the same position

🤖 Generated with [Claude Code](https://claude.com/claude-code)