### PR TITLE
Flip collapsible: cuts and tiers visible, sliders collapse

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -319,6 +319,28 @@ title: "Deficit Dynamics Model"
 </svg>
 
 <div class="dm-controls">
+  <div class="dm-control" style="grid-column: 1 / -1;">
+    <span class="dm-control-label">Position cuts: <span class="dm-value" id="dm-cuts-val">0</span></span>
+    <div class="dm-presets" style="margin-top: 0;">
+      <button type="button" class="dm-cuts-btn" data-cuts="0">Reset</button>
+      <button type="button" class="dm-cuts-btn" data-cuts="1">+1</button>
+      <button type="button" class="dm-cuts-btn" data-cuts="10">+10</button>
+      <button type="button" class="dm-cuts-btn" data-cuts="50">+50</button>
+      <button type="button" class="dm-cuts-btn" data-cuts="100">+100</button>
+    </div>
+    <div class="dm-hint" id="dm-cuts-hint">Each position costs ~$100K/yr (salary + benefits). Cutting positions shifts the expense line down but does not change its slope. GIC, PERAC, and union contracts still grow at the same rate on the remaining staff.</div>
+  </div>
+  <div class="dm-presets">
+    <button type="button" data-preset="baseline">No override</button>
+    <button type="button" data-preset="tier1">Tier 1 ($9M)</button>
+    <button type="button" data-preset="tier2">Tier 2 ($12M)</button>
+    <button type="button" data-preset="tier3">Tier 3 ($15M)</button>
+  </div>
+</div>
+
+<details class="dm-controls-wrap">
+<summary class="dm-controls-summary">Growth rates, healthcare shift, and other settings</summary>
+<div class="dm-controls">
   <div class="dm-control">
     <span class="dm-control-label">Revenue growth: <span class="dm-value" id="dm-rev-growth-val">3.5%</span></span>
     <input type="range" id="dm-rev-growth" min="0" max="6" step="0.1" value="3.5">
@@ -343,28 +365,6 @@ title: "Deficit Dynamics Model"
         <div class="dm-hint">The override funds specific items (positions, programs, trash). This means the expense line rises with the revenue line, because the money is being spent on what it was approved for. Turn off to see the scenario where override revenue is collected but not spent.</div>
       </div>
     </div>
-  </div>
-  <div class="dm-presets">
-    <button type="button" data-preset="baseline">No override</button>
-    <button type="button" data-preset="tier1">Tier 1 ($9M)</button>
-    <button type="button" data-preset="tier2">Tier 2 ($12M)</button>
-    <button type="button" data-preset="tier3">Tier 3 ($15M)</button>
-  </div>
-</div>
-
-<details class="dm-controls-wrap">
-<summary class="dm-controls-summary">What if we also cut positions or shift healthcare costs?</summary>
-<div class="dm-controls">
-  <div class="dm-control" style="grid-column: 1 / -1;">
-    <span class="dm-control-label">Position cuts: <span class="dm-value" id="dm-cuts-val">0</span></span>
-    <div class="dm-presets" style="margin-top: 0;">
-      <button type="button" class="dm-cuts-btn" data-cuts="0">Reset</button>
-      <button type="button" class="dm-cuts-btn" data-cuts="1">+1</button>
-      <button type="button" class="dm-cuts-btn" data-cuts="10">+10</button>
-      <button type="button" class="dm-cuts-btn" data-cuts="50">+50</button>
-      <button type="button" class="dm-cuts-btn" data-cuts="100">+100</button>
-    </div>
-    <div class="dm-hint" id="dm-cuts-hint">Each position costs ~$100K/yr (salary + benefits). Cutting positions shifts the expense line down but does not change its slope. GIC, PERAC, and union contracts still grow at the same rate on the remaining staff.</div>
   </div>
   <div class="dm-control">
     <span class="dm-control-label">Healthcare employer share: <span class="dm-value" id="dm-hc-share-val">83%</span></span>


### PR DESCRIPTION
## Summary
Flipped what's collapsible. The layout below the chart is now:

1. **Always visible**: Position cuts (+1/+10/+50/+100/Reset) and tier preset buttons (No override, Tier 1/2/3). These are click-and-watch controls.
2. **Collapsed**: Growth rate sliders, override slider, ratchet toggle, healthcare shift. These are set-once controls tucked under "Growth rates, healthcare shift, and other settings."

You can now click +10 three times and watch the chart react without the chart scrolling off screen.

## Test plan
- [ ] Position cuts and tier presets visible immediately below chart
- [ ] Sliders and healthcare controls hidden by default
- [ ] Opening the details reveals all sliders
- [ ] Chart stays in view while clicking position cut buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)