### PR TITLE
Add Tools nav dropdown and Run the numbers landing row

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -64,6 +64,16 @@
     <a href="{{ '/' | relative_url }}what-you-can-do.html"{% if page.url == '/what-you-can-do.html' %} aria-current="page"{% endif %}>Get involved</a>
 
     <div class="nav-dropdown">
+      <button class="nav-dropdown-toggle" aria-expanded="false">Tools <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+      <div class="nav-dropdown-menu">
+        <a href="{{ '/' | relative_url }}charts/deficit_model.html"{% if page.url == '/charts/deficit_model.html' %} aria-current="page"{% endif %}>Deficit model</a>
+        <a href="{{ '/' | relative_url }}charts/town_explorer.html"{% if page.url == '/charts/town_explorer.html' %} aria-current="page"{% endif %}>Town explorer</a>
+        <a href="{{ '/' | relative_url }}charts/override_calculator.html"{% if page.url == '/charts/override_calculator.html' %} aria-current="page"{% endif %}>Override calculator</a>
+        <a href="{{ '/' | relative_url }}senior-tax-relief.html"{% if page.url == '/senior-tax-relief.html' %} aria-current="page"{% endif %}>Senior tax relief</a>
+      </div>
+    </div>
+
+    <div class="nav-dropdown">
       <button class="nav-dropdown-toggle" aria-expanded="false">Data <svg class="nav-caret" viewBox="0 0 10 6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <div class="nav-dropdown-menu">
         <a href="{{ '/' | relative_url }}data/master-data.html"{% if page.url == '/data/master-data.html' %} aria-current="page"{% endif %}>Annual rollup (FY01-FY27)</a>

--- a/browse.html
+++ b/browse.html
@@ -82,6 +82,12 @@ og_url: https://marbleheaddata.org/browse.html
       <p>Ten years of general fund revenue and expenses, from balanced budgets through growing free cash reliance to the FY27 gap. Shows how each override tier compares to projected expenses through FY30.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
+
+    <a class="question" href="charts/deficit_model.html">
+      <h2>What if the assumptions are wrong?</h2>
+      <p>Set your own revenue and expense growth rates, toggle override tiers on and off, and see when the gap reopens. Interactive deficit projection model.</p>
+      <span class="tag tag-charts">Interactive</span>
+    </a>
   </div>
 
   <p class="section-label">The budget</p>

--- a/index.html
+++ b/index.html
@@ -225,6 +225,65 @@ og_url: https://marbleheaddata.org/
     margin-top: 3px;
   }
 
+  /* ── Tools row on landing ── */
+  .explore-tools {
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid var(--divider);
+  }
+  .explore-tools-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-subtle);
+    margin: 0 0 10px;
+    text-align: center;
+  }
+  .explore-tools-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+  .explore-tool-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 6px;
+    padding: 16px 14px;
+    background: var(--surface);
+    border: 1.5px solid var(--border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: all 0.15s ease;
+    text-decoration: none;
+    color: var(--text);
+  }
+  .explore-tool-card:hover {
+    border-color: var(--c-teal);
+    box-shadow: var(--shadow-sm);
+  }
+  .explore-tool-icon {
+    width: 22px;
+    height: 22px;
+    color: var(--c-teal);
+    flex-shrink: 0;
+  }
+  .explore-tool-title {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .explore-tool-desc {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.4;
+  }
+  @media (max-width: 400px) {
+    .explore-tools-row { grid-template-columns: 1fr; }
+  }
+
   /* Share strip on landing */
   .explore-share-strip {
     display: none;
@@ -1640,6 +1699,23 @@ og_url: https://marbleheaddata.org/
     <div class="explore-question-list" id="questionList">
       <!-- JS builds these from the actual question h1s -->
     </div>
+
+    <div class="explore-tools">
+      <p class="explore-tools-label">Run the numbers yourself</p>
+      <div class="explore-tools-row">
+        <a class="explore-tool-card" href="charts/deficit_model.html">
+          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+          <span class="explore-tool-title">Deficit Model</span>
+          <span class="explore-tool-desc">Set growth rates, toggle tiers, see when the gap reopens</span>
+        </a>
+        <a class="explore-tool-card" href="charts/town_explorer.html">
+          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <span class="explore-tool-title">Town Explorer</span>
+          <span class="explore-tool-desc">Filter, sort, and compare all 351 MA communities</span>
+        </a>
+      </div>
+    </div>
+
     <div class="explore-share-strip" id="shareStrip">
       <button type="button" class="explore-copy-link" data-copy-positions>
         <svg class="icon-link" viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>

--- a/index.html
+++ b/index.html
@@ -1964,6 +1964,9 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Full sustainability projections
         </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Build your own deficit projection
+        </a>
         <a class="evidence-chart-link" href="charts/budget_flow.html">
           Where the money goes: spending by category
         </a>
@@ -2688,6 +2691,9 @@ og_url: https://marbleheaddata.org/
           $463K (+9%). Together they consume more than the full 2.5%
           levy increase. Everything else has to come from cuts.
         </p>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Model the gap: drag revenue and expense growth rates yourself
+        </a>
       </div>
 
       <details class="counter-argument">
@@ -2815,6 +2821,9 @@ og_url: https://marbleheaddata.org/
         </p>
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Full sustainability projections
+        </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Adjust the assumptions and see when the gap reopens
         </a>
       </div>
 
@@ -2953,6 +2962,9 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="charts/statewide_tax_burden.html">
           Full 351-community ranking
         </a>
+        <a class="evidence-chart-link" href="charts/town_explorer.html">
+          Compare all 351 communities yourself
+        </a>
       </div>
 
       <details class="counter-argument">
@@ -3002,6 +3014,9 @@ og_url: https://marbleheaddata.org/
         </p>
         <a class="evidence-chart-link" href="charts/four_town_rates.html">
           Bill as share of income
+        </a>
+        <a class="evidence-chart-link" href="charts/town_explorer.html">
+          Build your own peer comparison
         </a>
       </div>
 
@@ -3388,6 +3403,9 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="no-override-budget.html">
           What gets cut without an override
         </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Model how long each tier lasts
+        </a>
       </div>
 
       <details class="counter-argument">
@@ -3426,6 +3444,9 @@ og_url: https://marbleheaddata.org/
         </a>
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Revenue vs. expenses forecast
+        </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Toggle tiers on/off and see the crossover year
         </a>
       </div>
 
@@ -3660,6 +3681,9 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Sustainability projections
         </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Set your own growth rates and watch the gap reopen
+        </a>
       </div>
 
       <div class="evidence-point">
@@ -3721,6 +3745,9 @@ og_url: https://marbleheaddata.org/
         </p>
         <a class="evidence-chart-link" href="what-you-can-do.html#better-oversight">
           Reform options
+        </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Model the gap under different cost-growth scenarios
         </a>
       </div>
 
@@ -3831,6 +3858,9 @@ og_url: https://marbleheaddata.org/
           districts, and zoning constrain development. Rezoning
           takes years.
         </p>
+        <a class="evidence-chart-link" href="charts/town_explorer.html">
+          See how Marblehead's tax base compares to all 351 communities
+        </a>
       </div>
 
       <details class="counter-argument">


### PR DESCRIPTION
## Summary
- **Nav**: New "Tools" dropdown with deficit model, town explorer, override calculator, and senior tax relief
- **Landing page**: "Run the numbers yourself" row below the question list with two tool cards (deficit model + town explorer)

Both tools are now reachable in one click from any page (nav) and from the first thing visitors see (landing).

## Test plan
- [ ] Desktop: verify Tools dropdown opens/closes, links navigate correctly
- [ ] Mobile: verify Tools dropdown renders in mobile panel
- [ ] Landing: tool cards render as a 2-column row, collapse to 1-column at 400px
- [ ] Tool cards hover state uses teal accent

🤖 Generated with [Claude Code](https://claude.com/claude-code)