### PR TITLE
Fix back button navigating off-site

### DIFF
--- a/assets/deep-dive.js
+++ b/assets/deep-dive.js
@@ -84,7 +84,7 @@
       requestAnimationFrame(function () {
         target.scrollIntoView({ behavior: 'smooth', block: 'start' });
       });
-      history.pushState(null, '', hash);
+      history.replaceState(null, '', hash);
     }
   });
 


### PR DESCRIPTION
## Summary
- `deep-dive.js` used `history.pushState()` when opening collapsible sections via anchor links, stacking history entries for each hash fragment
- Hitting back cycled through `#section-1`, `#section-2`, etc. instead of returning to the previous page
- Switched to `history.replaceState()` — URL bar still updates (bookmarks/sharing work) but no extra history entries are created

## Test plan
- [ ] Open a deep-dive page (e.g. where-has-the-money-gone), click several section links, then hit back — should return to the previous page in one press

🤖 Generated with [Claude Code](https://claude.com/claude-code)