### PR TITLE
Embed deficit model in answer page evidence sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -2196,49 +2196,12 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>The override does not fix the underlying math</h4>
-
-        <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue bars vs expense line, FY24 to FY30. Gap grows even with override.">
-            <line class="axis-base" x1="60" y1="200" x2="500" y2="200"/>
-            <line class="grid-minor" x1="60" y1="160" x2="500" y2="160"/>
-            <line class="grid-minor" x1="60" y1="120" x2="500" y2="120"/>
-            <line class="grid-minor" x1="60" y1="80" x2="500" y2="80"/>
-            <text class="tick-label" x="53" y="204" text-anchor="end">$80M</text>
-            <text class="tick-label" x="53" y="164" text-anchor="end">$100M</text>
-            <text class="tick-label" x="53" y="124" text-anchor="end">$120M</text>
-            <text class="tick-label" x="53" y="84" text-anchor="end">$140M</text>
-            <text class="tick-label tick-label--major" x="94" y="220" text-anchor="middle">FY24</text>
-            <text class="tick-label tick-label--major" x="234" y="220" text-anchor="middle">FY27</text>
-            <text class="tick-label tick-label--major" x="374" y="220" text-anchor="middle">FY29</text>
-            <text class="tick-label tick-label--major" x="444" y="220" text-anchor="middle">FY30</text>
-            <rect class="data-fill s-revenue" x="80" y="123" width="28" height="77"/>
-            <rect class="data-fill s-revenue" x="150" y="112" width="28" height="88" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="220" y="103" width="28" height="97" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="290" y="94" width="28" height="106" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="360" y="86" width="28" height="114" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="430" y="78" width="28" height="122" opacity="0.65"/>
-            <polyline class="data-line data-line--bold s-neutral" points="94,120 164,105 234,72 304,52 374,32 444,12"/>
-            <circle class="data-dot s-neutral" cx="94" cy="120" r="3"/>
-            <circle class="data-dot s-neutral" cx="234" cy="72" r="3"/>
-            <circle class="data-dot s-neutral" cx="444" cy="12" r="4"/>
-            <text class="annotation" x="460" y="18">$140M expenses</text>
-            <text class="annotation" x="460" y="82">$121M revenue</text>
-          </svg>
-        </div>
-
-        <p class="caption">
-          Without an override, the gap between what the town spends and
-          what it collects grows to $18M by FY30. Even Tier 3 ($15M)
-          only closes it briefly before expenses pull ahead again. The
-          override buys time; it doesn't change the trend.
+        <p>
+          Without an override, the gap keeps growing. Try adding
+          position cuts to see how many it takes to move the expense
+          line, and notice that the slope stays the same.
         </p>
-        <a class="evidence-chart-link" href="charts/sustainability.html">
-          Full sustainability projections
-        </a>
-        <p class="evidence-caveat">
-          FY28-FY30 are projections (3% revenue growth,
-          5% expense growth), not forecasts.
-        </p>
+        <iframe src="charts/deficit_model.html?stance=cut&embed=1" style="width:100%; height:520px; border:none; margin: 12px 0;"></iframe>
       </div>
 
       <div class="evidence-point">
@@ -3558,9 +3521,7 @@ og_url: https://marbleheaddata.org/
           gap closes and the town doesn't need to come back to voters
           for several years.
         </p>
-        <a class="evidence-chart-link" href="how-we-got-here.html">
-          How we got here
-        </a>
+        <iframe src="charts/deficit_model.html?stance=bridge&embed=1" style="width:100%; height:520px; border:none; margin: 12px 0;"></iframe>
       </div>
 
       <details class="counter-argument">
@@ -3592,42 +3553,12 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>The gap reopens even at Tier 3</h4>
-
-        <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue vs expenses FY24-FY30, gap growing.">
-            <line class="axis-base" x1="60" y1="200" x2="500" y2="200"/>
-            <line class="grid-minor" x1="60" y1="160" x2="500" y2="160"/>
-            <line class="grid-minor" x1="60" y1="120" x2="500" y2="120"/>
-            <line class="grid-minor" x1="60" y1="80" x2="500" y2="80"/>
-            <text class="tick-label" x="53" y="204" text-anchor="end">$80M</text>
-            <text class="tick-label" x="53" y="164" text-anchor="end">$100M</text>
-            <text class="tick-label" x="53" y="124" text-anchor="end">$120M</text>
-            <text class="tick-label" x="53" y="84" text-anchor="end">$140M</text>
-            <text class="tick-label tick-label--major" x="94" y="220" text-anchor="middle">FY24</text>
-            <text class="tick-label tick-label--major" x="234" y="220" text-anchor="middle">FY27</text>
-            <text class="tick-label tick-label--major" x="444" y="220" text-anchor="middle">FY30</text>
-            <rect class="data-fill s-revenue" x="80" y="123" width="28" height="77"/>
-            <rect class="data-fill s-revenue" x="150" y="112" width="28" height="88" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="220" y="103" width="28" height="97" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="290" y="94" width="28" height="106" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="360" y="86" width="28" height="114" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="430" y="78" width="28" height="122" opacity="0.65"/>
-            <polyline class="data-line data-line--bold s-neutral" points="94,120 164,105 234,72 304,52 374,32 444,12"/>
-            <circle class="data-dot s-neutral" cx="94" cy="120" r="3"/>
-            <circle class="data-dot s-neutral" cx="444" cy="12" r="4"/>
-            <text class="annotation" x="460" y="18">expenses</text>
-            <text class="annotation" x="460" y="82">revenue</text>
-          </svg>
-        </div>
-
-        <p class="caption">
-          Expenses grow at ~5%/year. Revenue grows at ~2.5%. An
-          override adds a fixed amount that doesn't grow. By FY30
-          the gap reopens even at Tier 3. Tier 1 reopens sooner.
+        <p>
+          If new override revenue is absorbed quickly into deferred
+          spending, both lines jump together and the gap barely changes.
+          Drag the absorption slider to see the difference.
         </p>
-        <a class="evidence-chart-link" href="charts/sustainability.html">
-          Sustainability projections
-        </a>
+        <iframe src="charts/deficit_model.html?stance=skeptic&embed=1" style="width:100%; height:520px; border:none; margin: 12px 0;"></iframe>
       </div>
 
       <div class="evidence-point">
@@ -3838,9 +3769,7 @@ og_url: https://marbleheaddata.org/
           $1M/year. It requires collective bargaining, not a ballot
           question.
         </p>
-        <a class="evidence-chart-link" href="charts/peer_compensation.html">
-          Peer compensation and premium splits
-        </a>
+        <iframe src="charts/deficit_model.html?stance=healthcare&embed=1" style="width:100%; height:520px; border:none; margin: 12px 0;"></iframe>
       </div>
 
       <div class="evidence-point">


### PR DESCRIPTION
## Summary
Four interactive deficit model embeds on the homepage, each pre-set to match the argument being made:

| Question | Answer | Stance | What it shows |
|----------|--------|--------|---------------|
| Will we need another override? | A: "designed to last" | `?stance=bridge` | Tier 3 with 5yr absorption, visible bridge |
| Will we need another override? | B: "math says we will" | `?stance=skeptic` | Tier 3 with 1yr absorption, gap barely moves |
| What if override fails? | C: "force reform" | `?stance=cut` | 50 position cuts, no override |
| Are there alternatives? | B: "alternatives exist" | `?stance=healthcare` | 50% employer share, shows net savings |

Replaces two static SVG charts that showed similar data but weren't interactive. Each embed lets readers click tier buttons, add position cuts, and try different scenarios right in the evidence section.

## Test plan
- [ ] "again-a" evidence shows bridge stance embed
- [ ] "again-b" evidence shows skeptic stance embed (replaced static chart)
- [ ] "voteno-c" evidence shows cut stance embed (replaced static chart)
- [ ] "alternatives-b" evidence shows healthcare stance embed
- [ ] All embeds are interactive (buttons, slider work)
- [ ] "Explore the full model" links work from each embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)