### PR TITLE
Fix override sort defaults

### DIFF
--- a/charts/town_explorer.html
+++ b/charts/town_explorer.html
@@ -685,7 +685,7 @@ scripts: [citations]
     sortExplainer.innerHTML = COL_EXPLAINERS[sortCol] || '';
   }
   // Columns where high = notable (default descending)
-  var DESC_DEFAULT = { p: true, ipc: true, epc: true, ng: true, rpct: true, ahv: true, ovr: true, opr: true };
+  var DESC_DEFAULT = { p: true, ipc: true, epc: true, ng: true, rpct: true, ahv: true, ovr: true, yso: true };
   function applySort(col) {
     if (sortCol === col) { sortAsc = !sortAsc; }
     else { sortCol = col; sortAsc = !DESC_DEFAULT[col]; }


### PR DESCRIPTION
Override pass rate now defaults low-first (Marblehead's 30% near top). Years since override defaults high-first (21 years near top).