### PR TITLE
Count community totals up from zero on initial stats-strip render

### DIFF
--- a/index.html
+++ b/index.html
@@ -5550,6 +5550,32 @@ og_url: https://marbleheaddata.org/
 
   // Personal view count is now derived from topic views (incremented in switchTopic)
 
+  // Count-up animation for the community totals on initial server response.
+  // Runs once per page load (the first time real server data arrives); later
+  // updates from single-user increments just set textContent directly so a
+  // share of 97 -> 98 doesn't trigger a visible animation.
+  var statsCommunityAnimated = false;
+  var prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  function animateStatCount(el, from, to, duration) {
+    if (!el) return;
+    if (prefersReducedMotion || from === to) { el.textContent = to; return; }
+    var start = null;
+    var diff = to - from;
+    function step(ts) {
+      if (start === null) start = ts;
+      var t = Math.min(1, (ts - start) / duration);
+      // Ease-out cubic: fast at first, slows as it finishes
+      var eased = 1 - Math.pow(1 - t, 3);
+      el.textContent = Math.round(from + diff * eased);
+      if (t < 1) {
+        requestAnimationFrame(step);
+      } else {
+        el.textContent = to;
+      }
+    }
+    requestAnimationFrame(step);
+  }
+
   function updateStatsStrip() {
     var statsEl = document.getElementById('exploreStats');
     var decidedCount = topicOrder.filter(function (t) { return !!selections[t]; }).length;
@@ -5567,8 +5593,17 @@ og_url: https://marbleheaddata.org/
     document.getElementById('statTotal').textContent = totalCount;
     document.getElementById('statYourViews').textContent = getYourViews();
     document.getElementById('statYourShares').textContent = getYourShares();
-    document.getElementById('statAllViews').textContent = allViews;
-    document.getElementById('statAllShares').textContent = allShares;
+    var allViewsEl = document.getElementById('statAllViews');
+    var allSharesEl = document.getElementById('statAllShares');
+    if (!statsCommunityAnimated && (allViews > 0 || allShares > 0)) {
+      // First time real server totals arrive: count up from zero.
+      animateStatCount(allViewsEl, 0, allViews, 1200);
+      animateStatCount(allSharesEl, 0, allShares, 1200);
+      statsCommunityAnimated = true;
+    } else {
+      allViewsEl.textContent = allViews;
+      allSharesEl.textContent = allShares;
+    }
     var pct = totalCount > 0 ? Math.round((decidedCount / totalCount) * 100) : 0;
     document.getElementById('statBar').style.width = pct + '%';
 


### PR DESCRIPTION
## Summary

On the Explore stats strip (`index.html`), the community views/shares counts used to snap from `0` to their final server values as soon as `fetchAllCounts()` resolved, which read as a flicker. Animate those two numbers up from zero with an ease-out cubic so they count up and slow down as they finish, matching the behavior the issue asked about.

## Behavior

- Animates `#statAllViews` and `#statAllShares` from 0 to their first non-zero server value over 1.2s, ease-out cubic (fast start, slow finish).
- Runs **once per page load**, guarded by `statsCommunityAnimated`. Subsequent updates (e.g. a single share bumping `97 -> 98` after a user action) just set `textContent` directly, so they don't re-trigger the intro animation.
- Respects `prefers-reduced-motion`: skips the animation and snaps to the final value.
- Only applies to the community totals. `statDecided`, `statYourViews`, and `statYourShares` come from local state and keep setting `textContent` directly.

## Test plan

- [ ] Hard-refresh the home page, confirm the community views/shares numbers count up from 0 and ease into their final values once the `/api/reactions` fetch resolves.
- [ ] Take an action that bumps a share count (decide on a question, copy a share link) and confirm the community numbers do **not** re-animate from 0 on the subsequent `updateStatsStrip()` call.
- [ ] Toggle `prefers-reduced-motion: reduce` in DevTools and reload; confirm numbers appear immediately with no animation.
- [ ] Confirm `#statDecided`, `#statYourViews`, `#statYourShares`, and the progress bar behave unchanged.
- [ ] `tests/explore-test.mjs` still passes (it only reads `#statDecided`, which is unchanged).