### PR TITLE
Fix first-pick tutorial reappearing on every subsequent pick

### DIFF
--- a/index.html
+++ b/index.html
@@ -5624,6 +5624,10 @@ og_url: https://marbleheaddata.org/
 
   function showTutorial() {
     if (tutorialSeen) return;
+    // Mark as seen immediately on display, not only on "Got it" click.
+    // Otherwise users who ignore the box keep seeing it on every later pick.
+    tutorialSeen = true;
+    localStorage.setItem(TUTORIAL_KEY, '1');
     tutorialEl.classList.add('visible');
   }
 
@@ -5637,9 +5641,11 @@ og_url: https://marbleheaddata.org/
 
   document.getElementById('tutorialDismiss').addEventListener('click', dismissTutorial);
 
-  // Show browse hint on subsequent visits if tutorial was already seen
+  // Show browse hint on subsequent visits if tutorial was already seen.
+  // Suppress it while the tutorial box itself is still on screen -- the
+  // tutorial already contains the same hint, so showing both is redundant.
   function updateBrowseHint(topic) {
-    if (tutorialSeen && selections[topic]) {
+    if (tutorialSeen && selections[topic] && !tutorialEl.classList.contains('visible')) {
       browseHintEl.classList.add('visible');
     } else {
       browseHintEl.classList.remove('visible');
@@ -6186,6 +6192,10 @@ og_url: https://marbleheaddata.org/
     if (typeof posthog !== 'undefined') {
       posthog.capture('explore_answer_selected', { topic: question, answer: answer });
     }
+    // Capture pre-pick state so we can tell if this is the user's very first
+    // pick. Anything else ("you already have picks, you're just making another")
+    // should not trigger the first-pick tutorial.
+    var wasFirstPick = Object.keys(selections).length === 0;
     // Update checkmark: only the selected card gets .selected
     document.querySelectorAll('.answer-card[data-question="' + question + '"]').forEach(function (c) {
       c.classList.remove('selected');
@@ -6213,8 +6223,8 @@ og_url: https://marbleheaddata.org/
     // Show answer distribution now that the user has picked
     showPickDistribution(question);
 
-    // First-time tutorial
-    if (!tutorialSeen) showTutorial();
+    // First-time tutorial -- only on the user's actual first-ever pick
+    if (wasFirstPick && !tutorialSeen) showTutorial();
 
     // Show browse hint (after tutorial is seen)
     updateBrowseHint(question);


### PR DESCRIPTION
## Summary

The "You just made your first pick" tutorial box was gated only on a `localStorage` flag that got set when the user clicked **Got it**. If they ignored the box (or refreshed before dismissing), `tutorialSeen` stayed `false` and the box reappeared on every subsequent pick — which is exactly what you reported.

## Fix

In `index.html`:

- `selectAnswer` now captures `wasFirstPick = Object.keys(selections).length === 0` before assigning the new pick, and only triggers the tutorial when the user had zero prior selections. Returning users with picks from a previous session no longer see "You just made your first pick" on any new pick.
- `showTutorial` now writes the seen flag to `localStorage` the moment the box is shown, not only on **Got it** click. Even if the user ignores the box, it can't come back.
- `updateBrowseHint` suppresses the persistent browse hint while the tutorial box is still visible, since the auto-seen behavior would otherwise show both simultaneously (they contain the same hint).

## Test plan

- [ ] Fresh browser: make first pick → tutorial shows, browse hint hidden
- [ ] Without clicking Got it, make a second pick → tutorial stays as-is (not re-triggered), no duplicate
- [ ] Refresh the page, make another pick → tutorial does not reappear
- [ ] Click **Got it** → tutorial hides, browse hint appears
- [ ] Returning user with prior picks in `localStorage` but `tutorialSeen=false` (simulating the bug state) → next pick does not show tutorial
- [ ] **Reset my data** still clears the flag and re-enables the tutorial for the next first pick