### PR TITLE
Log April 10 S&P AAA/negative outlook change on changelog

### DIFF
--- a/data/changelog.html
+++ b/data/changelog.html
@@ -10,6 +10,30 @@ body_class: doc-page
 
   <p>This is not a meeting recap. It is a data audit trail: a way to see how the numbers on this site have shifted over time and why. Entries are sourced from public video, official presentations, and primary documents. Where auto-generated captions were the initial source, claims are cross-referenced against primary documents before appearing on topic pages.</p>
 
+  <h2 id="apr-10-2026">April 10, 2026</h2>
+  <p>S&amp;P Global Ratings surveillance action (<a href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-10_SP_Rating_Letter.pdf">archived letter, ref 40447311</a>)</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>What changed</th>
+        <th>Before</th>
+        <th>After</th>
+        <th>Who / why</th>
+        <th>See</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Bond rating outlook</td>
+        <td>AAA / stable</td>
+        <td>AAA / negative</td>
+        <td>S&amp;P Global Ratings, letter to Finance Director Aleesha Benjamin, dated April 10, 2026. Rating affirmed; outlook revised. The publicly distributed letter is the rating-action notice only; the supporting research update with reserve ratios, debt figures, and downgrade triggers is referenced as an enclosure but not included. Secondary paraphrases of the rationale appear in Marblehead Independent reporting.</td>
+        <td><a href="SOURCE_LOOKUP.html#bond-rating-aaa-affirmed-outlook-to-negative-april-10-2026">Source lookup &rarr; Bond Rating</a></td>
+      </tr>
+    </tbody>
+  </table>
+
   <h2 id="apr-8-2026">April 8, 2026</h2>
   <p>Select Board (<a href="https://vimeo.com/1181632658">Vimeo</a>) and School Committee (<a href="https://www.youtube.com/watch?v=VFf_HUGS1o0">YouTube</a>)</p>
 


### PR DESCRIPTION
## Summary
- Adds a dated April 10, 2026 entry to `data/changelog.html` for the S&P Global Ratings action: AAA affirmed, outlook revised from stable to negative (ref 40447311).
- Uses the page's existing five-column table format. Links to the archived S&P letter in the source archive and to the Bond Rating section of SOURCE_LOOKUP in the "See" column.
- "Who / why" cell explicitly notes that the archived letter is the rating-action notice only (no research-update enclosure) and that rationale paraphrases come from Marblehead Independent reporting, not the letter itself. Prevents a future reader from treating the "~$7.7M" secondary paraphrase as S&P quoted language.

## Test plan
- [ ] `/data/changelog.html` shows the April 10 entry above the April 8 entry.
- [ ] Archive link resolves to `2026-04-10_SP_Rating_Letter.pdf` on the `source-archive-v1` release.
- [ ] "See" link lands near the Bond Rating heading in SOURCE_LOOKUP (anchor is kramdown-generated and may drift; if so, page still loads and top-of-page is acceptable fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)