### PR TITLE
Add "What has the town already done to save?" explainer page

### DIFF
--- a/data/savings_measures_compiled.md
+++ b/data/savings_measures_compiled.md
@@ -1,0 +1,261 @@
+# What Has the Town Already Done to Save?
+
+Compiled April 2026 from FinCom Annual Reports (FY17, FY20, FY22, FY23, FY26),
+budget appropriations tables, news reporting from March 2026 budget hearings,
+and Select Board/FinCom meeting coverage.
+
+This document assembles the factual record of cost-control and savings measures
+the town has taken before asking voters for an override. No single official
+presentation has compiled this list; the data is scattered across multiple
+years of budget documents and public meetings.
+
+---
+
+## 1. Free Cash Discipline
+
+The town reduced its reliance on free cash (one-time reserves) to balance
+the operating budget after peaking in FY23.
+
+| Fiscal Year | Free Cash to Operating Budget | Source |
+|-------------|------------------------------|--------|
+| FY17 | $6,025,000 | 2016 FinCom Report, Art 28 |
+| FY22 | $8,950,000 | 2021 FinCom Report, Art 30 |
+| FY23 | $10,200,000 | 2022 FinCom Report, Art 29 |
+| FY24 | $8,000,000 | 2023 FinCom Report |
+| FY25 | $5,500,000 | 2025 FinCom Report, Art 19 |
+| FY26 | $7,000,000 | 2026 FinCom Report, Art 18 |
+| FY27 | $5,000,000 | 2026 State of the Town (proposed) |
+
+Kezer (TA, arrived mid-FY23): "When I rolled in three and a half years ago,
+we were using $10 million to supplement the operating budget."
+Source: Marblehead Independent, March 2026
+
+Note: FY26 is up $1.5M from FY25 due to collective bargaining settlements
+and revised local receipt estimates. The 2026 FinCom Report describes both
+the free cash increase and the revised receipts as "one-time adjustments."
+
+---
+
+## 2. Staffing Attrition (Not Replaced)
+
+Municipal workforce declined from 199 positions to approximately 190 between
+2018 and 2026 (Kezer, March 2026 budget hearing). Specific reductions
+documented in public meetings and budget tables:
+
+**Police Department**
+- Reduced from 32 sworn officers to 30 (FY24-FY26)
+- School Resource Officer pulled back to patrol duty
+- 1 full-time officer defunded through five years of level-funding
+- Source: Erin Noonan (Select Board), late 2025; March 2026 budget hearing
+
+**Department of Public Works**
+- Workforce reduced from 30+ workers to 19 over multiple years
+- Lost 3 FTEs through level-funding: heavy equipment operator, working
+  foreman, general laborer
+- Source: Erin Noonan (Select Board), late 2025; Marblehead Independent
+
+**Fire Department**
+- "Several firefighter positions" defunded through level-funding
+- Vacancy unfilled for one year, forcing 96-hour shifts
+- Source: Erin Noonan; March 2026 budget hearing testimony
+
+**Community Development & Planning**
+- Director position (Brendan Callahan's role) eliminated in FY27 budget
+- Reduced from 4-person office to 1 vacant planner slot plus clerk
+- Despite cuts, department had secured $1.9M in grants within two years
+- Source: March 2026 Select Board budget hearing
+
+---
+
+## 3. Departmental Consolidation
+
+**Engineer Department eliminated (FY26)**
+- Budget zeroed out: -$210,559 (salaries $199,914 + expense $10,645)
+- Functions absorbed into Department of Public Works
+- Source: 2026 FinCom Report, Table of Estimated Appropriations
+
+**Highway, Drain, and Tree budgets consolidated (FY22)**
+- Previously three separate budget lines; merged under Highway (DPW)
+- Note in FY23 budget table: "Highway, Drain and Tree budgets have been
+  consolidated in FY22"
+- Source: 2022 FinCom Report, Table of Estimated Appropriations
+
+---
+
+## 4. New Capacity (Investments in Efficiency)
+
+These are costs the town added, but they represent infrastructure intended
+to reduce costs or improve operations over time:
+
+**Human Resources Department (created FY24)**
+- First-ever HR director (Thomas Howard, hired January 2024)
+- FY26 budget: $294,927 (salaries $279,927 + expense $15,000)
+- Previously: no centralized personnel management
+- Source: 2026 FinCom Report; Marblehead Current, January 2024
+
+**Community Development & Planning Department (created FY26)**
+- FY26 budget: $494,402 (salaries $456,696 + expense $37,706)
+- Consolidates planning functions; director secured $1.9M in grants
+- Source: 2026 FinCom Report
+
+**Procurement Director (hired)**
+- Jim Zisson (Select Board) urged competitive bidding through the new
+  procurement director position
+- Source: Marblehead Independent, late 2025
+
+**Collins Center / UMass financial forecasting partnership (FY22)**
+- Town worked with Collins Center to improve financial forecasting model
+- Source: 2021 FinCom Report transmittal letter
+
+**Three-year operating budget forecast (FY26)**
+- FinCom liaison teams collaborated with department heads to create
+  comprehensive three-year forecast for FY26-FY28
+- Presented to Select Board and FinCom in December 2025
+- Source: 2026 FinCom Report transmittal letter
+
+**Five-year Capital Improvement Plan (FY22)**
+- Comprehensive plan created; capital investments identified through
+  capital improvement planning process
+- Source: 2021 FinCom Report transmittal letter
+
+**General Fund Stabilization Fund (created FY20 ATM)**
+- $250,000 annual contributions beginning FY21
+- Balance at start of FY26: $1,500,000
+- FinCom reserve fund also increased by $300,000 in FY26 to $444,000
+- Accessible only through 2/3 vote of Town Meeting
+- Source: 2021, 2022, 2026 FinCom Reports
+
+---
+
+## 5. Contract and Fee Adjustments
+
+**Trash collection contract renegotiated**
+- Reduced from $844,575 to approximately $800,000 (~$44,575 savings)
+- Source: Aleesha Benjamin (Finance Director), FinCom hearing March 2026
+
+**Building permit violation fees increased (2019 ATM)**
+- Permit fee for unpermitted work: doubled to tripled
+- New fees added: re-inspection $50, lost permit card $100,
+  certificate of inspection $100, certificate of occupancy $100
+- Source: 2019 FinCom Report, Article 17
+
+**Tax demand fee doubled (2019 ATM)**
+- Fee per written demand increased from $15 to $30
+- Source: 2019 FinCom Report, Article 18
+
+**Mooring fees increased (2022 ATM)**
+- Harbor/Little Harbor/Dolibers: $8.00 to $10.00 per foot
+- All other locations: $7.00 to $9.00 per foot
+- Working commercial fishermen: $3.50 to $4.25 per foot
+- Source: 2022 FinCom Report, Article 34
+
+**Out-of-town parking fee increased (2019 ATM)**
+- Devereux Beach weekend parking: $10.00 to $15.00
+- Source: 2019 FinCom Report, Article 7
+
+**Marijuana local sales tax adopted (2019 ATM)**
+- 3% local option sales tax on marijuana retail
+- Source: 2019 FinCom Report, Article 32
+
+---
+
+## 6. Level-Funding as De Facto Cuts
+
+FinCom reports consistently describe budgets as "level-funded expense
+budgets" from FY17 through FY25. In an inflationary environment, this
+represents real purchasing power reductions.
+
+Select Board member Erin Noonan: level-funding over five years has
+"effectively amounted to cuts" across departments.
+Source: Marblehead Independent, late 2025
+
+Energy reserve level-funded at $533,544 for 10+ consecutive years
+(FY11 through FY20 per 2019 FinCom Report; continued through FY26
+per subsequent reports, though zeroed out in FY26 budget).
+
+Utility reserve level-funded at $100,000 from FY17 through FY25
+(zeroed out in FY26 budget).
+
+---
+
+## 7. What Has NOT Been Done
+
+These are commonly cited cost-control measures that Marblehead has not
+implemented:
+
+**Health insurance cost sharing unchanged**
+- Marblehead pays 83% of employee health insurance premiums
+- State law allows anywhere from 50% to 99%
+- Comparison: Hingham pays 50%
+- Moving to 75% would save approximately $1M per year
+- Source: Marblehead Independent, news reporting March 2026
+
+**No operational efficiency study**
+- No outside consultant review of town operations
+- No formal performance-based budgeting (advocated by Moses Grader
+  but not yet implemented)
+- Source: Select Board discussions, late 2025
+
+**Competitive bidding review proposed but not completed**
+- Jim Zisson urged using the new procurement director for competitive
+  bidding on purchased services; framed as future initiative
+- Source: Marblehead Independent, late 2025
+
+**No regionalization of services**
+- No shared-service agreements with neighboring communities for
+  dispatch, IT, procurement, or other back-office functions
+- (Note: South Essex Sewer District is a regional arrangement but
+  predates the current fiscal situation)
+
+---
+
+## 8. The 2019 Budget Scrub
+
+The single most significant documented cost-control initiative was the
+FY20 budget scrub ordered by Town Administrator Jason Silva.
+
+From the 2019 FinCom Report transmittal letter (Benjamin Berman, Chair):
+
+> "This budget cycle was undertaken in an almost unprecedented financial
+> context. Our Town Administrator ascertained that the Town's reliance
+> on free cash to help balance the budget has become unsustainable. In
+> response he asked for and received considerable support from
+> departments to scrub their budgets for savings. The departments
+> responded extremely positively finding innovative and creative
+> solutions to generate savings while simultaneously ensuring the same
+> level of services."
+
+No dollar amount or specific savings measures were documented in the
+report. The results of the scrub are not itemized in any public document
+we have identified.
+
+---
+
+## 9. Town Administrator Timeline
+
+Understanding who was in charge when:
+
+| Period | Town Administrator | Finance Director |
+|--------|-------------------|-----------------|
+| Through ~2019 | John McGinn | Alison Nieto |
+| ~2019-2022 | Jason Silva | Alison Nieto, then Steve Poulos |
+| 2022 (interim) | John McGinn (interim) | Steve Poulos |
+| Late 2022-present | Thatcher Kezer | Steve Poulos, then Aleesha Benjamin |
+
+Note: The 2019 FinCom Report thanks TA Jason Silva. The 2022 FinCom Report
+thanks Interim TA John McGinn. The 2026 FinCom Report thanks TA Thatcher
+Kezer and FD Aleesha Benjamin.
+
+---
+
+## Source Documents
+
+- 2016 FinCom Annual Report (FY17 budget), May 2, 2016 ATM
+- 2019 FinCom Annual Report (FY20 budget), May 6, 2019 ATM
+- 2021 FinCom Annual Report (FY22 budget), May 3, 2021 ATM
+- 2022 FinCom Annual Report (FY23 budget), May 2, 2022 ATM
+- 2026 FinCom Annual Report (FY26 budget), May 5, 2025 ATM
+- Marblehead Independent, multiple articles March 2026
+- Marblehead Current, multiple articles March 2026
+- Itemlive, October 2025 and March 2026
+- Select Board budget hearings, March 2026

--- a/index.html
+++ b/index.html
@@ -1870,6 +1870,9 @@ og_url: https://marbleheaddata.org/
           line-by-line audits. A state <abbr class="g" title="Division of Local Services">DLS</abbr> review could provide
           independent scrutiny, but one hasn't been requested.
         </p>
+        <a class="evidence-chart-link" href="what-has-the-town-done.html">
+          What has the town already done to save?
+        </a>
       </div>
 
       <details class="counter-argument">
@@ -1909,6 +1912,9 @@ og_url: https://marbleheaddata.org/
         </p>
         <a class="evidence-chart-link" href="no-override-budget.html">
           No-override budget details
+        </a>
+        <a class="evidence-chart-link" href="what-has-the-town-done.html">
+          What has the town already done to save?
         </a>
       </div>
 

--- a/what-has-the-town-done.html
+++ b/what-has-the-town-done.html
@@ -1,0 +1,177 @@
+---
+title: "What has the town already done to save?"
+scripts: [citations]
+og_title: What has the town already done to save?
+og_description: A factual inventory of cost-control measures Marblehead has taken before asking voters for an override, compiled from FinCom reports and budget documents.
+og_url: https://marbleheaddata.org/what-has-the-town-done.html
+---
+<h1>What has the town already done to save?</h1>
+
+  <div class="takeaway takeaway--neutral">
+    Override skeptics ask a fair question: what has the town already done to control costs before asking for more money? The answer is scattered across a decade of budget documents and meeting testimony. No single official presentation has compiled it. This page does.
+  </div>
+
+  <nav class="page-toc" aria-label="On this page">
+    <span class="page-toc-label">On this page</span>
+    <a href="#staffing">Staffing attrition</a>
+    <a href="#consolidation">Departmental consolidation</a>
+    <a href="#free-cash">Free cash discipline</a>
+    <a href="#contracts-fees">Contracts and fees</a>
+    <a href="#planning">Planning infrastructure</a>
+    <a href="#level-funding">Level-funding as cuts</a>
+    <a href="#not-done">What has not been done</a>
+    <a href="#budget-scrub">The 2019 budget scrub</a>
+  </nav>
+
+  <h2 id="staffing">Staffing: 199 positions down to ~190</h2>
+
+  <p>The municipal workforce declined from 199 positions to approximately 190 between 2018 and 2026, according to Town Administrator Thatcher Kezer at the March 2026 budget hearings.<sup class="cite" data-href="https://www.marbleheadindependent.com/marblehead-advances-122-8m-budget-built-on-cuts-defers-override-decisions/" data-source="Marblehead Independent, March 2026 (Kezer on workforce count)"></sup> The reductions came through attrition, not layoffs. Specific cuts documented in public testimony:</p>
+
+  <h3>Police</h3>
+  <ul>
+    <li>Sworn officers reduced from 32 to 30 over two years</li>
+    <li>School Resource Officer pulled back to patrol duty</li>
+    <li>One full-time officer defunded through five years of level-funding</li>
+  </ul>
+  <p class="source-note">Source: Select Board member Erin Noonan, late 2025; March 2026 budget hearing testimony<sup class="cite" data-href="https://www.marbleheadindependent.com/select-board-confronts-the-limits-of-marbleheads-tax-cap/" data-source="Marblehead Independent, Select Board confronts limits of tax cap (Noonan staffing testimony)"></sup></p>
+
+  <h3>Department of Public Works</h3>
+  <ul>
+    <li>Workforce reduced from 30+ to 19 over multiple years</li>
+    <li>Three FTEs lost through level-funding: heavy equipment operator, working foreman, general laborer</li>
+  </ul>
+  <p class="source-note">Source: Select Board member Erin Noonan; Marblehead Independent<sup class="cite" data-href="https://www.marbleheadindependent.com/select-board-confronts-the-limits-of-marbleheads-tax-cap/" data-source="Marblehead Independent, Select Board confronts limits of tax cap (Noonan on DPW staffing)"></sup></p>
+
+  <h3>Fire</h3>
+  <ul>
+    <li>Several firefighter positions defunded through level-funding</li>
+    <li>One vacancy unfilled for over a year, forcing 96-hour shifts</li>
+  </ul>
+  <p class="source-note">Source: March 2026 budget hearing testimony<sup class="cite" data-href="https://www.marbleheadindependent.com/cuts-across-departments-shape-select-boards-56-6m-budget/" data-source="Marblehead Independent, Cuts across departments shape Select Board's $56.6M budget"></sup></p>
+
+  <h3>Community Development</h3>
+  <ul>
+    <li>Department Director position eliminated in the FY27 budget</li>
+    <li>Reduced from four-person office to one vacant planner slot plus clerk</li>
+    <li>Despite the cuts, the department secured $1.9M in grants within two years</li>
+  </ul>
+  <p class="source-note">Source: March 2026 Select Board budget hearing<sup class="cite" data-href="https://www.marbleheadindependent.com/cuts-across-departments-shape-select-boards-56-6m-budget/" data-source="Marblehead Independent, Cuts across departments (Community Development testimony)"></sup></p>
+
+  <h2 id="consolidation">Departmental consolidation</h2>
+
+  <p>Two structural reorganizations are documented in the budget tables:</p>
+
+  <ul>
+    <li><strong>Engineer Department eliminated (FY26).</strong> Budget zeroed out (-$210,559). Functions absorbed into Department of Public Works.<sup class="cite" data-href="data/2026_FinCom_Report.pdf" data-source="2026 FinCom Report, Table of Estimated Appropriations (Engineer lines 105-106 zeroed for FY26)"></sup></li>
+    <li><strong>Highway, Drain, and Tree budgets consolidated (FY22).</strong> Previously three separate budget lines; merged under a single DPW budget. The FY23 appropriations table notes: "Highway, Drain and Tree budgets have been consolidated in FY22."<sup class="cite" data-href="data/2022_FinCom_Report.pdf" data-source="2022 FinCom Report, Table of Estimated Appropriations, Public Works &amp; Facilities footnote"></sup></li>
+  </ul>
+
+  <h2 id="free-cash">Free cash: from $10.2M down to $7M</h2>
+
+  <p>The town reduced its reliance on free cash (one-time reserves) to balance the operating budget after peaking in FY23, though the trajectory is uneven:</p>
+
+  <table class="data-table">
+    <thead>
+      <tr><th>Fiscal Year</th><th>Free Cash to Operating</th><th>Source</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>FY17</td><td>$6.0M</td><td>2016 FinCom Report, Art 28<sup class="cite" data-href="data/2016_FinCom_Report.pdf" data-source="2016 FinCom Report, Article 26 Available Funds"></sup></td></tr>
+      <tr><td>FY22</td><td>$9.0M</td><td>2021 FinCom Report, Art 30<sup class="cite" data-href="data/2021_FinCom_Report.pdf" data-source="2021 FinCom Report, Article 17 Available Funds"></sup></td></tr>
+      <tr><td>FY23</td><td>$10.2M</td><td>2022 FinCom Report, Art 29<sup class="cite" data-href="data/2022_FinCom_Report.pdf" data-source="2022 FinCom Report, Article 29 Available Funds"></sup></td></tr>
+      <tr><td>FY24</td><td>$8.0M</td><td>2023 FinCom Report<sup class="cite" data-href="data/2023_FinCom_Report.pdf" data-source="2023 FinCom Report, Available Funds"></sup></td></tr>
+      <tr><td>FY25</td><td>$5.5M</td><td>2025 FinCom Report<sup class="cite" data-href="data/2025_FinCom_Report.pdf" data-source="2025 FinCom Report, Article 19"></sup></td></tr>
+      <tr><td>FY26</td><td>$7.0M</td><td>2026 FinCom Report, Art 18<sup class="cite" data-href="data/2026_FinCom_Report.pdf" data-source="2026 FinCom Report, Article 18 Available Funds"></sup></td></tr>
+      <tr><td>FY27</td><td>$5.0M (proposed)</td><td>2026 State of the Town<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2026/02/2026-State-of-the-Town-Presenation-Final.pdf" data-source="2026 State of the Town presentation, FY27 proposed budget"></sup></td></tr>
+    </tbody>
+  </table>
+
+  <p>Kezer: <span class="quoted">"When I rolled in three and a half years ago, we were using $10 million to supplement the operating budget."</span> He called the practice <span class="quoted">"bad practice."</span><sup class="cite" data-href="https://www.marbleheadindependent.com/marblehead-advances-122-8m-budget-built-on-cuts-defers-override-decisions/" data-source="Marblehead Independent, March 2026 (Kezer on free cash)"></sup></p>
+
+  <p>The FY26 bounce from $5.5M back to $7M reflects collective bargaining settlements and revised local receipt estimates. The 2026 FinCom Report describes both as <span class="quoted">"one-time adjustments."</span><sup class="cite" data-href="data/2026_FinCom_Report.pdf" data-source="2026 FinCom Report, transmittal letter"></sup></p>
+
+  <h2 id="contracts-fees">Contract and fee adjustments</h2>
+
+  <h3>Contract savings</h3>
+  <ul>
+    <li><strong>Trash collection contract renegotiated:</strong> reduced from $844,575 to approximately $800,000, saving roughly $45,000<sup class="cite" data-href="https://www.marbleheadindependent.com/finance-committee-presses-for-detail-behind-marbleheads-8-5m-budget-gap/" data-source="Marblehead Independent, Finance Committee hearing (Benjamin on trash contract)"></sup></li>
+  </ul>
+
+  <h3>Fee increases</h3>
+  <ul>
+    <li>Building permit violation fee: doubled to tripled (2019 ATM, Article 17)<sup class="cite" data-href="data/2019_FinCom_Report.pdf" data-source="2019 FinCom Report, Article 17 Amend General Bylaw, Building Fees"></sup></li>
+    <li>Tax demand fee: $15 to $30 (2019 ATM, Article 18)<sup class="cite" data-href="data/2019_FinCom_Report.pdf" data-source="2019 FinCom Report, Article 18 Amend Fee for Demand for Payment of Taxes"></sup></li>
+    <li>Mooring fees: harbor $8 to $10/ft, other $7 to $9/ft (2022 ATM)<sup class="cite" data-href="data/2022_FinCom_Report.pdf" data-source="2022 FinCom Report, Article 34 Mooring Fees"></sup></li>
+    <li>Out-of-town parking at Devereux Beach: $10 to $15 (2019 ATM)<sup class="cite" data-href="data/2019_FinCom_Report.pdf" data-source="2019 FinCom Report, Article 7 Amend Recreation and Parks Revolving Fund"></sup></li>
+    <li>3% local marijuana sales tax adopted (2019 ATM, Article 32)<sup class="cite" data-href="data/2019_FinCom_Report.pdf" data-source="2019 FinCom Report, Article 32 Marijuana Tax"></sup></li>
+  </ul>
+
+  <h2 id="planning">Planning infrastructure</h2>
+
+  <p>Several structural investments were made to improve fiscal planning and oversight:</p>
+
+  <ul>
+    <li><strong>General Fund Stabilization Fund</strong> created at 2020 ATM. $250,000 annual contributions; balance at start of FY26: $1,500,000. Accessible only by 2/3 vote of Town Meeting.<sup class="cite" data-href="data/2021_FinCom_Report.pdf" data-source="2021 FinCom Report, transmittal letter (Stabilization Fund creation and $250K annual contribution)"></sup></li>
+    <li><strong>Collins Center / UMass financial forecasting partnership</strong> (FY22). Improved the town's financial forecasting model.<sup class="cite" data-href="data/2021_FinCom_Report.pdf" data-source="2021 FinCom Report, transmittal letter (Collins Center work)"></sup></li>
+    <li><strong>Three-year operating budget forecast</strong> created for FY26-FY28. FinCom liaison teams collaborated with department heads; presented to Select Board and FinCom in December 2025.<sup class="cite" data-href="data/2026_FinCom_Report.pdf" data-source="2026 FinCom Report, transmittal letter (three-year forecast)"></sup></li>
+    <li><strong>Five-year Capital Improvement Plan</strong> created (FY22). Capital investments identified through a comprehensive planning process.<sup class="cite" data-href="data/2021_FinCom_Report.pdf" data-source="2021 FinCom Report, transmittal letter (5-year capital plan)"></sup></li>
+    <li><strong>First HR director hired</strong> (January 2024). Previously: no centralized personnel management.<sup class="cite" data-href="https://marbleheadcurrent.org/2024/01/18/abbot-hall-town-hires-its-first-hr-director/" data-source="Marblehead Current, Jan 2024 (first HR director hired)"></sup></li>
+    <li><strong>Procurement director hired.</strong> Select Board member Jim Zisson urged competitive bidding through the new position.<sup class="cite" data-href="https://www.marbleheadindependent.com/select-board-confronts-the-limits-of-marbleheads-tax-cap/" data-source="Marblehead Independent, Zisson on procurement director and competitive bidding"></sup></li>
+  </ul>
+
+  <h2 id="level-funding">Level-funding as de facto cuts</h2>
+
+  <p>FinCom reports from FY17 through FY25 consistently describe budgets as <span class="quoted">"level-funded expense budgets."</span> In an inflationary environment, flat dollars buy less each year.</p>
+
+  <p>Select Board member Erin Noonan characterized level-funding over five years as having <span class="quoted">"effectively amounted to cuts"</span> across departments.<sup class="cite" data-href="https://www.marbleheadindependent.com/select-board-confronts-the-limits-of-marbleheads-tax-cap/" data-source="Marblehead Independent (Noonan on level-funding as cuts)"></sup></p>
+
+  <p>Two examples from the FinCom reports:</p>
+  <ul>
+    <li>Energy reserve level-funded at $533,544 for 10+ consecutive years (FY11 through at least FY20), then zeroed out in FY26<sup class="cite" data-href="data/2019_FinCom_Report.pdf" data-source="2019 FinCom Report, transmittal letter (energy reserve level-funded tenth year in a row)"></sup></li>
+    <li>Utility reserve level-funded at $100,000 from FY17 through FY25, then zeroed out in FY26<sup class="cite" data-href="data/2026_FinCom_Report.pdf" data-source="2026 FinCom Report, Table of Estimated Appropriations (Utility Reserve line 216)"></sup></li>
+  </ul>
+
+  <h2 id="not-done">What has not been done</h2>
+
+  <div class="takeaway takeaway--neutral">
+    A fair accounting of "what has been done" requires also asking "what hasn't." These are commonly cited cost-control measures that Marblehead has not implemented.
+  </div>
+
+  <ul>
+    <li><strong>Health insurance cost sharing:</strong> Marblehead pays 83% of employee health insurance premiums. State law allows anywhere from 50% to 99%. Hingham pays 50%. Moving to 75% would save approximately $1M per year.<sup class="cite" data-href="https://www.marbleheadindependent.com/select-board-confronts-the-limits-of-marbleheads-tax-cap/" data-source="Marblehead Independent, Select Board discussion (83% share, Hingham comparison, $1M savings estimate)"></sup></li>
+    <li><strong>No operational efficiency study.</strong> No outside consultant has reviewed town operations for redundancies or savings opportunities.</li>
+    <li><strong>No formal performance-based budgeting.</strong> Select Board member Moses Grader advocated for it; not yet implemented.<sup class="cite" data-href="https://www.marbleheadindependent.com/select-board-confronts-the-limits-of-marbleheads-tax-cap/" data-source="Marblehead Independent (Grader on performance budgeting)"></sup></li>
+    <li><strong>Competitive bidding review proposed but not completed.</strong> Jim Zisson urged using the procurement director for competitive bidding on purchased services; framed as a future initiative, not a done deal.<sup class="cite" data-href="https://www.marbleheadindependent.com/select-board-confronts-the-limits-of-marbleheads-tax-cap/" data-source="Marblehead Independent (Zisson on competitive bidding)"></sup></li>
+    <li><strong>No regionalized services.</strong> No shared-service agreements with neighboring communities for dispatch, IT, procurement, or other functions.</li>
+  </ul>
+
+  <h2 id="budget-scrub">The 2019 budget scrub</h2>
+
+  <p>The single most significant documented cost-control initiative was the FY20 budget scrub ordered by Town Administrator Jason Silva. From the 2019 FinCom transmittal letter:</p>
+
+  <blockquote class="quote">
+    <p>"This budget cycle was undertaken in an almost unprecedented financial context. Our Town Administrator ascertained that the Town's reliance on free cash to help balance the budget has become unsustainable. In response he asked for and received considerable support from departments to scrub their budgets for savings. The departments responded extremely positively finding innovative and creative solutions to generate savings while simultaneously ensuring the same level of services."</p>
+    <footer>2019 Finance Committee Annual Report, transmittal letter (for the FY20 budget). <a href="data/2019_FinCom_Report.pdf">PDF</a>.</footer>
+  </blockquote>
+
+  <p>No dollar amount or specific savings measures were documented in the report. The results of the scrub are not itemized in any public document identified to date.</p>
+
+  <div class="read-next">
+    <a class="read-next-link" href="how-we-got-here.html">
+      <div class="read-next-title">How did we get here? &rarr;</div>
+      <div class="read-next-desc">The Finance Committee's own transmittal letters trace the arc from "pleased to report no override" to "significant budgetary challenges," year by year.</div>
+    </a>
+    <a class="read-next-link" href="no-override-budget.html">
+      <div class="read-next-title">What's in the no-override budget? &rarr;</div>
+      <div class="read-next-desc">The specific staffing and service cuts in the FY27 balanced budget without an override, line by line.</div>
+    </a>
+    <a class="read-next-link" href="the-debate.html">
+      <div class="read-next-title">Both sides of the override debate &rarr;</div>
+      <div class="read-next-desc">The strongest version of each case, with the key tensions and tradeoffs.</div>
+    </a>
+  </div>
+
+  <details class="notes">
+    <summary>Sources and methodology</summary>
+    <p>Staffing figures are from public testimony at Select Board and Finance Committee budget hearings in March 2026, as reported by the Marblehead Independent. Free cash amounts are from the "Available Funds Appropriate to Reduce Tax Rate" articles in each year's Finance Committee Annual Report. Departmental consolidation data is from the Tables of Estimated Appropriations in the 2022 and 2026 FinCom Reports. Fee increases are from the warrant articles in the 2019 and 2022 FinCom Reports. The health insurance cost-sharing comparison (83% vs. Hingham's 50%) appeared in Marblehead Independent coverage of Select Board budget discussions in late 2025. The $1M savings estimate for moving to 75% is from the same reporting. The 2019 budget scrub quote is a direct excerpt from the signed 2019 Finance Committee Annual Report transmittal letter.</p>
+    <p>Local copies of the 2016, 2019, 2021, 2022, and 2026 Finance Committee Annual Reports are in <a href="data/">/data/</a>.</p>
+  </details>


### PR DESCRIPTION
## Summary
- New explainer page compiling the factual record of cost-control measures from five FinCom Annual Reports (FY17, FY20, FY22, FY23, FY26), budget hearing testimony, and news coverage
- Covers staffing attrition (199→~190), departmental consolidation, free cash discipline ($10.2M→$7M), contract/fee adjustments, planning infrastructure, and what has NOT been done (83% health insurance share, no efficiency study)
- Includes the 2019 budget scrub quote from primary source, noting no dollar figures were ever published
- Links from homepage Q1 evidence sections B ("there is real waste") and C ("both are true")
- Source data compiled in `data/savings_measures_compiled.md`

## Test plan
- [ ] Verify page renders correctly on desktop and mobile
- [ ] Verify all citation links resolve
- [ ] Verify homepage evidence links navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)