### PR TITLE
Add interactive deficit dynamics model chart

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1,0 +1,445 @@
+---
+title: "Deficit Dynamics Model"
+---
+<style>
+  .dm-controls {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px 24px;
+    margin: 20px 0 8px;
+  }
+  @media (max-width: 600px) {
+    .dm-controls { grid-template-columns: 1fr; }
+  }
+  .dm-control {
+    font-size: 13px;
+  }
+  .dm-control-label {
+    display: block;
+    color: var(--text);
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+  .dm-hint {
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 400;
+    margin-top: 4px;
+    line-height: 1.4;
+  }
+  .dm-control input[type="range"] {
+    width: 100%;
+    accent-color: var(--c-navy);
+  }
+  .dm-value {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    color: var(--c-navy);
+    margin-left: 8px;
+  }
+  .dm-toggle-row {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 10px 12px;
+    background: var(--c-fog);
+    border-radius: 6px;
+  }
+  .dm-toggle-row input[type="checkbox"] {
+    margin-top: 2px;
+    accent-color: var(--c-navy);
+  }
+  .dm-toggle-label {
+    font-weight: 600;
+    color: var(--text);
+    font-size: 13px;
+  }
+  .dm-presets {
+    grid-column: 1 / -1;
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-top: 4px;
+  }
+  .dm-presets button {
+    padding: 6px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .dm-presets button:hover {
+    background: var(--c-fog);
+    border-color: var(--c-navy);
+  }
+  .dm-readout {
+    margin: 20px 0;
+    padding: 14px 18px;
+    background: var(--c-fog);
+    border-left: 3px solid var(--c-navy);
+  }
+  .dm-readout-line {
+    font-size: 14px;
+    color: var(--text);
+  }
+  .dm-readout strong {
+    font-variant-numeric: tabular-nums;
+    font-size: 22px;
+    color: var(--c-navy);
+    font-weight: 700;
+  }
+  .dm-svg {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-width: 720px;
+    margin: 0 auto;
+  }
+  .dm-svg .dm-rev-line {
+    fill: none;
+    stroke: var(--c-sage);
+    stroke-width: 2.5;
+  }
+  .dm-svg .dm-exp-line {
+    fill: none;
+    stroke: var(--c-buoy);
+    stroke-width: 2.5;
+  }
+  .dm-svg .dm-deficit-fill {
+    fill: var(--c-buoy);
+    opacity: 0.15;
+  }
+  .dm-svg .dm-grid-line {
+    stroke: var(--divider);
+    stroke-width: 1;
+    stroke-dasharray: 2 3;
+  }
+  .dm-svg .dm-axis-label {
+    font-size: 11px;
+    fill: var(--text-muted);
+    font-family: inherit;
+  }
+  .dm-svg .dm-override-marker {
+    stroke: var(--c-teal);
+    stroke-width: 1.5;
+    stroke-dasharray: 5 4;
+  }
+  .dm-svg .dm-override-label {
+    font-size: 10px;
+    fill: var(--c-teal);
+    font-family: inherit;
+    font-weight: 600;
+  }
+  .dm-svg .dm-legend-bg {
+    fill: var(--surface);
+    stroke: var(--border);
+  }
+  .dm-svg .dm-legend-swatch-rev {
+    stroke: var(--c-sage);
+    stroke-width: 2.5;
+  }
+  .dm-svg .dm-legend-swatch-exp {
+    stroke: var(--c-buoy);
+    stroke-width: 2.5;
+  }
+  .dm-svg .dm-legend-text {
+    font-size: 11px;
+    fill: var(--text);
+    font-family: inherit;
+  }
+  .dm-hidden {
+    display: none;
+  }
+</style>
+
+<h1 class="h-center">Deficit Dynamics: How Two Lines Decide the Gap</h1>
+<p class="subtitle h-center">Illustrative model. Starting values are round numbers, not forecasts. Use the controls to see how theories about the expense line's behavior change what a revenue change actually does to a budget gap.</p>
+
+<div class="dm-readout">
+  <div class="dm-readout-line">At FY40, this model shows a <strong id="dm-gap">$12.6M</strong> <span id="dm-gap-label">annual deficit</span>.</div>
+  <div class="dm-hint" id="dm-gap-hint">Move the sliders, or click a preset below the chart, to see how it changes.</div>
+</div>
+
+<svg class="dm-svg" viewBox="0 0 720 380" role="img" aria-labelledby="dm-title dm-desc">
+  <title id="dm-title">Revenue and expense lines over FY25 to FY40</title>
+  <desc id="dm-desc">Two lines showing modeled revenue and expenses over a sixteen-year window, with a shaded region highlighting any deficit where expenses exceed revenue.</desc>
+  <g id="dm-grid"></g>
+  <g id="dm-axes"></g>
+  <g id="dm-deficit-fill"></g>
+  <path id="dm-rev-path" class="dm-rev-line"></path>
+  <path id="dm-exp-path" class="dm-exp-line"></path>
+  <line id="dm-override-marker" class="dm-override-marker dm-hidden" x1="0" y1="0" x2="0" y2="0"></line>
+  <text id="dm-override-label" class="dm-override-label dm-hidden" x="0" y="0" text-anchor="middle">Override</text>
+  <g id="dm-legend"></g>
+</svg>
+
+<div class="dm-controls">
+  <div class="dm-control">
+    <span class="dm-control-label">Revenue growth: <span class="dm-value" id="dm-rev-growth-val">3.5%</span></span>
+    <input type="range" id="dm-rev-growth" min="0" max="6" step="0.1" value="3.5">
+    <div class="dm-hint">Prop 2&frac12; caps Marblehead's levy growth at 2.5% plus new growth, typically landing around 3% to 4%.</div>
+  </div>
+  <div class="dm-control">
+    <span class="dm-control-label">Expense growth: <span class="dm-value" id="dm-exp-growth-val">4.0%</span></span>
+    <input type="range" id="dm-exp-growth" min="0" max="6" step="0.1" value="4.0">
+    <div class="dm-hint">Marblehead's FY15 to FY24 actual expense growth averaged about 4.0% per year.</div>
+  </div>
+  <div class="dm-control">
+    <span class="dm-control-label">Override at FY28: <span class="dm-value" id="dm-override-val">$0.0M</span></span>
+    <input type="range" id="dm-override" min="0" max="15" step="0.5" value="0">
+    <div class="dm-hint">A one-time step up in the revenue line.</div>
+  </div>
+  <div class="dm-control">
+    <span class="dm-control-label">&nbsp;</span>
+    <div class="dm-toggle-row">
+      <input type="checkbox" id="dm-ratchet">
+      <div>
+        <label for="dm-ratchet" class="dm-toggle-label">Ratchet: expense line jumps with the override</label>
+        <div class="dm-hint">If on, passing the override also bumps the expense line by the same amount. This is the "governments spend whatever they take in" theory stated as a slope rule.</div>
+      </div>
+    </div>
+  </div>
+  <div class="dm-presets">
+    <button type="button" data-preset="baseline">Marblehead baseline (no override)</button>
+    <button type="button" data-preset="no-ratchet">Override, no ratchet</button>
+    <button type="button" data-preset="ratchet">Override with ratchet</button>
+    <button type="button" data-preset="matched">Matched slopes</button>
+  </div>
+</div>
+
+<h2>What this shows</h2>
+<p>There are two lines. One is revenue, one is expenses. If the expense line is above the revenue line, there's a gap that has to be closed by reserves, cuts, or an override. The gap shrinks when the lines converge, grows when they diverge, and stays flat when they run parallel.</p>
+
+<p>The "ratchet" theory holds that when the revenue line jumps from an override, the expense line jumps right along with it, because officials adapt spending to the new ceiling. If that's true, the gap never closes. An override just produces bigger numbers on both sides and the deficit reappears, sometimes worse than before. Toggle the ratchet on to see that scenario.</p>
+
+<p>The alternative theory holds that the two slopes are set by different forces. Revenue is capped at 2.5% plus new growth by Proposition 2&frac12;. Expenses are driven by health insurance rates, pension assessments, contractual wages, and other costs that are only loosely coupled to what the town collects in taxes. In that model, an override can close the gap for a while, and eventually reopens it only if the expense slope stays steeper than the revenue slope.</p>
+
+<p>Marblehead's own FY15 to FY24 data is closer to the second model. Revenue grew at about 3.7% per year (basically the Prop 2&frac12; formula). Expenses grew at about 4.0%. That 0.3% gap compounded into a growing structural deficit, absorbed by rising free cash draws until free cash reliance was flagged as unsustainable in 2019.</p>
+
+<details class="notes">
+  <summary>Notes and methodology</summary>
+  <p>This is an illustrative model, not a forecast. The starting values ($100M for both revenue and expenses in FY25) are round numbers chosen to make the lines easy to read, not to match Marblehead's actual budget levels in FY25. The growth rates are applied as constant annual compounding rates, which is a simplification. Real budgets have lumpy cost spikes (GIC rate jumps, PERAC revaluations) and uneven revenue growth (new growth from development is not constant).</p>
+  <p>The "ratchet" toggle is a crude representation of the behavioral adaptation theory. It models the theory as "expense line immediately jumps by the full override amount and then resumes its prior slope." A more sophisticated version would model the expense slope itself changing (e.g., growing faster for a few years post-override). The chart uses the blunt version because it's easier to see in a graph.</p>
+  <p>Marblehead's historical figures cited in the text above are from <a href="../data/general_fund_budgetary_FY15-24.csv">general_fund_budgetary_FY15-24.csv</a> and <a href="../data/free_cash_operating_history.csv">free_cash_operating_history.csv</a>, both sourced from the town's ACFRs and Finance Committee Annual Reports.</p>
+</details>
+
+<script>
+(function() {
+  var startYear = 25;
+  var endYear = 40;
+  var nYears = endYear - startYear + 1;
+  var startRev = 100;
+  var startExp = 100;
+  var overrideYearIdx = 3;
+
+  var svgW = 720;
+  var svgH = 380;
+  var marginL = 60;
+  var marginR = 30;
+  var marginT = 20;
+  var marginB = 60;
+  var plotW = svgW - marginL - marginR;
+  var plotH = svgH - marginT - marginB;
+
+  var yMin = 80;
+  var yMax = 260;
+
+  function xScale(i) { return marginL + (i / (nYears - 1)) * plotW; }
+  function yScale(v) { return marginT + (1 - (v - yMin) / (yMax - yMin)) * plotH; }
+
+  var revGrowthEl = document.getElementById('dm-rev-growth');
+  var expGrowthEl = document.getElementById('dm-exp-growth');
+  var overrideEl = document.getElementById('dm-override');
+  var ratchetEl = document.getElementById('dm-ratchet');
+  var revGrowthVal = document.getElementById('dm-rev-growth-val');
+  var expGrowthVal = document.getElementById('dm-exp-growth-val');
+  var overrideVal = document.getElementById('dm-override-val');
+  var gapEl = document.getElementById('dm-gap');
+  var gapLabelEl = document.getElementById('dm-gap-label');
+  var gapHintEl = document.getElementById('dm-gap-hint');
+
+  function compute() {
+    var revG = parseFloat(revGrowthEl.value) / 100;
+    var expG = parseFloat(expGrowthEl.value) / 100;
+    var ovr = parseFloat(overrideEl.value);
+    var ratchet = ratchetEl.checked;
+
+    var rev = [];
+    var exp = [];
+    var r = startRev;
+    var e = startExp;
+    for (var i = 0; i < nYears; i++) {
+      if (i === overrideYearIdx && ovr > 0) {
+        r += ovr;
+        if (ratchet) e += ovr;
+      }
+      rev.push(r);
+      exp.push(e);
+      r = r * (1 + revG);
+      e = e * (1 + expG);
+    }
+    return { rev: rev, exp: exp, override: ovr };
+  }
+
+  function buildLinePath(values) {
+    var d = '';
+    for (var i = 0; i < values.length; i++) {
+      d += (i === 0 ? 'M' : 'L') + xScale(i) + ',' + yScale(values[i]) + ' ';
+    }
+    return d;
+  }
+
+  function buildDeficitPath(rev, exp) {
+    var segments = [];
+    var current = null;
+    for (var i = 0; i < nYears; i++) {
+      if (exp[i] > rev[i]) {
+        if (!current) current = [];
+        current.push(i);
+      } else {
+        if (current) { segments.push(current); current = null; }
+      }
+    }
+    if (current) segments.push(current);
+
+    var d = '';
+    for (var s = 0; s < segments.length; s++) {
+      var pts = segments[s];
+      if (pts.length === 0) continue;
+      d += 'M' + xScale(pts[0]) + ',' + yScale(exp[pts[0]]) + ' ';
+      for (var i = 1; i < pts.length; i++) {
+        d += 'L' + xScale(pts[i]) + ',' + yScale(exp[pts[i]]) + ' ';
+      }
+      for (var i = pts.length - 1; i >= 0; i--) {
+        d += 'L' + xScale(pts[i]) + ',' + yScale(rev[pts[i]]) + ' ';
+      }
+      d += 'Z ';
+    }
+    return d;
+  }
+
+  function render() {
+    var data = compute();
+    var rev = data.rev;
+    var exp = data.exp;
+
+    document.getElementById('dm-rev-path').setAttribute('d', buildLinePath(rev));
+    document.getElementById('dm-exp-path').setAttribute('d', buildLinePath(exp));
+
+    var fillG = document.getElementById('dm-deficit-fill');
+    fillG.innerHTML = '';
+    var fillD = buildDeficitPath(rev, exp);
+    if (fillD) {
+      var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('d', fillD);
+      path.setAttribute('class', 'dm-deficit-fill');
+      fillG.appendChild(path);
+    }
+
+    var marker = document.getElementById('dm-override-marker');
+    var markerLabel = document.getElementById('dm-override-label');
+    if (data.override > 0) {
+      var mx = xScale(overrideYearIdx);
+      marker.setAttribute('x1', mx);
+      marker.setAttribute('x2', mx);
+      marker.setAttribute('y1', marginT);
+      marker.setAttribute('y2', marginT + plotH);
+      marker.classList.remove('dm-hidden');
+      markerLabel.setAttribute('x', mx);
+      markerLabel.setAttribute('y', marginT - 4);
+      markerLabel.classList.remove('dm-hidden');
+    } else {
+      marker.classList.add('dm-hidden');
+      markerLabel.classList.add('dm-hidden');
+    }
+
+    var gap = exp[nYears - 1] - rev[nYears - 1];
+    if (gap > 0.05) {
+      gapEl.textContent = '$' + gap.toFixed(1) + 'M';
+      gapLabelEl.textContent = 'annual deficit';
+    } else if (gap < -0.05) {
+      gapEl.textContent = '$' + Math.abs(gap).toFixed(1) + 'M';
+      gapLabelEl.textContent = 'annual surplus';
+    } else {
+      gapEl.textContent = '$0.0M';
+      gapLabelEl.textContent = 'balanced';
+    }
+  }
+
+  function drawAxes() {
+    var grid = '';
+    for (var i = 0; i <= nYears - 1; i += 3) {
+      var x = xScale(i);
+      grid += '<line class="dm-grid-line" x1="' + x + '" y1="' + marginT + '" x2="' + x + '" y2="' + (marginT + plotH) + '"></line>';
+      grid += '<text class="dm-axis-label" x="' + x + '" y="' + (marginT + plotH + 16) + '" text-anchor="middle">FY' + (startYear + i) + '</text>';
+    }
+    for (var v = yMin; v <= yMax; v += 40) {
+      var y = yScale(v);
+      grid += '<line class="dm-grid-line" x1="' + marginL + '" y1="' + y + '" x2="' + (marginL + plotW) + '" y2="' + y + '"></line>';
+      grid += '<text class="dm-axis-label" x="' + (marginL - 8) + '" y="' + (y + 4) + '" text-anchor="end">$' + v + 'M</text>';
+    }
+    document.getElementById('dm-grid').innerHTML = grid;
+
+    var legend = '<g transform="translate(' + (marginL + 10) + ',' + (marginT + 10) + ')">'
+      + '<rect class="dm-legend-bg" width="150" height="44" rx="4"></rect>'
+      + '<line class="dm-legend-swatch-rev" x1="12" y1="16" x2="32" y2="16"></line>'
+      + '<text class="dm-legend-text" x="38" y="19">Revenue</text>'
+      + '<line class="dm-legend-swatch-exp" x1="12" y1="32" x2="32" y2="32"></line>'
+      + '<text class="dm-legend-text" x="38" y="35">Expenses</text>'
+      + '</g>';
+    document.getElementById('dm-legend').innerHTML = legend;
+  }
+
+  function updateLabels() {
+    revGrowthVal.textContent = parseFloat(revGrowthEl.value).toFixed(1) + '%';
+    expGrowthVal.textContent = parseFloat(expGrowthEl.value).toFixed(1) + '%';
+    overrideVal.textContent = '$' + parseFloat(overrideEl.value).toFixed(1) + 'M';
+  }
+
+  function onChange() {
+    updateLabels();
+    render();
+  }
+
+  [revGrowthEl, expGrowthEl, overrideEl].forEach(function(el) {
+    el.addEventListener('input', onChange);
+  });
+  ratchetEl.addEventListener('change', onChange);
+
+  document.querySelectorAll('.dm-presets button').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var p = btn.dataset.preset;
+      if (p === 'baseline') {
+        revGrowthEl.value = 3.5;
+        expGrowthEl.value = 4.0;
+        overrideEl.value = 0;
+        ratchetEl.checked = false;
+      } else if (p === 'no-ratchet') {
+        revGrowthEl.value = 3.5;
+        expGrowthEl.value = 4.0;
+        overrideEl.value = 10;
+        ratchetEl.checked = false;
+      } else if (p === 'ratchet') {
+        revGrowthEl.value = 3.5;
+        expGrowthEl.value = 4.0;
+        overrideEl.value = 10;
+        ratchetEl.checked = true;
+      } else if (p === 'matched') {
+        revGrowthEl.value = 3.5;
+        expGrowthEl.value = 3.5;
+        overrideEl.value = 0;
+        ratchetEl.checked = false;
+      }
+      onChange();
+    });
+  });
+
+  drawAxes();
+  updateLabels();
+  render();
+})();
+</script>


### PR DESCRIPTION
## Summary

Adds `charts/deficit_model.html`, a slope-based interactive visualization for exploring how revenue and expense lines interact under different theories of post-override behavior.

The page answers a specific question that comes up in override discussions: if higher taxes "never reduce the deficit" because "governments spend whatever they take in," is that claim testable? The chart reduces the question to a single toggle: does the expense line jump when the revenue line jumps? Users can turn the ratchet on and off and see the result at FY40 update live.

## Controls

- Revenue growth rate slider (0 to 6%)
- Expense growth rate slider (0 to 6%)
- Override amount slider ($0 to $15M, applied at FY28)
- Ratchet toggle: when on, the expense line jumps by the override amount at the same year
- Four preset buttons: Marblehead baseline, Override without ratchet, Override with ratchet, Matched slopes

## Key scenario

With default slopes (rev 3.5%, exp 4.0%):

- Baseline: $12.6M deficit at FY40
- $10M override without ratchet: ~$2.5M surplus at FY40
- $10M override with ratchet: ~$13.5M deficit at FY40, worse than baseline

This is the "you just fed the beast" visualization. The chart frames the disagreement between override supporters and opponents as an empirical question about whether the two slopes are behaviorally linked, rather than as a rhetorical dispute.

## Marblehead context in the copy

The page explains that Marblehead's FY15 to FY24 actuals (revenue ~3.7%, expenses ~4.0%, free cash draw growing from $5M to $10.2M) fit the second theory, not the ratchet. Sources are linked to `data/general_fund_budgetary_FY15-24.csv` and `data/free_cash_operating_history.csv`.

## Notes

- Page is currently orphan (not linked from navigation, homepage, or other pages). If wanted, the natural home is a link from `the-debate.html#tension-3` ("Is this a one-time reset or the start of annual asks?"). Happy to add that link as a follow-up if desired.
- Illustrative only. Starting values are round numbers ($100M each for revenue and expenses in FY25), chosen to make the lines readable, not to match Marblehead's actual FY25 budget levels. Methodology caveats are in the page's `<details>` block.
- No em-dashes, no inline `style=""` attributes on SVG or HTML elements, neutral semantic colors (sage for revenue, buoy for expense), CSS vars throughout so dark mode works.

## Test plan

- [ ] `bundle exec jekyll serve`, visit `http://localhost:4000/charts/deficit_model.html`, verify the chart renders and the sliders update live
- [ ] Click each of the four preset buttons, verify the readout values match expectations (~$12.6M deficit baseline, ~$2.5M surplus no-ratchet, ~$13.5M deficit ratchet, ~$0 matched)
- [ ] Toggle dark mode, verify colors remain legible
- [ ] Resize to mobile width (<600px), verify controls stack and chart remains readable
- [ ] Verify no horizontal scrolling on narrow viewports

https://claude.ai/code/session_01L3gSsenL9o1Rfk2vqR34g4