### PR TITLE
Fill in relatedMap entries for the four topics that were missing

### DIFF
--- a/index.html
+++ b/index.html
@@ -5117,14 +5117,18 @@ og_url: https://marbleheaddata.org/
 
   /* ── Related questions map ── */
   var relatedMap = {
-    override: ['voteno', 'levy', 'trust'],
-    voteno:   ['override', 'again', 'schools'],
-    schools:  ['override', 'mycost', 'voteno'],
-    levy:     ['taxrank', 'mycost', 'override'],
-    taxrank:  ['levy', 'mycost', 'schools'],
-    mycost:   ['size', 'levy', 'taxrank'],
-    size:     ['mycost', 'again', 'override'],
-    trust:    ['override', 'alternatives', 'voteno']
+    override:     ['voteno', 'levy', 'trust'],
+    voteno:       ['override', 'again', 'schools'],
+    schools:      ['override', 'mycost', 'voteno'],
+    levy:         ['taxrank', 'mycost', 'override'],
+    taxrank:      ['levy', 'mycost', 'schools'],
+    mycost:       ['size', 'levy', 'taxrank'],
+    size:         ['mycost', 'again', 'override'],
+    again:        ['size', 'override', 'voteno'],
+    alternatives: ['override', 'levy', 'trust'],
+    trash:        ['mycost', 'voteno', 'taxrank'],
+    library:      ['voteno', 'override', 'mycost'],
+    trust:        ['override', 'alternatives', 'voteno']
   };
 
   /* ── Topic order (for progress dots) ── */


### PR DESCRIPTION
## Summary

The homepage `relatedMap` object (`index.html:5119`) already powers the "Related questions" button cluster at the bottom of each question screen. It had entries for 8 of the 12 topics; four were missing entirely: `again`, `alternatives`, `trash`, and `library`. A reader who ended up on any of those four questions got no suggestions about where to go next.

This PR adds one line per missing topic:

```js
again:        ['size', 'override', 'voteno'],
alternatives: ['override', 'levy', 'trust'],
trash:        ['mycost', 'voteno', 'taxrank'],
library:      ['voteno', 'override', 'mycost'],
```

Also reformats the existing entries to aligned-colon style so the whole map reads as a single block.

## Why the specific picks

- **`again`**: size is the "how big should the ask be" sibling, override is "why do we need it," voteno is "what happens if we don't."
- **`alternatives`**: override is "is the deficit real," levy is the Prop 2.5 mechanism, trust is whether alternatives would actually be pursued if the override fails.
- **`trash`**: mycost is the personal tax impact sibling, voteno is the "what if Q2 fails" dynamic, taxrank is comparison context.
- **`library`**: voteno is the canonical "what gets cut" question, override is the debate frame, mycost is the personal tax angle for library-focused voters.

## Outcome for the `size` ↔ `again` cross-link concern

The merge-adjacent relationships flagged in the site review were already *mostly* present:
- `override → levy` existed
- `levy → override` existed
- `size → again` existed
- `again → size` did NOT exist (because `again` had no entry)

Filling in `again: ['size', ...]` closes that last direction. No content rewrites, no topic-ID changes, no existing data migration needed.

## Test plan

- [ ] Navigate to the `again` question on the homepage; the "Related questions" cluster appears at the bottom with buttons for size / override / voteno.
- [ ] Same for `alternatives`, `trash`, `library`.
- [ ] Existing relatedMap entries (override, voteno, schools, levy, taxrank, mycost, size, trust) still work the same.

https://claude.ai/code/session_01TXj5HFGAdGKPPBN1wHufDG