### PR TITLE
Change Answer C color from navy to buoy across all surfaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@ og_url: https://marbleheaddata.org/
   }
   .explore-mini-pos.picked[data-pos="a"] { background: var(--c-teal); box-shadow: 0 0 6px color-mix(in srgb, var(--c-teal) 40%, transparent); }
   .explore-mini-pos.picked[data-pos="b"] { background: var(--c-brass); box-shadow: 0 0 6px color-mix(in srgb, var(--c-brass) 40%, transparent); }
-  .explore-mini-pos.picked[data-pos="c"] { background: var(--c-navy); box-shadow: 0 0 6px color-mix(in srgb, var(--c-navy) 40%, transparent); }
+  .explore-mini-pos.picked[data-pos="c"] { background: var(--c-buoy); box-shadow: 0 0 6px color-mix(in srgb, var(--c-buoy) 40%, transparent); }
 
   /* Icon */
   .explore-card-icon {
@@ -538,7 +538,7 @@ og_url: https://marbleheaddata.org/
   }
   .answer-card[data-answer="a"] .answer-label { color: var(--c-teal); }
   .answer-card[data-answer="b"] .answer-label { color: var(--c-brass); }
-  .answer-card[data-answer="c"] .answer-label { color: var(--c-navy); }
+  .answer-card[data-answer="c"] .answer-label { color: var(--c-buoy); }
 
   .answer-card h2 {
     font-size: 17px;


### PR DESCRIPTION
## Summary

- Answer C now uses `--c-buoy` (red) instead of `--c-navy` everywhere: answer card labels, landing card position pips, and distribution bar
- All three answers are now visually distinct in both light and dark mode: teal (A), brass (B), buoy (C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)