### PR TITLE
Fix distribution bar: use buoy red for C instead of navy

### DIFF
--- a/index.html
+++ b/index.html
@@ -561,7 +561,7 @@ og_url: https://marbleheaddata.org/
   }
   .pick-dist-a { background: var(--c-teal); }
   .pick-dist-b { background: var(--c-brass); }
-  .pick-dist-c { background: var(--c-navy); }
+  .pick-dist-c { background: var(--c-buoy); }
   .pick-dist-legend {
     display: flex;
     gap: 12px;
@@ -583,7 +583,7 @@ og_url: https://marbleheaddata.org/
   }
   .pick-dist-dot-a { background: var(--c-teal); }
   .pick-dist-dot-b { background: var(--c-brass); }
-  .pick-dist-dot-c { background: var(--c-navy); }
+  .pick-dist-dot-c { background: var(--c-buoy); }
   .pick-dist-total {
     margin-left: auto;
     font-weight: 400;


### PR DESCRIPTION
## Summary

- Teal (A) and navy (C) were nearly indistinguishable in dark mode
- Swaps C segment and legend dot to `--c-buoy` (red) for clear contrast: teal / brass / buoy

🤖 Generated with [Claude Code](https://claude.com/claude-code)