### PR TITLE
Reframe "money gone" question as "what explains budget growth"

### DIFF
--- a/index.html
+++ b/index.html
@@ -4848,17 +4848,17 @@ og_url: https://marbleheaddata.org/
   </section>
 
   <!-- ═══════════════════════════════════════════════════
-       QUESTION: Where has the money actually gone?
+       QUESTION: What explains the budget growth?
        ═══════════════════════════════════════════════════ -->
   <section class="question-screen" data-topic="moneygone">
 
     <div class="question-block">
-      <h1>Where has the money actually gone?</h1>
+      <h1>What explains the budget growth?</h1>
       <p class="question-context">
         Marblehead's General Fund grew from $70.5M (FY15) to $106.2M
-        (FY26), an increase of $35.7M over 11 years. Where did that
-        $35.7M go, and did anything grow faster than inflation,
-        enrollment, or service levels?
+        (FY26), an increase of $35.7M over 11 years. What drove that
+        growth, and did anything grow faster than inflation,
+        enrollment, or service levels would suggest?
       </p>
     </div>
 
@@ -4866,7 +4866,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="a" data-question="moneygone">
         <p class="answer-label">Answer A</p>
-        <h2>Growth matches cost pressures the town doesn't control</h2>
+        <h2>Costs the town can't say no to</h2>
         <p class="answer-summary">
           Schools absorbed 48% of the growth, with mandated
           out-of-district special education one of the drivers. Health
@@ -4877,7 +4877,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="moneygone">
         <p class="answer-label">Answer B</p>
-        <h2>Growth outpaced inflation and service levels</h2>
+        <h2>Some growth ran ahead of any obvious driver</h2>
         <p class="answer-summary">
           Enrollment fell 19% while education staff rose 9.6%. The town
           has balanced the operating budget with one-time free cash
@@ -4888,11 +4888,13 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="c" data-question="moneygone">
         <p class="answer-label">Answer C</p>
-        <h2>The audit exists, but most haven't engaged it</h2>
+        <h2>Both, depending on which line item</h2>
         <p class="answer-summary">
-          Independent auditors certify the books every year. The data
-          is public. The question isn't "is there fraud" but "have I
-          read the source documents before deciding?"
+          Different lines tell different stories. Schools, pensions,
+          and health insurance look mandatory. Town Counsel and
+          free-cash patching look discretionary. The same audited
+          numbers support both A and B because both are true for
+          different lines.
         </p>
       </div>
 
@@ -4901,7 +4903,7 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence A: cost pressures -->
     <div class="evidence" data-evidence="moneygone-a">
       <div class="evidence-header">
-        <h3>The case for "matches cost pressures"</h3>
+        <h3>The case for "costs the town can't say no to"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
@@ -4974,10 +4976,10 @@ og_url: https://marbleheaddata.org/
       </details>
     </div>
 
-    <!-- Evidence B: outpaced inflation and service levels -->
+    <!-- Evidence B: some growth ran ahead of any obvious driver -->
     <div class="evidence" data-evidence="moneygone-b">
       <div class="evidence-header">
-        <h3>The case for "outpaced inflation and service levels"</h3>
+        <h3>The case for "some growth ran ahead of any obvious driver"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
@@ -5064,10 +5066,10 @@ og_url: https://marbleheaddata.org/
       </details>
     </div>
 
-    <!-- Evidence C: audit exists -->
+    <!-- Evidence C: both, depending on which line item -->
     <div class="evidence" data-evidence="moneygone-c">
       <div class="evidence-header">
-        <h3>The case for "audit exists, but most haven't engaged it"</h3>
+        <h3>The case for "both, depending on which line item"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
@@ -5126,12 +5128,13 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            "Read the source documents" is good hygiene but doesn't
-            resolve an $8.47M vote on a 12-week timeline. Voters have
-            to act on some reading of the numbers, and a reading that
-            refuses to commit still counts as a vote. "Both sides are
-            layered on the same data" is a starting point for analysis,
-            not a conclusion to rest on.
+            "It's mixed" is a starting point for analysis, not a
+            conclusion to rest on. Voters have to act on some reading
+            of the numbers within a 12-week budget cycle, and a reading
+            that refuses to commit still counts as a vote. The split
+            between "mandatory" and "discretionary" lines is itself a
+            judgment call &ndash; A would draw the line in one place, B
+            in another.
           </p>
         </div>
       </details>
@@ -5202,7 +5205,7 @@ og_url: https://marbleheaddata.org/
       'seniors',      // How does this affect seniors and fixed-income households?
       'taxrank',      // How does Marblehead's tax burden compare?
       'levy',         // Why don't 2.5% increases keep up?
-      'moneygone',    // Where has the money actually gone?
+      'moneygone',    // What explains the budget growth?
       'size',         // Does the size of the override matter?
       'schools',      // Why did staffing grow while enrollment fell?
       'trash',        // Why is trash collection on the ballot?


### PR DESCRIPTION
## Summary

The `moneygone` question screen had two mismatches that made the answers hard to parse:

1. **Question vs. answers mismatch.** "Where has the money actually gone?" promised a destination breakdown ($X to schools, $Y to health insurance, …), but the three answers delivered competing *explanations* of the growth, not a breakdown. Renamed the question to **"What explains the budget growth?"** so it matches what A, B, and C actually do.

2. **Dense noun-phrase headlines.** The three answer headlines read like policy-paper titles. Rewrote them in plainer English:
   - **A:** "Growth matches cost pressures the town doesn't control" &rarr; "Costs the town can't say no to"
   - **B:** "Growth outpaced inflation and service levels" &rarr; "Some growth ran ahead of any obvious driver"
   - **C:** "The audit exists, but most haven't engaged it" &rarr; "Both, depending on which line item"

Answer C is the biggest shift: the old C was a meta-answer ("go read the source documents") that didn't actually explain anything. It's now a synthesis answer ("it's mixed, depending on the line") that fits alongside A and B as a genuine third position. The underlying editorial point &ndash; that A and B both come from the same audited data &ndash; is preserved in the evidence bullets and the counter-argument.

The question-context paragraph, C's summary, C's counter-argument, and the three `evidence-header` H3s are updated for consistency. Evidence bullets, chart links, citations, and the A/B counter-arguments are unchanged.

`topicLabels` is built dynamically from each section's H1, so progress-dot tooltips and related-question link labels update automatically &ndash; no other strings to chase.

## Test plan

- [ ] Visit `/?q=moneygone` and confirm the new question, context paragraph, and three plainer answer headlines render correctly
- [ ] Open each evidence panel (A, B, C) and confirm the H3 "The case for …" headers match the new answer headlines
- [ ] Open the C counter-argument and confirm the new text reads coherently
- [ ] Confirm related-question links that point to `moneygone` (from `override`, `levy`, `schools`) show the new question title
- [ ] Confirm the progress-dot tooltip for `moneygone` shows the new title
- [ ] Spot-check `/?q=moneygone&pos=a`, `&pos=b`, `&pos=c` deep links still open the correct answer

https://claude.ai/code/session_011ks94rNGZHzMgteJUpjiAf