### PR TITLE
Update Claude AI subscription cost to ~$200/month

### DIFF
--- a/about.html
+++ b/about.html
@@ -186,7 +186,7 @@ claude "audit this site. find the bias. follow the money. be skeptical."</code><
   <div class="card">
     <div class="cut-item">
       <span class="cut-item-name">Claude AI subscription<span class="cut-item-note">Not exclusive to this site.</span></span>
-      <span class="cut-item-amount">~$100/month</span>
+      <span class="cut-item-amount">~$200/month</span>
     </div>
     <div class="cut-item">
       <span class="cut-item-name">Domain registration</span>


### PR DESCRIPTION
## Summary
- Corrects the Claude AI subscription line in the about page costs section from `~$100/month` to `~$200/month` to reflect the author's actual subscription tier.

## Test plan
- [ ] Visit `/about.html` and confirm the Costs section shows `~$200/month` next to "Claude AI subscription".
