### PR TITLE
Embed deficit model in 'it depends on reform' answer

### DIFF
--- a/index.html
+++ b/index.html
@@ -3607,7 +3607,9 @@ og_url: https://marbleheaddata.org/
           whether the breathing room from the override gets used to
           change the cost structure (insurance negotiations, staffing
           model, budget transparency) or just delays the next ask.
+          Drag the absorption slider to see the difference.
         </p>
+        <iframe src="charts/deficit_model.html?tier=3&absorption=5&embed=1" style="width:100%; height:520px; border:none; margin: 12px 0;"></iframe>
       </div>
 
       <div class="evidence-point">


### PR DESCRIPTION
## Summary
The "again-c" evidence section now has the deficit model at Tier 3 / 5yr absorption. The absorption slider is the literal answer to the question this answer poses: how fast does the new revenue get spent?

- Drag to 1: the skeptic case, gap barely moves
- Leave at 5: the bridge, gap shrinks for several years
- Set to 0: maximum gap closure (unrealistic)

This completes the ratchet coverage across all three "will we need another override?" answers.

## Test plan
- [ ] "again-c" evidence shows Tier 3 embed with absorption slider
- [ ] Absorption slider is interactive in the embed
- [ ] Dragging absorption changes the chart visibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)