### PR TITLE
Promote sibling Sankey cross-links above the fold

### DIFF
--- a/charts/budget_flow.html
+++ b/charts/budget_flow.html
@@ -7,6 +7,22 @@ title: "Where the Money Goes"
     text-align: center; font-size: 13px;
     color: var(--text-muted); margin: 0 0 16px;
   }
+  .sankey-sibling {
+    text-align: center; font-size: 13px;
+    margin: -8px 0 20px;
+  }
+  .sankey-sibling a {
+    display: inline-block;
+    padding: 8px 14px;
+    background: color-mix(in srgb, var(--c-teal) 8%, var(--surface));
+    border: 1px solid color-mix(in srgb, var(--c-teal) 30%, var(--border));
+    border-radius: var(--radius-sm);
+    color: var(--link);
+    text-decoration: none;
+  }
+  .sankey-sibling a:hover {
+    background: color-mix(in srgb, var(--c-teal) 14%, var(--surface));
+  }
 
   /* ── Sankey container ── */
   .sankey-wrap {
@@ -164,6 +180,7 @@ title: "Where the Money Goes"
 <div class="sankey-intro">
   <h1>Where the Money Goes</h1>
   <p class="sankey-fy">FY26 general fund: revenue sources flow to spending categories. Override tiers show the full annual amount at phase-in (FY29). Click any node to isolate its flows.</p>
+  <p class="sankey-sibling"><a href="your_tax_bill.html">Want the same flow scaled to your household? Try <strong>Where your tax dollars go</strong> &rarr;</a></p>
 </div>
 
 <div class="tabs">

--- a/charts/your_tax_bill.html
+++ b/charts/your_tax_bill.html
@@ -3,6 +3,22 @@ title: "Where Your Tax Dollars Go"
 ---
 <style>
   .sankey-intro h1 { text-align: center; }
+  .sankey-sibling {
+    text-align: center; font-size: 13px;
+    margin: -8px 0 20px;
+  }
+  .sankey-sibling a {
+    display: inline-block;
+    padding: 8px 14px;
+    background: color-mix(in srgb, var(--c-teal) 8%, var(--surface));
+    border: 1px solid color-mix(in srgb, var(--c-teal) 30%, var(--border));
+    border-radius: var(--radius-sm);
+    color: var(--link);
+    text-decoration: none;
+  }
+  .sankey-sibling a:hover {
+    background: color-mix(in srgb, var(--c-teal) 14%, var(--surface));
+  }
   .sankey-fy {
     text-align: center; font-size: 13px;
     color: var(--text-muted); margin: 0 0 16px;
@@ -189,6 +205,7 @@ title: "Where Your Tax Dollars Go"
 <div class="sankey-intro">
   <h1>Where Your Tax Dollars Go</h1>
   <p class="sankey-fy">Enter your home value to see how your FY26 property tax bill flows to town and school spending. Override tiers show the full annual amount at phase-in (FY29). Click any node to isolate its flows.</p>
+  <p class="sankey-sibling"><a href="budget_flow.html">Want the whole-town flow without the household filter? Try <strong>Where the money goes</strong> &rarr;</a></p>
 </div>
 
 <div class="calc-input">


### PR DESCRIPTION
## Summary

`charts/budget_flow.html` and `charts/your_tax_bill.html` show the same municipal-budget Sankey at two different scales (whole town vs. one household). Both pages already have "read next" links pointing at each other, but those sit at the bottom after the chart, tooltip, caption, and notes sections &ndash; so a reader who lands on one has no immediate signal that the other exists.

This PR adds a small teal callout button directly below each page's subtitle (inside the existing `.sankey-intro` block) pointing at the sibling page. No URL changes, no rendering-code merge, no narrative framing changes &ndash; both pages keep their distinct voice and independent homepage evidence links. This is option C from the design conversation with the site owner.

## Changes

- `charts/budget_flow.html`: added a `.sankey-sibling` callout linking to `your_tax_bill.html`, plus the small scoped CSS rule.
- `charts/your_tax_bill.html`: mirror callout linking back to `budget_flow.html`, with the same scoped CSS.

The existing `read-next` block at the bottom of each page is unchanged and continues to cross-link both files (plus their other siblings).

## Test plan

- [ ] Load `charts/budget_flow.html`: the callout appears under the subtitle, links to `your_tax_bill.html`, and renders with the teal background.
- [ ] Load `charts/your_tax_bill.html`: mirror callout appears and links back.
- [ ] Mobile layout: the callout wraps cleanly and doesn't break the intro layout.
- [ ] Both pages' existing Sankey interactivity and read-next footers still work.

https://claude.ai/code/session_01TXj5HFGAdGKPPBN1wHufDG