### PR TITLE
Tune pick-distribution legend: bigger font and gap, keep inline layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -712,71 +712,52 @@ og_url: https://marbleheaddata.org/
   .pick-dist-b { background: var(--c-brass); }
   .pick-dist-c { background: var(--c-buoy); }
   .pick-dist-u { background: var(--text-faint); }
-  /* Legend: one cell per answer in a 4-column grid so each category
-     reads as its own chunk. The old single-line layout ran the dot,
-     letter, percentage, and count together at the same weight, which
-     made it hard to tell which number belonged to which answer.
-     Percentage is the primary number (bold), count is a subdued
-     caption in parens. Drops to two columns on very narrow viewports. */
+  /* Legend: flat flex row where each answer is a tight dot+letter+pct+
+     count group, with generous breathing room between groups. Tuned
+     up from the pre-#435 original: font 11->12px and column gap 14->20
+     so the category groups don't blend into each other. Keep the
+     HTML structure flat so the letter and its percentage stay next to
+     each other visually -- the #436 grid layout pushed each percentage
+     to the right of its cell, which made the number look associated
+     with the *next* letter. */
   .pick-dist-legend {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    column-gap: 14px;
-    row-gap: 6px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 20px;
     margin-top: 10px;
+    font-size: 0.75rem;
+    color: var(--text-muted);
     font-variant-numeric: tabular-nums;
-  }
-  @media (max-width: 480px) {
-    .pick-dist-legend { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   }
   .pick-dist-key {
     display: flex;
-    align-items: baseline;
-    gap: 6px;
-    min-width: 0;
-    font-size: 0.75rem;
-    color: var(--text-muted);
+    align-items: center;
+    gap: 5px;
+    font-weight: 600;
+  }
+  .pick-dist-count {
+    font-weight: 400;
+    color: var(--text-subtle);
   }
   .pick-dist-dot {
     width: 8px;
     height: 8px;
     border-radius: 50%;
     flex-shrink: 0;
-    align-self: center;
   }
   .pick-dist-dot-a { background: var(--c-teal); }
   .pick-dist-dot-b { background: var(--c-brass); }
   .pick-dist-dot-c { background: var(--c-buoy); }
   .pick-dist-dot-u { background: var(--text-faint); }
-  .pick-dist-key-label {
-    font-weight: 600;
-    color: var(--text-muted);
-    flex-shrink: 0;
-  }
-  .pick-dist-key-pct {
-    font-weight: 700;
-    color: var(--text);
-    margin-left: auto;
-  }
-  .pick-dist-key-count {
-    font-size: 0.6875rem;
-    font-weight: 400;
-    color: var(--text-subtle);
-    flex-shrink: 0;
-  }
   .pick-dist-total {
-    margin-top: 8px;
-    text-align: right;
-    font-size: 0.6875rem;
-    color: var(--text-subtle);
+    margin-left: auto;
     font-weight: 400;
-    font-variant-numeric: tabular-nums;
+    color: var(--text-subtle);
   }
   /* "X readers changed their pick after reading the evidence" line,
      shown under the legend when the move-vote counter is non-zero. */
   .pick-dist-moves {
-    margin-top: 2px;
-    text-align: right;
+    margin-top: 6px;
     font-size: 0.6875rem;
     color: var(--text-subtle);
     font-variant-numeric: tabular-nums;
@@ -5491,10 +5472,12 @@ og_url: https://marbleheaddata.org/
   }
 
   // Show answer distribution bar below the answers container for a topic.
-  // Four segments: A, B, C, plus "Not sure yet" ('u'). The legend below
-  // renders each answer in its own grid cell so the numbers are easier
-  // to scan than a single run-on line. If anyone has reconsidered after
-  // reading, append a "X changed their pick" line under the legend.
+  // Four segments: A, B, C, plus "Not sure yet" ('u'). The legend keeps
+  // the dot, letter, percentage, and count for each answer tightly
+  // grouped in a flat flex row so the number reads as belonging to its
+  // own letter rather than floating toward the next one. If anyone has
+  // reconsidered after reading, append a "X changed their pick" line
+  // under the legend.
   function showPickDistribution(topic) {
     var screen = document.querySelector('.question-screen[data-topic="' + topic + '"]');
     if (!screen) return;
@@ -5522,17 +5505,6 @@ og_url: https://marbleheaddata.org/
     var pU = 100 - pA - pB - pC; // Absorb rounding drift on the muted segment
     if (pU < 0) pU = 0;
 
-    function legendKey(key, keyLabel, pct, count) {
-      return (
-        '<span class="pick-dist-key">' +
-          '<span class="pick-dist-dot pick-dist-dot-' + key + '"></span>' +
-          '<span class="pick-dist-key-label">' + keyLabel + '</span>' +
-          '<span class="pick-dist-key-pct">' + pct + '%</span>' +
-          '<span class="pick-dist-key-count">(' + count + ')</span>' +
-        '</span>'
-      );
-    }
-
     var moves = topicState.moves || 0;
     var movesHtml = '';
     if (moves > 0) {
@@ -5552,12 +5524,12 @@ og_url: https://marbleheaddata.org/
         '<div class="pick-dist-seg pick-dist-u" style="width:' + pU + '%">' + (pU >= 8 ? pU + '%' : '') + '</div>' +
       '</div>' +
       '<div class="pick-dist-legend">' +
-        legendKey('a', 'A', pA, cA) +
-        legendKey('b', 'B', pB, cB) +
-        legendKey('c', 'C', pC, cC) +
-        legendKey('u', 'Not sure', pU, cU) +
+        '<span class="pick-dist-key"><span class="pick-dist-dot pick-dist-dot-a"></span>A ' + pA + '% <span class="pick-dist-count">(' + cA + ')</span></span>' +
+        '<span class="pick-dist-key"><span class="pick-dist-dot pick-dist-dot-b"></span>B ' + pB + '% <span class="pick-dist-count">(' + cB + ')</span></span>' +
+        '<span class="pick-dist-key"><span class="pick-dist-dot pick-dist-dot-c"></span>C ' + pC + '% <span class="pick-dist-count">(' + cC + ')</span></span>' +
+        '<span class="pick-dist-key"><span class="pick-dist-dot pick-dist-dot-u"></span>Not sure ' + pU + '% <span class="pick-dist-count">(' + cU + ')</span></span>' +
+        '<span class="pick-dist-total">' + total + ' picked</span>' +
       '</div>' +
-      '<div class="pick-dist-total">' + total + ' picked</div>' +
       movesHtml;
   }
 


### PR DESCRIPTION
## Summary

agbaber/marblehead#436 rebuilt the pick-distribution legend as a 4-column grid with `margin-left: auto` on each cell's percentage. Because that auto-margin pushed every number to the far right of its cell, each percentage ended up **visually associated with the next letter**, not its own:

```
● A                    0%  ● B                    0%  ● C                    100%
        (A dot)      ↑                                    ↑
                     this 0% looks like it belongs to B   this 100% looks like it belongs to "Not sure"
```

The intra-cell gap was larger than the inter-cell gap, which is exactly the opposite of what a legend is supposed to communicate.

Go back to the pre-#435 inline flex layout where the dot, letter, percentage, and count sit tightly next to each other inside each `.pick-dist-key`, with generous breathing room between groups. The only differences from the pre-#435 original are three CSS property tweaks:

- `font-size` 0.6875rem → 0.75rem (11 → 12px)
- `gap` 4px 14px → 4px 20px (breathing room between categories)
- `margin-top` 6px → 10px (a touch more separation from the bar)

No grid, no HTML restructure, no visual hierarchy change. Just font and spacing.

## Test plan

- [ ] Load a question page, pick an answer, confirm the stacked bar looks unchanged
- [ ] Confirm each legend entry reads as a tight "● A 14% (1)" group — the letter and its percentage are adjacent, not separated by a big gap
- [ ] Confirm "N picked" sits at the right end of the legend line (via `margin-left: auto`)
- [ ] Confirm the "X readers changed their pick after reading the evidence" line sits left-aligned under the legend
- [ ] Dark and light theme both read cleanly

https://claude.ai/code/session_01Rmy3FPuG2LACu5y983vRSk