### PR TITLE
Add historical actuals to deficit dynamics model

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -109,19 +109,43 @@ title: "Deficit Dynamics Model"
     stroke: var(--c-buoy);
     stroke-width: 2.5;
   }
+  .dm-svg .dm-line-proj {
+    stroke-dasharray: 6 4;
+  }
   .dm-svg .dm-deficit-fill {
     fill: var(--c-buoy);
-    opacity: 0.15;
+    opacity: 0.12;
   }
   .dm-svg .dm-grid-line {
     stroke: var(--divider);
     stroke-width: 1;
     stroke-dasharray: 2 3;
   }
+  .dm-svg .dm-boundary {
+    stroke: var(--text-muted);
+    stroke-width: 1;
+    stroke-dasharray: 4 3;
+    opacity: 0.6;
+  }
+  .dm-svg .dm-boundary-label {
+    font-size: 9px;
+    fill: var(--text-muted);
+    font-family: inherit;
+  }
   .dm-svg .dm-axis-label {
     font-size: 11px;
     fill: var(--text-muted);
     font-family: inherit;
+  }
+  .dm-svg .dm-crossover-dot {
+    fill: var(--c-buoy);
+    opacity: 0.7;
+  }
+  .dm-svg .dm-crossover-label {
+    font-size: 9px;
+    fill: var(--c-buoy);
+    font-family: inherit;
+    font-weight: 600;
   }
   .dm-svg .dm-override-marker {
     stroke: var(--c-teal);
@@ -133,6 +157,17 @@ title: "Deficit Dynamics Model"
     fill: var(--c-teal);
     font-family: inherit;
     font-weight: 600;
+  }
+  .dm-svg .dm-end-label {
+    font-size: 10px;
+    font-family: inherit;
+    font-weight: 600;
+  }
+  .dm-svg .dm-end-label-rev {
+    fill: var(--c-sage);
+  }
+  .dm-svg .dm-end-label-exp {
+    fill: var(--c-buoy);
   }
   .dm-svg .dm-legend-bg {
     fill: var(--surface);
@@ -146,6 +181,9 @@ title: "Deficit Dynamics Model"
     stroke: var(--c-buoy);
     stroke-width: 2.5;
   }
+  .dm-svg .dm-legend-swatch-dash {
+    stroke-dasharray: 6 4;
+  }
   .dm-svg .dm-legend-text {
     font-size: 11px;
     fill: var(--text);
@@ -156,24 +194,32 @@ title: "Deficit Dynamics Model"
   }
 </style>
 
-<h1 class="h-center">Deficit Dynamics: How Two Lines Decide the Gap</h1>
-<p class="subtitle h-center">Illustrative model. Starting values are round numbers, not forecasts. Use the controls to see how theories about the expense line's behavior change what a revenue change actually does to a budget gap.</p>
+<h1 class="h-center">Deficit Dynamics: The Lines Already Crossed</h1>
+<p class="subtitle h-center">The left side is Marblehead's actual budget history from ACFRs. The right side projects forward at the growth rates you choose. The gap between the lines is what free cash and reserves have been covering since FY18.</p>
 
 <div class="dm-readout">
-  <div class="dm-readout-line">At FY40, this model shows a <strong id="dm-gap">$12.6M</strong> <span id="dm-gap-label">annual deficit</span>.</div>
+  <div class="dm-readout-line">Projected FY40 gap: <strong id="dm-gap">$12.6M</strong> <span id="dm-gap-label">annual deficit</span>.</div>
   <div class="dm-hint" id="dm-gap-hint">Move the sliders, or click a preset below the chart, to see how it changes.</div>
 </div>
 
-<svg class="dm-svg" viewBox="0 0 720 380" role="img" aria-labelledby="dm-title dm-desc">
-  <title id="dm-title">Revenue and expense lines over FY25 to FY40</title>
-  <desc id="dm-desc">Two lines showing modeled revenue and expenses over a sixteen-year window, with a shaded region highlighting any deficit where expenses exceed revenue.</desc>
+<svg class="dm-svg" viewBox="0 0 720 400" role="img" aria-labelledby="dm-title dm-desc">
+  <title id="dm-title">Revenue and expense lines, FY15 actual through FY40 projected</title>
+  <desc id="dm-desc">Two lines showing actual revenue and expenses from FY15 to FY24, then projected forward to FY40. A shaded region highlights the deficit where expenses exceed revenue, which began in FY18.</desc>
   <g id="dm-grid"></g>
-  <g id="dm-axes"></g>
   <g id="dm-deficit-fill"></g>
-  <path id="dm-rev-path" class="dm-rev-line"></path>
-  <path id="dm-exp-path" class="dm-exp-line"></path>
+  <line id="dm-boundary" class="dm-boundary"></line>
+  <text id="dm-boundary-label-l" class="dm-boundary-label"></text>
+  <text id="dm-boundary-label-r" class="dm-boundary-label"></text>
+  <path id="dm-rev-hist" class="dm-rev-line"></path>
+  <path id="dm-exp-hist" class="dm-exp-line"></path>
+  <path id="dm-rev-proj" class="dm-rev-line dm-line-proj"></path>
+  <path id="dm-exp-proj" class="dm-exp-line dm-line-proj"></path>
+  <circle id="dm-crossover-dot" class="dm-crossover-dot dm-hidden" r="4"></circle>
+  <text id="dm-crossover-label" class="dm-crossover-label dm-hidden"></text>
   <line id="dm-override-marker" class="dm-override-marker dm-hidden" x1="0" y1="0" x2="0" y2="0"></line>
   <text id="dm-override-label" class="dm-override-label dm-hidden" x="0" y="0" text-anchor="middle">Override</text>
+  <text id="dm-end-rev" class="dm-end-label dm-end-label-rev"></text>
+  <text id="dm-end-exp" class="dm-end-label dm-end-label-exp"></text>
   <g id="dm-legend"></g>
 </svg>
 
@@ -181,12 +227,12 @@ title: "Deficit Dynamics Model"
   <div class="dm-control">
     <span class="dm-control-label">Revenue growth: <span class="dm-value" id="dm-rev-growth-val">3.5%</span></span>
     <input type="range" id="dm-rev-growth" min="0" max="6" step="0.1" value="3.5">
-    <div class="dm-hint">Prop 2&frac12; caps Marblehead's levy growth at 2.5% plus new growth, typically landing around 3% to 4%.</div>
+    <div class="dm-hint">Prop 2&frac12; caps Marblehead's levy growth at 2.5% plus new growth, typically landing around 3% to 4%. Actual FY15 to FY24 average: 3.7%.</div>
   </div>
   <div class="dm-control">
     <span class="dm-control-label">Expense growth: <span class="dm-value" id="dm-exp-growth-val">4.0%</span></span>
     <input type="range" id="dm-exp-growth" min="0" max="6" step="0.1" value="4.0">
-    <div class="dm-hint">Marblehead's FY15 to FY24 actual expense growth averaged about 4.0% per year.</div>
+    <div class="dm-hint">Actual FY15 to FY24 expense growth averaged 4.0% per year.</div>
   </div>
   <div class="dm-control">
     <span class="dm-control-label">Override at FY28: <span class="dm-value" id="dm-override-val">$0.0M</span></span>
@@ -199,56 +245,60 @@ title: "Deficit Dynamics Model"
       <input type="checkbox" id="dm-ratchet">
       <div>
         <label for="dm-ratchet" class="dm-toggle-label">Ratchet: expense line jumps with the override</label>
-        <div class="dm-hint">If on, passing the override also bumps the expense line by the same amount. This is the "governments spend whatever they take in" theory stated as a slope rule.</div>
+        <div class="dm-hint">If on, passing the override also bumps the expense line by the same amount. This models the theory that governments spend whatever they take in.</div>
       </div>
     </div>
   </div>
   <div class="dm-presets">
-    <button type="button" data-preset="baseline">Marblehead baseline (no override)</button>
+    <button type="button" data-preset="baseline">Baseline (no override)</button>
     <button type="button" data-preset="no-ratchet">Override, no ratchet</button>
     <button type="button" data-preset="ratchet">Override with ratchet</button>
-    <button type="button" data-preset="matched">Matched slopes</button>
+    <button type="button" data-preset="matched">Matched slopes (3.5/3.5)</button>
   </div>
 </div>
 
 <h2>What this shows</h2>
-<p>There are two lines. One is revenue, one is expenses. If the expense line is above the revenue line, there's a gap that has to be closed by reserves, cuts, or an override. The gap shrinks when the lines converge, grows when they diverge, and stays flat when they run parallel.</p>
+<p>The two lines crossed in FY18. Since then, Marblehead's general fund expenditures have exceeded its budgetary revenues every year. The gap has been bridged by drawing down free cash, which peaked at $10.2M in FY23 before the <abbr class="g" title="Finance Committee">FinCom</abbr> flagged the reliance as unsustainable.</p>
 
-<p>The "ratchet" theory holds that when the revenue line jumps from an override, the expense line jumps right along with it, because officials adapt spending to the new ceiling. If that's true, the gap never closes. An override just produces bigger numbers on both sides and the deficit reappears, sometimes worse than before. Toggle the ratchet on to see that scenario.</p>
+<p>The right side of the chart projects both lines forward from the FY24 actuals. The sliders control the annual growth rates. At the historical averages (revenue 3.7%, expenses 4.0%), the gap widens steadily. An override shifts the revenue line up; whether that closes the gap depends on whether expenses ratchet up with it or hold their prior slope.</p>
 
-<p>The alternative theory holds that the two slopes are set by different forces. Revenue is capped at 2.5% plus new growth by Proposition 2&frac12;. Expenses are driven by health insurance rates, pension assessments, contractual wages, and other costs that are only loosely coupled to what the town collects in taxes. In that model, an override can close the gap for a while, and eventually reopens it only if the expense slope stays steeper than the revenue slope.</p>
+<p>The "ratchet" theory says that when the revenue line jumps from an override, the expense line jumps right along with it, because officials adapt spending to the new ceiling. If that's true, the gap never closes. Toggle the ratchet on to see that scenario.</p>
 
-<p>Marblehead's own FY15 to FY24 data is closer to the second model. Revenue grew at about 3.7% per year (basically the Prop 2&frac12; formula). Expenses grew at about 4.0%. That 0.3% gap compounded into a growing structural deficit, absorbed by rising free cash draws until free cash reliance was flagged as unsustainable in 2019.</p>
+<p>The alternative: the two slopes are set by different forces. Revenue is capped by <abbr class="g" title="Proposition 2&frac12;, the Massachusetts law limiting annual property tax levy increases to 2.5% plus new growth">Prop 2&frac12;</abbr>. Expenses are driven by health insurance rates, pension assessments, and contractual wages. In that model, an override can close the gap for a period, and it reopens only if the expense slope stays steeper than the revenue slope.</p>
 
 <details class="notes">
   <summary>Notes and methodology</summary>
-  <p>This is an illustrative model, not a forecast. The starting values ($100M for both revenue and expenses in FY25) are round numbers chosen to make the lines easy to read, not to match Marblehead's actual budget levels in FY25. The growth rates are applied as constant annual compounding rates, which is a simplification. Real budgets have lumpy cost spikes (GIC rate jumps, PERAC revaluations) and uneven revenue growth (new growth from development is not constant).</p>
-  <p>The "ratchet" toggle is a crude representation of the behavioral adaptation theory. It models the theory as "expense line immediately jumps by the full override amount and then resumes its prior slope." A more sophisticated version would model the expense slope itself changing (e.g., growing faster for a few years post-override). The chart uses the blunt version because it's easier to see in a graph.</p>
-  <p>Marblehead's historical figures cited in the text above are from <a href="../data/general_fund_budgetary_FY15-24.csv">general_fund_budgetary_FY15-24.csv</a> and <a href="../data/free_cash_operating_history.csv">free_cash_operating_history.csv</a>, both sourced from the town's ACFRs and Finance Committee Annual Reports.</p>
+  <p>Historical revenue and expenditure figures (FY15 to FY24) are from the General Fund Budgetary Comparison schedules in each year's <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>. These are budgetary-basis numbers, not GAAP. The data file is <a href="../data/general_fund_budgetary_FY15-24.csv">general_fund_budgetary_FY15-24.csv</a>.<sup class="cite" data-href="../data/general_fund_budgetary_FY15-24.csv" data-source="ACFRs FY15 through FY24, General Fund Budgetary Comparison schedules"></sup></p>
+  <p>Free cash draw history is from <a href="../data/free_cash_operating_history.csv">free_cash_operating_history.csv</a>, sourced from FinCom Annual Reports and ATM warrant articles.<sup class="cite" data-href="../data/free_cash_operating_history.csv" data-source="FinCom Annual Reports, ATM warrant articles"></sup></p>
+  <p>Projections use constant annual compounding, which is a simplification. Real budgets have lumpy cost spikes (<abbr class="g" title="Group Insurance Commission">GIC</abbr> rate jumps, <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr> revaluations) and uneven revenue growth.</p>
+  <p>The "ratchet" toggle models the behavioral adaptation theory as "expense line immediately jumps by the full override amount and then resumes its prior slope." A more sophisticated version would model the expense slope itself changing post-override.</p>
 </details>
 
 <script>
 (function() {
-  var startYear = 25;
-  var endYear = 40;
-  var nYears = endYear - startYear + 1;
-  var startRev = 100;
-  var startExp = 100;
-  var overrideYearIdx = 3;
+  // Historical data from general_fund_budgetary_FY15-24.csv (in $M)
+  var histRev = [71.32, 74.06, 77.06, 79.73, 82.54, 84.77, 85.39, 91.45, 95.13, 98.79];
+  var histExp = [70.50, 73.20, 76.86, 81.76, 83.27, 85.21, 85.80, 93.58, 96.83, 100.10];
+
+  var startYear = 15; // FY15
+  var endYear = 40;   // FY40
+  var nYears = endYear - startYear + 1; // 26
+  var histCount = histRev.length; // 10 (FY15-FY24)
+  var lastHistIdx = histCount - 1; // 9 = FY24
+  var overrideYearIdx = 13; // FY28
 
   var svgW = 720;
-  var svgH = 380;
+  var svgH = 400;
   var marginL = 60;
-  var marginR = 30;
-  var marginT = 20;
+  var marginR = 50;
+  var marginT = 24;
   var marginB = 60;
   var plotW = svgW - marginL - marginR;
   var plotH = svgH - marginT - marginB;
 
-  var yMin = 80;
-  var yMax = 260;
-
   function xScale(i) { return marginL + (i / (nYears - 1)) * plotW; }
+
+  var yMin, yMax;
   function yScale(v) { return marginT + (1 - (v - yMin) / (yMax - yMin)) * plotH; }
 
   var revGrowthEl = document.getElementById('dm-rev-growth');
@@ -260,7 +310,6 @@ title: "Deficit Dynamics Model"
   var overrideVal = document.getElementById('dm-override-val');
   var gapEl = document.getElementById('dm-gap');
   var gapLabelEl = document.getElementById('dm-gap-label');
-  var gapHintEl = document.getElementById('dm-gap-hint');
 
   function compute() {
     var revG = parseFloat(revGrowthEl.value) / 100;
@@ -268,27 +317,40 @@ title: "Deficit Dynamics Model"
     var ovr = parseFloat(overrideEl.value);
     var ratchet = ratchetEl.checked;
 
-    var rev = [];
-    var exp = [];
-    var r = startRev;
-    var e = startExp;
-    for (var i = 0; i < nYears; i++) {
+    var rev = histRev.slice();
+    var exp = histExp.slice();
+
+    // Project from FY24 actuals
+    var r = rev[lastHistIdx];
+    var e = exp[lastHistIdx];
+    for (var i = histCount; i < nYears; i++) {
+      r = r * (1 + revG);
+      e = e * (1 + expG);
       if (i === overrideYearIdx && ovr > 0) {
         r += ovr;
         if (ratchet) e += ovr;
       }
       rev.push(r);
       exp.push(e);
-      r = r * (1 + revG);
-      e = e * (1 + expG);
     }
     return { rev: rev, exp: exp, override: ovr };
   }
 
-  function buildLinePath(values) {
+  function computeYRange(rev, exp) {
+    var allVals = rev.concat(exp);
+    var lo = Math.min.apply(null, allVals);
+    var hi = Math.max.apply(null, allVals);
+    var pad = (hi - lo) * 0.12;
+    // Round to nice numbers
+    yMin = Math.floor((lo - pad) / 10) * 10;
+    yMax = Math.ceil((hi + pad) / 10) * 10;
+    if (yMax - yMin < 40) yMax = yMin + 40;
+  }
+
+  function buildLinePath(values, fromIdx, toIdx) {
     var d = '';
-    for (var i = 0; i < values.length; i++) {
-      d += (i === 0 ? 'M' : 'L') + xScale(i) + ',' + yScale(values[i]) + ' ';
+    for (var i = fromIdx; i <= toIdx; i++) {
+      d += (i === fromIdx ? 'M' : 'L') + xScale(i).toFixed(1) + ',' + yScale(values[i]).toFixed(1) + ' ';
     }
     return d;
   }
@@ -296,7 +358,7 @@ title: "Deficit Dynamics Model"
   function buildDeficitPath(rev, exp) {
     var segments = [];
     var current = null;
-    for (var i = 0; i < nYears; i++) {
+    for (var i = 0; i < rev.length; i++) {
       if (exp[i] > rev[i]) {
         if (!current) current = [];
         current.push(i);
@@ -310,12 +372,12 @@ title: "Deficit Dynamics Model"
     for (var s = 0; s < segments.length; s++) {
       var pts = segments[s];
       if (pts.length === 0) continue;
-      d += 'M' + xScale(pts[0]) + ',' + yScale(exp[pts[0]]) + ' ';
+      d += 'M' + xScale(pts[0]).toFixed(1) + ',' + yScale(exp[pts[0]]).toFixed(1) + ' ';
       for (var i = 1; i < pts.length; i++) {
-        d += 'L' + xScale(pts[i]) + ',' + yScale(exp[pts[i]]) + ' ';
+        d += 'L' + xScale(pts[i]).toFixed(1) + ',' + yScale(exp[pts[i]]).toFixed(1) + ' ';
       }
       for (var i = pts.length - 1; i >= 0; i--) {
-        d += 'L' + xScale(pts[i]) + ',' + yScale(rev[pts[i]]) + ' ';
+        d += 'L' + xScale(pts[i]).toFixed(1) + ',' + yScale(rev[pts[i]]).toFixed(1) + ' ';
       }
       d += 'Z ';
     }
@@ -327,9 +389,18 @@ title: "Deficit Dynamics Model"
     var rev = data.rev;
     var exp = data.exp;
 
-    document.getElementById('dm-rev-path').setAttribute('d', buildLinePath(rev));
-    document.getElementById('dm-exp-path').setAttribute('d', buildLinePath(exp));
+    computeYRange(rev, exp);
+    drawGrid();
 
+    // Historical lines (solid): FY15-FY24
+    document.getElementById('dm-rev-hist').setAttribute('d', buildLinePath(rev, 0, lastHistIdx));
+    document.getElementById('dm-exp-hist').setAttribute('d', buildLinePath(exp, 0, lastHistIdx));
+
+    // Projected lines (dashed): FY24-FY40 (overlap at FY24 for continuity)
+    document.getElementById('dm-rev-proj').setAttribute('d', buildLinePath(rev, lastHistIdx, nYears - 1));
+    document.getElementById('dm-exp-proj').setAttribute('d', buildLinePath(exp, lastHistIdx, nYears - 1));
+
+    // Deficit fill across all years
     var fillG = document.getElementById('dm-deficit-fill');
     fillG.innerHTML = '';
     var fillD = buildDeficitPath(rev, exp);
@@ -340,6 +411,46 @@ title: "Deficit Dynamics Model"
       fillG.appendChild(path);
     }
 
+    // Actual/projected boundary line
+    var bx = xScale(lastHistIdx);
+    var bndLine = document.getElementById('dm-boundary');
+    bndLine.setAttribute('x1', bx);
+    bndLine.setAttribute('x2', bx);
+    bndLine.setAttribute('y1', marginT);
+    bndLine.setAttribute('y2', marginT + plotH);
+    var lblL = document.getElementById('dm-boundary-label-l');
+    lblL.setAttribute('x', bx - 6);
+    lblL.setAttribute('y', marginT + plotH + 30);
+    lblL.setAttribute('text-anchor', 'end');
+    lblL.textContent = 'Actual \u2190';
+    var lblR = document.getElementById('dm-boundary-label-r');
+    lblR.setAttribute('x', bx + 6);
+    lblR.setAttribute('y', marginT + plotH + 30);
+    lblR.setAttribute('text-anchor', 'start');
+    lblR.textContent = '\u2192 Projected';
+
+    // Crossover annotation at FY18 (index 3)
+    var crossIdx = 3;
+    var crossDot = document.getElementById('dm-crossover-dot');
+    var crossLabel = document.getElementById('dm-crossover-label');
+    // Only show if FY18 is indeed a crossover (expenses > revenue)
+    if (exp[crossIdx] > rev[crossIdx]) {
+      var cx = xScale(crossIdx);
+      var cy = yScale((rev[crossIdx] + exp[crossIdx]) / 2);
+      crossDot.setAttribute('cx', cx);
+      crossDot.setAttribute('cy', cy);
+      crossDot.classList.remove('dm-hidden');
+      crossLabel.setAttribute('x', cx);
+      crossLabel.setAttribute('y', yScale(exp[crossIdx]) - 10);
+      crossLabel.setAttribute('text-anchor', 'middle');
+      crossLabel.textContent = 'FY18: lines cross';
+      crossLabel.classList.remove('dm-hidden');
+    } else {
+      crossDot.classList.add('dm-hidden');
+      crossLabel.classList.add('dm-hidden');
+    }
+
+    // Override marker
     var marker = document.getElementById('dm-override-marker');
     var markerLabel = document.getElementById('dm-override-label');
     if (data.override > 0) {
@@ -357,7 +468,21 @@ title: "Deficit Dynamics Model"
       markerLabel.classList.add('dm-hidden');
     }
 
-    var gap = exp[nYears - 1] - rev[nYears - 1];
+    // End labels at FY40
+    var lastIdx = nYears - 1;
+    var endRev = document.getElementById('dm-end-rev');
+    endRev.setAttribute('x', xScale(lastIdx) + 6);
+    endRev.setAttribute('y', yScale(rev[lastIdx]) + 4);
+    endRev.setAttribute('text-anchor', 'start');
+    endRev.textContent = '$' + rev[lastIdx].toFixed(0) + 'M';
+    var endExp = document.getElementById('dm-end-exp');
+    endExp.setAttribute('x', xScale(lastIdx) + 6);
+    endExp.setAttribute('y', yScale(exp[lastIdx]) + 4);
+    endExp.setAttribute('text-anchor', 'start');
+    endExp.textContent = '$' + exp[lastIdx].toFixed(0) + 'M';
+
+    // Readout
+    var gap = exp[lastIdx] - rev[lastIdx];
     if (gap > 0.05) {
       gapEl.textContent = '$' + gap.toFixed(1) + 'M';
       gapLabelEl.textContent = 'annual deficit';
@@ -370,26 +495,45 @@ title: "Deficit Dynamics Model"
     }
   }
 
-  function drawAxes() {
+  function drawGrid() {
     var grid = '';
-    for (var i = 0; i <= nYears - 1; i += 3) {
-      var x = xScale(i);
-      grid += '<line class="dm-grid-line" x1="' + x + '" y1="' + marginT + '" x2="' + x + '" y2="' + (marginT + plotH) + '"></line>';
-      grid += '<text class="dm-axis-label" x="' + x + '" y="' + (marginT + plotH + 16) + '" text-anchor="middle">FY' + (startYear + i) + '</text>';
+    // X-axis: label every 5 years, grid every 5 years
+    for (var yr = startYear; yr <= endYear; yr++) {
+      var i = yr - startYear;
+      if (yr % 5 === 0) {
+        var x = xScale(i);
+        grid += '<line class="dm-grid-line" x1="' + x + '" y1="' + marginT + '" x2="' + x + '" y2="' + (marginT + plotH) + '"></line>';
+        grid += '<text class="dm-axis-label" x="' + x + '" y="' + (marginT + plotH + 16) + '" text-anchor="middle">FY' + yr + '</text>';
+      }
     }
-    for (var v = yMin; v <= yMax; v += 40) {
+    // Also label FY15 and FY40 if not already
+    var firstX = xScale(0);
+    grid += '<text class="dm-axis-label" x="' + firstX + '" y="' + (marginT + plotH + 16) + '" text-anchor="middle">FY' + startYear + '</text>';
+    var lastX = xScale(nYears - 1);
+    grid += '<text class="dm-axis-label" x="' + lastX + '" y="' + (marginT + plotH + 16) + '" text-anchor="middle">FY' + endYear + '</text>';
+
+    // Y-axis: compute nice step
+    var range = yMax - yMin;
+    var step = range <= 80 ? 10 : range <= 160 ? 20 : 40;
+    for (var v = yMin; v <= yMax; v += step) {
       var y = yScale(v);
       grid += '<line class="dm-grid-line" x1="' + marginL + '" y1="' + y + '" x2="' + (marginL + plotW) + '" y2="' + y + '"></line>';
       grid += '<text class="dm-axis-label" x="' + (marginL - 8) + '" y="' + (y + 4) + '" text-anchor="end">$' + v + 'M</text>';
     }
     document.getElementById('dm-grid').innerHTML = grid;
 
-    var legend = '<g transform="translate(' + (marginL + 10) + ',' + (marginT + 10) + ')">'
-      + '<rect class="dm-legend-bg" width="150" height="44" rx="4"></rect>'
-      + '<line class="dm-legend-swatch-rev" x1="12" y1="16" x2="32" y2="16"></line>'
-      + '<text class="dm-legend-text" x="38" y="19">Revenue</text>'
-      + '<line class="dm-legend-swatch-exp" x1="12" y1="32" x2="32" y2="32"></line>'
-      + '<text class="dm-legend-text" x="38" y="35">Expenses</text>'
+    // Legend
+    var lx = marginL + 10;
+    var ly = marginT + 10;
+    var legend = '<g transform="translate(' + lx + ',' + ly + ')">'
+      + '<rect class="dm-legend-bg" width="180" height="60" rx="4"></rect>'
+      + '<line class="dm-legend-swatch-rev" x1="12" y1="14" x2="32" y2="14"></line>'
+      + '<text class="dm-legend-text" x="38" y="17">Revenue</text>'
+      + '<line class="dm-legend-swatch-exp" x1="12" y1="30" x2="32" y2="30"></line>'
+      + '<text class="dm-legend-text" x="38" y="33">Expenses</text>'
+      + '<line class="dm-grid-line" x1="12" y1="46" x2="22" y2="46" style="stroke-dasharray:none;stroke-width:2.5;stroke:var(--text-muted)"></line>'
+      + '<line class="dm-grid-line" x1="22" y1="46" x2="32" y2="46" style="stroke-dasharray:6 4;stroke-width:2.5;stroke:var(--text-muted)"></line>'
+      + '<text class="dm-legend-text" x="38" y="49">Solid = actual, dashed = projected</text>'
       + '</g>';
     document.getElementById('dm-legend').innerHTML = legend;
   }
@@ -438,7 +582,6 @@ title: "Deficit Dynamics Model"
     });
   });
 
-  drawAxes();
   updateLabels();
   render();
 })();


### PR DESCRIPTION
## Summary
- Adds FY15-FY24 actual ACFR budgetary data to the left side of the deficit dynamics chart
- Shows that the revenue/expense crossover already happened in FY18, not as a future hypothetical
- Solid lines for actuals, dashed lines for projections, with a boundary marker at FY24
- Projections now anchor to real FY24 values ($98.8M rev, $100.1M exp) instead of round $100M
- Annotates the FY18 crossover point and adds end-of-line dollar labels at FY40
- Dynamic y-axis scaling adjusts to the full data range

The key reframing: the deficit isn't something that might happen if two modeled lines diverge. It's something that already happened 8 years ago and has been covered by escalating free cash draws ever since.

## Test plan
- [ ] Verify chart renders with historical solid lines on left, dashed projections on right
- [ ] Confirm FY18 crossover annotation appears
- [ ] Test all four presets still work
- [ ] Test override slider shifts the projected revenue line correctly
- [ ] Test ratchet toggle behavior
- [ ] Verify deficit shading spans both historical and projected portions
- [ ] Check mobile layout (single-column controls, readable labels)
- [ ] Verify end labels at FY40 update with slider changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)