### PR TITLE
Fix community views/shares counts on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -4556,6 +4556,8 @@ og_url: https://marbleheaddata.org/
     if (currentTopic && selections[currentTopic]) {
       showPickDistribution(currentTopic);
     }
+    // Refresh the stats strip so community totals reflect server data
+    updateStatsStrip();
   }
 
   // Update the social proof bar on the active question screen


### PR DESCRIPTION
## Summary
- `updateSocialDisplays()` was called when server counts arrived but never called `updateStatsStrip()`, so the "Community: 0 views, 0 shares" line in the stats strip stayed at zero until the user happened to trigger another action (picking an answer, navigating).
- Added `updateStatsStrip()` call inside `updateSocialDisplays()` so community totals refresh as soon as server data arrives.

## Test plan
- [ ] Load the homepage, confirm the "Community: X views, Y shares" line populates shortly after page load
- [ ] Pick an answer and verify the community counts still update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)