### PR TITLE
Tighten neutral tone on size question Answer C

### DIFF
--- a/index.html
+++ b/index.html
@@ -3292,8 +3292,8 @@ og_url: https://marbleheaddata.org/
         <h2>The size doesn't matter because the answer is no</h2>
         <p class="answer-summary">
           No override of any size should pass until the town demonstrates
-          structural reform. Voting yes at any tier rewards the spending
-          patterns that created the deficit.
+          structural reform. Any tier continues the same spending
+          trajectory that created the deficit.
         </p>
       </div>
     </div>
@@ -3410,7 +3410,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>An override without reform is a blank check</h4>
+        <h4>An override without reform doesn't fix the structure</h4>
         <p>
           Marblehead has not consolidated departments, renegotiated
           health plan design, or moved to
@@ -3425,12 +3425,13 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Voting no is the only real leverage</h4>
+        <h4>A no vote is the strongest available leverage</h4>
         <p>
           Once an override passes, the levy ceiling rises permanently.
-          There is no mechanism for voters to claw it back. Voting no
-          forces the conversation about which services the town can
-          actually afford at its current tax base.
+          There is no mechanism for voters to claw it back. Proponents
+          of this view argue that voting no forces the conversation
+          about which services the town can afford at its current
+          tax base.
         </p>
         <a class="evidence-chart-link" href="what-you-can-do.html#better-oversight">
           Ways to push for reform


### PR DESCRIPTION
## Summary
- Softens editorial language in the "vote no at any size" answer (size question, Answer C)
- "rewards the spending patterns" → "continues the same spending trajectory"
- "blank check" → "doesn't fix the structure"  
- "only real leverage" → "strongest available leverage" + frames claim as "proponents argue"

## Why
Answer C's language was closer to advocacy than steelman. These changes keep the position fully represented while matching the neutral voice of Answers A and B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)