### PR TITLE
Add move-vote endpoint to prevent answer inflation

### DIFF
--- a/community-pulse/worker/schema/0002_votes.sql
+++ b/community-pulse/worker/schema/0002_votes.sql
@@ -1,0 +1,10 @@
+-- Track each user's pick per topic so vote changes can decrement the old answer.
+-- One row per IP hash per topic. The server is authoritative.
+
+CREATE TABLE IF NOT EXISTS votes (
+  ip_hash   TEXT NOT NULL,
+  topic     TEXT NOT NULL,
+  answer    TEXT NOT NULL,
+  voted_at  INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (ip_hash, topic)
+);

--- a/community-pulse/worker/src/index.js
+++ b/community-pulse/worker/src/index.js
@@ -1,13 +1,15 @@
 // Cloudflare Worker for the community pulse reactions counter.
-// Exposes two endpoints:
+// Exposes three endpoints:
 //   GET  /api/reactions?section_ids=a,b,c   (batched fetch)
 //   POST /api/reactions                     (increment one section)
+//   POST /api/votes                         (place or move a vote)
 //
-// Backed by a single D1 database with two tables. No auth, no sessions.
+// Backed by a D1 database. No auth, no sessions.
 
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 const RATE_LIMIT_MAX = 5; // per section per window per ip
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+const VALID_ANSWERS = ['a', 'b', 'c'];
 
 export default {
   async fetch(request, env) {
@@ -26,17 +28,16 @@ export async function handleRequest(request, env) {
     return corsResponse(request, env);
   }
 
-  if (url.pathname !== '/api/reactions') {
-    return new Response('Not Found', { status: 404, headers: corsHeaders(env) });
+  if (url.pathname === '/api/reactions') {
+    if (request.method === 'GET') return handleGet(request, env);
+    if (request.method === 'POST') return handlePost(request, env);
   }
 
-  if (request.method === 'GET') {
-    return handleGet(request, env);
+  if (url.pathname === '/api/votes') {
+    if (request.method === 'POST') return handleVotePost(request, env);
   }
-  if (request.method === 'POST') {
-    return handlePost(request, env);
-  }
-  return new Response('Method Not Allowed', { status: 405, headers: corsHeaders(env) });
+
+  return new Response('Not Found', { status: 404, headers: corsHeaders(env) });
 }
 
 async function handleGet(request, env) {
@@ -104,6 +105,68 @@ async function checkAndIncrementRateLimit(env, ip, sectionId) {
   return true;
 }
 
+/** Increment a reaction counter by 1. */
+async function incrementReaction(env, sectionId, now) {
+  const existing = await env.DB.prepare(
+    'SELECT total_count, count_24h, window_24h_start FROM reactions WHERE section_id = ?'
+  ).bind(sectionId).first();
+
+  if (existing) {
+    const windowElapsed = (now - existing.window_24h_start) >= TWENTY_FOUR_HOURS_MS;
+    const total = existing.total_count + 1;
+    const count24h = windowElapsed ? 1 : existing.count_24h + 1;
+    const windowStart = windowElapsed ? now : existing.window_24h_start;
+    await env.DB.prepare(
+      'UPDATE reactions SET total_count = ?, count_24h = ?, window_24h_start = ?, updated_at = ? WHERE section_id = ?'
+    ).bind(total, count24h, windowStart, now, sectionId).run();
+    return total;
+  } else {
+    await env.DB.prepare(
+      'INSERT INTO reactions (section_id, total_count, count_24h, window_24h_start, updated_at) VALUES (?, 1, 1, ?, ?)'
+    ).bind(sectionId, now, now).run();
+    return 1;
+  }
+}
+
+/** Decrement a reaction counter by 1, clamped to 0. */
+async function decrementReaction(env, sectionId, now) {
+  const existing = await env.DB.prepare(
+    'SELECT total_count, count_24h, window_24h_start FROM reactions WHERE section_id = ?'
+  ).bind(sectionId).first();
+
+  if (!existing || existing.total_count <= 0) return 0;
+
+  const windowElapsed = (now - existing.window_24h_start) >= TWENTY_FOUR_HOURS_MS;
+  const total = existing.total_count - 1;
+  const count24h = windowElapsed ? 0 : Math.max(existing.count_24h - 1, 0);
+  const windowStart = windowElapsed ? now : existing.window_24h_start;
+  await env.DB.prepare(
+    'UPDATE reactions SET total_count = ?, count_24h = ?, window_24h_start = ?, updated_at = ? WHERE section_id = ?'
+  ).bind(total, count24h, windowStart, now, sectionId).run();
+  return total;
+}
+
+/** Build the answer-pick section ID for a topic+answer. */
+function answerSectionId(topic, answer) {
+  return 'index.html#a-' + topic + '-' + answer;
+}
+
+/** Fetch current pick counts for all three answers on a topic. */
+async function getPickCounts(env, topic) {
+  const ids = VALID_ANSWERS.map(a => answerSectionId(topic, a));
+  const placeholders = ids.map(() => '?').join(',');
+  const { results } = await env.DB.prepare(
+    `SELECT section_id, total_count FROM reactions WHERE section_id IN (${placeholders})`
+  ).bind(...ids).all();
+
+  const map = new Map(results.map(r => [r.section_id, r.total_count]));
+  const picks = {};
+  VALID_ANSWERS.forEach(a => {
+    picks[a] = map.get(answerSectionId(topic, a)) || 0;
+  });
+  return picks;
+}
+
 async function handlePost(request, env) {
   let body;
   try {
@@ -155,6 +218,72 @@ async function handlePost(request, env) {
   }
 
   return new Response(JSON.stringify({ total, last_24h: count24h }), { status: 200, headers: corsHeaders(env) });
+}
+
+/**
+ * POST /api/votes -- place or move a vote.
+ * Body: { topic: "override", answer: "b" }
+ * Server checks its own votes table for what this IP previously picked.
+ * Returns: { picks: { a: 12, b: 34, c: 5 }, your_vote: "b" }
+ */
+async function handleVotePost(request, env) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'invalid body' }), { status: 400, headers: corsHeaders(env) });
+  }
+
+  const topic = body && body.topic;
+  const answer = body && body.answer;
+
+  if (!topic || typeof topic !== 'string') {
+    return new Response(JSON.stringify({ error: 'missing topic' }), { status: 400, headers: corsHeaders(env) });
+  }
+  if (!answer || !VALID_ANSWERS.includes(answer)) {
+    return new Response(JSON.stringify({ error: 'invalid answer' }), { status: 400, headers: corsHeaders(env) });
+  }
+
+  const clientIp = request.headers.get('CF-Connecting-IP') || request.headers.get('X-Forwarded-For') || 'unknown';
+  const allowed = await checkAndIncrementRateLimit(env, clientIp, 'vote-' + topic);
+
+  if (!allowed) {
+    // Rate-limited: return current counts without changing anything.
+    const picks = await getPickCounts(env, topic);
+    return new Response(JSON.stringify({ picks, your_vote: answer }), { status: 200, headers: corsHeaders(env) });
+  }
+
+  const ipHash = await hashIp(clientIp);
+  const now = Date.now();
+
+  // Look up existing vote for this IP + topic
+  const existing = await env.DB.prepare(
+    'SELECT answer FROM votes WHERE ip_hash = ? AND topic = ?'
+  ).bind(ipHash, topic).first();
+
+  if (existing) {
+    if (existing.answer === answer) {
+      // Already voted this way -- no-op
+      const picks = await getPickCounts(env, topic);
+      return new Response(JSON.stringify({ picks, your_vote: answer }), { status: 200, headers: corsHeaders(env) });
+    }
+
+    // Move vote: decrement old, increment new, update record
+    await decrementReaction(env, answerSectionId(topic, existing.answer), now);
+    await incrementReaction(env, answerSectionId(topic, answer), now);
+    await env.DB.prepare(
+      'UPDATE votes SET answer = ?, voted_at = ? WHERE ip_hash = ? AND topic = ?'
+    ).bind(answer, now, ipHash, topic).run();
+  } else {
+    // First vote: increment new, insert record
+    await incrementReaction(env, answerSectionId(topic, answer), now);
+    await env.DB.prepare(
+      'INSERT INTO votes (ip_hash, topic, answer, voted_at) VALUES (?, ?, ?, ?)'
+    ).bind(ipHash, topic, answer, now).run();
+  }
+
+  const picks = await getPickCounts(env, topic);
+  return new Response(JSON.stringify({ picks, your_vote: answer }), { status: 200, headers: corsHeaders(env) });
 }
 
 function corsHeaders(env) {

--- a/index.html
+++ b/index.html
@@ -5364,6 +5364,26 @@ og_url: https://marbleheaddata.org/
   /* ── Answer selection (lock) vs. viewing (browse) ── */
 
   // selectAnswer: locks your position (checkmark). Also opens evidence.
+  // Place or move a vote via the server. Server is authoritative about
+  // what the user previously picked, so vote changes are safe.
+  function submitVote(topic, answer) {
+    fetch(API_BASE + '/api/votes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topic: topic, answer: answer })
+    })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        if (data && data.picks) {
+          if (!socialCounts[topic]) socialCounts[topic] = { decided: 0, views: 0, shares: 0 };
+          socialCounts[topic].picks = data.picks;
+          showPickDistribution(topic);
+          updateSocialDisplays();
+        }
+      })
+      .catch(function () {});
+  }
+
   function selectAnswer(question, answer) {
     if (typeof posthog !== 'undefined') {
       posthog.capture('explore_answer_selected', { topic: question, answer: answer });
@@ -5384,9 +5404,9 @@ og_url: https://marbleheaddata.org/
     // Also view this answer's evidence
     viewEvidence(question, answer);
 
-    // Social proof: increment decided + answer-pick counts
+    // Social proof: increment decided count + submit vote to server
     incrementSocial('q', question);
-    incrementSocial('a', question + '-' + answer);
+    submitVote(question, answer);
 
     // Show answer distribution now that the user has picked
     showPickDistribution(question);


### PR DESCRIPTION
## Summary
- New `POST /api/votes` endpoint tracks each user's pick per topic by IP hash
- When a user changes their answer, the server decrements the old answer and increments the new one (instead of just adding +1 to the new answer)
- New `votes` table: `(ip_hash, topic, answer, voted_at)` with PK `(ip_hash, topic)`
- Server is authoritative: client sends the new answer, server looks up what was previously picked
- `decrementReaction` clamps to 0 to prevent negative counts from historical data
- Client `selectAnswer` now calls `submitVote()` instead of `incrementSocial('a', ...)`

## Deployment steps
1. Run migration: `wrangler d1 migrations apply community-pulse`
2. Deploy worker: `wrangler deploy` (from community-pulse/worker/)
3. Client code deploys automatically via GitHub Pages

## Test plan
- [ ] Pick answer A on a topic, verify distribution bar shows +1 for A
- [ ] Change to answer B, verify A decrements and B increments (total stays the same)
- [ ] Change back to A, verify counts move correctly again
- [ ] From a new browser/incognito, pick an answer, verify it counts independently
- [ ] Rapid-fire vote changes (>5 in an hour), verify rate limiting kicks in gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)