### PR TITLE
Link consolidation page from debate tension 4

### DIFF
--- a/the-debate.html
+++ b/the-debate.html
@@ -505,6 +505,7 @@ og_url: https://marbleheaddata.org/the-debate.html
   <h2 class="tension-heading" id="tension-4">4. Do meaningful alternatives exist?</h2>
   <p class="tension-framing">The debate turns on whether the town has real options other than override versus reductions. The structural data underneath this question is covered separately.</p>
   <a class="btn-link" href="why-not-elsewhere.html">Why some MA towns run overrides and others don't</a>
+  <a class="btn-link" href="town-school-admin.html">Why two sets of departments?</a>
   <a class="btn-link" href="charts/town_explorer.html">Town Explorer: compare all 351 MA communities</a>
 
   <div class="perspective perspective--for">


### PR DESCRIPTION
## Summary

Adds a `btn-link` to town-school-admin.html ("Why two sets of departments?") in debate tension 4 ("Do meaningful alternatives exist?"), alongside the existing why-not-elsewhere and Town Explorer links.

The page is now reachable from three paths:
- Homepage "vote no at any size" evidence section
- why-not-elsewhere.html summary card
- the-debate.html tension 4

## Test plan

- [ ] Verify the new button link renders between the existing two on the debate page

🤖 Generated with [Claude Code](https://claude.com/claude-code)