### PR TITLE
Update Select Board and School Committee candidate status for April mid-window

### DIFF
--- a/whats-on-the-ballot.html
+++ b/whats-on-the-ballot.html
@@ -133,13 +133,13 @@ og_url: https://marbleheaddata.org/whats-on-the-ballot.html
   <div class="office">
     <h3>Select Board</h3>
     <p class="office-meta">2 seats &middot; 3-year terms</p>
-    <p>The Select Board is the town's principal executive body. Both incumbents, Erin M. Noonan and Alexa J. Singer, had terms expiring in 2026. As of late March, Rossana Ferrante (chair of the Recreation &amp; Park Commission and a long-serving Planning Board member) had pulled nomination papers. Confirmed candidacies were still in flux.</p>
+    <p>The Select Board is the town's principal executive body. Both incumbents, Erin M. Noonan and Alexa J. Singer, had terms expiring in 2026. Singer announced on April 14 that she will not seek re-election, writing that "it is time for me to dedicate the coming years to my family and step aside to allow a new perspective to join the board."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/04/14/letter-a-message-from-select-board-member-alexa-singer/" data-source="Marblehead Current, &quot;LETTER: A message from Select Board member Alexa Singer&quot; (April 14, 2026): Singer announces she will not seek re-election, quoted statement"></sup> As of mid-April, confirmed filers for the two seats included Erin M. Noonan, Rossana Ferrante (chair of the Recreation &amp; Park Commission and a long-serving Planning Board member), and Jennifer Schaeffner (a sitting School Committee member who shifted to the Select Board race).<sup class="cite" data-href="https://www.marbleheadindependent.com/schaeffner-to-seek-select-board-seat-joining-growing-2026-field/" data-source="Marblehead Independent, &quot;Schaeffner to seek Select Board seat, joining growing 2026 field&quot; (April 13, 2026): Jennifer Schaeffner pulls papers for Select Board after previously stating she would not seek School Committee re-election"></sup></p>
   </div>
 
   <div class="office">
     <h3>School Committee</h3>
     <p class="office-meta">2 seats</p>
-    <p>One seat is held by Jennifer Schaeffner, who has said she is not seeking re-election. The second is the seat Brian Scott Ota left when he resigned in August 2025. Early reporting noted no candidates had pulled papers for either seat as of late March.</p>
+    <p>One seat is held by Jennifer Schaeffner, who has pulled nomination papers for Select Board rather than School Committee re-election. The second is the seat Brian Scott Ota left when he resigned in August 2025. As of mid-April, multiple candidates had pulled papers, including Sarah Fox, a former School Committee member who lost her 2025 re-election bid and is now seeking a return.<sup class="cite" data-href="https://www.marbleheadindependent.com/schaeffner-to-seek-select-board-seat-joining-growing-2026-field/" data-source="Marblehead Independent, &quot;Schaeffner to seek Select Board seat, joining growing 2026 field&quot; (April 13, 2026): Sarah Fox among candidates who pulled nomination papers for School Committee; Fox lost her 2025 re-election"></sup></p>
   </div>
 
   <div class="office">
@@ -219,4 +219,4 @@ og_url: https://marbleheaddata.org/whats-on-the-ballot.html
 
 <p>The authoritative list of certified candidates is posted on the town's <a href="https://marbleheadma.gov/elections-voting/">Elections &amp; Voting page</a> after the April 21 filing deadline. The town clerk can be reached at (781) 631-0528. Sample ballots are typically posted on the town website a few weeks before election day.</p>
 
-<p class="source">Reporting on seat counts, incumbents, and early nomination filings is drawn from the Marblehead Independent's March and early April 2026 coverage of the nomination-papers window. Candidate status in this page reflects that reporting and may have changed by the April 21 filing deadline.</p>
+<p class="source">Reporting on seat counts, incumbents, and nomination filings is drawn from the Marblehead Independent's March and April 2026 coverage of the nomination-papers window and the Marblehead Current's April 14 letter from Alexa Singer. Candidate status in this page reflects that reporting and may have changed by the April 21 filing deadline. For the official certified list, see the town's Elections &amp; Voting page after April 21.</p>


### PR DESCRIPTION
## Summary
- **Select Board**: Alexa Singer announced on April 14 that she will not seek re-election (Current letter). Mid-April filers are Noonan, Ferrante, and Jennifer Schaeffner, who shifted from the School Committee race to Select Board (Independent, April 13).
- **School Committee**: Removed stale framing that had no candidates filed. Jennifer Schaeffner is out of this race. Sarah Fox, who lost her 2025 SC re-election, is among mid-April filers (Independent, April 13).
- Source-note paragraph updated to reference April reporting.

Other offices are intentionally left at the late-March snapshot to avoid propagating single-source details that may shift before the April 21 filing deadline. Recommend a follow-up sweep from the town's certified list after April 21.

## Test plan
- [ ] Page renders at `/whats-on-the-ballot.html` with all six `<sup class="cite">` markers pointing at live URLs.
- [ ] No em-dashes in the diff.
- [ ] Quote from Singer matches the Current letter verbatim.
- [ ] "Sarah Fox" spelling and "2025 re-election" framing match the Independent April 13 article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)