### PR TITLE
Restyle share as copy-link buttons at top and bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,34 +174,50 @@ og_url: https://marbleheaddata.org/
     padding: 20px 0 4px;
   }
   .explore-share-strip.visible { display: block; }
-  .explore-share-btn {
+  .explore-copy-link {
     display: inline-flex;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
     font: inherit;
-    font-size: 14px;
-    font-weight: 700;
-    color: #fff;
-    background: var(--c-navy);
-    border: none;
-    border-radius: 8px;
-    padding: 12px 28px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-muted);
+    background: var(--surface);
+    border: 1.5px solid var(--border);
+    border-radius: 20px;
+    padding: 8px 16px;
     cursor: pointer;
     transition: all 0.15s ease;
-    box-shadow: var(--shadow-sm);
   }
-  .explore-share-btn:hover {
-    transform: translateY(-1px);
-    box-shadow: var(--shadow-md);
+  .explore-copy-link:hover {
+    border-color: var(--c-navy);
+    color: var(--c-navy);
   }
-  .explore-share-btn::before {
-    content: "";
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    background: #fff;
-    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='18' cy='5' r='3'/%3E%3Ccircle cx='6' cy='12' r='3'/%3E%3Ccircle cx='18' cy='19' r='3'/%3E%3Cline x1='8.59' y1='13.51' x2='15.42' y2='17.49'/%3E%3Cline x1='15.41' y1='6.51' x2='8.59' y2='10.49'/%3E%3C/svg%3E") center/contain no-repeat;
+  .explore-copy-link.copied {
+    border-color: var(--c-teal);
+    color: var(--c-teal);
   }
+  .explore-copy-link svg {
+    width: 14px;
+    height: 14px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    flex-shrink: 0;
+  }
+  .explore-copy-link .icon-copied { display: none; }
+  .explore-copy-link.copied .icon-link { display: none; }
+  .explore-copy-link.copied .icon-copied { display: inline; }
+
+  /* Top share link (inside stats area) */
+  .explore-share-top {
+    display: none;
+    text-align: right;
+    padding: 0;
+  }
+  .explore-share-top.visible { display: block; }
 
   /* Shared-positions view */
   .explore-shared-banner {
@@ -1409,11 +1425,22 @@ og_url: https://marbleheaddata.org/
       Tap any question to see the evidence behind their pick.
       <br><button type="button" class="explore-shared-fresh" id="sharedFresh">Start fresh with your own answers</button>
     </div>
+    <div class="explore-share-top" id="shareTop">
+      <button type="button" class="explore-copy-link" data-copy-positions>
+        <svg class="icon-link" viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+        <svg class="icon-copied" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"/></svg>
+        <span>Copy link to your positions</span>
+      </button>
+    </div>
     <div class="explore-question-list" id="questionList">
       <!-- JS builds these from the actual question h1s -->
     </div>
     <div class="explore-share-strip" id="shareStrip">
-      <button type="button" class="explore-share-btn" id="shareBtn">Share your positions</button>
+      <button type="button" class="explore-copy-link" data-copy-positions>
+        <svg class="icon-link" viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+        <svg class="icon-copied" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"/></svg>
+        <span>Copy link to your positions</span>
+      </button>
     </div>
   </div>
 
@@ -5005,9 +5032,12 @@ og_url: https://marbleheaddata.org/
         card.el.classList.remove('has-pick');
       }
     });
-    // Show share button if any selections
+    // Show share buttons if any selections
     if (shareStripEl) {
       shareStripEl.classList.toggle('visible', hasAny);
+    }
+    if (shareTopEl) {
+      shareTopEl.classList.toggle('visible', hasAny);
     }
     // Sort unanswered questions to the top
     if (hasAny && listEl) {
@@ -5021,10 +5051,10 @@ og_url: https://marbleheaddata.org/
     }
   }
 
-  /* ── Share button ── */
-  var shareBtnEl = document.getElementById('shareBtn');
-  if (shareBtnEl) {
-    shareBtnEl.addEventListener('click', function () {
+  /* ── Copy-link buttons (top + bottom) ── */
+  var shareTopEl = document.getElementById('shareTop');
+  document.querySelectorAll('[data-copy-positions]').forEach(function (btn) {
+    btn.addEventListener('click', function () {
       var pairs = [];
       Object.keys(selections).forEach(function (topic) {
         pairs.push(topic + ':' + selections[topic]);
@@ -5032,10 +5062,18 @@ og_url: https://marbleheaddata.org/
       if (!pairs.length) return;
       var url = window.location.origin + window.location.pathname + '?positions=' + pairs.join(',');
       navigator.clipboard.writeText(url).then(function () {
-        shareBtnEl.textContent = 'Link copied';
-        setTimeout(function () { shareBtnEl.textContent = 'Share your positions'; }, 2000);
+        // Flash all copy-link buttons to "copied" state
+        document.querySelectorAll('[data-copy-positions]').forEach(function (b) {
+          b.classList.add('copied');
+          b.querySelector('span').textContent = 'Copied!';
+        });
+        setTimeout(function () {
+          document.querySelectorAll('[data-copy-positions]').forEach(function (b) {
+            b.classList.remove('copied');
+            b.querySelector('span').textContent = 'Copy link to your positions';
+          });
+        }, 2000);
         bumpYourShares();
-        // Increment server-side share count for each shared topic
         Object.keys(selections).forEach(function (t) { incrementShareCount(t); });
         updateStatsStrip();
         if (typeof posthog !== 'undefined') {
@@ -5043,7 +5081,7 @@ og_url: https://marbleheaddata.org/
         }
       });
     });
-  }
+  });
 
   /* ── Answer selection (lock) vs. viewing (browse) ── */
 
@@ -5550,8 +5588,9 @@ og_url: https://marbleheaddata.org/
     if (sharedBanner) sharedBanner.classList.add('visible');
     document.querySelector('.explore-landing').classList.add('shared-mode');
 
-    // Hide "Share your positions" button in shared view
+    // Hide copy-link buttons in shared view
     if (shareStripEl) shareStripEl.style.display = 'none';
+    if (shareTopEl) shareTopEl.style.display = 'none';
 
     // "Start fresh" restores the viewer's own picks (not blank)
     document.getElementById('sharedFresh').addEventListener('click', function () {
@@ -5567,6 +5606,7 @@ og_url: https://marbleheaddata.org/
       sharedBanner.classList.remove('visible');
       document.querySelector('.explore-landing').classList.remove('shared-mode');
       if (shareStripEl) shareStripEl.style.display = '';
+      if (shareTopEl) shareTopEl.style.display = '';
       // Clear positions param from URL
       var cleanUrl = new URL(window.location);
       cleanUrl.searchParams.delete('positions');


### PR DESCRIPTION
## Summary
- Replaced big navy "Share your positions" button with lighter pill-style "Copy link to your positions" using a chain-link icon
- Added a second copy-link button above the question list so users see it without scrolling
- On click: both buttons flash to a checkmark + "Copied!" for 2 seconds, then reset
- Both hidden in shared-positions view, restored on "start fresh"

## Test plan
- [ ] Pick at least one answer, return to landing -- both top and bottom copy-link buttons should appear
- [ ] Click either -- both should flash "Copied!" with checkmark, clipboard should contain positions URL
- [ ] Open a shared link -- neither copy-link button should be visible
- [ ] Click "Start fresh" -- buttons should reappear
- [ ] Check mobile and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)