### PR TITLE
Move green bands to bottom where override ribbons connect

### DIFF
--- a/charts/budget_flow.html
+++ b/charts/budget_flow.html
@@ -584,15 +584,18 @@ title: "Where the Money Goes"
       /* Base node rect */
       svg += '<rect class="sk-node sk-node-' + n.id + '" x="' + n.x + '" y="' + n.y + '" width="' + nodeW + '" height="' + n.h + '" rx="2" data-node="' + n.id + '"/>';
 
-      /* Green band at TOP: total override addition (grows with each tier).
-         Red band at BOTTOM: remaining unrestored cuts. */
+      /* Green band at BOTTOM: override additions (grows with each tier),
+         aligning with where override ribbons connect into the node.
+         Red band above green: remaining unrestored cuts. */
+      var bandBottom = n.y + n.h;
       if (n.add > 0) {
         var addH = Math.max((n.add / n.value) * n.h, 2);
-        svg += '<rect class="sk-delta-gain" x="' + n.x + '" y="' + n.y + '" width="' + nodeW + '" height="' + addH + '" rx="0"/>';
+        svg += '<rect class="sk-delta-gain" x="' + n.x + '" y="' + (bandBottom - addH) + '" width="' + nodeW + '" height="' + addH + '" rx="0"/>';
+        bandBottom -= addH;
       }
       if (n.stillCut > 0) {
         var stillH = Math.max((n.stillCut / n.value) * n.h, 2);
-        svg += '<rect class="sk-delta-cut" x="' + n.x + '" y="' + (n.y + n.h - stillH) + '" width="' + nodeW + '" height="' + stillH + '" rx="0"/>';
+        svg += '<rect class="sk-delta-cut" x="' + n.x + '" y="' + (bandBottom - stillH) + '" width="' + nodeW + '" height="' + stillH + '" rx="0"/>';
       }
 
       var ly = n.y + n.h / 2;


### PR DESCRIPTION
## Summary
Green override bands now grow upward from the bottom of spending nodes, aligning with where the override ribbons actually land. Red cut bands stack just above. Creates visual continuity between incoming override flow and the addition band.

## Test plan
- [ ] Green bands at bottom of nodes, growing upward with higher tiers
- [ ] Override ribbons visually connect into the green bands
- [ ] Red cut bands sit above green bands

🤖 Generated with [Claude Code](https://claude.com/claude-code)