### PR TITLE
Fix evidence links stacking on same line

### DIFF
--- a/index.html
+++ b/index.html
@@ -751,7 +751,7 @@ og_url: https://marbleheaddata.org/
   .evidence-point p:last-child { margin-bottom: 0; }
 
   .evidence-chart-link {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     gap: 6px;
     font-size: 13px;


### PR DESCRIPTION
## Summary
- Changed `evidence-chart-link` from `inline-flex` to `flex` so consecutive links in answer sections each get their own line
- Affected 4 evidence sections where multiple links ran together horizontally: override-c (3 links), mycost-a (2), size-a (2), size-b (2)

## Test plan
- [ ] Check the 4 affected answer sections on desktop and mobile to confirm links stack vertically
- [ ] Verify single-link evidence points still look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)