### PR TITLE
Fix bar chart visibility on mobile

### DIFF
--- a/charts/town_explorer.html
+++ b/charts/town_explorer.html
@@ -139,12 +139,13 @@ scripts: [citations]
     letter-spacing: 0.8px; color: var(--text-subtle); margin-bottom: 10px;
   }
   .bar-chart {
-    display: flex; align-items: flex-end; gap: 1px;
-    height: 120px; position: relative;
+    display: flex; align-items: flex-end; gap: 0;
+    height: 140px; position: relative;
+    overflow: hidden;
   }
   .bar-chart .bar {
-    flex: 1; min-width: 1px; background: var(--text-subtle); opacity: 0.25;
-    border-radius: 1px 1px 0 0; cursor: pointer; transition: opacity 0.1s;
+    flex: 1; min-width: 0; background: var(--text-subtle); opacity: 0.25;
+    cursor: pointer; transition: opacity 0.1s;
     position: relative;
   }
   .bar-chart .bar:hover { opacity: 0.6; }
@@ -230,6 +231,10 @@ scripts: [citations]
   @media (max-width: 600px) {
     .filter-grid { grid-template-columns: 1fr 1fr; gap: 10px; }
     .filter-count { margin-left: 0; width: 100%; text-align: center; margin-top: 4px; }
+    .sort-bar { gap: 5px; }
+    .sort-bar-label { font-size: 12px; width: 100%; margin-bottom: 2px; }
+    .sort-btn { font-size: 11px; padding: 5px 10px; }
+    .bar-chart { height: 100px; }
     table.explorer { font-size: 11px; }
     table.explorer th { font-size: 8px; padding: 8px 4px; letter-spacing: 0.2px; }
     table.explorer td { padding: 6px 4px; }


### PR DESCRIPTION
239 bars with 1px gaps were invisible on 375px screens. Removed gaps so bars fill the container as a continuous density chart.