### PR TITLE
Add interactive tooltips to schools evidence charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -2322,7 +2322,21 @@ og_url: https://marbleheaddata.org/
       <div class="evidence-point">
         <h4>Enrollment fell 21%; the town's own count shows staffing up 9.6%</h4>
 
-        <div class="chart-wrapper">
+        <div class="chart-wrapper" data-chart-tooltip>
+          <script type="application/json" class="chart-tooltip-data">
+          {
+            "xLabels": ["FY01","FY02","FY03","FY04","FY05","FY06","FY07","FY08","FY09","FY10","FY11","FY12","FY13","FY14","FY15","FY16","FY17","FY18","FY19","FY20","FY21","FY22","FY23","FY24"],
+            "xPositions": [70,93,117,140,164,187,211,234,258,281,305,328,352,375,399,422,446,469,493,516,540,563,587,610],
+            "valueDecimals": 0,
+            "series": [
+              {
+                "name": "Student enrollment",
+                "className": "s-neutral",
+                "values": [2792,2875,2970,3003,3067,3133,3242,3212,3262,3232,3206,3172,3269,3327,3245,3208,3264,3185,3051,2963,2703,2602,2622,2617]
+              }
+            ]
+          }
+          </script>
           <svg class="chart" viewBox="0 0 740 185" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Student enrollment FY2001 to FY2024, peaking at 3,327 in FY2014 and declining to 2,617.">
             <line class="axis-base" x1="70" y1="170" x2="610" y2="170"/>
             <line class="tick" x1="66" y1="156" x2="70" y2="156"/>
@@ -2432,7 +2446,26 @@ og_url: https://marbleheaddata.org/
       <div class="evidence-point">
         <h4>Special education teachers rose as gen-ed teachers fell</h4>
 
-        <div class="chart-wrapper">
+        <div class="chart-wrapper" data-chart-tooltip>
+          <script type="application/json" class="chart-tooltip-data">
+          {
+            "xLabels": ["FY15","FY16","FY17","FY18","FY19","FY20","FY21","FY22","FY23","FY24"],
+            "xPositions": [70,130,190,250,310,370,430,490,550,610],
+            "valueDecimals": 1,
+            "series": [
+              {
+                "name": "Gen-ed teachers",
+                "className": "s-neutral",
+                "values": [210.1,215.3,216.4,210.4,222.2,231.4,223.7,209.6,193.5,184.5]
+              },
+              {
+                "name": "SPED teachers",
+                "className": "s-marblehead",
+                "values": [44.6,43.6,45.5,47.2,31.0,22.9,28.6,41.3,51.8,56.7]
+              }
+            ]
+          }
+          </script>
           <svg class="chart" viewBox="0 0 740 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Gen-ed teacher FTE declining from 210 to 185 while SPED teacher FTE rises from 45 to 57, FY15 to FY24.">
             <line class="axis-base" x1="70" y1="130" x2="610" y2="130"/>
             <!-- Y ticks: scale 0-250, 130px range, factor=0.52 -->


### PR DESCRIPTION
## Summary

Two charts in the schools question evidence sections (index.html) were static SVGs without hover/tap tooltips. Added `data-chart-tooltip` and tooltip data JSON to both:

- Evidence A: enrollment chart (FY01-FY24)
- Evidence B: gen-ed vs SPED teacher FTE chart (FY15-FY24)

## Test plan

- [ ] Hover/tap the enrollment chart in evidence A -- should show year and enrollment value
- [ ] Hover/tap the gen-ed vs SPED chart in evidence B -- should show both series values

🤖 Generated with [Claude Code](https://claude.com/claude-code)