### PR TITLE
Clarify that 2.5% levy growth compounds on top of override

### DIFF
--- a/charts/override_calculator.html
+++ b/charts/override_calculator.html
@@ -121,7 +121,7 @@ title: "What the Override Costs You"
   <div id="income-panel"></div>
 
   <div class="footnotes">
-    <p><span class="footnote-marker"></span>Exact numbers from the Town Administrator's override presentation (April 8, 2026). Anchored to the average single-family assessed value of $1,291,507 and scaled linearly to your value.</p>
+    <p><span class="footnote-marker"></span>Exact numbers from the Town Administrator's override presentation (April 8, 2026). Anchored to the average single-family assessed value of $1,291,507 and scaled linearly to your value. These figures include the normal 2.5% Proposition 2&frac12; levy growth compounding on the override base during the three-year phase-in, which is why they are slightly higher than the simplified per-$1,000 rates in the April 15 presentation (e.g. $918/yr vs. $899/yr at median home for Tier 1). The 2.5% growth is state law, not a local policy choice.</p>
     <p><span class="footnote-marker"></span>Tiers are nested: Tier 2 includes Tier 1, Tier 3 includes Tiers 1 and 2. The highest passing tier sets the amount.</p>
     <p><span class="footnote-marker"></span>Year 2 and Year 3 are cumulative and permanent: each year's figure is your new total ongoing tax bill once that year's draw kicks in, not a one-time increase.</p>
     <p><span class="footnote-marker"></span>Cumulative totals assume the Year 3 rate continues unchanged. Actual future rates may differ if the town adjusts spending or if a subsequent override passes.</p>

--- a/data/changelog.html
+++ b/data/changelog.html
@@ -46,6 +46,13 @@ body_class: doc-page
         <td><a href="../charts/override_calculator.html">Override calculator</a></td>
       </tr>
       <tr>
+        <td>2.5% levy growth stacks on override</td>
+        <td>Site did not address whether normal Prop 2&frac12; growth continues on top of the override</td>
+        <td>Explicit note added: the 2.5% annual levy growth compounds from the new, higher base after an override. The April 15 presentation's simplified cost table ($899/yr Tier 1 at median) excludes this; the calculator's figures ($918/yr) include it because the town's own phase-in schedule from April 8 bakes in 2.5% compounding on portions added in earlier years.</td>
+        <td>Comparison of April 15 presentation cost table (flat rate, $0.90/$1,000) against calculator rates derived from April 8 line items. The ~2% gap is the 2.5% compounding during the three-year phase-in. Prop 2&frac12; (M.G.L. c. 59 &sect; 21C) requires this by law.</td>
+        <td><a href="../what-is-the-override.html#how-much-will-it-cost">Override cost</a>, <a href="../charts/override_calculator.html">Calculator</a></td>
+      </tr>
+      <tr>
         <td>FTE impact summary</td>
         <td>Position counts embedded in tier line items</td>
         <td>Explicit totals: 21.5 positions cut with no override; Tier 1 restores 15; Tier 2 restores 6.5 more and adds 7 new; Tier 3 adds 6 more new</td>

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -485,6 +485,8 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
     You do not pay the full override amount in year one. The cost phases in over three fiscal years, reaching its full amount only in FY29.
   </div>
 
+  <p>The normal 2.5% annual levy growth under Proposition 2&frac12; continues on top of the override. An override permanently raises the levy limit; after that, the 2.5% growth compounds from the new, higher base. This is state law (<a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter59/Section21C">M.G.L. c. 59 &sect; 21C</a>), not a local policy choice. The town's April 15 presentation shows the override cost without the 2.5% (e.g. $899/yr at median home for Tier 1). The <a href="charts/override_calculator.html">override cost calculator</a>, which uses the town's own phase-in schedule from the April 8 presentation, produces slightly higher figures ($918/yr for Tier 1) because the 2.5% compounds on portions added in earlier years of the phase-in.</p>
+
   <p>See the <a href="charts/override_calculator.html">override cost calculator</a> for year-by-year costs at different home values.</p>
 
   <h2 data-stance-section="mou-commitments" id="mou-commitments">The three-board commitment</h2>


### PR DESCRIPTION
## Summary
- **Override page**: added paragraph explaining that the normal 2.5% Prop 2½ levy growth continues from the new, higher base after an override, and that the ~2% gap between the April 15 presentation's simplified numbers ($899/yr Tier 1 at median) and the calculator ($918/yr) is the compounding
- **Calculator footnote**: updated to explain why these figures are slightly higher than the April 15 presentation's per-$1,000 rates
- **Changelog**: new row documenting the finding and its derivation

The April 15 presentation uses a flat rate that excludes 2.5% growth. The calculator uses the town's own April 8 phase-in schedule, which bakes it in. The gap between the two confirms the 2.5% stacks -- it's state law (M.G.L. c. 59 § 21C), not a local policy choice.

## Test plan
- [ ] Read the new paragraph on what-is-the-override.html for clarity
- [ ] Verify calculator footnote renders correctly
- [ ] Review changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)