### PR TITLE
Log April 14 COA line-item decomposition on changelog

### DIFF
--- a/data/changelog.html
+++ b/data/changelog.html
@@ -10,6 +10,30 @@ body_class: doc-page
 
   <p>This is not a meeting recap. It is a data audit trail: a way to see how the numbers on this site have shifted over time and why. Entries are sourced from public video, official presentations, and primary documents. Where auto-generated captions were the initial source, claims are cross-referenced against primary documents before appearing on topic pages.</p>
 
+  <h2 id="apr-14-2026">April 14, 2026</h2>
+  <p>Marblehead Current interview with Council on Aging Director Lisa Hooper</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>What changed</th>
+        <th>Before</th>
+        <th>After</th>
+        <th>Who / why</th>
+        <th>See</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Council on Aging line-item detail</td>
+        <td>Bar-chart entry: &minus;$36K (&minus;9%), no decomposition and no service-level detail</td>
+        <td>Decomposed to Salaries &minus;$44K (&minus;11.2%) and Expense +$8K (+29.2%); operational impact identified as elimination of the Nutrition Coordinator and Special Laborer position, which the department reports would threaten the Tuesday lunch program (roughly 100 seniors weekly)</td>
+        <td>FY27 Proposed Budget page 3 for the line-item decomposition; COA Director Lisa Hooper's April 14 interview with the Marblehead Current for the service-level impact. The Current reported the cut as "$76,000," which does not match the primary budget figures; the site uses only the primary-source line-item numbers.</td>
+        <td><a href="no-override-budget.html#town-side-reductions">No-override budget &rarr; Town-side reductions</a></td>
+      </tr>
+    </tbody>
+  </table>
+
   <h2 id="apr-10-2026">April 10, 2026</h2>
   <p>S&amp;P Global Ratings surveillance action (<a href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-10_SP_Rating_Letter.pdf">archived letter, ref 40447311</a>)</p>
 


### PR DESCRIPTION
## Summary
- Companion entry to the merged PR #427, which added the Council on Aging service-impact paragraph to `no-override-budget.html`. Before that update readers saw only the bar-chart entry of −$36K (−9%); after, they see a salary/expense decomposition plus operational impact.
- New row dated April 14, 2026 (the date of the Marblehead Current interview with COA Director Lisa Hooper that supplied the service-level detail).
- The "Who / why" cell explicitly notes that the Current reported the cut as "$76,000," which does not reconcile with the primary budget figures, and that the site uses only the primary-source line-item numbers.

## Scope decisions (not logging)
- PR #421 (archived S&P letter + 2026 ATM Warrant) did not move a site-visible number; the archive is an operational improvement captured in SOURCE_LOOKUP.
- PR #422 (candidate roster refresh) and PR #423 (page rename) are outside the changelog's "numbers or policy shifts" scope.

## Test plan
- [ ] `/data/changelog.html` renders the new April 14 entry above the April 10 S&P entry.
- [ ] "See" link matches the existing pattern used by other rows in the table (relative `no-override-budget.html#town-side-reductions`).
- [ ] No em-dashes introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)