### PR TITLE
Polish share button into stats row

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,13 +255,47 @@ og_url: https://marbleheaddata.org/
   .explore-copy-link.copied .icon-link { display: none; }
   .explore-copy-link.copied .icon-copied { display: inline; }
 
-  /* Top share link (inside stats area) */
-  .explore-share-top {
-    display: none;
-    text-align: right;
-    padding: 0;
+  /* Inline copy-link variant (inside stats detail row) */
+  .explore-copy-link--inline {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-faint);
+    background: none;
+    border: none;
+    border-radius: 0;
+    padding: 2px 0;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    gap: 4px;
   }
-  .explore-share-top.visible { display: block; }
+  .explore-copy-link--inline:hover {
+    color: var(--text-muted);
+    border-color: transparent;
+  }
+  .explore-copy-link--inline.copied {
+    color: var(--c-teal);
+    border-color: transparent;
+  }
+  .explore-copy-link--inline svg {
+    width: 11px;
+    height: 11px;
+  }
+  .explore-stats-detail-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    white-space: nowrap;
+  }
+  .explore-share-inline {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .explore-stats-sep {
+    width: 1px;
+    height: 12px;
+    background: var(--divider);
+  }
 
   /* Shared-positions view */
   .explore-shared-banner {
@@ -1480,20 +1514,23 @@ og_url: https://marbleheaddata.org/
           <span>You: <strong id="statYourViews">0</strong> views, <strong id="statYourShares">0</strong> shares</span>
           <span>Community: <strong id="statAllViews">0</strong> views, <strong id="statAllShares">0</strong> shares</span>
         </div>
-        <button type="button" class="explore-stats-reset" id="statsReset">Reset my data</button>
+        <div class="explore-stats-detail-right">
+          <span class="explore-share-inline" id="shareTop" style="display:none">
+            <button type="button" class="explore-copy-link explore-copy-link--inline" data-copy-positions>
+              <svg class="icon-link" viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+              <svg class="icon-copied" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"/></svg>
+              <span>Share</span>
+            </button>
+            <span class="explore-stats-sep"></span>
+          </span>
+          <button type="button" class="explore-stats-reset" id="statsReset">Reset my data</button>
+        </div>
       </div>
     </div>
 
     <div class="explore-shared-banner" id="sharedBanner">
       Tap any question to see the evidence behind their pick.
       <br><button type="button" class="explore-shared-fresh" id="sharedFresh">Start fresh with your own answers</button>
-    </div>
-    <div class="explore-share-top" id="shareTop">
-      <button type="button" class="explore-copy-link" data-copy-positions>
-        <svg class="icon-link" viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
-        <svg class="icon-copied" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"/></svg>
-        <span>Copy link to your positions</span>
-      </button>
     </div>
     <div class="explore-question-list" id="questionList">
       <!-- JS builds these from the actual question h1s -->
@@ -5248,7 +5285,7 @@ og_url: https://marbleheaddata.org/
       shareStripEl.classList.toggle('visible', hasAny);
     }
     if (shareTopEl) {
-      shareTopEl.classList.toggle('visible', hasAny);
+      shareTopEl.style.display = hasAny ? '' : 'none';
     }
     // Sort unanswered questions to the top
     if (hasAny && listEl) {
@@ -5275,15 +5312,14 @@ og_url: https://marbleheaddata.org/
       navigator.clipboard.writeText(url).then(function () {
         // Flash all copy-link buttons to "copied" state
         document.querySelectorAll('[data-copy-positions]').forEach(function (b) {
+          var original = b.querySelector('span').textContent;
           b.classList.add('copied');
           b.querySelector('span').textContent = 'Copied!';
-        });
-        setTimeout(function () {
-          document.querySelectorAll('[data-copy-positions]').forEach(function (b) {
+          setTimeout(function () {
             b.classList.remove('copied');
-            b.querySelector('span').textContent = 'Copy link to your positions';
-          });
-        }, 2000);
+            b.querySelector('span').textContent = original;
+          }, 2000);
+        });
         bumpYourShares();
         incrementPageShare();
         updateStatsStrip();


### PR DESCRIPTION
## Summary
- Moved the "Copy link to your positions" button from a standalone floating div into the stats detail row as a compact inline "Share" text link
- Styled to match the existing "Reset my data" link, with a vertical separator between them
- Bottom-of-list pill button unchanged

## Test plan
- [ ] Open the explore page, answer at least one question, verify "Share" link appears in the stats row next to "Reset my data"
- [ ] Click "Share" and confirm it copies the URL and flashes "Copied!"
- [ ] Verify the bottom pill button still works and says "Copy link to your positions"
- [ ] Check mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)