### PR TITLE
Consolidate duplicative entry points and ballot explainer

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,17 +2,16 @@
   <div class="nav-inner">
     <a class="nav-brand" href="{{ '/' | relative_url }}"><img class="nav-logo" src="{{ '/' | relative_url }}favicon.svg" alt="" width="22" height="22"> MHD Data</a>
 
-    <a href="{{ '/' | relative_url }}the-debate.html"{% if page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Debate</a>
-
     <div class="nav-dropdown">
       <button class="nav-dropdown-toggle" aria-expanded="false">Vote <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <div class="nav-dropdown-menu">
         <a href="{{ '/' | relative_url }}what-is-the-override.html"{% if page.url == '/what-is-the-override.html' %} aria-current="page"{% endif %}>What is the override?</a>
+        <a href="{{ '/' | relative_url }}whats-on-the-ballot.html"{% if page.url == '/whats-on-the-ballot.html' %} aria-current="page"{% endif %}>What's on the ballot?</a>
         <a href="{{ '/' | relative_url }}question-2-trash.html"{% if page.url == '/question-2-trash.html' %} aria-current="page"{% endif %}>Trash: levy or fee?</a>
-        <a href="{{ '/' | relative_url }}whats-on-the-ballot.html"{% if page.url == '/whats-on-the-ballot.html' %} aria-current="page"{% endif %}>What else is on the ballot?</a>
         <a href="{{ '/' | relative_url }}how-we-got-here.html"{% if page.url == '/how-we-got-here.html' %} aria-current="page"{% endif %}>How we got here</a>
         <a href="{{ '/' | relative_url }}marblehead-voting-record.html"{% if page.url == '/marblehead-voting-record.html' %} aria-current="page"{% endif %}>Voting record</a>
         <a href="{{ '/' | relative_url }}no-override-budget.html"{% if page.url == '/no-override-budget.html' %} aria-current="page"{% endif %}>No-override budget</a>
+        <a href="{{ '/' | relative_url }}the-debate.html"{% if page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Both sides of the debate</a>
         <a href="{{ '/' | relative_url }}charts/sustainability.html"{% if page.url == '/charts/sustainability.html' %} aria-current="page"{% endif %}>Sustainability</a>
       </div>
     </div>

--- a/browse.html
+++ b/browse.html
@@ -8,8 +8,8 @@ og_type: website
 og_url: https://marbleheaddata.org/browse.html
 ---
 <div class="hero">
-    <h1>Do we need an override?</h1>
-    <p>Every claim on this site cites a primary source. Every dollar traces to a town document. Make your own call. <a href="#data-sources">See all sources.</a></p>
+    <h1>All pages</h1>
+    <p>Every page on marbleheaddata.org, grouped by topic. For the interactive question flow, start at the <a href="/">home page</a>. Every claim cites a primary source &ndash; <a href="#data-sources">see all sources</a>.</p>
   </div>
 
   <a class="featured-card" href="super-summary.html">

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -1,6 +1,6 @@
 ---
 title: "What is the override?"
-scripts: [citations, deep-dive, ballot]
+scripts: [citations, deep-dive]
 og_title: What is the override?
 og_description: The three-tier structure of the proposed Marblehead override, what each tier funds, key terms, and historical context.
 og_url: https://marbleheaddata.org/what-is-the-override.html
@@ -59,7 +59,6 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
   <nav class="page-toc" aria-label="On this page">
     <span class="page-toc-label">On this page</span>
     <a href="#three-tiers">The three tiers</a>
-    <a href="#how-youll-vote">How you'll vote</a>
     <a href="#what-it-costs">What it costs</a>
     <a href="#history">History</a>
     <a href="#key-terms">Key terms</a>
@@ -426,81 +425,7 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
     </div>
   </section>
 
-  <details class="deep-dive">
-    <summary>
-      <h2 data-stance-section="how-youll-vote" id="how-youll-vote">How You'll Vote</h2>
-      <p class="deep-dive-teaser">Practice filling out the ballot and see how the two questions work together.</p>
-    </summary>
-    <div class="deep-dive-body">
-  <p>Two ballot questions at the Annual Town Election on June 9, 2026.</p>
-
-  <div class="ballot">
-    <div class="ballot-header">
-      <div class="ballot-header-sub">Sample Ballot &middot; Town of Marblehead &middot; June 9, 2026</div>
-      <div class="ballot-header-main">Question 1: Operating Override</div>
-    </div>
-    <div class="ballot-instructions">
-      <p class="ballot-instructions-gesture">To vote, completely fill in the oval to the right of your choice like this: <span class="ballot-instructions-example" aria-hidden="true"></span></p>
-      <p class="ballot-instructions-strategy">Vote YES or NO on each question. You may vote YES on more than one.</p>
-    </div>
-    <div class="ballot-row">
-      <div class="ballot-q-num">1A</div>
-      <div class="ballot-q-main">
-        <div class="ballot-q-text">Shall the Town of Marblehead be allowed to assess an additional <strong>$15,000,000</strong> in real estate and personal property taxes for the fiscal year beginning July 1, 2026? <span class="ballot-q-tier">Invest</span></div>
-        <div class="ballot-choices">
-          <span class="ballot-choice"><span class="ballot-choice-label">Yes</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark Yes"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
-          <span class="ballot-choice"><span class="ballot-choice-label">No</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark No"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
-        </div>
-      </div>
-    </div>
-    <div class="ballot-row">
-      <div class="ballot-q-num">1B</div>
-      <div class="ballot-q-main">
-        <div class="ballot-q-text">Shall the Town of Marblehead be allowed to assess an additional <strong>$12,000,000</strong> in real estate and personal property taxes for the fiscal year beginning July 1, 2026? <span class="ballot-q-tier">Stabilize</span></div>
-        <div class="ballot-choices">
-          <span class="ballot-choice"><span class="ballot-choice-label">Yes</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark Yes"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
-          <span class="ballot-choice"><span class="ballot-choice-label">No</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark No"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
-        </div>
-      </div>
-    </div>
-    <div class="ballot-row">
-      <div class="ballot-q-num">1C</div>
-      <div class="ballot-q-main">
-        <div class="ballot-q-text">Shall the Town of Marblehead be allowed to assess an additional <strong>$9,000,000</strong> in real estate and personal property taxes for the fiscal year beginning July 1, 2026? <span class="ballot-q-tier">Restore</span></div>
-        <div class="ballot-choices">
-          <span class="ballot-choice"><span class="ballot-choice-label">Yes</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark Yes"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
-          <span class="ballot-choice"><span class="ballot-choice-label">No</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark No"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <p>The highest tier that gets a majority wins. If you'd accept any override, vote yes on all three. If only 1C passes, you get $9M. If all three pass, you get $15M. The ballot language is based on the sample text from the <a href="https://marbleheadma.gov/wp-content/uploads/2026/03/2026-03-25-Override-Presentation.pdf">Town Administrator's March 25, 2026 override presentation</a>.</p>
-
-  <div class="ballot">
-    <div class="ballot-header">
-      <div class="ballot-header-sub">Sample Ballot &middot; Town of Marblehead &middot; June 9, 2026</div>
-      <div class="ballot-header-main">Question 2: Curbside Trash Funding</div>
-    </div>
-    <div class="ballot-instructions">
-      <p class="ballot-instructions-gesture">To vote, completely fill in the oval to the right of your choice like this: <span class="ballot-instructions-example" aria-hidden="true"></span></p>
-    </div>
-    <div class="ballot-row">
-      <div class="ballot-q-num">2</div>
-      <div class="ballot-q-main">
-        <div class="ballot-q-text">Shall the Town of Marblehead be allowed to assess an additional <strong>$2,298,575</strong> in real estate and personal property taxes to fund curbside trash and recycling for the fiscal year beginning July 1, 2026? <span class="ballot-q-tier">Trash</span></div>
-        <div class="ballot-choices">
-          <span class="ballot-choice"><span class="ballot-choice-label">Yes</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark Yes"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
-          <span class="ballot-choice"><span class="ballot-choice-label">No</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark No"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <p>Question 2 is independent of Question 1. Either way, residents pay for trash: the override spreads the cost by home value, while the Board of Health's fallback is a flat fee of roughly $281 per household.</p>
-  <a class="btn-link" href="question-2-trash.html">Trash: levy or fee?</a>
-
-  <p>The same June 9 ballot also fills 24 seats across 11 elected town bodies, including the Select Board, School Committee, and Board of Health. See <a href="whats-on-the-ballot.html">what else is on the ballot</a> for the full rundown.</p>
-    </div>
-  </details>
+  <p>For an interactive sample ballot showing how Questions 1A, 1B, 1C, and Question 2 appear on the June 9 paper ballot, see <a href="whats-on-the-ballot.html#how-youll-vote">how you'll vote</a> on the ballot rundown page.</p>
 
   <h2 data-stance-section="what-it-costs" id="what-it-costs">What It Costs</h2>
   <p>The override phases in over three years (FY27 to FY29). Year 1 draws only a fraction of the full amount; the full override is active only in Year 3:</p>

--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -273,7 +273,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
       <div class="vote-step-date">Tuesday, June 9, 2026 &middot; Annual Town Election</div>
       <h3>Voters pick the tier at the ballot</h3>
       <p>All registered Marblehead voters can vote at their precinct polling place. The ballot has three tier questions (<strong>1A: $15M "Invest"</strong>, <strong>1B: $12M "Stabilize"</strong>, <strong>1C: $9M "Restore"</strong>), and you may vote yes on more than one. The highest tier with a majority yes sets the override amount. If none of the three get a majority, no override takes effect.<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2026/03/2026-03-25-Override-Presentation.pdf" data-source="Town Administrator's March 25, 2026 override presentation, sample ballot language for three tiers"></sup></p>
-      <p>See the <a href="what-is-the-override.html#how-youll-vote">sample ballot walkthrough</a> on the what-is-the-override page, and the <a href="charts/override_calculator.html">override cost calculator</a> for what each tier costs at different home values.</p>
+      <p>See the <a href="whats-on-the-ballot.html#how-youll-vote">sample ballot walkthrough</a> on the ballot rundown page, and the <a href="charts/override_calculator.html">override cost calculator</a> for what each tier costs at different home values.</p>
       <p>The same ballot fills 24 seats across 11 elected town bodies, from Select Board to Cemetery Commission. See <a href="whats-on-the-ballot.html">what else is on the ballot</a> for the office races.</p>
     </div>
   </div>

--- a/whats-on-the-ballot.html
+++ b/whats-on-the-ballot.html
@@ -1,6 +1,6 @@
 ---
 title: "What else is on the June 9 ballot?"
-scripts: [citations]
+scripts: [citations, ballot]
 og_title: "What else is on the June 9 ballot?"
 og_description: "Beyond the override questions, Marblehead voters will fill 24 seats across 11 elected bodies on June 9, 2026. Here is every office up for election, the seats available, and how to confirm the final candidate list."
 og_url: https://marbleheaddata.org/whats-on-the-ballot.html
@@ -56,17 +56,74 @@ og_url: https://marbleheaddata.org/whats-on-the-ballot.html
 
 <h2 id="ballot-questions">Ballot questions</h2>
 
-<p>Two ballot questions appear alongside the office races. Both are covered in depth elsewhere on this site:</p>
+<p>Two ballot questions appear alongside the office races: a three-tier Proposition 2&frac12; operating override and a separate curbside trash funding question.</p>
 
-<div class="card">
-  <h3>Question 1: Proposition 2&frac12; operating override</h3>
-  <p>Three nested tier options (1A: $15M, 1B: $12M, 1C: $9M). You may vote yes on more than one; the highest tier with a majority yes sets the override amount. See <a href="what-is-the-override.html">what is the override</a> for the tier breakdown and <a href="what-is-the-override.html#how-youll-vote">how you'll vote</a> for a sample-ballot walkthrough.</p>
-</div>
+<h2 data-stance-section="how-youll-vote" id="how-youll-vote">How you'll vote</h2>
 
-<div class="card">
-  <h3>Question 2: Curbside trash funding</h3>
-  <p>A separate $2,298,575 levy to fund curbside trash and recycling. Question 2 passes or fails on its own, independent of Question 1. If it fails, the Board of Health implements a flat fee of roughly $281 per household instead. See <a href="question-2-trash.html">trash: levy or fee?</a> for the details.</p>
+<p>Practice filling in the paper ballot below. Both questions appear at the Annual Town Election on June 9, 2026.</p>
+
+<div class="ballot">
+  <div class="ballot-header">
+    <div class="ballot-header-sub">Sample Ballot &middot; Town of Marblehead &middot; June 9, 2026</div>
+    <div class="ballot-header-main">Question 1: Operating Override</div>
+  </div>
+  <div class="ballot-instructions">
+    <p class="ballot-instructions-gesture">To vote, completely fill in the oval to the right of your choice like this: <span class="ballot-instructions-example" aria-hidden="true"></span></p>
+    <p class="ballot-instructions-strategy">Vote YES or NO on each question. You may vote YES on more than one.</p>
+  </div>
+  <div class="ballot-row">
+    <div class="ballot-q-num">1A</div>
+    <div class="ballot-q-main">
+      <div class="ballot-q-text">Shall the Town of Marblehead be allowed to assess an additional <strong>$15,000,000</strong> in real estate and personal property taxes for the fiscal year beginning July 1, 2026? <span class="ballot-q-tier">Invest</span></div>
+      <div class="ballot-choices">
+        <span class="ballot-choice"><span class="ballot-choice-label">Yes</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark Yes"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
+        <span class="ballot-choice"><span class="ballot-choice-label">No</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark No"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
+      </div>
+    </div>
+  </div>
+  <div class="ballot-row">
+    <div class="ballot-q-num">1B</div>
+    <div class="ballot-q-main">
+      <div class="ballot-q-text">Shall the Town of Marblehead be allowed to assess an additional <strong>$12,000,000</strong> in real estate and personal property taxes for the fiscal year beginning July 1, 2026? <span class="ballot-q-tier">Stabilize</span></div>
+      <div class="ballot-choices">
+        <span class="ballot-choice"><span class="ballot-choice-label">Yes</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark Yes"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
+        <span class="ballot-choice"><span class="ballot-choice-label">No</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark No"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
+      </div>
+    </div>
+  </div>
+  <div class="ballot-row">
+    <div class="ballot-q-num">1C</div>
+    <div class="ballot-q-main">
+      <div class="ballot-q-text">Shall the Town of Marblehead be allowed to assess an additional <strong>$9,000,000</strong> in real estate and personal property taxes for the fiscal year beginning July 1, 2026? <span class="ballot-q-tier">Restore</span></div>
+      <div class="ballot-choices">
+        <span class="ballot-choice"><span class="ballot-choice-label">Yes</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark Yes"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
+        <span class="ballot-choice"><span class="ballot-choice-label">No</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark No"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
+      </div>
+    </div>
+  </div>
 </div>
+<p>The highest tier that gets a majority wins. If you'd accept any override, vote yes on all three. If only 1C passes, you get $9M. If all three pass, you get $15M. The ballot language is based on the sample text from the <a href="https://marbleheadma.gov/wp-content/uploads/2026/03/2026-03-25-Override-Presentation.pdf">Town Administrator's March 25, 2026 override presentation</a>. For the tier breakdowns (what each tier funds), see <a href="what-is-the-override.html">what is the override</a>.</p>
+
+<div class="ballot">
+  <div class="ballot-header">
+    <div class="ballot-header-sub">Sample Ballot &middot; Town of Marblehead &middot; June 9, 2026</div>
+    <div class="ballot-header-main">Question 2: Curbside Trash Funding</div>
+  </div>
+  <div class="ballot-instructions">
+    <p class="ballot-instructions-gesture">To vote, completely fill in the oval to the right of your choice like this: <span class="ballot-instructions-example" aria-hidden="true"></span></p>
+  </div>
+  <div class="ballot-row">
+    <div class="ballot-q-num">2</div>
+    <div class="ballot-q-main">
+      <div class="ballot-q-text">Shall the Town of Marblehead be allowed to assess an additional <strong>$2,298,575</strong> in real estate and personal property taxes to fund curbside trash and recycling for the fiscal year beginning July 1, 2026? <span class="ballot-q-tier">Trash</span></div>
+      <div class="ballot-choices">
+        <span class="ballot-choice"><span class="ballot-choice-label">Yes</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark Yes"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
+        <span class="ballot-choice"><span class="ballot-choice-label">No</span><button type="button" class="ballot-oval" aria-pressed="false" aria-label="Mark No"><svg class="ballot-oval-fill" viewBox="0 0 24 16" aria-hidden="true"><ellipse cx="12" cy="8" rx="10" ry="6"/></svg></button></span>
+      </div>
+    </div>
+  </div>
+</div>
+<p>Question 2 is independent of Question 1. Either way, residents pay for trash: the override spreads the cost by home value, while the Board of Health's fallback is a flat fee of roughly $281 per household. See <a href="question-2-trash.html">trash: levy or fee?</a> for the details.</p>
 
 <h2 id="offices">Offices up for election</h2>
 


### PR DESCRIPTION
## Summary

Three related cleanups from the site review, all aimed at reducing parallel editorial structures that compete with the homepage question flow.

### 1. Move the sample ballot to `whats-on-the-ballot.html`

The interactive sample ballot (1A/1B/1C + Q2, with clickable ovals) used to live in a `<details class="deep-dive">` block on `what-is-the-override.html`. That page now focuses on **tier content** (what each tier funds) and the ballot widget moves to `whats-on-the-ballot.html` &ndash; the page actually named after ballot mechanics.

- `what-is-the-override.html`: removed the 75-line deep-dive block, removed `ballot` from the frontmatter scripts array, removed the "How you'll vote" entry from the on-page TOC, replaced the section with a single pointer paragraph linking to `whats-on-the-ballot.html#how-youll-vote`.
- `whats-on-the-ballot.html`: added `ballot` to frontmatter scripts, added the full interactive ballot under a new `<h2 id="how-youll-vote">How you'll vote</h2>` with `data-stance-section="how-youll-vote"` so community-pulse slugs stay consistent.
- `what-you-can-do.html`: updated its one `#how-youll-vote` cross-link to point at the new location.

### 2. Demote the-debate.html from top nav

Previously a top-level "Debate" link in the site nav. The homepage question flow has absorbed most of its role, so it gets demoted into the "Vote" dropdown as "Both sides of the debate." The page itself is unchanged and keeps its distinctive content (the "where they actually disagree" syntheses and the Facts/Interpretation/Values/Governance meta-frame); it just stops being a parallel front door.

### 3. Slim browse.html hero

Replaced the editorial `<h1>Do we need an override?</h1>` + lead paragraph with a neutral `<h1>All pages</h1>` + directory-style lead. Everything else on the page (featured super-summary card, section-labeled card grid) is unchanged. This stops browse.html from reading as a second landing page competing with the homepage.

## Test plan

- [ ] `what-is-the-override.html` loads without the ballot widget; TOC no longer has "How you'll vote" entry; pointer paragraph links correctly
- [ ] `whats-on-the-ballot.html` shows the interactive sample ballot under "How you'll vote"; clicking ovals works (ballot.js is loading)
- [ ] `what-you-can-do.html#vote` links to `whats-on-the-ballot.html#how-youll-vote` and the anchor scrolls to the right section
- [ ] Nav dropdown "Vote" shows "Both sides of the debate"; top nav no longer has a bare "Debate" link
- [ ] `browse.html` shows "All pages" as h1; all page cards still render

## Notes

- The-debate.html file itself is unchanged. This PR only demotes its nav position.
- Community-pulse reactions previously tagged with `how-youll-vote` on `what-is-the-override.html` will not migrate automatically across pages, but the slug is preserved on the new h2 so any slug-based aggregation still works.

https://claude.ai/code/session_01TXj5HFGAdGKPPBN1wHufDG