### PR TITLE
Fix override ribbon and healthcare node colors

### DIFF
--- a/charts/your_tax_bill.html
+++ b/charts/your_tax_bill.html
@@ -47,7 +47,7 @@ title: "Where Your Tax Dollars Go"
   .sk-node-override-t3 { fill: var(--series-tier-3); }
 
   .sk-node-schools    { fill: var(--c-navy); }
-  .sk-node-healthcare { fill: var(--c-buoy); }
+  .sk-node-healthcare { fill: color-mix(in srgb, var(--c-plum) 65%, var(--c-buoy)); }
   .sk-node-safety     { fill: var(--c-teal); }
   .sk-node-debt       { fill: var(--c-plum); }
   .sk-node-pensions   { fill: var(--c-brass); }
@@ -62,11 +62,11 @@ title: "Where Your Tax Dollars Go"
     opacity: 0.18;
   }
   .sk-ribbon-base:hover { opacity: 0.32; }
-  .sk-ribbon-override { opacity: 0.4; }
-  .sk-ribbon-override:hover { opacity: 0.6; }
-  .sk-ribbon-override.tier-t1 { fill: var(--series-tier-1); }
-  .sk-ribbon-override.tier-t2 { fill: var(--series-tier-2); }
-  .sk-ribbon-override.tier-t3 { fill: var(--series-tier-3); }
+  .sk-ribbon-override {
+    fill: var(--c-sage);
+    opacity: 0.35;
+  }
+  .sk-ribbon-override:hover { opacity: 0.5; }
 
   /* Focused state */
   .sankey-wrap.has-focus .sk-ribbon { opacity: 0; pointer-events: none; }


### PR DESCRIPTION
## Summary
- Override ribbons changed from tier-colored (blue/red) to sage green, matching base ribbons. Single person = single color for all flows; tier is already indicated by the left node.
- Healthcare node changed from `--c-buoy` to a plum/buoy mix so it no longer matches the red cut indicator bands.

## Test plan
- [ ] All tiers: ribbons uniformly sage green
- [ ] Healthcare node visually distinct from red cut bands
- [ ] Override left node still uses tier colors (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)