### PR TITLE
Wire Town Explorer and Deficit Model into question evidence links

### DIFF
--- a/browse.html
+++ b/browse.html
@@ -82,6 +82,12 @@ og_url: https://marbleheaddata.org/browse.html
       <p>Ten years of general fund revenue and expenses, from balanced budgets through growing free cash reliance to the FY27 gap. Shows how each override tier compares to projected expenses through FY30.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
+
+    <a class="question" href="charts/deficit_model.html">
+      <h2>What if the assumptions are wrong?</h2>
+      <p>Set your own revenue and expense growth rates, toggle override tiers on and off, and see when the gap reopens. Interactive deficit projection model.</p>
+      <span class="tag tag-charts">Interactive</span>
+    </a>
   </div>
 
   <p class="section-label">The budget</p>

--- a/index.html
+++ b/index.html
@@ -1964,6 +1964,9 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Full sustainability projections
         </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Build your own deficit projection
+        </a>
         <a class="evidence-chart-link" href="charts/budget_flow.html">
           Where the money goes: spending by category
         </a>
@@ -2688,6 +2691,9 @@ og_url: https://marbleheaddata.org/
           $463K (+9%). Together they consume more than the full 2.5%
           levy increase. Everything else has to come from cuts.
         </p>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Model the gap: drag revenue and expense growth rates yourself
+        </a>
       </div>
 
       <details class="counter-argument">
@@ -2815,6 +2821,9 @@ og_url: https://marbleheaddata.org/
         </p>
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Full sustainability projections
+        </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Adjust the assumptions and see when the gap reopens
         </a>
       </div>
 
@@ -2953,6 +2962,9 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="charts/statewide_tax_burden.html">
           Full 351-community ranking
         </a>
+        <a class="evidence-chart-link" href="charts/town_explorer.html">
+          Compare all 351 communities yourself
+        </a>
       </div>
 
       <details class="counter-argument">
@@ -3002,6 +3014,9 @@ og_url: https://marbleheaddata.org/
         </p>
         <a class="evidence-chart-link" href="charts/four_town_rates.html">
           Bill as share of income
+        </a>
+        <a class="evidence-chart-link" href="charts/town_explorer.html">
+          Build your own peer comparison
         </a>
       </div>
 
@@ -3388,6 +3403,9 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="no-override-budget.html">
           What gets cut without an override
         </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Model how long each tier lasts
+        </a>
       </div>
 
       <details class="counter-argument">
@@ -3426,6 +3444,9 @@ og_url: https://marbleheaddata.org/
         </a>
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Revenue vs. expenses forecast
+        </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Toggle tiers on/off and see the crossover year
         </a>
       </div>
 
@@ -3660,6 +3681,9 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Sustainability projections
         </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Set your own growth rates and watch the gap reopen
+        </a>
       </div>
 
       <div class="evidence-point">
@@ -3721,6 +3745,9 @@ og_url: https://marbleheaddata.org/
         </p>
         <a class="evidence-chart-link" href="what-you-can-do.html#better-oversight">
           Reform options
+        </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Model the gap under different cost-growth scenarios
         </a>
       </div>
 
@@ -3831,6 +3858,9 @@ og_url: https://marbleheaddata.org/
           districts, and zoning constrain development. Rezoning
           takes years.
         </p>
+        <a class="evidence-chart-link" href="charts/town_explorer.html">
+          See how Marblehead's tax base compares to all 351 communities
+        </a>
       </div>
 
       <details class="counter-argument">


### PR DESCRIPTION
## Summary
- Added Town Explorer links as evidence in **taxrank** (both sides) and **alternatives** (tax base constraint)
- Added Deficit Model links as evidence in **levy** (gap math + reform), **size** (both sides), **again** (gap reopening + reform scenarios), and **override** (sustainability)
- Added Deficit Model to **browse.html** under "The stakes" section (it was missing entirely)

These are the two pages where the user controls the assumptions. Every link is placed where a static chart already exists, so the interactive version is a natural "go deeper" step.

## Test plan
- [ ] Click each new evidence link from within a question to confirm it navigates correctly
- [ ] Verify browse.html renders the new Deficit Model card in the right section
- [ ] Check mobile layout for evidence link spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)