### PR TITLE
Fix bar chart scaling on mobile

### DIFF
--- a/charts/town_explorer.html
+++ b/charts/town_explorer.html
@@ -151,6 +151,7 @@ scripts: [citations]
   .bar-chart .bar:hover { opacity: 0.6; }
   .bar-chart .bar.bar-mh {
     background: var(--series-marblehead); opacity: 0.85;
+    min-width: 3px; flex: 2;
   }
   .bar-chart .bar.bar-mh:hover { opacity: 1; }
   .bar-tip {
@@ -588,14 +589,17 @@ scripts: [citations]
       return;
     }
     barLabel.textContent = COL_LABELS[sortCol] + ' (sorted ' + (sortAsc ? 'low to high' : 'high to low') + ')';
-    var vals = filtered.map(function (t) { return t[sortCol]; });
-    var maxVal = Math.max.apply(null, vals);
-    if (maxVal <= 0) maxVal = 1;
+    var vals = filtered.map(function (t) { return t[sortCol]; }).sort(function (a, b) { return a - b; });
+    // Use 95th percentile as max to prevent outliers from squashing the chart
+    var p95 = vals[Math.floor(vals.length * 0.95)] || vals[vals.length - 1];
+    var maxVal = Math.max(p95, 0.001);
 
     var barsHtml = '';
+    var chartH = barChart.offsetHeight || 120;
     for (var i = 0; i < filtered.length; i++) {
       var t = filtered[i];
-      var h = Math.max(2, Math.round((t[sortCol] / maxVal) * 110));
+      var ratio = Math.min(t[sortCol] / maxVal, 1.3);
+      var h = Math.max(3, Math.round(ratio * (chartH - 10)));
       var cls = t.n === 'Marblehead' ? 'bar bar-mh' : 'bar';
       barsHtml += '<div class="' + cls + '" style="height:' + h + 'px" data-idx="' + i + '"></div>';
     }


### PR DESCRIPTION
Outliers compressed all bars to near-invisible. Uses 95th percentile scaling and widens the Marblehead bar.