### PR TITLE
Chunk /api/reactions reads to stay under D1 100-param limit

### DIFF
--- a/community-pulse/worker/src/index.js
+++ b/community-pulse/worker/src/index.js
@@ -53,15 +53,22 @@ async function handleGet(request, env) {
     return new Response('{}', { status: 200, headers: corsHeaders(env) });
   }
 
-  // Build a single SQL query with a parameterized IN clause.
-  const placeholders = sectionIds.map(() => '?').join(',');
-  const stmt = env.DB.prepare(
-    `SELECT section_id, total_count, count_24h FROM reactions WHERE section_id IN (${placeholders})`
-  ).bind(...sectionIds);
-  const { results } = await stmt.all();
+  // D1 rejects prepared statements with more than 100 bound parameters, so
+  // split the IN-clause query into chunks.
+  const CHUNK = 90;
+  const found = new Map();
+  for (let i = 0; i < sectionIds.length; i += CHUNK) {
+    const chunk = sectionIds.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => '?').join(',');
+    const { results } = await env.DB.prepare(
+      `SELECT section_id, total_count, count_24h FROM reactions WHERE section_id IN (${placeholders})`
+    ).bind(...chunk).all();
+    for (const r of results) {
+      found.set(r.section_id, { total: r.total_count, last_24h: r.count_24h });
+    }
+  }
 
   // Assemble response with zeros for unknown sections.
-  const found = new Map(results.map(r => [r.section_id, { total: r.total_count, last_24h: r.count_24h }]));
   const response = {};
   for (const id of sectionIds) {
     response[id] = found.get(id) || { total: 0, last_24h: 0 };


### PR DESCRIPTION
## Summary

- Community Pulse Worker was returning HTTP 500 on every `/api/reactions` GET from the homepage, breaking the stats strip and per-card distribution bars.
- Root cause: D1 rejects prepared statements with more than 100 bound parameters. The handler built one `WHERE section_id IN (?, ?, ...)` query with every id bound. Adding seniors + moneygone topics in #419 pushed the client batch from 97 ids to 113 ids, crossing the limit.
- Fix: chunk into groups of 90 and merge results. Request/response shape unchanged; no client edits needed.
- Already deployed to prod via `wrangler deploy` and verified live: the real 113-id batch now returns `status=200`, views_sum=95, shares_sum=93.

## Test plan

- [x] Repro: `curl` full 113-id batch against old worker -> 500 "Worker threw exception"
- [x] After fix, same batch -> 200 with all 113 keys populated
- [x] Small batches (<=90) still work (unchanged code path semantics)
- [ ] Reload marbleheaddata.org and confirm landing cards show distribution bars and community stats read the real numbers

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>