### PR TITLE
Remove Balanced budget preset

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -344,7 +344,6 @@ title: "Deficit Dynamics Model"
     <button type="button" data-preset="baseline">Baseline (no override)</button>
     <button type="button" data-preset="no-ratchet">Override, no ratchet</button>
     <button type="button" data-preset="ratchet">Override with ratchet</button>
-    <button type="button" data-preset="balanced">Balanced budget (3.5/3.5)</button>
   </div>
 </div>
 
@@ -1009,11 +1008,6 @@ title: "Deficit Dynamics Model"
         expGrowthEl.value = 4.0;
         overrideEl.value = 10;
         ratchetEl.checked = true;
-      } else if (p === 'balanced') {
-        revGrowthEl.value = 3.5;
-        expGrowthEl.value = 3.5;
-        overrideEl.value = 0;
-        ratchetEl.checked = false;
       }
       onChange();
     });


### PR DESCRIPTION
## Summary
- Removes the "Balanced budget (3.5/3.5)" preset that assumed expenses could grow at the same rate as Prop 2.5-capped revenue
- Expenses grow at ~4% due to health insurance, pensions, and contracts the town doesn't control; pretending otherwise is not a real scenario
- Three remaining presets (baseline, override no ratchet, override with ratchet) all correspond to actual possibilities

## Test plan
- [ ] Only three preset buttons remain
- [ ] All three still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)