### PR TITLE
Phase override over FY27-FY29, add dynamic slider hints

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -203,10 +203,9 @@ title: "Deficit Dynamics Model"
     font-family: inherit;
     font-weight: 600;
   }
-  .dm-svg .dm-override-marker {
-    stroke: var(--c-teal);
-    stroke-width: 1.5;
-    stroke-dasharray: 5 4;
+  .dm-svg .dm-override-band {
+    fill: var(--c-teal);
+    opacity: 0.08;
   }
   .dm-svg .dm-override-label {
     font-size: 10px;
@@ -266,15 +265,6 @@ title: "Deficit Dynamics Model"
     fill: var(--text);
     font-family: inherit;
   }
-  .dm-svg .dm-legend-swatch-solid {
-    stroke: var(--text-muted);
-    stroke-width: 2.5;
-  }
-  .dm-svg .dm-legend-swatch-dash {
-    stroke: var(--text-muted);
-    stroke-width: 2.5;
-    stroke-dasharray: 6 4;
-  }
   .dm-hidden {
     display: none;
   }
@@ -307,8 +297,8 @@ title: "Deficit Dynamics Model"
   <path id="dm-exp-proj" class="dm-exp-line dm-line-proj"></path>
   <circle id="dm-crossover-dot" class="dm-crossover-dot dm-hidden" r="4"></circle>
   <text id="dm-crossover-label" class="dm-crossover-label dm-hidden"></text>
-  <line id="dm-override-marker" class="dm-override-marker dm-hidden" x1="0" y1="0" x2="0" y2="0"></line>
-  <text id="dm-override-label" class="dm-override-label dm-hidden" x="0" y="0" text-anchor="middle">Override</text>
+  <rect id="dm-override-band" class="dm-override-band dm-hidden"></rect>
+  <text id="dm-override-label" class="dm-override-label dm-hidden" text-anchor="middle"></text>
   <text id="dm-end-rev" class="dm-end-label dm-end-label-rev"></text>
   <text id="dm-end-exp" class="dm-end-label dm-end-label-exp"></text>
   <g id="dm-legend"></g>
@@ -318,17 +308,17 @@ title: "Deficit Dynamics Model"
   <div class="dm-control">
     <span class="dm-control-label">Revenue growth: <span class="dm-value" id="dm-rev-growth-val">3.5%</span></span>
     <input type="range" id="dm-rev-growth" min="0" max="6" step="0.1" value="3.5">
-    <div class="dm-hint">Prop 2&frac12; caps Marblehead's levy growth at 2.5% plus new growth, typically landing around 3% to 4%. Actual FY15 to FY24 average: 3.7%.</div>
+    <div class="dm-hint" id="dm-rev-hint">Near Marblehead's FY15 to FY24 average of 3.7%. Typical Prop 2&frac12; plus new growth.</div>
   </div>
   <div class="dm-control">
     <span class="dm-control-label">Expense growth: <span class="dm-value" id="dm-exp-growth-val">4.0%</span></span>
     <input type="range" id="dm-exp-growth" min="0" max="6" step="0.1" value="4.0">
-    <div class="dm-hint">Actual FY15 to FY24 expense growth averaged 4.0% per year.</div>
+    <div class="dm-hint" id="dm-exp-hint">FY15 to FY24 actual average. No change in trajectory.</div>
   </div>
   <div class="dm-control">
-    <span class="dm-control-label">Override at FY28: <span class="dm-value" id="dm-override-val">$0.0M</span></span>
+    <span class="dm-control-label">Override (FY27 to FY29): <span class="dm-value" id="dm-override-val">$0.0M</span></span>
     <input type="range" id="dm-override" min="0" max="15" step="0.5" value="0">
-    <div class="dm-hint">A one-time step up in the revenue line. The ballot options are $9M, $12M, or $15M.</div>
+    <div class="dm-hint">Phases in over three years per the town's proposed draw schedule. The ballot options are $9M, $12M, or $15M.</div>
   </div>
   <div class="dm-control">
     <span class="dm-control-label">&nbsp;</span>
@@ -348,7 +338,7 @@ title: "Deficit Dynamics Model"
 </div>
 
 <h2>How long does each tier last?</h2>
-<p>The three ballot questions ask voters to choose among $9M, $12M, or $15M. Below, the same growth rates from the sliders above are applied to all three tiers simultaneously, without ratchet. The question each line answers: how many years before expenses catch the boosted revenue line again?</p>
+<p>The three ballot questions ask voters to choose among $9M, $12M, or $15M. Below, the same growth rates from the sliders above are applied to all three tiers simultaneously, without ratchet. Each tier phases in over FY27 to FY29 per the town's proposed draw schedule. The question each line answers: how many years before expenses catch the boosted revenue line again?</p>
 
 <div class="dm-tier-readout" id="dm-tier-readout">
   <div><strong class="dm-tier-1-color">Tier 1 ($9M):</strong> <span id="dm-tier1-text">buys until FY33 (5 years)</span></div>
@@ -366,8 +356,8 @@ title: "Deficit Dynamics Model"
   <path id="dt-tier1" class="dm-tier-1-line"></path>
   <path id="dt-tier2" class="dm-tier-2-line"></path>
   <path id="dt-tier3" class="dm-tier-3-line"></path>
-  <line id="dt-override-marker" class="dm-override-marker dm-hidden"></line>
-  <text id="dt-override-label" class="dm-override-label dm-hidden" text-anchor="middle">Override</text>
+  <rect id="dt-override-band" class="dm-override-band dm-hidden"></rect>
+  <text id="dt-override-label" class="dm-override-label dm-hidden" text-anchor="middle"></text>
   <text id="dt-end-exp" class="dm-end-label dm-end-label-exp"></text>
   <text id="dt-end-base" class="dm-end-label dm-end-label-rev"></text>
   <text id="dt-end-t1" class="dm-end-label dm-end-label-t1"></text>
@@ -379,7 +369,7 @@ title: "Deficit Dynamics Model"
 <h2>What this shows</h2>
 <p>The two lines crossed in FY18. Since then, Marblehead's general fund expenditures have exceeded its budgetary revenues every year. The gap has been bridged by drawing down free cash, which peaked at $10.2M in FY23 before the <abbr class="g" title="Finance Committee">FinCom</abbr> flagged the reliance as unsustainable.</p>
 
-<p>The right side of the chart projects both lines forward from the FY24 actuals. The sliders control the annual growth rates. At the historical averages (revenue 3.7%, expenses 4.0%), the gap widens steadily. An override shifts the revenue line up; whether that closes the gap depends on whether expenses ratchet up with it or hold their prior slope.</p>
+<p>The right side of the chart projects both lines forward from the FY24 actuals. The sliders control the annual growth rates. At the historical averages (revenue 3.7%, expenses 4.0%), the gap widens steadily. An override shifts the revenue line up over three years (FY27 to FY29); whether that closes the gap depends on whether expenses ratchet up with it or hold their prior slope.</p>
 
 <p>The "ratchet" theory says that when the revenue line jumps from an override, the expense line jumps right along with it, because officials adapt spending to the new ceiling. If that's true, the gap never closes. Toggle the ratchet on to see that scenario.</p>
 
@@ -389,9 +379,9 @@ title: "Deficit Dynamics Model"
   <summary>Notes and methodology</summary>
   <p>Historical revenue and expenditure figures (FY15 to FY24) are from the General Fund Budgetary Comparison schedules in each year's <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>. These are budgetary-basis numbers, not GAAP. The data file is <a href="../data/general_fund_budgetary_FY15-24.csv">general_fund_budgetary_FY15-24.csv</a>.<sup class="cite" data-href="../data/general_fund_budgetary_FY15-24.csv" data-source="ACFRs FY15 through FY24, General Fund Budgetary Comparison schedules"></sup></p>
   <p>Free cash draw history is from <a href="../data/free_cash_operating_history.csv">free_cash_operating_history.csv</a>, sourced from FinCom Annual Reports and ATM warrant articles.<sup class="cite" data-href="../data/free_cash_operating_history.csv" data-source="FinCom Annual Reports, ATM warrant articles"></sup></p>
-  <p>The tax bill conversion uses $132.36 per $1M of override, derived from the town's <a href="../data/override_tax_impact_asf.csv">override tax impact data</a> for an average single-family home assessed at $1,291,507.<sup class="cite" data-href="../data/override_tax_impact_asf.csv" data-source="Override tax impact schedule, average single-family assessed value $1,291,507"></sup></p>
+  <p>The override phase-in schedule (FY27 to FY29) and tax bill conversion ($132.36 per $1M) are from the town's <a href="../data/override_tax_impact_asf.csv">override tax impact data</a> for an average single-family home assessed at $1,291,507.<sup class="cite" data-href="../data/override_tax_impact_asf.csv" data-source="Override tax impact schedule, average single-family assessed value $1,291,507"></sup></p>
   <p>Projections use constant annual compounding, which is a simplification. Real budgets have lumpy cost spikes (<abbr class="g" title="Group Insurance Commission">GIC</abbr> rate jumps, <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr> revaluations) and uneven revenue growth.</p>
-  <p>The "ratchet" toggle models the behavioral adaptation theory as "expense line immediately jumps by the full override amount and then resumes its prior slope." A more sophisticated version would model the expense slope itself changing post-override.</p>
+  <p>The "ratchet" toggle models the behavioral adaptation theory as "expense line immediately jumps by the override amount at each phase-in step and then resumes its prior slope."</p>
 </details>
 
 <script>
@@ -400,12 +390,20 @@ title: "Deficit Dynamics Model"
   var histRev = [71.32, 74.06, 77.06, 79.73, 82.54, 84.77, 85.39, 91.45, 95.13, 98.79];
   var histExp = [70.50, 73.20, 76.86, 81.76, 83.27, 85.21, 85.80, 93.58, 96.83, 100.10];
 
-  // Override tiers on the ballot
+  // Override tiers and phase-in draws from override_tax_impact_asf.csv (in $M)
   var tierAmounts = [9, 12, 15];
   var tierLabels = ['Tier 1', 'Tier 2', 'Tier 3'];
+  var tierDraws = [
+    [1.3, 4.9, 2.8],   // Tier 1: FY27, FY28, FY29
+    [2.8, 5.9, 3.3],   // Tier 2
+    [4.3, 6.2, 4.5]    // Tier 3
+  ];
+  // Phase-in year indices: FY27=12, FY28=13, FY29=14
+  var phaseYears = [12, 13, 14];
+  // Proportional phase-in for arbitrary override slider (uses Tier 3 ratios)
+  var phaseRatios = [4.3/15, 6.2/15, 4.5/15];
 
   // Tax bill conversion: $/yr per $1M, from override_tax_impact_asf.csv
-  // $15M override = $1,985.39/yr at full phase-in for avg home ($1,291,507)
   var taxFactor = 1985.39 / 15;  // 132.36
 
   var startYear = 15;
@@ -413,7 +411,7 @@ title: "Deficit Dynamics Model"
   var nYears = endYear - startYear + 1; // 26
   var histCount = histRev.length; // 10
   var lastHistIdx = histCount - 1; // 9 = FY24
-  var overrideYearIdx = 13; // FY28
+  var lastPhaseIdx = 14; // FY29
 
   var taxMode = false;
 
@@ -434,10 +432,8 @@ title: "Deficit Dynamics Model"
   var tPlotW = tsvgW - tmL - tmR;
   var tPlotH = tsvgH - tmT - tmB;
 
-  // Tier chart shows FY24-FY40 (indices lastHistIdx..nYears-1 in main arrays)
   var tIdx0 = lastHistIdx;
   var tIdxN = nYears - 1;
-  var tCount = tIdxN - tIdx0 + 1; // 17
 
   function txScale(i) { return tmL + ((i - tIdx0) / (tIdxN - tIdx0)) * tPlotW; }
 
@@ -456,6 +452,8 @@ title: "Deficit Dynamics Model"
   var gapLabelEl = document.getElementById('dm-gap-label');
   var taxBtn = document.getElementById('dm-tax-btn');
   var taxHint = document.getElementById('dm-tax-hint');
+  var revHintEl = document.getElementById('dm-rev-hint');
+  var expHintEl = document.getElementById('dm-exp-hint');
 
   // === Formatting ===
   function fmtM(v) {
@@ -464,15 +462,6 @@ title: "Deficit Dynamics Model"
       return '$' + d.toLocaleString() + '/yr';
     }
     return '$' + v.toFixed(1) + 'M';
-  }
-
-  function fmtAxis(v) {
-    if (taxMode) {
-      var d = Math.round(v * taxFactor);
-      if (d >= 10000) return '$' + (d / 1000).toFixed(0) + 'K';
-      return '$' + d.toLocaleString();
-    }
-    return '$' + v + 'M';
   }
 
   function fmtEnd(v) {
@@ -491,7 +480,6 @@ title: "Deficit Dynamics Model"
     return '$' + v.toFixed(1) + 'M';
   }
 
-  // === Nice tick step ===
   function niceStep(range) {
     var rough = range / 5;
     var mag = Math.pow(10, Math.floor(Math.log10(rough)));
@@ -502,7 +490,43 @@ title: "Deficit Dynamics Model"
     return 10 * mag;
   }
 
-  // === Compute main chart data ===
+  // === Dynamic slider hints ===
+  function updateHints() {
+    var rv = parseFloat(revGrowthEl.value);
+    var ev = parseFloat(expGrowthEl.value);
+
+    // Revenue hints
+    if (rv < 1.5) {
+      revHintEl.textContent = 'Well below Prop 2\u00BD. Would require declining assessed values or negative new growth.';
+    } else if (rv < 2.5) {
+      revHintEl.textContent = 'Prop 2\u00BD only, minimal new growth from development.';
+    } else if (rv < 3.2) {
+      revHintEl.textContent = 'Modest new growth. Below Marblehead\u2019s FY15 to FY24 average of 3.7%.';
+    } else if (rv < 4.2) {
+      revHintEl.textContent = 'Near Marblehead\u2019s FY15 to FY24 average of 3.7%. Typical Prop 2\u00BD plus new growth.';
+    } else if (rv < 5.0) {
+      revHintEl.textContent = 'Above historical average. Would need significant new development revenue.';
+    } else {
+      revHintEl.textContent = 'Well above historical. Rarely achieved without an override or major development.';
+    }
+
+    // Expense hints
+    if (ev < 2.0) {
+      expHintEl.textContent = 'Near-zero real growth. Would require freezing wages, cutting positions, or health insurance costs declining.';
+    } else if (ev < 3.0) {
+      expHintEl.textContent = 'Well below historical (4.0%). Assumes significant cost containment on health insurance and wages.';
+    } else if (ev < 3.5) {
+      expHintEl.textContent = 'Below historical. Requires holding GIC rate increases and wage growth below recent trends.';
+    } else if (ev < 4.5) {
+      expHintEl.textContent = 'Near Marblehead\u2019s FY15 to FY24 average of 4.0%. No change in cost trajectory.';
+    } else if (ev < 5.5) {
+      expHintEl.textContent = 'Above historical. Consistent with years when GIC premiums or pension assessments spiked.';
+    } else {
+      expHintEl.textContent = 'Sharp acceleration. Would require multiple simultaneous cost drivers (health insurance, pensions, wages).';
+    }
+  }
+
+  // === Compute main chart data (with phased override) ===
   function compute() {
     var revG = parseFloat(revGrowthEl.value) / 100;
     var expG = parseFloat(expGrowthEl.value) / 100;
@@ -517,9 +541,15 @@ title: "Deficit Dynamics Model"
     for (var i = histCount; i < nYears; i++) {
       r = r * (1 + revG);
       e = e * (1 + expG);
-      if (i === overrideYearIdx && ovr > 0) {
-        r += ovr;
-        if (ratchet) e += ovr;
+      // Phase in override over FY27-FY29
+      if (ovr > 0) {
+        for (var p = 0; p < phaseYears.length; p++) {
+          if (i === phaseYears[p]) {
+            var draw = ovr * phaseRatios[p];
+            r += draw;
+            if (ratchet) e += draw;
+          }
+        }
       }
       rev.push(r);
       exp.push(e);
@@ -527,12 +557,11 @@ title: "Deficit Dynamics Model"
     return { rev: rev, exp: exp, override: ovr };
   }
 
-  // === Compute tier chart data ===
+  // === Compute tier chart data (with exact CSV draws) ===
   function computeTiers() {
     var revG = parseFloat(revGrowthEl.value) / 100;
     var expG = parseFloat(expGrowthEl.value) / 100;
 
-    // Baseline (no override)
     var baseRev = histRev.slice();
     var exp = histExp.slice();
     var r = baseRev[lastHistIdx];
@@ -544,14 +573,16 @@ title: "Deficit Dynamics Model"
       exp.push(e);
     }
 
-    // Three tier revenue lines
     var tierRevs = [];
     for (var t = 0; t < tierAmounts.length; t++) {
       var tr = histRev.slice();
       var rv = tr[lastHistIdx];
       for (var i = histCount; i < nYears; i++) {
         rv = rv * (1 + revG);
-        if (i === overrideYearIdx) rv += tierAmounts[t];
+        // Apply exact draws from CSV at each phase year
+        for (var p = 0; p < phaseYears.length; p++) {
+          if (i === phaseYears[p]) rv += tierDraws[t][p];
+        }
         tr.push(rv);
       }
       tierRevs.push(tr);
@@ -560,13 +591,12 @@ title: "Deficit Dynamics Model"
     return { baseRev: baseRev, exp: exp, tierRevs: tierRevs };
   }
 
-  // === Find when expenses catch the tier revenue line ===
+  // Find when expenses catch the tier revenue line (after full phase-in)
   function findRunout(tierRev, exp) {
-    // After override at FY28, find first year where exp >= tierRev
-    for (var i = overrideYearIdx + 1; i < nYears; i++) {
+    for (var i = lastPhaseIdx + 1; i < nYears; i++) {
       if (exp[i] >= tierRev[i]) return startYear + i;
     }
-    return null; // doesn't cross within FY40
+    return null;
   }
 
   // === Path builders ===
@@ -590,24 +620,18 @@ title: "Deficit Dynamics Model"
       }
     }
     if (current) segments.push(current);
-
     var d = '';
     for (var s = 0; s < segments.length; s++) {
       var pts = segments[s];
       if (pts.length === 0) continue;
       d += 'M' + xFn(pts[0]).toFixed(1) + ',' + yFn(exp[pts[0]]).toFixed(1) + ' ';
-      for (var i = 1; i < pts.length; i++) {
-        d += 'L' + xFn(pts[i]).toFixed(1) + ',' + yFn(exp[pts[i]]).toFixed(1) + ' ';
-      }
-      for (var i = pts.length - 1; i >= 0; i--) {
-        d += 'L' + xFn(pts[i]).toFixed(1) + ',' + yFn(rev[pts[i]]).toFixed(1) + ' ';
-      }
+      for (var i = 1; i < pts.length; i++) d += 'L' + xFn(pts[i]).toFixed(1) + ',' + yFn(exp[pts[i]]).toFixed(1) + ' ';
+      for (var i = pts.length - 1; i >= 0; i--) d += 'L' + xFn(pts[i]).toFixed(1) + ',' + yFn(rev[pts[i]]).toFixed(1) + ' ';
       d += 'Z ';
     }
     return d;
   }
 
-  // Build a surplus fill between tier rev (above) and exp (below)
   function buildSurplusPath(tierRev, exp, fromIdx, toIdx, xFn, yFn) {
     var segments = [];
     var current = null;
@@ -620,18 +644,13 @@ title: "Deficit Dynamics Model"
       }
     }
     if (current) segments.push(current);
-
     var d = '';
     for (var s = 0; s < segments.length; s++) {
       var pts = segments[s];
       if (pts.length === 0) continue;
       d += 'M' + xFn(pts[0]).toFixed(1) + ',' + yFn(tierRev[pts[0]]).toFixed(1) + ' ';
-      for (var i = 1; i < pts.length; i++) {
-        d += 'L' + xFn(pts[i]).toFixed(1) + ',' + yFn(tierRev[pts[i]]).toFixed(1) + ' ';
-      }
-      for (var i = pts.length - 1; i >= 0; i--) {
-        d += 'L' + xFn(pts[i]).toFixed(1) + ',' + yFn(exp[pts[i]]).toFixed(1) + ' ';
-      }
+      for (var i = 1; i < pts.length; i++) d += 'L' + xFn(pts[i]).toFixed(1) + ',' + yFn(tierRev[pts[i]]).toFixed(1) + ' ';
+      for (var i = pts.length - 1; i >= 0; i--) d += 'L' + xFn(pts[i]).toFixed(1) + ',' + yFn(exp[pts[i]]).toFixed(1) + ' ';
       d += 'Z ';
     }
     return d;
@@ -645,6 +664,26 @@ title: "Deficit Dynamics Model"
     yMin = Math.floor((lo - pad) / 10) * 10;
     yMax = Math.ceil((hi + pad) / 10) * 10;
     if (yMax - yMin < 40) yMax = yMin + 40;
+  }
+
+  // === Render override band (FY27-FY29) ===
+  function renderBand(bandEl, labelEl, xFn, yT, pH, override) {
+    if (override > 0) {
+      var x1 = xFn(phaseYears[0]);
+      var x2 = xFn(phaseYears[2]);
+      bandEl.setAttribute('x', x1);
+      bandEl.setAttribute('y', yT);
+      bandEl.setAttribute('width', x2 - x1);
+      bandEl.setAttribute('height', pH);
+      bandEl.classList.remove('dm-hidden');
+      labelEl.setAttribute('x', (x1 + x2) / 2);
+      labelEl.setAttribute('y', yT - 4);
+      labelEl.textContent = 'Phase-in FY27\u201329';
+      labelEl.classList.remove('dm-hidden');
+    } else {
+      bandEl.classList.add('dm-hidden');
+      labelEl.classList.add('dm-hidden');
+    }
   }
 
   // === Render main chart ===
@@ -661,7 +700,6 @@ title: "Deficit Dynamics Model"
     document.getElementById('dm-rev-proj').setAttribute('d', buildPath(rev, lastHistIdx, nYears - 1, xScale, yScale));
     document.getElementById('dm-exp-proj').setAttribute('d', buildPath(exp, lastHistIdx, nYears - 1, xScale, yScale));
 
-    // Deficit fill
     var fillG = document.getElementById('dm-deficit-fill');
     fillG.innerHTML = '';
     var fillD = buildDeficitPath(rev, exp, 0, nYears - 1, xScale, yScale);
@@ -686,7 +724,7 @@ title: "Deficit Dynamics Model"
     lblR.setAttribute('text-anchor', 'start');
     lblR.textContent = '\u2192 Projected';
 
-    // Crossover annotation at FY18 (index 3)
+    // Crossover annotation at FY18
     var crossIdx = 3;
     var crossDot = document.getElementById('dm-crossover-dot');
     var crossLabel = document.getElementById('dm-crossover-label');
@@ -705,20 +743,12 @@ title: "Deficit Dynamics Model"
       crossLabel.classList.add('dm-hidden');
     }
 
-    // Override marker
-    var marker = document.getElementById('dm-override-marker');
-    var markerLabel = document.getElementById('dm-override-label');
-    if (data.override > 0) {
-      var mx = xScale(overrideYearIdx);
-      marker.setAttribute('x1', mx); marker.setAttribute('x2', mx);
-      marker.setAttribute('y1', mT); marker.setAttribute('y2', mT + plotH);
-      marker.classList.remove('dm-hidden');
-      markerLabel.setAttribute('x', mx); markerLabel.setAttribute('y', mT - 4);
-      markerLabel.classList.remove('dm-hidden');
-    } else {
-      marker.classList.add('dm-hidden');
-      markerLabel.classList.add('dm-hidden');
-    }
+    // Override band
+    renderBand(
+      document.getElementById('dm-override-band'),
+      document.getElementById('dm-override-label'),
+      xScale, mT, plotH, data.override
+    );
 
     // End labels
     var li = nYears - 1;
@@ -757,8 +787,6 @@ title: "Deficit Dynamics Model"
         grid += '<text class="dm-axis-label" x="' + x + '" y="' + (mT + plotH + 16) + '" text-anchor="middle">FY' + yr + '</text>';
       }
     }
-
-    // Y-axis ticks
     var range = yMax - yMin;
     if (taxMode) {
       var taxLo = yMin * taxFactor;
@@ -781,7 +809,6 @@ title: "Deficit Dynamics Model"
     }
     document.getElementById('dm-grid').innerHTML = grid;
 
-    // Legend
     var lx = mL + 10, ly = mT + 10;
     var legend = '<g transform="translate(' + lx + ',' + ly + ')">'
       + '<rect class="dm-legend-bg" width="110" height="40" rx="4"></rect>'
@@ -800,7 +827,6 @@ title: "Deficit Dynamics Model"
     var baseRev = td.baseRev;
     var tierRevs = td.tierRevs;
 
-    // Compute y range from all tier + exp values in the FY24-FY40 window
     var allVals = [];
     for (var i = tIdx0; i <= tIdxN; i++) {
       allVals.push(exp[i], baseRev[i]);
@@ -815,7 +841,6 @@ title: "Deficit Dynamics Model"
 
     drawTierGrid();
 
-    // Draw lines
     document.getElementById('dt-exp').setAttribute('d', buildPath(exp, tIdx0, tIdxN, txScale, tyScale));
     document.getElementById('dt-rev-base').setAttribute('d', buildPath(baseRev, tIdx0, tIdxN, txScale, tyScale));
 
@@ -825,7 +850,6 @@ title: "Deficit Dynamics Model"
       document.getElementById(tierPathIds[t]).setAttribute('d', buildPath(tierRevs[t], tIdx0, tIdxN, txScale, tyScale));
     }
 
-    // Surplus fills (tier revenue above expenses)
     var fillG = document.getElementById('dt-fills');
     fillG.innerHTML = '';
     for (var t = tierRevs.length - 1; t >= 0; t--) {
@@ -837,7 +861,6 @@ title: "Deficit Dynamics Model"
         fillG.appendChild(path);
       }
     }
-    // Also show deficit fill where baseline rev < exp (to show the problem)
     var dfp = buildDeficitPath(baseRev, exp, tIdx0, tIdxN, txScale, tyScale);
     if (dfp) {
       var dp = document.createElementNS('http://www.w3.org/2000/svg', 'path');
@@ -846,20 +869,16 @@ title: "Deficit Dynamics Model"
       fillG.appendChild(dp);
     }
 
-    // Override marker at FY28
-    var tMarker = document.getElementById('dt-override-marker');
-    var tMarkerLabel = document.getElementById('dt-override-label');
-    var tmx = txScale(overrideYearIdx);
-    tMarker.setAttribute('x1', tmx); tMarker.setAttribute('x2', tmx);
-    tMarker.setAttribute('y1', tmT); tMarker.setAttribute('y2', tmT + tPlotH);
-    tMarker.classList.remove('dm-hidden');
-    tMarkerLabel.setAttribute('x', tmx); tMarkerLabel.setAttribute('y', tmT - 4);
-    tMarkerLabel.classList.remove('dm-hidden');
+    // Phase-in band
+    renderBand(
+      document.getElementById('dt-override-band'),
+      document.getElementById('dt-override-label'),
+      txScale, tmT, tPlotH, 1  // always show in tier chart
+    );
 
     // End labels
     var endIds = ['dt-end-exp', 'dt-end-base', 'dt-end-t1', 'dt-end-t2', 'dt-end-t3'];
     var endVals = [exp[tIdxN], baseRev[tIdxN], tierRevs[0][tIdxN], tierRevs[1][tIdxN], tierRevs[2][tIdxN]];
-    // Sort by value to stagger labels that are close together
     var endItems = endIds.map(function(id, j) { return { id: id, val: endVals[j] }; });
     endItems.sort(function(a, b) { return b.val - a.val; });
     var lastY = -999;
@@ -874,22 +893,21 @@ title: "Deficit Dynamics Model"
       lastY = rawY;
     }
 
-    // Tier readout: "buys until FY__"
+    // Tier readout
     var tierTextEls = ['dm-tier1-text', 'dm-tier2-text', 'dm-tier3-text'];
     for (var t = 0; t < tierRevs.length; t++) {
       var runout = findRunout(tierRevs[t], exp);
       var el = document.getElementById(tierTextEls[t]);
       var tierCost = taxMode ? ' (' + fmtOverride(tierAmounts[t]) + ')' : '';
       if (runout !== null) {
-        var yrsFromOverride = runout - (startYear + overrideYearIdx);
-        el.textContent = 'buys until FY' + runout + ' (' + yrsFromOverride + ' years)' + tierCost;
+        var yrsFromPhaseEnd = runout - (startYear + lastPhaseIdx);
+        el.textContent = 'buys until FY' + runout + ' (' + yrsFromPhaseEnd + ' years after full phase-in)' + tierCost;
       } else {
-        var yrsToEnd = endYear - (startYear + overrideYearIdx);
-        el.textContent = 'lasts beyond FY' + endYear + ' (' + yrsToEnd + '+ years)' + tierCost;
+        var yrsToEnd = endYear - (startYear + lastPhaseIdx);
+        el.textContent = 'lasts beyond FY' + endYear + ' (' + yrsToEnd + '+ years after full phase-in)' + tierCost;
       }
     }
 
-    // Update tier readout labels with tax amounts
     if (taxMode) {
       for (var t = 0; t < tierAmounts.length; t++) {
         var labelEl = document.querySelector('.dm-tier-readout div:nth-child(' + (t + 1) + ') strong');
@@ -906,21 +924,17 @@ title: "Deficit Dynamics Model"
   function drawTierGrid() {
     var grid = '';
     for (var yr = 25; yr <= endYear; yr++) {
-      var i = yr - startYear + startYear; // index in main array
-      // Actually: main array index for FYxx = xx - startYear
       var mi = yr - startYear;
-      if (yr % 5 === 0 || yr === 24 || yr === endYear) {
+      if (yr % 5 === 0 || yr === endYear) {
         var x = txScale(mi);
         grid += '<line class="dm-grid-line" x1="' + x + '" y1="' + tmT + '" x2="' + x + '" y2="' + (tmT + tPlotH) + '"></line>';
         grid += '<text class="dm-axis-label" x="' + x + '" y="' + (tmT + tPlotH + 16) + '" text-anchor="middle">FY' + yr + '</text>';
       }
     }
-    // Always label FY24 start
     var fx24 = txScale(tIdx0);
     grid += '<line class="dm-grid-line" x1="' + fx24 + '" y1="' + tmT + '" x2="' + fx24 + '" y2="' + (tmT + tPlotH) + '"></line>';
     grid += '<text class="dm-axis-label" x="' + fx24 + '" y="' + (tmT + tPlotH + 16) + '" text-anchor="middle">FY24</text>';
 
-    // Y-axis
     if (taxMode) {
       var taxLo = tyMin * taxFactor;
       var taxHi = tyMax * taxFactor;
@@ -943,7 +957,6 @@ title: "Deficit Dynamics Model"
     }
     document.getElementById('dt-grid').innerHTML = grid;
 
-    // Legend
     var lx = tmL + 10, ly = tmT + 10;
     var legend = '<g transform="translate(' + lx + ',' + ly + ')">'
       + '<rect class="dm-legend-bg" width="130" height="68" rx="4"></rect>'
@@ -968,6 +981,7 @@ title: "Deficit Dynamics Model"
 
   function onChange() {
     updateLabels();
+    updateHints();
     renderMain();
     renderTiers();
   }
@@ -977,16 +991,13 @@ title: "Deficit Dynamics Model"
   });
   ratchetEl.addEventListener('change', onChange);
 
-  // Tax toggle
   taxBtn.addEventListener('click', function() {
     taxMode = !taxMode;
     taxBtn.textContent = taxMode ? 'Show as town budget ($M)' : 'Show as annual tax bill per average home';
     taxBtn.classList.toggle('dm-active', taxMode);
-    taxHint.style.display = taxMode ? '' : '';
     onChange();
   });
 
-  // Presets
   document.querySelectorAll('.dm-presets button').forEach(function(btn) {
     btn.addEventListener('click', function() {
       var p = btn.dataset.preset;
@@ -1010,8 +1021,8 @@ title: "Deficit Dynamics Model"
     });
   });
 
-  // Initial render
   updateLabels();
+  updateHints();
   renderMain();
   renderTiers();
 })();


### PR DESCRIPTION
## Summary
- **Phased override**: Override now draws down over FY27-FY29 matching the actual schedule from `override_tax_impact_asf.csv` instead of dumping the full amount at FY28. Tier chart uses exact CSV values ($1.3M/$4.9M/$2.8M for Tier 1, etc.). Main chart uses proportional ratios for the arbitrary slider. Override marker becomes a shaded band spanning FY27-FY29.
- **Dynamic slider hints**: Hint text below each growth rate slider updates as you drag, explaining what the percentage implies in practice:
  - Revenue at 2.0%: "Prop 2½ only, minimal new growth from development"
  - Revenue at 5.0%: "Well above historical. Rarely achieved without an override or major development"
  - Expenses at 3.0%: "Well below historical (4.0%). Assumes significant cost containment on health insurance and wages"
  - Expenses at 4.0%: "FY15 to FY24 actual average. No change in cost trajectory"
  - Expenses at 5.5%: "Above historical. Consistent with years when GIC premiums or pension assessments spiked"

## Test plan
- [ ] Override phases in visibly as three steps (FY27, FY28, FY29) rather than one jump
- [ ] Shaded band appears from FY27-FY29 when override > 0
- [ ] Tier chart uses exact CSV draw amounts (verify Tier 3: $4.3M + $6.2M + $4.5M = $15M)
- [ ] Revenue slider hint text updates as you drag through different ranges
- [ ] Expense slider hint text updates as you drag through different ranges
- [ ] "Buys until" readout says "years after full phase-in" (counting from FY29, not FY28)
- [ ] Ratchet mode phases in expense bumps over the same three years
- [ ] Tax bill toggle still works with phased override

🤖 Generated with [Claude Code](https://claude.com/claude-code)