### PR TITLE
Wrap bare acronyms in abbr tags on consolidation page

### DIFF
--- a/town-school-admin.html
+++ b/town-school-admin.html
@@ -7,7 +7,7 @@ og_url: https://marbleheaddata.org/town-school-admin.html
 ---
 <h1>Why two sets of departments?</h1>
 
-  <p class="page-lead">Marblehead runs parallel administrative operations for town government and schools. Each side has its own HR, finance, IT, and facilities staff. This page explains why, maps the actual overlap, and sizes the realistic savings.</p>
+  <p class="page-lead">Marblehead runs parallel administrative operations for town government and schools. Each side has its own HR, finance, IT, and facilities staff. The parallel structure is required by state law, not a local policy choice.</p>
 
   <div class="key-stats">
     <div class="key-stat">
@@ -68,7 +68,7 @@ og_url: https://marbleheaddata.org/town-school-admin.html
       <div class="comparison-side">
         <div class="comparison-side-label">Schools</div>
         <strong>1 staff</strong><br>
-        HR coordinator. Handles teacher licensing, DESE reporting, school-specific contract compliance, and onboarding across 7 buildings.
+        HR coordinator. Handles teacher licensing, <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> reporting, school-specific contract compliance, and onboarding across 7 buildings.
       </div>
     </div>
 
@@ -104,13 +104,13 @@ og_url: https://marbleheaddata.org/town-school-admin.html
       <div class="comparison-label">Facilities</div>
       <div class="comparison-side">
         <div class="comparison-side-label">Town</div>
-        <strong>DPW + Public Buildings</strong><br>
+        <strong><abbr class="g" title="Department of Public Works">DPW</abbr> + Public Buildings</strong><br>
         Maintains public ways, storm sewers, shade trees, vehicle fleet, and town buildings.
       </div>
       <div class="comparison-side">
         <div class="comparison-side-label">Schools</div>
         <strong>Director + coordinator</strong><br>
-        Maintenance, repair, and cleaning of all school buildings, plus transportation operations (METCO, internal routes, athletics).
+        Maintenance, repair, and cleaning of all school buildings, plus transportation operations (<abbr class="g" title="Metropolitan Council for Educational Opportunity">METCO</abbr>, internal routes, athletics).
       </div>
     </div>
 
@@ -152,9 +152,9 @@ og_url: https://marbleheaddata.org/town-school-admin.html
 
   <ul>
     <li>Arlington had already consolidated IT and payroll between town and school (voted at 2007 Town Meeting).</li>
-    <li>DLS found those mergers had <strong>unresolved service-quality issues</strong>. The school side felt its needs were not being met.</li>
-    <li>DLS concluded: "Arlington's current management structure is not well suited to a merged department since finance officials act outside of the manager's purview."</li>
-    <li>DLS recommended fixing the existing mergers before attempting further consolidation.</li>
+    <li><abbr class="g" title="Division of Local Services">DLS</abbr> found those mergers had <strong>unresolved service-quality issues</strong>. The school side felt its needs were not being met.</li>
+    <li><abbr class="g" title="Division of Local Services">DLS</abbr> concluded: "Arlington's current management structure is not well suited to a merged department since finance officials act outside of the manager's purview."</li>
+    <li><abbr class="g" title="Division of Local Services">DLS</abbr> recommended fixing the existing mergers before attempting further consolidation.</li>
   </ul>
 
   <div class="takeaway takeaway--neutral">


### PR DESCRIPTION
## Summary

- DESE, METCO, DPW, DLS now have `<abbr class="g">` tooltips so they show their full names on hover
- Page lead rewritten to lead with a claim instead of meta-narration

## Test plan

- [ ] Hover over DESE, METCO, DPW, DLS on the page to see tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)