### PR TITLE
Surface statewide tax burden ranking in the taxrank question

### DIFF
--- a/index.html
+++ b/index.html
@@ -2874,6 +2874,20 @@ og_url: https://marbleheaddata.org/
         </a>
       </div>
 
+      <div class="evidence-point">
+        <h4>Lighter than all but 24 of 351 MA communities</h4>
+        <p>
+          Tax bill as a share of household income: Marblehead ranks 327
+          out of 351 Massachusetts communities at 9.6%. Only 24 towns
+          statewide have a lighter tax-to-income burden. Even at full
+          Tier 3 the projected 7.1% would still stay below Swampscott's
+          current 8.5%.
+        </p>
+        <a class="evidence-chart-link" href="charts/statewide_tax_burden.html">
+          Full 351-community ranking
+        </a>
+      </div>
+
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>


### PR DESCRIPTION
## Summary

Adds a new evidence point under Evidence A ("our rate is the lowest") in the homepage `taxrank` question linking to `charts/statewide_tax_burden.html`. The chart ranks all 351 MA communities by tax bill as share of household income; Marblehead is at rank 327 (9.6%), with only 24 towns statewide having a lighter tax-to-income burden.

This is one of the most distinctive single facts on the site and was previously only linked from individual chart pages &ndash; it had no path from the homepage. The new evidence point extends the "rate is lowest" argument from the four-town peer comparison to full statewide context.

## Notes on two other things from the site review that ended up being no-ops

- **Reorder mycost to position 3**: turned out to already be handled better by the existing runtime JS reorder in `index.html` (the `reorderQuestions` IIFE). Mycost is already displayed *first* at runtime, even though the HTML source order has it sixth. No change needed.
- **Shorten the trust question**: on re-reading, the three trust perspectives each have three evidence points like every other question &ndash; not actually thinner. The only minor concern was two evidence blocks both linking to `what-you-can-do.html#better-oversight`, which doesn't justify trimming real content. Left as-is.

## Test plan

- [ ] Homepage `taxrank` question shows the new "Lighter than all but 24 of 351 MA communities" evidence point under Answer A
- [ ] Link to `charts/statewide_tax_burden.html` resolves to the full 351-community chart
- [ ] Evidence layout still renders cleanly with 3 points instead of 2

https://claude.ai/code/session_01TXj5HFGAdGKPPBN1wHufDG