### PR TITLE
Add one-line chart explainer

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -346,9 +346,11 @@ title: "Deficit Dynamics Model"
   <span class="dm-hint" id="dm-tax-hint">Based on average single-family assessed value of $1,291,507</span>
 </div>
 
+<p class="dm-hint" style="margin-bottom: 12px;">Green line = what the town collects. Orange line = what it spends. The shaded area is the gap that free cash, cuts, or an override has to close.</p>
+
 <div class="dm-readout">
   <div class="dm-readout-line">Projected FY40 gap: <strong id="dm-gap">$12.6M</strong> <span id="dm-gap-label">annual deficit</span>.</div>
-  <div class="dm-hint" id="dm-gap-hint">Move the sliders, or click a preset below the chart, to see how it changes.</div>
+  <div class="dm-hint" id="dm-gap-hint">Pick a tier or drag the sliders below the chart to see how it changes.</div>
 </div>
 
 <svg class="dm-svg" viewBox="0 0 880 460" role="img" aria-labelledby="dm-title dm-desc">


### PR DESCRIPTION
## Summary
One line above the readout: "Green line = what the town collects. Orange line = what it spends. The shaded area is the gap that free cash, cuts, or an override has to close."

Also updated the readout hint from "Move the sliders" to "Pick a tier or drag the sliders below the chart" to match the new layout.

## Test plan
- [ ] Explainer visible above the readout, below the tax toggle
- [ ] No meta-narration ("this page shows...")

🤖 Generated with [Claude Code](https://claude.com/claude-code)