### PR TITLE
Fix Town Explorer column sorting

### DIFF
--- a/charts/town_explorer.html
+++ b/charts/town_explorer.html
@@ -197,7 +197,7 @@ scripts: [citations]
     <thead>
       <tr>
         <th data-col="n">Municipality <span class="sa"></span></th>
-        <th data-col="rank" title="Rank within filtered set">#</th>
+        <th title="Rank within filtered set">#</th>
         <th data-col="p" title="Population">Pop <span class="sa"></span></th>
         <th data-col="ipc" title="DOR per-capita income">Income/Cap <span class="sa"></span></th>
         <th data-col="bill" title="Average single-family tax bill">Avg Bill <span class="sa"></span></th>


### PR DESCRIPTION
The # (rank) column header had `data-col=\"rank\"` but no `.sa` span, so `querySelector('.sa')` returned null and threw a TypeError on any sort click, breaking all column sorting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)