### PR TITLE
Fix spacing between bullet lists and takeaway callouts

### DIFF
--- a/town-school-admin.html
+++ b/town-school-admin.html
@@ -211,6 +211,7 @@ og_url: https://marbleheaddata.org/town-school-admin.html
   </div>
 
 <style>
+  ul + .takeaway, ol + .takeaway { margin-top: 20px; }
   .comparison-grid {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary

Adds `ul + .takeaway, ol + .takeaway { margin-top: 20px; }` so takeaway boxes don't sit flush against the preceding list.

## Test plan

- [ ] Check spacing between the statute list and the "cannot unilaterally merge" callout
- [ ] Check spacing between the Arlington bullets and the "no MA town" callout
- [ ] Check spacing between the named positions list and the "both eliminated" callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)