### PR TITLE
Add 'seniors' and 'moneygone' homepage questions

### DIFF
--- a/index.html
+++ b/index.html
@@ -4569,6 +4569,544 @@ og_url: https://marbleheaddata.org/
 
   </section>
 
+  <!-- ═══════════════════════════════════════════════════
+       QUESTION: How does this affect seniors?
+       ═══════════════════════════════════════════════════ -->
+  <section class="question-screen" data-topic="seniors">
+
+    <div class="question-block">
+      <h1>How does this affect seniors and people on fixed incomes?</h1>
+      <p class="question-context">
+        Property taxes are the same whether the household writing the check
+        is a working family or a retiree on Social Security. Marblehead has
+        several relief programs, but they only help if you qualify and apply.
+      </p>
+    </div>
+
+    <div class="answers">
+
+      <div class="answer-card" data-answer="a" data-question="seniors">
+        <p class="answer-label">Answer A</p>
+        <h2>Existing relief meaningfully offsets the increase</h2>
+        <p class="answer-summary">
+          The state Senior Circuit Breaker refunds up to $2,820/year. For
+          an income-qualified senior it covers most of a Tier 3 increase.
+          The programs exist; the problem is low uptake, not low benefit.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="b" data-question="seniors">
+        <p class="answer-label">Answer B</p>
+        <h2>Relief doesn't reach most of the seniors who need it</h2>
+        <p class="answer-summary">
+          Only 418 of roughly 1,158 eligible Marblehead seniors claimed
+          the Circuit Breaker in 2022. For the rest, the override is a
+          straight tax increase with no offset.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="c" data-question="seniors">
+        <p class="answer-label">Answer C</p>
+        <h2>The override is the wrong instrument for targeted relief</h2>
+        <p class="answer-summary">
+          Property taxes tax the home, not the income. Voting yes or no
+          on the override doesn't change fixed-income exposure. Making
+          existing relief easier to access does.
+        </p>
+      </div>
+
+    </div>
+
+    <!-- Evidence A: existing relief offsets it -->
+    <div class="evidence" data-evidence="seniors-a">
+      <div class="evidence-header">
+        <h3>The case for "existing relief offsets it"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The Senior Circuit Breaker is worth up to $2,820/year</h4>
+        <p>
+          The <abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr>
+          Senior Circuit Breaker is a refundable state tax credit for
+          homeowners 65 and older with MA income below $75,000 (single),
+          $94,000 (head of household), or $112,000 (joint), and a home
+          assessed at or below $1,298,000. The credit is the portion of
+          property tax (plus half water and sewer) above 10% of income,
+          capped at $2,820. It's refundable: you get a check even if
+          you owe no state income tax. Social Security income does not
+          disqualify you.
+        </p>
+        <a class="evidence-chart-link" href="senior-tax-relief.html#circuit-breaker">
+          Circuit Breaker walkthrough
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Worked example: $900K home, $60K income</h4>
+        <p>
+          At Marblehead's FY26 tax rate of $8.60 per $1,000: property tax
+          $7,740. Half water and sewer: $750. Total eligible: $8,490. 10%
+          of income: $6,000. Excess: $2,490. That's the credit the state
+          writes you a check for. Even at full Tier 3, most of the
+          increase falls inside the $2,820 cap that the credit absorbs
+          automatically.
+        </p>
+        <a class="evidence-chart-link" href="senior-tax-relief.html">
+          Senior relief calculator
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Additional exemptions stack on top</h4>
+        <p>
+          Veteran exemptions ($400 to full), the senior tax deferral
+          (Clause 41A), the low-income senior exemption (Clause 41C),
+          and the surviving spouse exemption (Clause 17D) all stack with
+          the Circuit Breaker. The Council on Aging also runs a Senior
+          Tax Work-Off Program. The deadline for local exemptions is
+          April 1; Circuit Breaker follows the state tax filing deadline.
+        </p>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            A program that exists and a program that reaches people are
+            different things. In 2022, only 36% of eligible Marblehead
+            seniors claimed the Circuit Breaker, and the average credit
+            received was $1,054 &ndash; far below the $2,820 cap. The
+            relief math works in the abstract; in practice most of the
+            benefit is left on the table every year.
+          </p>
+        </div>
+      </details>
+    </div>
+
+    <!-- Evidence B: relief doesn't reach who needs it -->
+    <div class="evidence" data-evidence="seniors-b">
+      <div class="evidence-header">
+        <h3>The case for "relief doesn't reach who needs it"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>36% uptake of the Circuit Breaker in 2022</h4>
+        <p>
+          418 Marblehead seniors filed Schedule CB and claimed the
+          Circuit Breaker in 2022. The estimated eligible population is
+          roughly 1,158 senior households at or below the $75,000
+          single-filer income limit. That leaves roughly 740 households
+          either unaware of the program, not filing state returns, or
+          facing application friction that blocks them. The credit is
+          worth nothing to a senior who never files.
+        </p>
+        <a class="evidence-chart-link" href="senior-tax-relief.html#how-to-actually-get-this">
+          Uptake data and application steps
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The average claim is $1,054, not $2,820</h4>
+        <p>
+          The average Marblehead Circuit Breaker claim in 2022 was $1,054,
+          about 37% of the $2,820 cap. For seniors who do file, the
+          credit partially offsets an override; for those who don't file
+          at all, the offset is zero.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The local means-tested exemption hasn't taken effect yet</h4>
+        <p>
+          Marblehead Town Meeting passed Article 28 in May 2025 with
+          roughly 93% support. It would add a means-tested local
+          exemption on top of the Circuit Breaker for longtime Marblehead
+          seniors, funded from the tax overlay rather than the operating
+          budget. The enabling state legislation (H.4225) passed the MA
+          House on March 30, 2026, but is still awaiting Senate action.
+          Until it becomes law, the local exemption does not exist for
+          FY27.
+        </p>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer A would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            Low uptake is a distribution problem, not a funding problem.
+            The Circuit Breaker is fully funded by the state, requires no
+            local appropriation, and is waiting to be claimed. Outreach
+            campaigns, Council on Aging assistance, and pre-filled forms
+            could close most of the gap in a year or two. "Not reaching
+            enough people" is a reason to improve the program, not a
+            reason to vote down the override.
+          </p>
+        </div>
+      </details>
+    </div>
+
+    <!-- Evidence C: override is the wrong instrument -->
+    <div class="evidence" data-evidence="seniors-c">
+      <div class="evidence-header">
+        <h3>The case for "override is the wrong instrument"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Property taxes tax the home, not the income</h4>
+        <p>
+          An override raises property tax on the assessed value of a
+          home, regardless of the household's current income. A retiree
+          who bought their house in 1985 and sees it appraised today at
+          $1.2 million pays the same rate as a working professional who
+          bought the same house last year. Any override, any size, any
+          year carries this property-vs-income mismatch &ndash; it's
+          built into property tax as a mechanism.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The relief levers are separate from the override vote</h4>
+        <p>
+          Voting yes or no on the override doesn't change the Circuit
+          Breaker uptake rate, doesn't accelerate H.4225 in the Senate,
+          and doesn't enroll seniors in programs they're not currently
+          using. Those are separate policy levers with separate
+          decision-makers. Pushing for better outreach, automatic
+          enrollment where possible, and state-level caps that scale
+          with home values is the direct path to fixed-income relief,
+          override or no override.
+        </p>
+        <a class="evidence-chart-link" href="what-you-can-do.html#better-oversight">
+          Better oversight and reform options
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The local exemption doesn't compete with services</h4>
+        <p>
+          Article 28's means-tested local exemption is paid from the tax
+          overlay, not the operating budget, which means it does not
+          compete with schools, public safety, or library funding.
+          Whatever happens at the override ballot, pushing for faster
+          Senate action on H.4225 has no tradeoff against service levels.
+        </p>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answers A and B would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            "Use other levers" is a non-answer to "what do I do about
+            this specific tax bill on June 9?" Seniors voting on the
+            override are not in a position to accelerate Senate action
+            on H.4225 or redesign the Circuit Breaker. Saying "the
+            override is the wrong instrument" names the exposure but
+            leaves the voter without a concrete response to it on the
+            actual ballot they are holding.
+          </p>
+        </div>
+      </details>
+    </div>
+
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════
+       QUESTION: Where has the money actually gone?
+       ═══════════════════════════════════════════════════ -->
+  <section class="question-screen" data-topic="moneygone">
+
+    <div class="question-block">
+      <h1>Where has the money actually gone?</h1>
+      <p class="question-context">
+        Marblehead's General Fund grew from $70.5M (FY15) to $106.2M
+        (FY26), an increase of $35.7M over 11 years. Where did that
+        $35.7M go, and did anything grow faster than inflation,
+        enrollment, or service levels?
+      </p>
+    </div>
+
+    <div class="answers">
+
+      <div class="answer-card" data-answer="a" data-question="moneygone">
+        <p class="answer-label">Answer A</p>
+        <h2>Growth matches cost pressures the town doesn't control</h2>
+        <p class="answer-summary">
+          Schools absorbed 48% of the growth, mostly through mandated
+          special education and rising health insurance. Pensions and
+          debt service are on fixed schedules. These aren't choices.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="b" data-question="moneygone">
+        <p class="answer-label">Answer B</p>
+        <h2>Growth outpaced inflation and service levels</h2>
+        <p class="answer-summary">
+          Enrollment fell 19% while education staff rose 9.6%. The town
+          has balanced the operating budget with one-time free cash
+          for years. Several line items grew faster than any obvious
+          driver.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="c" data-question="moneygone">
+        <p class="answer-label">Answer C</p>
+        <h2>The audit exists, but most haven't engaged it</h2>
+        <p class="answer-summary">
+          Independent auditors certify the books every year. The data
+          is public. The question isn't "is there fraud" but "have I
+          read the source documents before deciding?"
+        </p>
+      </div>
+
+    </div>
+
+    <!-- Evidence A: cost pressures -->
+    <div class="evidence" data-evidence="moneygone-a">
+      <div class="evidence-header">
+        <h3>The case for "matches cost pressures"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Schools absorbed 48% of total growth</h4>
+        <p>
+          Schools grew from $32.1M (FY15) to $46.2M (FY24), absorbing
+          roughly 48% of the $35.7M total General Fund growth. About
+          $4.6M of the FY26 school budget &ndash; roughly 9% &ndash;
+          pays for out-of-district special education placements that
+          are mandated by the federal
+          <abbr class="g" title="Individuals with Disabilities Education Act">IDEA</abbr>
+          and Massachusetts special education law. The town does not
+          have discretion to stop paying for placements once a
+          student's Individualized Education Program requires them.
+        </p>
+        <a class="evidence-chart-link" href="where-has-the-money-gone.html">
+          Where the money went
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Health insurance is set by the state pool, not the town</h4>
+        <p>
+          The town pays 83% of employee health insurance premiums
+          through the <abbr class="g" title="Group Insurance Commission">GIC</abbr>,
+          Massachusetts's state insurance pool. GIC rates are set by
+          the pool and have grown substantially faster than
+          Proposition 2&frac12;'s 2.5% annual levy cap. The FY27 rate
+          increase alone added roughly $1.65M to the operating budget
+          on a single line item.
+        </p>
+        <a class="evidence-chart-link" href="charts/healthcare_costs.html">
+          Health insurance vs. tax levy
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Pensions and debt service are fixed schedules</h4>
+        <p>
+          Marblehead's pension obligations are on a
+          <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>-certified
+          actuarial schedule rising 8.6% per year through FY35.
+          Voter-approved debt service (Abbot Library, Mary Alley
+          <abbr class="g" title="Heating, Ventilation, and Air Conditioning">HVAC</abbr>,
+          and other capital projects) is contractual. Neither line
+          has meaningful near-term local discretion.
+        </p>
+        <a class="evidence-chart-link" href="charts/budget_flow.html">
+          Full budget flow, by category
+        </a>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            "Mandated" and "chosen" blur over a 10-year horizon. The
+            83/17 GIC premium split is a contract provision the town
+            chose and can renegotiate at contract renewal. Staffing
+            composition is a policy choice even when specific positions
+            trigger benefits eligibility. Calling growth "external"
+            assumes a 12-week budget-cycle view; the same lines look
+            discretionary on a 5-year view.
+          </p>
+        </div>
+      </details>
+    </div>
+
+    <!-- Evidence B: outpaced inflation and service levels -->
+    <div class="evidence" data-evidence="moneygone-b">
+      <div class="evidence-header">
+        <h3>The case for "outpaced inflation and service levels"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Enrollment fell 19%, total education headcount grew 9.6%</h4>
+        <p>
+          Between 2015 and 2024, Marblehead school enrollment fell from
+          3,245 to 2,617 students &ndash; a drop of 628 students, or
+          19%. Classroom teacher headcount dropped about 4% over the
+          same window. But total education headcount (including
+          paraprofessionals, specialists, and administrators) rose by
+          roughly 58 positions to 537
+          <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>,
+          a 9.6% increase. The student-to-teacher ratio fell from 12.6
+          to 10.7, the lowest of Marblehead's four peer towns.
+        </p>
+        <a class="evidence-chart-link" href="inside-school-staffing.html">
+          Inside school staffing
+        </a>
+        <a class="evidence-chart-link" href="charts/enrollment_vs_staffing.html">
+          Enrollment vs. staffing chart
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Operating budget balanced on free cash for years</h4>
+        <p>
+          Town Meeting appropriated $7.0M of free cash (prior-year
+          surplus) into the FY26 operating budget, $5.5M into FY25,
+          and $10.2M into FY23. The
+          <abbr class="g" title="Finance Committee">FinCom</abbr>'s
+          2022 report described the pattern as a "structural budget
+          challenge" caused by "recurring costs structurally outpacing
+          recurring revenues." The 2025 report noted reserves at only
+          2.5% of the operating budget, below the state-recommended
+          range of 5 to 10%.
+        </p>
+        <a class="evidence-chart-link" href="how-we-got-here.html">
+          Seven years of FinCom warnings
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Town Counsel rose 142% in one year, unexplained</h4>
+        <p>
+          The FY27 Proposed Budget moves Town Counsel from $115,000 to
+          $278,000 &ndash; a one-year increase of $163,000 or 142%.
+          Two FY26 town documents disagree on the starting figure (one
+          lists $115,000, the other $228,000), and the reason for the
+          year-over-year increase and the discrepancy between the two
+          FY26 figures is not publicly documented. That one line is
+          roughly three times the annual
+          <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr>
+          retiree-benefits-trust contribution that the same budget
+          zeros out.
+        </p>
+        <a class="evidence-chart-link" href="where-has-the-money-gone.html#what-grew-faster">
+          What grew faster
+        </a>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer A would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            The peer-town comparison cuts both ways. A 10.7
+            student-teacher ratio is low, but some of the headcount
+            growth reflects mandated special education staffing that
+            rose even as total enrollment fell. Free cash use is a
+            structural concern the Finance Committee has flagged, but
+            it does not by itself prove the underlying spending was
+            discretionary rather than contractually obligated.
+          </p>
+        </div>
+      </details>
+    </div>
+
+    <!-- Evidence C: audit exists -->
+    <div class="evidence" data-evidence="moneygone-c">
+      <div class="evidence-header">
+        <h3>The case for "audit exists, but most haven't engaged it"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Six independent reviewers check the books every year</h4>
+        <p>
+          Marblehead's books are audited annually by an independent
+          firm (clean opinion every year). The
+          <abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr>
+          certifies the tax rate. PERAC audits the pension fund on a
+          biennial actuarial schedule. The Finance Committee publishes
+          an annual report. The town's outside auditor issues a
+          management letter in most years. These are not self-reported
+          numbers.
+        </p>
+        <a class="evidence-chart-link" href="where-has-the-money-gone.html#who-checks-books">
+          Who has been checking the books
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The source documents are free, public, and long</h4>
+        <p>
+          The
+          <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>
+          publishes every line item, every year, with departmental
+          breakdowns and multi-year trends. The Finance Committee
+          Annual Report summarizes the year's budget process in about
+          40 pages. Both documents are posted on the town website.
+          How many residents read any of them in a given year is a
+          separate question.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Answers A and B read the same numbers differently</h4>
+        <p>
+          The A and B perspectives on this question use the same
+          underlying data &ndash; the same ACFR, the same
+          <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr>
+          enrollment file, the same FinCom reports &ndash; and reach
+          opposite conclusions. Without engaging the source documents,
+          both answers are narratives layered on identical data. The
+          goal of this site is to make verification easier, not to
+          settle which narrative is correct.
+        </p>
+        <a class="evidence-chart-link" href="data/SOURCE_LOOKUP.html">
+          Trace any number to its source
+        </a>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answers A and B would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            "Read the source documents" is good hygiene but doesn't
+            resolve an $8.47M vote on a 12-week timeline. Voters have
+            to act on some reading of the numbers, and a reading that
+            refuses to commit still counts as a vote. "Both sides are
+            layered on the same data" is a starting point for analysis,
+            not a conclusion to rest on.
+          </p>
+        </div>
+      </details>
+    </div>
+
+  </section>
+
   <!-- Related questions (JS populates based on current topic) -->
   <div class="related-questions" id="relatedQuestions">
     <div class="related-questions-label">Related questions</div>
@@ -4629,8 +5167,10 @@ og_url: https://marbleheaddata.org/
   (function reorderQuestions() {
     var preferredOrder = [
       'mycost',       // How will this affect my taxes?
+      'seniors',      // How does this affect seniors and fixed-income households?
       'taxrank',      // How does Marblehead's tax burden compare?
       'levy',         // Why don't 2.5% increases keep up?
+      'moneygone',    // Where has the money actually gone?
       'size',         // Does the size of the override matter?
       'schools',      // Why did staffing grow while enrollment fell?
       'trash',        // Why is trash collection on the ballot?
@@ -5121,8 +5661,10 @@ og_url: https://marbleheaddata.org/
     voteno:       ['override', 'again', 'schools'],
     schools:      ['override', 'mycost', 'voteno'],
     levy:         ['taxrank', 'mycost', 'override'],
+    moneygone:    ['override', 'levy', 'schools'],
     taxrank:      ['levy', 'mycost', 'schools'],
     mycost:       ['size', 'levy', 'taxrank'],
+    seniors:      ['mycost', 'override', 'voteno'],
     size:         ['mycost', 'again', 'override'],
     again:        ['size', 'override', 'voteno'],
     alternatives: ['override', 'levy', 'trust'],


### PR DESCRIPTION
## Summary

Adds two new homepage question screens with the same structure as the existing 12: question block + three answer cards with summary + three evidence blocks with multiple evidence-points and counter-argument details.

### 1. `seniors`: "How does this affect seniors and people on fixed incomes?"

**Three perspectives:**
- **A: Existing relief meaningfully offsets the increase** &ndash; Circuit Breaker up to $2,820/yr, worked example at $900K home / $60K income showing $2,490 credit, stacking exemptions.
- **B: Relief doesn't reach most of the seniors who need it** &ndash; 36% uptake (418 of ~1,158 eligible seniors filed in 2022), average claim $1,054 (not $2,820), Article 28 / H.4225 local exemption still awaiting MA Senate action.
- **C: The override is the wrong instrument for targeted relief** &ndash; property tax taxes the home not the income, separate policy levers for uptake and enrollment, Article 28 is funded from tax overlay not operating budget.

All three link to `senior-tax-relief.html` (the authoritative deep dive the site review flagged as unreferenced from the homepage).

### 2. `moneygone`: "Where has the money actually gone?"

**Three perspectives:**
- **A: Growth matches cost pressures the town doesn't control** &ndash; schools absorbed 48% of the $35.7M growth, mandated out-of-district SPED (~$4.6M / 9% of FY26 school budget), GIC health insurance as a state-pool mechanism (+$1.65M in FY27 alone), PERAC pension schedule +8.6%/yr.
- **B: Growth outpaced inflation and service levels** &ndash; enrollment 3,245→2,617 (-19%) while total education FTE +9.6% to 537, $7.0M/$5.5M/$10.2M free cash used to balance FY26/FY25/FY23 operating budgets, Town Counsel +142% in one year unexplained, FinCom 2022 "structural budget challenge" framing.
- **C: The audit exists, but most haven't engaged it** &ndash; six independent reviewers every year (outside audit, DOR, PERAC, FinCom, management letter, Town Meeting), ACFR + FinCom report are public but rarely read, same numbers produce opposite conclusions depending on reading.

All three link to `where-has-the-money-gone.html` and related charts. This was the biggest "unreferenced substantial page" the site review flagged.

## JS changes

- **`preferredOrder`**: `seniors` slots into position 2 (right after `mycost`, so personal-cost and who-bears-it questions cluster), and `moneygone` slots into position 5 (right after `levy`, so the attribution / mechanism / spending-history questions sit together).
- **`relatedMap`**: new entries for `seniors: ['mycost', 'override', 'voteno']` and `moneygone: ['override', 'levy', 'schools']`. Existing entries are **unchanged** to minimize merge conflict with agbaber/marblehead#418 which adds entries for `again`, `alternatives`, `trash`, `library`.

## Not changed

- No topic-ID renames.
- No existing question content edited.
- No existing evidence links altered.
- Both new sections inherit the homepage's existing CSS, JS topic switching, progress dots, landing-card generation, "Not sure yet" injection, and stats strip automatically because they use the standard `.question-screen` / `.answer-card` / `.evidence` / `.counter-argument` structure.

## Sources for factual claims

- **seniors**: `senior-tax-relief.html` (Circuit Breaker TY2025 caps, TIR 25-7, 2022 uptake data, worked examples, Article 28 / H.4225 status).
- **moneygone**: `where-has-the-money-gone.html` (FY15&ndash;FY26 General Fund totals, schools sub-totals, enrollment, FTE, free cash appropriations, Town Counsel discrepancy, FinCom 2022/2025 report citations, PERAC schedule). The $1.65M FY27 GIC rate increase figure is from the April 8, 2026 Town Administrator override presentation via the-debate.html and FY27 Proposed Balanced Budget pp. 1-4.

All numbers in the evidence text are traceable to the linked source pages; nothing is invented.

## Test plan

- [ ] Homepage loads and shows 14 question screens total (was 12).
- [ ] Landing card grid (built at runtime from `.question-screen` H1s) shows seniors and moneygone cards.
- [ ] Runtime order shows seniors second (right after mycost) and moneygone fifth (right after levy).
- [ ] Related-questions buttons appear at the bottom of both new question screens when viewed.
- [ ] Progress dots cluster shows 14 dots.
- [ ] "Not sure yet" button renders on both new screens.
- [ ] Existing 12 questions still render and switch the same as before.
- [ ] No `data-topic` collisions (new IDs `seniors`, `moneygone` are unique).

https://claude.ai/code/session_01TXj5HFGAdGKPPBN1wHufDG