### PR TITLE
Fix factual errors in the two new homepage questions

### DIFF
--- a/index.html
+++ b/index.html
@@ -4611,8 +4611,9 @@ og_url: https://marbleheaddata.org/
         <h2>Existing relief meaningfully offsets the increase</h2>
         <p class="answer-summary">
           The state Senior Circuit Breaker refunds up to $2,820/year. For
-          an income-qualified senior it covers most of a Tier 3 increase.
-          The programs exist; the problem is low uptake, not low benefit.
+          a lower-income senior with a modest home, it absorbs a
+          meaningful share of a Tier 3 increase. The programs exist; the
+          problem is low uptake, not low benefit.
         </p>
       </div>
 
@@ -4669,9 +4670,12 @@ og_url: https://marbleheaddata.org/
           At Marblehead's FY26 tax rate of $8.60 per $1,000: property tax
           $7,740. Half water and sewer: $750. Total eligible: $8,490. 10%
           of income: $6,000. Excess: $2,490. That's the credit the state
-          writes you a check for. Even at full Tier 3, most of the
-          increase falls inside the $2,820 cap that the credit absorbs
-          automatically.
+          writes you a check for. A full Tier 3 override would add about
+          $1,380 to the tax bill on a $900K home; the Circuit Breaker
+          credit grows by $330 (from $2,490 to the $2,820 cap), leaving
+          the senior paying about $1,050 of the override out of pocket.
+          Seniors who start farther below the cap see a larger share
+          absorbed; seniors already at the cap see none.
         </p>
         <a class="evidence-chart-link" href="senior-tax-relief.html">
           Senior relief calculator
@@ -4864,9 +4868,10 @@ og_url: https://marbleheaddata.org/
         <p class="answer-label">Answer A</p>
         <h2>Growth matches cost pressures the town doesn't control</h2>
         <p class="answer-summary">
-          Schools absorbed 48% of the growth, mostly through mandated
-          special education and rising health insurance. Pensions and
-          debt service are on fixed schedules. These aren't choices.
+          Schools absorbed 48% of the growth, with mandated
+          out-of-district special education one of the drivers. Health
+          insurance, pensions, and debt service are on rate sheets and
+          fixed schedules the town doesn't set. These aren't choices.
         </p>
       </div>
 
@@ -4987,7 +4992,12 @@ og_url: https://marbleheaddata.org/
           roughly 58 positions to 537
           <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>,
           a 9.6% increase. The student-to-teacher ratio fell from 12.6
-          to 10.7, the lowest of Marblehead's four peer towns.
+          to 10.7, the lowest of Marblehead's four peer towns. Most of
+          that FTE increase lands in a single FY22-to-FY23 jump (483 to
+          537) that the town has not publicly explained; the source may
+          reflect expired federal ESSER positions or a change in
+          reporting methodology, and the number has held at exactly
+          537.0 for two years since.
         </p>
         <a class="evidence-chart-link" href="inside-school-staffing.html">
           Inside school staffing
@@ -5023,11 +5033,12 @@ og_url: https://marbleheaddata.org/
           Two FY26 town documents disagree on the starting figure (one
           lists $115,000, the other $228,000), and the reason for the
           year-over-year increase and the discrepancy between the two
-          FY26 figures is not publicly documented. That one line is
-          roughly three times the annual
+          FY26 figures is not publicly documented. The same budget
+          zeros out the town's $250,000 annual
           <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr>
-          retiree-benefits-trust contribution that the same budget
-          zeros out.
+          retiree-benefits-trust contribution, so one legal line grew
+          by about two-thirds of the retiree-benefits contribution in
+          the same budget cycle.
         </p>
         <a class="evidence-chart-link" href="where-has-the-money-gone.html#what-grew-faster">
           What grew faster


### PR DESCRIPTION
## Summary

Audit of the `seniors` and `moneygone` homepage questions (added in #419) against their primary source pages found three factual errors and one missing caveat. This PR fixes them in-place; no structural changes to either question.

## What was wrong

**1. seniors Answer A — worked example contradicted its own conclusion.**
The `$900K home / $60K income` worked example ends with "Even at full Tier 3, most of the increase falls inside the $2,820 cap that the credit absorbs automatically." The math doesn't support that:

- Pre-override credit: $2,490 (= $8,490 total burden − $6,000 (10% of income))
- Headroom to cap: $2,820 − $2,490 = **$330**
- Tier 3 override at $900K home: $1,985.39 × (900,000 / 1,291,507) ≈ **$1,384** (scaled from `OVERRIDE_RATES[3]` in `senior-tax-relief.html:768`)
- Credit absorbs only $330 of the $1,384; senior pays **~$1,054 out of pocket**
- Absorption rate: ~24%, not "most"

I checked all four worked examples on `senior-tax-relief.html:466-482` and absorption rates range from 0% to 31%. None support "most of the increase."

Fix: rewrite the evidence paragraph to state the actual math ($1,380 added, $330 absorbed, ~$1,050 OOP) and add the scope caveat that lower-value homes and higher-headroom seniors see larger absorption.

**2. seniors Answer A summary — over-generalized.**
"For an income-qualified senior it covers most of a Tier 3 increase" is false as a universal claim. Softened to "For a lower-income senior with a modest home, it absorbs a meaningful share of a Tier 3 increase."

**3. moneygone Answer B — "three times OPEB" is arithmetically wrong.**
The Town Counsel evidence claimed `$278K is "roughly three times the annual OPEB retiree-benefits-trust contribution."` Per `where-has-the-money-gone.html:577`, the OPEB contribution is **$250,000**. So $278K is ~1.1× OPEB, not 3×. The $163K increase is ~0.65× OPEB. No interpretation yields "three times."

Fix: rewrite to state the accurate comparison — "one legal line grew by about two-thirds of the retiree-benefits contribution in the same budget cycle."

**4. moneygone Answer B — missing CLAUDE.md-required FY23 FTE caveat.**
The 9.6% FTE growth figure (489.8 → 537.0) is dominated by a single FY22→FY23 jump from 483 to 537 that `charts/enrollment_vs_staffing.html:101` explicitly flags as *"unexplained in public records and may reflect federal ESSER-funded positions or a change in reporting methodology"* and `inside-school-staffing.html:428` notes the number then *"held exactly at 537.0 for two years, unusual for a 'real' count."* CLAUDE.md specifically names the FY23 FTE jump in the list of volatile-data caveats that must be surfaced wherever the number appears.

Fix: add one sentence surfacing the caveat inline in the evidence paragraph.

## Also softened

**moneygone Answer A summary** lumped "mandated special education and rising health insurance" under schools. Health insurance is a separate budget category ($4.7M of total growth, not in the schools line), and mandated out-of-district SPED is ~$4.6M / ~27% of schools' $17M growth, not "mostly." Rewritten to separate the two and drop the "mostly" claim.

## Test plan

- [ ] Load homepage, click through to seniors question, verify Answer A summary and worked example read correctly
- [ ] Click through to moneygone question, verify Answer A summary, Answer B FTE evidence paragraph, and Answer B Town Counsel evidence paragraph read correctly
- [ ] Verify no layout regressions in evidence cards (same number of `<div class="evidence-point">` per evidence block, same counter-argument structure)
- [ ] Verify all existing internal links (senior-tax-relief.html, where-has-the-money-gone.html, inside-school-staffing.html, charts/enrollment_vs_staffing.html) still resolve

https://claude.ai/code/session_01VBWV8Lcrf2c1LmMGeBz811