### PR TITLE
Add missing size icon and update voteno to ballot ovals

### DIFF
--- a/index.html
+++ b/index.html
@@ -5197,11 +5197,12 @@ og_url: https://marbleheaddata.org/
   /* Lucide-based icons, 24x24 viewBox */
   var topicIcons = {
     override:     '<circle cx="12" cy="12" r="10"/><line x1="12" y1="6" x2="12" y2="18"/><path d="M15.5 9.5a3 3 0 0 0-3-2h-1a3 3 0 0 0 0 6h1a3 3 0 0 1 0 6h-1a3 3 0 0 1-3-2"/>',  /* coin with $ */
-    voteno:       '<ellipse cx="12" cy="12" rx="9" ry="9"/>',                     /* empty ballot oval */
+    voteno:       '<ellipse cx="12" cy="6" rx="7" ry="3.5"/><ellipse cx="12" cy="13" rx="7" ry="3.5"/><ellipse cx="12" cy="20" rx="7" ry="3.5"/>', /* three ballot ovals */
     schools:      '<path d="M22 10v6M2 10l10-5 10 5-10 5z"/><path d="M6 12v5c0 1.1 2.7 3 6 3s6-1.9 6-3v-5"/>', /* graduation cap */
     levy:         '<path d="M3 3v18h18"/><path d="M7 16l4-4 4 4 5-7"/>',          /* trending up */
     taxrank:      '<path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 1 1 16 0z"/><circle cx="12" cy="10" r="3"/>',  /* map pin */
     mycost:       '<line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>', /* dollar sign */
+    size:         '<rect x="3" y="14" width="4" height="8" rx="1"/><rect x="10" y="9" width="4" height="13" rx="1"/><rect x="17" y="4" width="4" height="18" rx="1"/>', /* three tiered bars */
     again:        '<path d="M21 2v6h-6"/><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M3 22v-6h6"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/>', /* refresh */
     alternatives: '<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/>', /* question circle */
     trash:        '<path d="M20 7l-1.2 12.5a2 2 0 0 1-2 1.5H7.2a2 2 0 0 1-2-1.5L4 7"/><path d="M10 11v6m4-6v6M1 7h22M8 7V3.5A1.5 1.5 0 0 1 9.5 2h5A1.5 1.5 0 0 1 16 3.5V7"/>', /* trash */


### PR DESCRIPTION
## Summary
- Add tiered-bars icon for the "Does the size of the override matter?" question (was missing entirely)
- Update voteno icon from single circle to three stacked ballot ovals

🤖 Generated with [Claude Code](https://claude.com/claude-code)