### PR TITLE
Move 'Not sure yet' from 4th card to text button below answers

### DIFF
--- a/index.html
+++ b/index.html
@@ -646,56 +646,31 @@ og_url: https://marbleheaddata.org/
     margin: 0;
   }
 
-  /* ── "Not sure yet" option: a real fourth choice, not a bypass. ──
-     Sits inside .answers as the last child, full width even on desktop
-     where the other three cards are row-aligned. Visually subtler so it
-     reads as "still thinking" rather than a competing position. */
-  .answer-card.answer-card-unsure {
-    flex: 0 0 100%;
-    padding: 12px 16px;
-    background: color-mix(in srgb, var(--border) 30%, transparent);
-    border: 1px dashed var(--border);
-    display: flex;
+  /* ── "Not sure yet" button below the answer cards ── */
+  .unsure-btn {
+    display: inline-flex;
     align-items: center;
-    gap: 12px;
+    gap: 6px;
+    margin-top: 4px;
+    padding: 6px 0;
+    background: none;
+    border: none;
     cursor: pointer;
-  }
-  .answer-card.answer-card-unsure:hover {
-    border-color: var(--text-muted);
-    border-style: solid;
-    box-shadow: none;
-  }
-  .answer-card.answer-card-unsure .answer-unsure-body {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    min-width: 0;
-  }
-  .answer-card.answer-card-unsure .answer-unsure-label {
-    font-size: 14px;
-    font-weight: 600;
+    font-family: inherit;
+    font-size: 13px;
     color: var(--text-muted);
-    letter-spacing: 0.1px;
+    opacity: 0.7;
+    transition: opacity 0.15s;
   }
-  .answer-card.answer-card-unsure .answer-unsure-sub {
-    font-size: 12px;
-    color: var(--text-subtle);
-    line-height: 1.4;
+  .unsure-btn:hover { opacity: 1; }
+  .unsure-btn.selected {
+    opacity: 1;
+    color: var(--text);
   }
-  .answer-card.answer-card-unsure.selected {
-    border-style: solid;
-    border-color: var(--text-muted);
-    box-shadow: 0 0 0 1px var(--text-muted);
-    background: var(--surface);
+  .unsure-btn.selected::before {
+    content: '\2713';
+    font-size: 11px;
   }
-  .answer-card.answer-card-unsure.selected .answer-unsure-label { color: var(--text); }
-  .answer-card.answer-card-unsure.viewing {
-    border-color: var(--text-muted);
-    box-shadow: none;
-  }
-  /* Checkmark is still wired up, but a round badge on this compact card
-     looks out of place. Hide it; clicking the body casts the vote. */
-  .answer-card.answer-card-unsure .answer-check { display: none; }
 
   /* ── Pick distribution bar ── */
   .pick-distribution {
@@ -767,24 +742,6 @@ og_url: https://marbleheaddata.org/
     color: var(--text-muted);
     font-weight: 600;
   }
-  /* Lighter variant of the evidence panel for the "Not sure yet" state. */
-  .evidence.evidence-unsure {
-    background: transparent;
-    border-style: dashed;
-    padding: 16px 18px;
-  }
-  .evidence.evidence-unsure .evidence-header h3 {
-    font-size: 14px;
-    color: var(--text-muted);
-    font-weight: 600;
-  }
-  .evidence.evidence-unsure p {
-    margin: 0;
-    font-size: 14px;
-    color: var(--text-muted);
-    line-height: 1.55;
-  }
-
   /* ── Evidence panel ── */
   .evidence {
     display: none;
@@ -4671,40 +4628,28 @@ og_url: https://marbleheaddata.org/
     });
   })();
 
-  /* ── Inject "Not sure yet" as a first-class fourth option for every
-     question. Clicking it submits a real vote ('u'), which means a later
-     switch to a concrete answer goes through the move-vote endpoint and
-     counts as a genuine reconsideration, not noise from a forced pick. */
-  (function injectUnsureAnswer() {
+  /* ── Inject "Not sure yet" button below the answer cards ── */
+  (function injectUnsureButton() {
     document.querySelectorAll('.question-screen').forEach(function (screen) {
       var topic = screen.dataset.topic;
       var answersEl = screen.querySelector('.answers');
-      if (!answersEl || answersEl.querySelector('[data-answer="u"]')) return;
+      if (!answersEl) return;
 
-      var card = document.createElement('div');
-      card.className = 'answer-card answer-card-unsure';
-      card.dataset.answer = 'u';
-      card.dataset.question = topic;
-      card.innerHTML =
-        '<span class="answer-unsure-body">' +
-          '<span class="answer-unsure-label">Not sure yet</span>' +
-          '<span class="answer-unsure-sub">Let me read the cases first</span>' +
-        '</span>';
-      answersEl.appendChild(card);
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'unsure-btn';
+      btn.dataset.answer = 'u';
+      btn.dataset.question = topic;
+      btn.textContent = 'Not sure yet';
+      answersEl.parentNode.insertBefore(btn, answersEl.nextSibling);
 
-      // Lightweight evidence panel so clicking "Not sure yet" lands
-      // somewhere rather than opening an empty area. Intentionally
-      // short: it points the reader at the three real cases above.
-      var ev = document.createElement('div');
-      ev.className = 'evidence evidence-unsure';
-      ev.dataset.evidence = topic + '-u';
-      ev.innerHTML =
-        '<div class="evidence-header">' +
-          '<h3>Take your time</h3>' +
-          '<button class="evidence-close" type="button">Collapse</button>' +
-        '</div>' +
-        '<p>Tap any answer above to read the case for it. When something clicks, use the checkmark on that card to lock your pick.</p>';
-      screen.appendChild(ev);
+      btn.addEventListener('click', function () {
+        var q = btn.dataset.question;
+        if (selections[q] === 'u') return; // already unsure
+        selectAnswer(q, 'u');
+        updateNotesPill();
+        updateNotesPanel();
+      });
     });
   })();
 
@@ -5064,6 +5009,9 @@ og_url: https://marbleheaddata.org/
     document.querySelectorAll('.answer-card').forEach(function (c) {
       c.classList.remove('selected', 'viewing', 'dimmed');
     });
+    document.querySelectorAll('.unsure-btn').forEach(function (b) {
+      b.classList.remove('selected');
+    });
     updateAnswerCheckTitles();
     document.querySelectorAll('.evidence').forEach(function (e) {
       e.classList.remove('open');
@@ -5266,6 +5214,8 @@ og_url: https://marbleheaddata.org/
         c.classList.remove('selected');
         if (c.dataset.answer === pick) c.classList.add('selected');
       });
+      var unsureBtn = document.querySelector('.unsure-btn[data-question="' + topic + '"]');
+      if (unsureBtn) unsureBtn.classList.toggle('selected', pick === 'u');
       updateAnswerCheckTitles();
       viewEvidence(topic, pick);
       var screen = document.querySelector('.question-screen[data-topic="' + topic + '"]');
@@ -5618,6 +5568,9 @@ og_url: https://marbleheaddata.org/
       c.classList.remove('selected');
       if (c.dataset.answer === answer) c.classList.add('selected');
     });
+    // Update unsure button state
+    var unsureBtn = document.querySelector('.unsure-btn[data-question="' + question + '"]');
+    if (unsureBtn) unsureBtn.classList.toggle('selected', answer === 'u');
     updateAnswerCheckTitles();
 
     selections[question] = answer;
@@ -5700,6 +5653,8 @@ og_url: https://marbleheaddata.org/
     document.querySelectorAll('.answer-card[data-question="' + question + '"]').forEach(function (c) {
       c.classList.remove('selected', 'dimmed', 'viewing');
     });
+    var unsureBtn = document.querySelector('.unsure-btn[data-question="' + question + '"]');
+    if (unsureBtn) unsureBtn.classList.remove('selected');
     document.querySelectorAll('.evidence').forEach(function (e) {
       if (e.dataset.evidence && e.dataset.evidence.startsWith(question + '-')) {
         e.classList.remove('open');
@@ -5722,9 +5677,6 @@ og_url: https://marbleheaddata.org/
   }
 
   // Card body click: first time selects, after that just browses evidence.
-  // Exception: clicking "Not sure yet" always casts (or re-casts) the vote,
-  // because it's labeled as an explicit reconsideration and there's no
-  // checkmark on that card.
   document.querySelectorAll('.answer-card').forEach(function (card) {
     card.addEventListener('click', function (e) {
       // Don't fire if they clicked the checkmark (handled separately)
@@ -5733,20 +5685,14 @@ og_url: https://marbleheaddata.org/
       var question = this.dataset.question;
       var answer   = this.dataset.answer;
       var hasSelection = !!selections[question];
-      var isUnsureCard = (answer === 'u');
 
-      if (!hasSelection || isUnsureCard) {
-        // First pick, or explicit "back to unsure" click.
-        if (selections[question] === answer) {
-          // Already on this answer: just reopen the panel, no re-vote.
-          viewEvidence(question, answer);
-        } else {
-          selectAnswer(question, answer);
-          updateNotesPill();
-          updateNotesPanel();
-        }
+      if (!hasSelection) {
+        // First pick: select AND view
+        selectAnswer(question, answer);
+        updateNotesPill();
+        updateNotesPanel();
       } else {
-        // Already have a pick on a/b/c: just browse this evidence
+        // Already have a pick: just browse this evidence
         viewEvidence(question, answer);
       }
     });

--- a/index.html
+++ b/index.html
@@ -646,25 +646,30 @@ og_url: https://marbleheaddata.org/
     margin: 0;
   }
 
-  /* ── "Not sure yet" button below the answer cards ── */
+  /* ── "Not sure yet" pill below the answer cards ── */
   .unsure-btn {
     display: inline-flex;
     align-items: center;
     gap: 6px;
     margin-top: 4px;
-    padding: 6px 0;
-    background: none;
-    border: none;
+    padding: 7px 16px;
+    background: transparent;
+    border: 1px dashed var(--border);
+    border-radius: 999px;
     cursor: pointer;
     font-family: inherit;
     font-size: 13px;
     color: var(--text-muted);
-    opacity: 0.7;
-    transition: opacity 0.15s;
+    transition: border-color 0.15s, color 0.15s;
   }
-  .unsure-btn:hover { opacity: 1; }
+  .unsure-btn:hover {
+    border-color: var(--text-muted);
+    border-style: solid;
+    color: var(--text);
+  }
   .unsure-btn.selected {
-    opacity: 1;
+    border-style: solid;
+    border-color: var(--text-muted);
     color: var(--text);
   }
   .unsure-btn.selected::before {


### PR DESCRIPTION
## Summary
- Removes the "Not sure yet" answer card that was rendering as a broken 4th column in the desktop answer grid
- Replaces it with a small text button placed below the three answer cards
- Keeps the same vote behavior (answer='u'), distribution bar segment, and landing card pip

## Test plan
- [ ] Desktop: verify three answer cards render in a row with no 4th column
- [ ] "Not sure yet" button appears below the cards, not inside the grid
- [ ] Clicking it submits a 'u' vote and shows checkmark state
- [ ] Selecting A/B/C after clears the unsure state
- [ ] Mobile layout still works
- [ ] Reset clears unsure button state

🤖 Generated with [Claude Code](https://claude.com/claude-code)