### PR TITLE
Default homeowner share sort to high-first

### DIFF
--- a/charts/town_explorer.html
+++ b/charts/town_explorer.html
@@ -608,7 +608,7 @@ scripts: [citations]
     });
   }
   // Columns where high = notable (default descending)
-  var DESC_DEFAULT = { p: true, ipc: true, epc: true, ng: true };
+  var DESC_DEFAULT = { p: true, ipc: true, epc: true, ng: true, rpct: true };
   function applySort(col) {
     if (sortCol === col) { sortAsc = !sortAsc; }
     else { sortCol = col; sortAsc = !DESC_DEFAULT[col]; }


### PR DESCRIPTION
High residential share is the notable/constraining position (Marblehead 95.5%). #1 should be most residential-dependent, not least.