### PR TITLE
Feature budget flow Sankey on where-has-the-money-gone page

### DIFF
--- a/where-has-the-money-gone.html
+++ b/where-has-the-money-gone.html
@@ -72,6 +72,14 @@ og_url: https://marbleheaddata.org/where-has-the-money-gone.html
     </div>
   </div>
 
+  <div class="read-next" style="margin-bottom: 24px;">
+    <div class="read-next-label">Interactive</div>
+    <a class="read-next-link" href="charts/budget_flow.html">
+      <div class="read-next-title">Where the money goes: full budget flow &rarr;</div>
+      <div class="read-next-desc">All five revenue sources flowing to eight spending categories, with override tier toggle.</div>
+    </a>
+  </div>
+
   <p>The property tax levy doubled from $39M in 2005 to $82M in 2024.<sup class="cite" data-href="data/SOURCE_LOOKUP.md" data-source="Marblehead ACFR schedules of Property Tax Levies and Collections (FY05 ACFR p.121, FY14 ACFR p.117, FY24 ACFR p.129)"></sup> Here is where every additional dollar went, who has been checking the books, and what grew faster than it probably should have.</p>
 
   <nav class="page-toc" aria-label="On this page">


### PR DESCRIPTION
## Summary
- Adds a prominent "read-next" style link card to the budget flow Sankey chart near the top of `where-has-the-money-gone.html`, right after the key-stats block
- Makes the interactive Sankey (revenue sources flowing to spending categories with override tier toggle) discoverable from the Budget section of the site

## Context
The budget flow chart was previously only reachable via a small evidence link buried deep in the homepage and a "read next" at the bottom of the tax bill page. It's one of the most compelling charts on the site and deserves prominent placement on the page that directly asks "where has the money gone?"

## Test plan
- [ ] Visit where-has-the-money-gone.html and confirm the link card appears after key-stats, before the prose
- [ ] Click through to budget_flow.html and confirm it loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)