### PR TITLE
Remove "All done" from progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -4845,7 +4845,7 @@ og_url: https://marbleheaddata.org/
       msgEl.textContent = (totalCount - decidedCount) + ' to go';
       msgEl.className = 'explore-stats-msg';
     } else {
-      msgEl.textContent = 'All done';
+      msgEl.textContent = '';
       msgEl.className = 'explore-stats-msg explore-stats-msg--complete';
     }
 


### PR DESCRIPTION
## Summary
- Clears the progress message text when all questions are decided instead of showing "All done"
- The full progress bar + "12 / 12 decided" label already communicate completion

## Test plan
- [ ] Decide all 12 questions, verify no "All done" text appears
- [ ] Verify progress messages ("Pick your first answer", "X to go") still work for partial completion