### PR TITLE
Fix homepage back button stacking history entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -5420,8 +5420,7 @@ og_url: https://marbleheaddata.org/
 
   /* ── Nav back button ── */
   document.getElementById('navBack').addEventListener('click', function () {
-    showLanding();
-    window.scrollTo(0, 0);
+    history.back();
   });
 
   /* ── Inject "Next question" buttons ── */


### PR DESCRIPTION
## Summary
- The in-app "Back" arrow on the question explorer called `showLanding()`, which pushed a new history entry via `writeURL(null, null)`
- This stacked entries: landing -> question -> landing(new) -> question -> ...
- Browser back button cycled through these instead of leaving the site
- Changed to `history.back()`, which pops the entry — the existing `popstate` handler already restores the landing UI

## Test plan
- [ ] Go to homepage, click a question, click the back arrow — browser back should now leave the site in one press
- [ ] Click through multiple questions, then use browser back — should step back through questions and then off-site

🤖 Generated with [Claude Code](https://claude.com/claude-code)