### PR TITLE
Add takeaway callouts to key conclusions on consolidation page

### DIFF
--- a/town-school-admin.html
+++ b/town-school-admin.html
@@ -48,7 +48,9 @@ og_url: https://marbleheaddata.org/town-school-admin.html
     <li><a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleXII/Chapter71/Section59B"><abbr class="g" title="Massachusetts General Laws">MGL</abbr> c.71 &sect;59B</a> vests hiring authority in the superintendent, not the town administrator.</li>
   </ul>
 
-  <p>A town cannot unilaterally merge school administrative functions into town departments. The school committee must consent, because only the school committee can redirect its own appropriated funds. This is not a Marblehead quirk. It is how every municipality in Massachusetts works.</p>
+  <div class="takeaway takeaway--neutral">
+    <p>A town cannot unilaterally merge school administrative functions into town departments. The school committee must consent, because only the school committee can redirect its own appropriated funds. This is not a Marblehead quirk. It is how every municipality in Massachusetts works.</p>
+  </div>
 
   <h2 id="the-overlap">What the overlap looks like</h2>
 
@@ -155,7 +157,9 @@ og_url: https://marbleheaddata.org/town-school-admin.html
     <li>DLS recommended fixing the existing mergers before attempting further consolidation.</li>
   </ul>
 
-  <p>No Massachusetts town has been widely cited as having completed a clean merger of town and school administrative functions. The state's Efficiency and Regionalization grant program has funded planning studies for inter-town shared services (dispatch, public health, regional IT), but intra-municipal town/school consolidation remains rare.</p>
+  <div class="takeaway takeaway--neutral">
+    <p>No Massachusetts town has been widely cited as having completed a clean merger of town and school administrative functions. The state's Efficiency and Regionalization grant program has funded planning studies for inter-town shared services (dispatch, public health, regional IT), but intra-municipal town/school consolidation remains rare.</p>
+  </div>
 
   <h2 id="honest-scale">Honest scale</h2>
 
@@ -186,7 +190,9 @@ og_url: https://marbleheaddata.org/town-school-admin.html
     <li><strong>Director of Community Development and Planning</strong> ($128,000). Created at May 2024 Town Meeting (vote: 373 to 360). Consolidated the prior standalone Town Planner function and secured $1.9 million in grants in under two years. Eliminated in FY27.<sup class="cite" data-href="https://marbleheadcurrent.org/2024/05/08/town-meeting-approves-fee-hikes-creates-new-community-development-department/" data-source="Marblehead Current, &quot;Town Meeting approves fee hikes, creates new community development department&quot; (May 8, 2024)"></sup></li>
   </ul>
 
-  <p>Both positions are real. Neither exists in the FY27 budget. Whether creating them in 2024 was the right call is a legitimate question. But citing them as current spending is not accurate as of the proposed FY27 budget.</p>
+  <div class="takeaway takeaway--neutral">
+    <p>Both positions are real. Neither exists in the FY27 budget. Whether creating them in 2024 was the right call is a legitimate question. But citing them as current spending is not accurate as of the proposed FY27 budget.</p>
+  </div>
 
   <div class="read-next">
     <div class="read-next-label">Related</div>


### PR DESCRIPTION
## Summary

Three key conclusions on town-school-admin.html now use `takeaway--neutral` callout boxes (the same component used on inside-school-staffing.html) so they visually break out of the surrounding prose:

1. "A town cannot unilaterally merge..." (after the legal structure section)
2. "No Massachusetts town has completed a clean merger..." (after the precedent section)
3. "Both positions are real. Neither exists in the FY27 budget." (after positions named)

## Test plan

- [ ] Verify the three callout boxes render with the left border and tinted background
- [ ] Check mobile rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)