### PR TITLE
Restore votes-strip countdown badges (recovers lost #345)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1250,6 +1250,26 @@ og_url: https://marbleheaddata.org/
     letter-spacing: 0.6px;
     color: var(--text-subtle);
     margin-bottom: 2px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .votes-strip-countdown {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+    text-transform: none;
+    color: var(--c-navy);
+    background: color-mix(in srgb, var(--c-navy) 10%, transparent);
+    border-radius: 3px;
+    padding: 1px 5px;
+    white-space: nowrap;
+  }
+  .votes-strip-countdown.past {
+    color: var(--text-subtle);
+    background: color-mix(in srgb, var(--text-subtle) 10%, transparent);
   }
   .votes-strip-step-what {
     font-size: 14px;
@@ -1563,13 +1583,13 @@ og_url: https://marbleheaddata.org/
       <p class="votes-strip-label">Two votes decide the override</p>
       <div class="votes-strip-steps">
         <div class="votes-strip-step">
-          <div class="votes-strip-step-when">Mon, May 4</div>
+          <div class="votes-strip-step-when">Mon, May 4 <span class="votes-strip-countdown" data-date="2026-05-04"></span></div>
           <div class="votes-strip-step-what">Annual Town Meeting</div>
           <p class="votes-strip-step-desc">Residents vote yes or no on sending the override to the ballot as three tiers, ceiling $15M. A no ends the override here.</p>
         </div>
         <div class="votes-strip-arrow" aria-hidden="true">&rarr;</div>
         <div class="votes-strip-step">
-          <div class="votes-strip-step-when">Tue, Jun 9</div>
+          <div class="votes-strip-step-when">Tue, Jun 9 <span class="votes-strip-countdown" data-date="2026-06-09"></span></div>
           <div class="votes-strip-step-what">Annual Town Election</div>
           <p class="votes-strip-step-desc">If Town Meeting sends it forward, voters pick the tier at the ballot. The highest tier with a majority sets the amount.</p>
         </div>
@@ -6262,6 +6282,28 @@ og_url: https://marbleheaddata.org/
   fetchAllCounts(topicOrder);
   updateStatsStrip();
 
+})();
+</script>
+
+<script>
+(function () {
+  var spans = document.querySelectorAll('.votes-strip-countdown[data-date]');
+  var now = new Date();
+  now.setHours(0, 0, 0, 0);
+  spans.forEach(function (el) {
+    var target = new Date(el.getAttribute('data-date') + 'T00:00:00');
+    var diff = Math.ceil((target - now) / 86400000);
+    if (diff > 1) {
+      el.textContent = diff + ' days away';
+    } else if (diff === 1) {
+      el.textContent = 'tomorrow';
+    } else if (diff === 0) {
+      el.textContent = 'today';
+    } else {
+      el.textContent = 'complete';
+      el.classList.add('past');
+    }
+  });
 })();
 </script>
 

--- a/index.html
+++ b/index.html
@@ -1261,12 +1261,13 @@ og_url: https://marbleheaddata.org/
     font-weight: 700;
     letter-spacing: 0.3px;
     text-transform: none;
-    color: var(--c-navy);
-    background: color-mix(in srgb, var(--c-navy) 10%, transparent);
+    color: var(--c-teal);
+    background: color-mix(in srgb, var(--c-teal) 10%, transparent);
     border-radius: 3px;
     padding: 1px 5px;
     white-space: nowrap;
   }
+  .votes-strip-countdown:empty { display: none; }
   .votes-strip-countdown.past {
     color: var(--text-subtle);
     background: color-mix(in srgb, var(--text-subtle) 10%, transparent);


### PR DESCRIPTION
## Summary

PR #345 ("Add live countdown badges to votes strip") was merged on 2026-04-14 at 23:53 UTC but its commits (`299a05b` and its base `9c41a0e`) do not appear in the current `main` history — they only live on `refs/pull/345/head`. They got orphaned during the history rewrite that happened in the same window (the revert/re-add of #362 and the various feature merges around it). That's why the homepage no longer has the "X days away" badges you remembered seeing.

This PR restores them.

### Commits
1. **`4a39370` Add live countdown badges to votes strip on homepage** — clean cherry-pick of the original `299a05b` from PR #345. Applied to the current `index.html` without conflicts because the votes-strip copy has been stable since #326.
2. **`37fc388` Tint votes-strip countdown badges teal, hide empty pre-JS** — two small improvements to the restored code:
   - Badge color changed from `--c-navy` to `--c-teal` so the pill matches the strip's teal accent border. Recent palette work (#388, #398) moved navy out of the foreground-accent role, so teal reads more on-palette now than it did on April 14.
   - Added `.votes-strip-countdown:empty { display: none }` so the padded pill doesn't flicker for a frame before the inline script fills in its text.

### Behavior

`<span class="votes-strip-countdown" data-date="YYYY-MM-DD">` next to each of the two dates. An inline script at the end of `index.html` computes whole-day differences at local midnight and renders one of:

- `N days away` (N > 1)
- `tomorrow` (N == 1)
- `today` (N == 0)
- `complete` (N < 0, with `.past` class for muted styling)

As of today (2026-04-15): Town Meeting reads **19 days away**, Election Day reads **55 days away**. Verified by running the script logic through node.

## Test plan

- [ ] Load the homepage and confirm both countdown pills render next to "Mon, May 4" and "Tue, Jun 9"
- [ ] Confirm the pills render in teal (not navy) in light mode
- [ ] Confirm dark mode still has enough contrast on the teal-tinted background
- [ ] Narrow the viewport below 540px and confirm the pills wrap correctly below the date (flex-wrap)
- [ ] On or after May 4, confirm the first pill flips to `complete` with the muted `.past` style and Jun 9 still shows its countdown
- [ ] Disable JS and confirm no empty rounded pill appears (the `:empty` rule should hide it)

https://claude.ai/code/session_01J1qKMJpDrtHieJ2S4UUYbr