### PR TITLE
Fix sort direction: new growth defaults high-first

### DIFF
--- a/charts/town_explorer.html
+++ b/charts/town_explorer.html
@@ -607,9 +607,11 @@ scripts: [citations]
       b.classList.toggle('active', b.getAttribute('data-sort') === sortCol);
     });
   }
+  // Columns where high = notable (default descending)
+  var DESC_DEFAULT = { p: true, ipc: true, epc: true, ng: true };
   function applySort(col) {
     if (sortCol === col) { sortAsc = !sortAsc; }
-    else { sortCol = col; sortAsc = true; }
+    else { sortCol = col; sortAsc = !DESC_DEFAULT[col]; }
     headers.forEach(function (h) { h.classList.remove('sorted'); h.querySelector('.sa').textContent = ''; });
     // Sync column header highlight
     headers.forEach(function (h) {


### PR DESCRIPTION
New construction, population, income, and property wealth now default to high-to-low sorting (#1 = most). Tax rate, bill, bill/income stay low-to-high (#1 = lowest). Previously all columns defaulted to ascending, which made Marblehead #237 of 239 on new growth display as "#3" (3rd lowest) -- technically correct but confusing when the bar chart shows it on the far left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)