### PR TITLE
Hide My Positions pill (no organic usage)

### DIFF
--- a/index.html
+++ b/index.html
@@ -878,7 +878,8 @@ og_url: https://marbleheaddata.org/
     cursor: pointer;
     transition: all 0.2s ease;
   }
-  .notes-pill.visible { display: inline-flex; }
+  /* Hidden until we see organic demand — re-enable by uncommenting */
+  /* .notes-pill.visible { display: inline-flex; } */
   .notes-pill:hover { transform: scale(1.05); }
   .notes-pill.pulse {
     animation: pill-pulse 0.4s ease;


### PR DESCRIPTION
## Summary
- Commented out the `.notes-pill.visible` CSS rule so the floating "My positions" pill never renders
- All JS/panel code stays intact for easy re-enable (uncomment one line)
- PostHog showed zero interactions across the first week; all clicks were test traffic

## Test plan
- [ ] Verify the pill does not appear on any explore question page
- [ ] Verify no console errors from the dormant JS


🤖 Generated with [Claude Code](https://claude.com/claude-code)