### PR TITLE
Stop stray scrolls from highlighting answer cards on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -553,9 +553,18 @@ og_url: https://marbleheaddata.org/
     transition: all 0.2s ease;
     position: relative;
   }
-  .answer-card:hover {
-    border-color: var(--c-navy);
-    box-shadow: var(--shadow-sm);
+  /* :hover styles are gated on (hover: hover) so touch devices don't get
+     stuck in a pseudo-selected state from a stray scroll-start tap. The
+     hover look is visually identical to .viewing, which on iOS would
+     persist until another element was tapped. */
+  @media (hover: hover) {
+    .answer-card:hover {
+      border-color: var(--c-navy);
+      box-shadow: var(--shadow-sm);
+    }
+    .answer-card.dimmed:hover {
+      opacity: 0.8;
+    }
   }
   .answer-card.selected {
     border-color: var(--c-teal);
@@ -567,9 +576,6 @@ og_url: https://marbleheaddata.org/
   }
   .answer-card.dimmed {
     opacity: 0.5;
-  }
-  .answer-card.dimmed:hover {
-    opacity: 0.8;
   }
 
   /* Checkmark button on cards */
@@ -591,9 +597,11 @@ og_url: https://marbleheaddata.org/
     transition: all 0.15s;
     z-index: 1;
   }
-  .answer-check:hover {
-    border-color: var(--c-teal);
-    color: var(--c-teal);
+  @media (hover: hover) {
+    .answer-check:hover {
+      border-color: var(--c-teal);
+      color: var(--c-teal);
+    }
   }
   .answer-card.selected .answer-check {
     border-color: var(--c-teal);
@@ -612,8 +620,10 @@ og_url: https://marbleheaddata.org/
     margin-top: 10px;
     transition: opacity 0.2s;
   }
-  .answer-card:hover .answer-hint {
-    color: var(--c-teal);
+  @media (hover: hover) {
+    .answer-card:hover .answer-hint {
+      color: var(--c-teal);
+    }
   }
   .answer-card.selected .answer-hint,
   .answer-card.dimmed .answer-hint {
@@ -660,10 +670,12 @@ og_url: https://marbleheaddata.org/
     gap: 12px;
     cursor: pointer;
   }
-  .answer-card.answer-card-unsure:hover {
-    border-color: var(--text-muted);
-    border-style: solid;
-    box-shadow: none;
+  @media (hover: hover) {
+    .answer-card.answer-card-unsure:hover {
+      border-color: var(--text-muted);
+      border-style: solid;
+      box-shadow: none;
+    }
   }
   .answer-card.answer-card-unsure .answer-unsure-body {
     display: flex;
@@ -5725,10 +5737,55 @@ og_url: https://marbleheaddata.org/
   // Exception: clicking "Not sure yet" always casts (or re-casts) the vote,
   // because it's labeled as an explicit reconsideration and there's no
   // checkmark on that card.
+  //
+  // Touch guard: on mobile, a finger touch that turns into a scroll (or a
+  // tap-to-stop during iOS momentum scroll) can still fire a synthetic
+  // click, which would apply .viewing / .selected to a card the user
+  // didn't mean to pick. We ignore clicks where (a) the finger moved past
+  // the tap slop, (b) the document scrolled between touchstart and click,
+  // or (c) the page was actively scrolling in the moment before the click
+  // (tap-to-stop-momentum case, where scrollY at touchstart and click are
+  // the same because the tap halted the scroll).
+  var TAP_SLOP_PX = 10;
+  var _lastScrollAt = 0;
+  window.addEventListener('scroll', function () {
+    _lastScrollAt = Date.now();
+  }, { passive: true });
   document.querySelectorAll('.answer-card').forEach(function (card) {
+    var tStartX = 0, tStartY = 0, tStartScrollY = 0, tStartAt = 0, tMoved = false;
+    card.addEventListener('touchstart', function (e) {
+      tStartAt = Date.now();
+      if (!e.touches || e.touches.length !== 1) { tMoved = true; return; }
+      tStartX = e.touches[0].clientX;
+      tStartY = e.touches[0].clientY;
+      tStartScrollY = window.pageYOffset || document.documentElement.scrollTop || 0;
+      // If a scroll event fired very recently, the page is mid-momentum
+      // and this touch is likely a stop-scroll gesture, not a tap.
+      tMoved = (tStartAt - _lastScrollAt) < 150;
+    }, { passive: true });
+    card.addEventListener('touchmove', function (e) {
+      if (tMoved || !e.touches || e.touches.length !== 1) return;
+      var dx = Math.abs(e.touches[0].clientX - tStartX);
+      var dy = Math.abs(e.touches[0].clientY - tStartY);
+      if (dx > TAP_SLOP_PX || dy > TAP_SLOP_PX) tMoved = true;
+    }, { passive: true });
     card.addEventListener('click', function (e) {
       // Don't fire if they clicked the checkmark (handled separately)
       if (e.target.closest('.answer-check')) return;
+
+      // Only apply touch-scroll guards when this click actually followed
+      // a recent touchstart. On desktop (mouse clicks) tStartAt stays 0,
+      // so the guards are skipped and scroll position is irrelevant.
+      if (tStartAt && (Date.now() - tStartAt) < 1000) {
+        var nowScrollY = window.pageYOffset || document.documentElement.scrollTop || 0;
+        if (tMoved || Math.abs(nowScrollY - tStartScrollY) > TAP_SLOP_PX) {
+          tMoved = false;
+          tStartAt = 0;
+          return;
+        }
+      }
+      tMoved = false;
+      tStartAt = 0;
 
       var question = this.dataset.question;
       var answer   = this.dataset.answer;


### PR DESCRIPTION
## Summary

On mobile (especially iOS Safari), scrolling past an answer card on a question page would sometimes leave the card looking highlighted/selected even though the user hadn't deliberately picked it. Two separate things contributed:

1. **Sticky `:hover` on touch devices.** `.answer-card:hover` and `.answer-card.viewing` use the same navy border + shadow. iOS persists `:hover` after a touch until another element is tapped, so a stray scroll-start touch would leave a card visually stuck in the "viewing" look.
2. **Click firing during scroll gestures.** The card click handler calls `viewEvidence()` (or `selectAnswer()` on a first pick), which explicitly adds `.viewing` / `.selected`. A tap during iOS momentum scroll (tap-to-stop) — or a touch that turned into a scroll but still fired a synthetic click — could land on a card the user never meant to open.

## Changes

- Gate `.answer-card` / `.answer-check` / `.answer-card-unsure` `:hover` rules behind `@media (hover: hover)` so they only apply on real pointer devices. Desktop hover behavior is unchanged.
- Add a touch-movement guard on the card click handler that suppresses the click when any of:
  - the finger moved more than 10px from touchstart (tap-slop),
  - the page scrolled more than 10px between touchstart and click,
  - or a scroll event fired within 150ms before the touch (mid-momentum tap-to-stop).
- Guards are scoped to clicks that followed a recent touchstart, so desktop mouse clicks are unaffected regardless of scroll position.

## Test plan

- [ ] Desktop: hovering a card still shows the navy border/shadow.
- [ ] Desktop: clicking a card still selects it and opens evidence, even after scrolling.
- [ ] Mobile: scrolling past a question page no longer leaves cards in a highlighted state.
- [ ] Mobile: deliberate tap on a card still selects it / opens evidence on first tap.
- [ ] Mobile: after picking answer A, tap-to-stop a momentum scroll over card B no longer opens B's evidence.
- [ ] Landing on `?q=override&pos=a` still shows answer A as selected (URL-driven selection path is unchanged).

https://claude.ai/code/session_01B5aTXyXeQ4Jnhz7dqS3TGS