### PR TITLE
Neutral tier colors: single-hue teal ramp

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -79,7 +79,7 @@ Do not reintroduce `Explainer`, `History`, `Analysis`, `Guide`, `Read`, or any o
 | `--c-surface` | #FFFFFF | Card/container background |
 | `--c-navy` | #1B3A57 | Marblehead, primary accent |
 | `--c-buoy` | #C8553D | Melrose, costs, warnings |
-| `--c-teal` | #2F7D8E | Links, Tier 1 |
+| `--c-teal` | #2F7D8E | Links, Tier 2 |
 | `--c-brass` | #B8860B | Swampscott |
 | `--c-sage` | #5B7553 | Revenue, positive |
 | `--c-plum` | #6C4A6E | Stoneham |
@@ -93,6 +93,9 @@ Do not reintroduce `Explainer`, `History`, `Analysis`, `Guide`, `Read`, or any o
 | `--series-stoneham` | plum | Stoneham data |
 | `--series-revenue` | sage | Revenue/levy lines |
 | `--series-cost` | buoy | Cost/expense lines |
+| `--series-tier-1` | #6BB8C9 | Override Tier 1 (light teal) |
+| `--series-tier-2` | teal | Override Tier 2 |
+| `--series-tier-3` | #133E4A | Override Tier 3 (dark teal) |
 | `--series-neutral` | text | Single-series charts |
 
 ## SVG Chart Classes

--- a/assets/site.css
+++ b/assets/site.css
@@ -55,9 +55,9 @@
   --series-neutral:    var(--c-text);
   --series-everything: #93A4B0; /* light slate, for catch-all "everything else" categories */
 
-  --series-tier-1: var(--c-teal);
-  --series-tier-2: var(--c-navy);
-  --series-tier-3: var(--c-buoy);
+  --series-tier-1: #6BB8C9;
+  --series-tier-2: var(--c-teal);
+  --series-tier-3: #133E4A;
 
   /* Tag colors (category pills) */
   --tag-chart-bg:   #E6F0EE;
@@ -100,6 +100,9 @@
     --c-brass: #E4B363;
     --c-sage:  #9DBC7A;
     --c-plum:  #B08AB4;
+
+    --series-tier-1: #8ED4E6;
+    --series-tier-3: #2A6475;
 
     --series-everything: #5B6B78;
 
@@ -165,6 +168,8 @@ html[data-theme="dark"] {
   --c-brass: #E4B363;
   --c-sage:  #9DBC7A;
   --c-plum:  #B08AB4;
+  --series-tier-1: #8ED4E6;
+  --series-tier-3: #2A6475;
   --series-everything: #5B6B78;
   --chart-grid-major: #24323F;
   --chart-grid-minor: #1B2834;


### PR DESCRIPTION
## Summary
- Override tier colors changed from teal/navy/buoy to a single-hue teal ramp (light → medium → dark)
- Old palette editorialized: buoy (orange) is the site's "costs/warnings" color, making Tier 3 visually read as a warning
- New palette: tiers feel like sizes of the same thing, not a progression from calm to danger
- Dark-mode overrides ensure all three weights stay visible against the dark background
- Cascades site-wide via `--series-tier-*` CSS variables: override calculator, sustainability chart, budget flow, personal tax Sankey, homepage evidence, senior tax relief, super-summary

## Test plan
- [ ] Override calculator: three tier bars distinguishable in light and dark mode
- [ ] Sustainability chart: tier lines distinguishable when overlapping
- [ ] Budget flow Sankey: override node color correct at each tier
- [ ] Personal tax Sankey: override node color correct at each tier
- [ ] Homepage mycost evidence: bar chart colors updated
- [ ] Senior tax relief: swatch colors updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)