### PR TITLE
Recap reader's pick in completed question card subheaders

### DIFF
--- a/index.html
+++ b/index.html
@@ -5412,14 +5412,23 @@ og_url: https://marbleheaddata.org/
     titleSpan.textContent = h1.textContent;
     btn.appendChild(titleSpan);
 
-    /* Context subtitle */
+    /* Context subtitle. When the reader has picked an answer for this
+       topic, this slot recaps their choice instead of re-explaining
+       the question. We stash the original elaboration text and the
+       per-answer headings so updateLandingCards() can swap between
+       them without re-querying the DOM. */
     var ctxP = screen.querySelector('.question-context');
-    if (ctxP) {
-      var ctxSpan = document.createElement('span');
-      ctxSpan.className = 'explore-card-context';
-      ctxSpan.textContent = ctxP.textContent.trim();
-      btn.appendChild(ctxSpan);
-    }
+    var ctxText = ctxP ? ctxP.textContent.trim() : '';
+    var answerHeadings = {};
+    ['a', 'b', 'c'].forEach(function (pos) {
+      var ac = screen.querySelector('.answer-card[data-answer="' + pos + '"]');
+      var h2 = ac ? ac.querySelector('h2') : null;
+      if (h2) answerHeadings[pos] = h2.textContent.trim();
+    });
+    var ctxSpan = document.createElement('span');
+    ctxSpan.className = 'explore-card-context';
+    ctxSpan.textContent = ctxText;
+    btn.appendChild(ctxSpan);
 
     /* Mini position indicators (a, b, c, u). The 'u' pip is the
        muted "Not sure yet" state -- lights up when the reader's
@@ -5446,7 +5455,14 @@ og_url: https://marbleheaddata.org/
       window.scrollTo(0, 0);
     });
     listEl.appendChild(btn);
-    landingCards[topic] = { el: btn, pips: pips, dist: distEl };
+    landingCards[topic] = {
+      el: btn,
+      pips: pips,
+      dist: distEl,
+      ctxSpan: ctxSpan,
+      ctxText: ctxText,
+      answerHeadings: answerHeadings
+    };
   });
 
   /* Update landing cards to reflect current selections */
@@ -5463,6 +5479,14 @@ og_url: https://marbleheaddata.org/
         hasAny = true;
         if (card.pips[answer]) card.pips[answer].classList.add('picked');
         card.el.classList.add('has-pick');
+        // Recap the reader's pick in the subheader slot. For 'u'
+        // (Not sure yet) there's no answer heading to show, so keep
+        // the original question elaboration -- the muted pip already
+        // signals the unsure state.
+        if (card.ctxSpan) {
+          var recap = card.answerHeadings[answer];
+          card.ctxSpan.textContent = recap || card.ctxText;
+        }
         // Populate community split bar from server counts. 'u' is a
         // real fourth segment; the muted pip keeps it from competing
         // visually with the three real positions.
@@ -5493,6 +5517,7 @@ og_url: https://marbleheaddata.org/
       } else {
         card.el.classList.remove('has-pick');
         if (card.dist) card.dist.innerHTML = '';
+        if (card.ctxSpan) card.ctxSpan.textContent = card.ctxText;
       }
     });
     // Show share buttons if any selections


### PR DESCRIPTION
## Summary

On the home screen, cards for answered questions now show the heading of the position the reader selected instead of the generic question elaboration. The elaboration is still shown on unanswered cards where it actually helps frame the question — once a position is locked in, the more useful thing to see is "what did I say about this?"

For the "Not sure yet" (`u`) pick, the card keeps the original elaboration: "Not sure yet" is not a useful recap, and the muted pip already signals the unsure state.

## Implementation notes

- Card creation (`index.html:5415`) now always builds the `.explore-card-context` span and stashes on the landing card entry:
  - `ctxText` — the original question elaboration
  - `answerHeadings` — a lookup of `{a,b,c}` → the `<h2>` text inside each `.answer-card` for that topic
- `updateLandingCards()` swaps `ctxSpan.textContent` to `answerHeadings[answer]` when a/b/c is picked, falls back to `ctxText` for `u` or when the pick is cleared.

Not touched: checkmark badge. The teal border, teal-tinted icon, lit mini-position pip, and community distribution bar already give four "this is answered" signals — adding a fifth would be redundant with the mini-bar, which is strictly more informative (it says *which* answer).

## Test plan

- [ ] Load home screen with no selections → every card shows the question elaboration, as before
- [ ] Pick answer A/B/C on a question → the home card's subheader swaps to that answer's heading
- [ ] Pick "Not sure yet" → the subheader stays on the elaboration (muted pip still lights)
- [ ] Clear an answer (re-select → none) → subheader restores to the elaboration
- [ ] Restore from localStorage on reload → subheader renders recap text on initial paint
- [ ] Shared-position URL (`?positions=override:a,...`) → subheader renders recap text on load
