### PR TITLE
Clean up top nav: rename Civic, populate Budget, trim Peer Towns

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -21,6 +21,7 @@
       <button class="nav-dropdown-toggle" aria-expanded="false">Budget <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <div class="nav-dropdown-menu">
         <a href="{{ '/' | relative_url }}where-has-the-money-gone.html"{% if page.url == '/where-has-the-money-gone.html' %} aria-current="page"{% endif %}>Where the money went</a>
+        <a href="{{ '/' | relative_url }}charts/budget_flow.html"{% if page.url == '/charts/budget_flow.html' %} aria-current="page"{% endif %}>Budget flow (interactive)</a>
       </div>
     </div>
 
@@ -53,16 +54,14 @@
     <div class="nav-dropdown">
       <button class="nav-dropdown-toggle" aria-expanded="false">Peer Towns <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <div class="nav-dropdown-menu">
-        <a href="{{ '/' | relative_url }}charts/four_town_rates.html"{% if page.url == '/charts/four_town_rates.html' %} aria-current="page"{% endif %}>Four-town tax rates</a>
-        <a href="{{ '/' | relative_url }}charts/per_capita_levy.html"{% if page.url == '/charts/per_capita_levy.html' %} aria-current="page"{% endif %}>Per-capita levy</a>
-        <a href="{{ '/' | relative_url }}charts/tax_comparison.html"{% if page.url == '/charts/tax_comparison.html' %} aria-current="page"{% endif %}>Marblehead vs. Swampscott</a>
+        <a href="{{ '/' | relative_url }}charts/four_town_rates.html"{% if page.url == '/charts/four_town_rates.html' or page.url == '/charts/per_capita_levy.html' or page.url == '/charts/tax_comparison.html' %} aria-current="page"{% endif %}>Four-town tax rates</a>
         <a href="{{ '/' | relative_url }}charts/rate_value_schools.html"{% if page.url == '/charts/rate_value_schools.html' %} aria-current="page"{% endif %}>Rate, value, and schools</a>
         <a href="{{ '/' | relative_url }}why-not-elsewhere.html"{% if page.url == '/why-not-elsewhere.html' %} aria-current="page"{% endif %}>Why not elsewhere?</a>
         <a href="{{ '/' | relative_url }}data/case_studies.html"{% if page.url == '/data/case_studies.html' %} aria-current="page"{% endif %}>Case studies</a>
       </div>
     </div>
 
-    <a href="{{ '/' | relative_url }}what-you-can-do.html"{% if page.url == '/what-you-can-do.html' %} aria-current="page"{% endif %}>Civic</a>
+    <a href="{{ '/' | relative_url }}what-you-can-do.html"{% if page.url == '/what-you-can-do.html' %} aria-current="page"{% endif %}>Get involved</a>
 
     <div class="nav-dropdown">
       <button class="nav-dropdown-toggle" aria-expanded="false">Data <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>


### PR DESCRIPTION
## Summary

Three small top-nav fixes from the site review:

- **Rename "Civic" to "Get involved"** — clearer action label for `what-you-can-do.html`. "Civic" reads like a category header with nothing under it.
- **Populate the Budget dropdown** — it only had one item (`where-has-the-money-gone.html`). Added `charts/budget_flow.html` so the dropdown is meaningful. `budget_flow.html` was not in nav anywhere before.
- **Trim the Peer Towns dropdown from 6 items to 4** — removed `charts/per_capita_levy.html` and `charts/tax_comparison.html`. Both pages stay on the site as files and remain linked as homepage evidence from the `taxrank` question. They're already cross-linked from `four_town_rates.html` via read-next-links, so they're still discoverable from the anchor peer-town chart. When you visit either demoted page, the Four-town tax rates nav entry now marks itself `aria-current` so the dropdown still opens to the right spot on mobile.

No files deleted, no homepage evidence links broken.

## Test plan

- [ ] Nav renders with "Get involved" on desktop and in mobile panel
- [ ] Budget dropdown shows two items
- [ ] Peer Towns dropdown shows four items
- [ ] Visiting `/charts/per_capita_levy.html` highlights Four-town tax rates in the Peer Towns dropdown
- [ ] Homepage `taxrank` question still links to both demoted charts as evidence

https://claude.ai/code/session_01TXj5HFGAdGKPPBN1wHufDG