### PR TITLE
Add scenario buttons: common override arguments visualized

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -384,6 +384,14 @@ title: "Deficit Dynamics Model"
   <button type="button" data-preset="tier3">Tier 3 ($15M)</button>
 </div>
 
+<div class="dm-presets" style="margin-top: 8px;">
+  <span class="dm-hint" style="margin: 0; align-self: center;">Try a scenario:</span>
+  <button type="button" class="dm-stance-btn" data-stance="bridge">"The override buys time"</button>
+  <button type="button" class="dm-stance-btn" data-stance="skeptic">"It all gets spent immediately"</button>
+  <button type="button" class="dm-stance-btn" data-stance="cut">"Just cut spending"</button>
+  <button type="button" class="dm-stance-btn" data-stance="healthcare">"Shift healthcare costs"</button>
+</div>
+
 <div class="dm-controls">
   <div class="dm-control" style="grid-column: 1 / -1;">
     <span class="dm-control-label">Override (FY27 to FY29): <span class="dm-value" id="dm-override-val">$0.0M</span></span>
@@ -1264,6 +1272,37 @@ title: "Deficit Dynamics Model"
         overrideEl.value = 12;
       } else if (p === 'tier3') {
         overrideEl.value = 15;
+      }
+      onChange();
+    });
+  });
+
+  // Stance scenario buttons
+  document.querySelectorAll('.dm-stance-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var s = btn.dataset.stance;
+      // Reset everything to defaults first
+      revGrowthEl.value = 3.5;
+      expGrowthEl.value = 4.0;
+      overrideEl.value = 0;
+      ratchetEl.value = 5;
+      positionCuts = 0;
+      hcShareEl.value = 83;
+      wageOffsetEl.value = 50;
+
+      if (s === 'bridge') {
+        // "The override buys time" - Tier 3, 5yr absorption
+        overrideEl.value = 15;
+      } else if (s === 'skeptic') {
+        // "It all gets spent immediately" - Tier 3, instant absorption
+        overrideEl.value = 15;
+        ratchetEl.value = 1;
+      } else if (s === 'cut') {
+        // "Just cut spending" - no override, 50 position cuts
+        positionCuts = 50;
+      } else if (s === 'healthcare') {
+        // "Shift healthcare costs" - no override, 50% employer share
+        hcShareEl.value = 50;
       }
       onChange();
     });


### PR DESCRIPTION
## Summary
Four scenario buttons below the tier selector, each representing a real argument from the Marblehead override debate:

- **"The override buys time"** - Tier 3, 5yr absorption. Shows the bridge period.
- **"It all gets spent immediately"** - Tier 3, 1yr absorption. The skeptic's case.
- **"Just cut spending"** - No override, 50 position cuts. Shows how many jobs it takes.
- **"Shift healthcare costs"** - No override, 50/50 employer share. Shows net savings after wage offset.

Each button resets all controls to defaults, then applies the scenario. No editorial framing - the chart shows what each argument implies and the voter draws their own conclusion.

## Test plan
- [ ] "The override buys time" sets Tier 3 + 5yr absorption, shows bridge
- [ ] "It all gets spent immediately" sets Tier 3 + 1yr absorption, gap barely moves
- [ ] "Just cut spending" sets 50 position cuts, no override
- [ ] "Shift healthcare costs" sets 50% employer share, no override
- [ ] Each resets previous settings before applying
- [ ] All sliders update to match the scenario
- [ ] Assumptions section reflects the new values

🤖 Generated with [Claude Code](https://claude.com/claude-code)