### PR TITLE
Let users clear an answer without picking a different one

### DIFF
--- a/index.html
+++ b/index.html
@@ -4874,6 +4874,7 @@ og_url: https://marbleheaddata.org/
     document.querySelectorAll('.answer-card').forEach(function (c) {
       c.classList.remove('selected', 'viewing', 'dimmed');
     });
+    updateAnswerCheckTitles();
     document.querySelectorAll('.evidence').forEach(function (e) {
       e.classList.remove('open');
     });
@@ -4928,7 +4929,11 @@ og_url: https://marbleheaddata.org/
       e.stopPropagation();
       var q = card.dataset.question;
       var a = card.dataset.answer;
-      selectAnswer(q, a);
+      if (card.classList.contains('selected')) {
+        deselectAnswer(q);
+      } else {
+        selectAnswer(q, a);
+      }
       updateNotesPill();
       updateNotesPanel();
     });
@@ -5071,6 +5076,7 @@ og_url: https://marbleheaddata.org/
         c.classList.remove('selected');
         if (c.dataset.answer === pick) c.classList.add('selected');
       });
+      updateAnswerCheckTitles();
       viewEvidence(topic, pick);
       var screen = document.querySelector('.question-screen[data-topic="' + topic + '"]');
       var prompt = screen && screen.querySelector('.answers + .answers-prompt');
@@ -5407,6 +5413,7 @@ og_url: https://marbleheaddata.org/
       c.classList.remove('selected');
       if (c.dataset.answer === answer) c.classList.add('selected');
     });
+    updateAnswerCheckTitles();
 
     selections[question] = answer;
     // Selecting an answer is an in-place state change on the current topic,
@@ -5469,7 +5476,22 @@ og_url: https://marbleheaddata.org/
     });
   }
 
+  // Keep each checkmark's tooltip in sync with whether that card is
+  // currently the user's pick. Called after any selection state change.
+  function updateAnswerCheckTitles() {
+    document.querySelectorAll('.answer-card').forEach(function (card) {
+      var check = card.querySelector('.answer-check');
+      if (!check) return;
+      check.title = card.classList.contains('selected')
+        ? 'Clear this view'
+        : 'Make this my view';
+    });
+  }
+
   function deselectAnswer(question) {
+    if (typeof posthog !== 'undefined') {
+      posthog.capture('explore_answer_deselected', { topic: question });
+    }
     document.querySelectorAll('.answer-card[data-question="' + question + '"]').forEach(function (c) {
       c.classList.remove('selected', 'dimmed', 'viewing');
     });
@@ -5482,8 +5504,16 @@ og_url: https://marbleheaddata.org/
     writeURL(question, null, true);
     persistSelections();
     updateQuestionHeader(question);
+    updateAnswerCheckTitles();
 
+    // Hide the "next question" button until they pick again
     var screen = document.querySelector('.question-screen[data-topic="' + question + '"]');
+    var nextBtn = screen && screen.querySelector('.next-question');
+    if (nextBtn) nextBtn.classList.remove('visible');
+
+    updateBrowseHint(question);
+    updateStatsStrip();
+    updateQuestionSocialBar(question);
   }
 
   // Card body click: first time selects, after that just browses evidence


### PR DESCRIPTION
## Summary

Clicking the checkmark on an already-selected answer card now clears the selection instead of being a no-op. Previously the only way to change state on a question was to pick a *different* answer — you couldn't return to an undecided state. That nudged residents toward committing to a view, which is at odds with the site's neutral stance, and also inflated the "My positions" count for users who only meant to browse (the first card tap auto-selects).

The `deselectAnswer` function was already defined in `index.html` but nothing called it — dead code. This wires it up and fills in the side effects it was missing.

## Changes

- **`.answer-check` click handler** (index.html:4928): toggles — if the card is already `.selected`, call `deselectAnswer(q)`; otherwise `selectAnswer(q, a)` as before.
- **`deselectAnswer`** (index.html:5491): now also hides the "next question" button, refreshes the stats strip, question social bar, and browse hint, updates checkmark tooltips, and fires an `explore_answer_deselected` PostHog event.
- **`updateAnswerCheckTitles()` helper** (index.html:5481): keeps each checkmark's tooltip in sync — "Make this my view" when unpicked, "Clear this view" when picked. Called from `selectAnswer`, `deselectAnswer`, `switchTopic`'s restore path, and the reset button handler.

The card body's click behavior is unchanged: first tap still selects + views, subsequent taps still browse evidence. Deselection is only available via the checkmark, so it's a deliberate action rather than something you can trigger by accidentally tapping a card you'd already committed to.

Server-side counters (`incrementSocial('q', ...)`, `submitVote`) are **not** rolled back on deselect — those are fire-and-forget and the "decided count" for the community stays sticky.

## Test plan

- [ ] Fresh session → tap a card → checkmark fills, evidence opens, next-question button appears
- [ ] Hover the filled checkmark → tooltip reads "Clear this view"
- [ ] Click the filled checkmark → selection clears, evidence closes, next-question button hides, progress dot for that topic un-lights, stats strip "decided" count decrements
- [ ] After deselect, tooltip on all three checkmarks reads "Make this my view"
- [ ] Notes pill count updates correctly on deselect; if it drops to 0, the pill hides and any open notes panel closes
- [ ] Deselect, then navigate back to landing → that topic's pip is cleared and `has-pick` is gone
- [ ] Deselect, then reload → selection stays cleared (localStorage persisted)
- [ ] Switching to a different answer still works as before (no extra deselect step required)
- [ ] URL `?q=override&pos=a` → deselect → URL becomes `?q=override` (history.replaceState, not a new entry)