### PR TITLE
Add pie-chart icon for the budget-growth question

### DIFF
--- a/index.html
+++ b/index.html
@@ -6060,7 +6060,8 @@ og_url: https://marbleheaddata.org/
     trash:        '<path d="M20 7l-1.2 12.5a2 2 0 0 1-2 1.5H7.2a2 2 0 0 1-2-1.5L4 7"/><path d="M10 11v6m4-6v6M1 7h22M8 7V3.5A1.5 1.5 0 0 1 9.5 2h5A1.5 1.5 0 0 1 16 3.5V7"/>', /* trash */
     library:      '<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>', /* book */
     trust:        '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>',     /* shield */
-    seniors:      '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.87a4 4 0 0 1 0 7.75"/>' /* two people */
+    seniors:      '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.87a4 4 0 0 1 0 7.75"/>', /* two people */
+    moneygone:    '<path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/>' /* pie chart */
   };
 
   /* ── Build landing question cards from actual h1s ── */


### PR DESCRIPTION
## Summary

Follow-up to #434. The `topicIcons` dictionary in `index.html` (around line 6010) still had one missing entry after that PR merged: `moneygone` &mdash; the `What explains the budget growth?` question &mdash; so its landing card on the explore screen still renders with an empty icon box.

Adds a Lucide `pie-chart` icon.

### Why a pie chart rather than a trending-up line

- **`levy` already uses trending-up** (line 6014, for `Why don't 2.5% increases keep up?`). A second up-arrow two questions away would make the two cards visually confusable.
- **The question is about composition, not direction.** The answers break growth down by share (schools 48%, health insurance, pensions, debt service, etc.). "Number went up" is already established in the question's context paragraph &mdash; the actual thing the reader is asking is *what's inside* the growth, which a pie chart maps to directly.

## Test plan

- [ ] Load the home page and scroll to the explore grid; confirm the "What explains the budget growth?" card now shows a pie chart icon instead of an empty box.
- [ ] Confirm the other 13 question cards still render their existing icons unchanged (including the `seniors` two-person icon from #434 and the `levy` trending-up icon, which should remain visually distinct from the new pie chart).
- [ ] Sanity-check at the mobile breakpoint (`.explore-card-icon { width: 30px }` rule around line 1556) that the pie chart silhouette is legible at 16px.