### PR TITLE
Preserve focused node when switching override tiers

### DIFF
--- a/charts/budget_flow.html
+++ b/charts/budget_flow.html
@@ -701,7 +701,7 @@ title: "Where the Money Goes"
     btn.addEventListener('click', function () {
       document.querySelectorAll('.tab').forEach(function (b) { b.classList.remove('active'); });
       btn.classList.add('active');
-      render(btn.dataset.tier, null);
+      render(btn.dataset.tier, focusedNode);
     });
   });
 


### PR DESCRIPTION
## Summary
One-line fix: tab switching now preserves the focused/expanded node instead of clearing it. You can click Schools to expand, then toggle through tiers to see how its override funding changes.

## Test plan
- [ ] Click a node to expand, then switch tiers: node stays expanded
- [ ] Click expanded node to unfocus, switch tiers: no focus (normal behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)