### PR TITLE
Link personal tax Sankey from question flow and calculator

### DIFF
--- a/charts/override_calculator.html
+++ b/charts/override_calculator.html
@@ -131,6 +131,10 @@ title: "What the Override Costs You"
 
   <div class="read-next">
     <div class="read-next-label">Read next</div>
+    <a class="read-next-link" href="your_tax_bill.html">
+      <div class="read-next-title">Where your tax dollars go &rarr;</div>
+      <div class="read-next-desc">See how your tax bill splits across schools, public safety, healthcare, and five other categories, with override tier toggle.</div>
+    </a>
     <a class="read-next-link" href="../no-override-budget.html">
       <div class="read-next-title">What's in the no-override budget? &rarr;</div>
       <div class="read-next-desc">22 town positions removed, 14 school positions, library reduced 43%, and what other MA towns did after similar votes.</div>

--- a/index.html
+++ b/index.html
@@ -1825,6 +1825,9 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="charts/budget_flow.html">
           Where the money goes: spending by category
         </a>
+        <a class="evidence-chart-link" href="charts/your_tax_bill.html">
+          Where your tax dollars go
+        </a>
         <p class="evidence-caveat">
           FY28-FY30 are illustrative projections (3% revenue growth,
           5% expense growth), not forecasts.
@@ -2962,6 +2965,9 @@ og_url: https://marbleheaddata.org/
         </p>
         <a class="evidence-chart-link" href="charts/override_calculator.html">
           Calculate your exact cost
+        </a>
+        <a class="evidence-chart-link" href="charts/your_tax_bill.html">
+          See where your tax dollars go
         </a>
         <p class="evidence-caveat">
           Source: Town Administrator presentation, April 8, 2026.


### PR DESCRIPTION
## Summary
- Evidence link in "How will this affect my taxes?" question (mycost-a): "See where your tax dollars go"
- Evidence link in "Do we need an override?" question (override-a): "Where your tax dollars go"
- Read-next from the override calculator page (first position)

Now discoverable from: nav dropdown, budget_flow read-next, override_calculator read-next, and two homepage question evidence sections.

## Test plan
- [ ] Click "See where your tax dollars go" from mycost evidence
- [ ] Click "Where your tax dollars go" from override evidence  
- [ ] Click read-next from override calculator

🤖 Generated with [Claude Code](https://claude.com/claude-code)