### PR TITLE
Drop "notes" from reset-data confirmation copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -5002,9 +5002,11 @@ og_url: https://marbleheaddata.org/
     statsEl.style.display = '';
   }
 
-  // Reset button: clears all local data (selections, notes, counters, tutorial)
+  // Reset button: clears all local data (selections, notes, counters, tutorial).
+  // Notes UI is currently hidden (#405) but the underlying data is still
+  // cleared here in case it comes back.
   document.getElementById('statsReset').addEventListener('click', function () {
-    if (!confirm('Erase all your picks and notes? Nothing about you is stored anywhere except your browser.')) return;
+    if (!confirm('Erase all your picks? Nothing about you is stored anywhere except your browser.')) return;
     // Clear selections
     Object.keys(selections).forEach(function (k) { delete selections[k]; });
     persistSelections();


### PR DESCRIPTION
## Summary
- The notes UI has been inaccessible since #405 hid the "My positions" floating pill, so the reset confirmation saying "Erase all your picks and notes?" is misleading — there's no way to create notes anymore.
- Shortens the prompt to just "Erase all your picks?" and leaves the underlying notes cleanup in place in case the pill is re-enabled via the one-line CSS uncomment #405 left behind.

## Test plan
- [ ] Click "Reset my data" on the homepage and confirm the prompt no longer mentions notes.
- [ ] Confirm reset still clears selections, counters, and tutorial flag as before.

https://claude.ai/code/session_01BLU2prFh2jWjXFNBCCbrgi