### PR TITLE
Fix regressions from cbaaed6 (verification network commit)

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,6 +225,65 @@ og_url: https://marbleheaddata.org/
     margin-top: 3px;
   }
 
+  /* ── Tools row on landing ── */
+  .explore-tools {
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid var(--divider);
+  }
+  .explore-tools-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-subtle);
+    margin: 0 0 10px;
+    text-align: center;
+  }
+  .explore-tools-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+  .explore-tool-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 6px;
+    padding: 16px 14px;
+    background: var(--surface);
+    border: 1.5px solid var(--border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: all 0.15s ease;
+    text-decoration: none;
+    color: var(--text);
+  }
+  .explore-tool-card:hover {
+    border-color: var(--c-teal);
+    box-shadow: var(--shadow-sm);
+  }
+  .explore-tool-icon {
+    width: 22px;
+    height: 22px;
+    color: var(--c-teal);
+    flex-shrink: 0;
+  }
+  .explore-tool-title {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .explore-tool-desc {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.4;
+  }
+  @media (max-width: 400px) {
+    .explore-tools-row { grid-template-columns: 1fr; }
+  }
+
   /* Share strip on landing */
   .explore-share-strip {
     display: none;
@@ -553,9 +612,18 @@ og_url: https://marbleheaddata.org/
     transition: all 0.2s ease;
     position: relative;
   }
-  .answer-card:hover {
-    border-color: var(--c-navy);
-    box-shadow: var(--shadow-sm);
+  /* :hover styles are gated on (hover: hover) so touch devices don't get
+     stuck in a pseudo-selected state from a stray scroll-start tap. The
+     hover look is visually identical to .viewing, which on iOS would
+     persist until another element was tapped. */
+  @media (hover: hover) {
+    .answer-card:hover {
+      border-color: var(--c-navy);
+      box-shadow: var(--shadow-sm);
+    }
+    .answer-card.dimmed:hover {
+      opacity: 0.8;
+    }
   }
   .answer-card.selected {
     border-color: var(--c-teal);
@@ -567,9 +635,6 @@ og_url: https://marbleheaddata.org/
   }
   .answer-card.dimmed {
     opacity: 0.5;
-  }
-  .answer-card.dimmed:hover {
-    opacity: 0.8;
   }
 
   /* Checkmark button on cards */
@@ -591,9 +656,11 @@ og_url: https://marbleheaddata.org/
     transition: all 0.15s;
     z-index: 1;
   }
-  .answer-check:hover {
-    border-color: var(--c-teal);
-    color: var(--c-teal);
+  @media (hover: hover) {
+    .answer-check:hover {
+      border-color: var(--c-teal);
+      color: var(--c-teal);
+    }
   }
   .answer-card.selected .answer-check {
     border-color: var(--c-teal);
@@ -612,8 +679,10 @@ og_url: https://marbleheaddata.org/
     margin-top: 10px;
     transition: opacity 0.2s;
   }
-  .answer-card:hover .answer-hint {
-    color: var(--c-teal);
+  @media (hover: hover) {
+    .answer-card:hover .answer-hint {
+      color: var(--c-teal);
+    }
   }
   .answer-card.selected .answer-hint,
   .answer-card.dimmed .answer-hint {
@@ -722,19 +791,27 @@ og_url: https://marbleheaddata.org/
   .pick-dist-b { background: var(--c-brass); }
   .pick-dist-c { background: var(--c-buoy); }
   .pick-dist-u { background: var(--text-faint); }
+  /* Legend: flat flex row where each answer is a tight dot+letter+pct+
+     count group, with generous breathing room between groups. Tuned
+     up from the pre-#435 original: font 11->12px and column gap 14->20
+     so the category groups don't blend into each other. Keep the
+     HTML structure flat so the letter and its percentage stay next to
+     each other visually -- the #436 grid layout pushed each percentage
+     to the right of its cell, which made the number look associated
+     with the *next* letter. */
   .pick-dist-legend {
     display: flex;
     flex-wrap: wrap;
-    gap: 4px 14px;
-    margin-top: 6px;
-    font-size: 0.6875rem;
+    gap: 4px 20px;
+    margin-top: 10px;
+    font-size: 0.75rem;
     color: var(--text-muted);
     font-variant-numeric: tabular-nums;
   }
   .pick-dist-key {
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: 5px;
     font-weight: 600;
   }
   .pick-dist-count {
@@ -754,9 +831,10 @@ og_url: https://marbleheaddata.org/
   .pick-dist-total {
     margin-left: auto;
     font-weight: 400;
+    color: var(--text-subtle);
   }
-  /* "X reconsidered after reading the evidence" line, shown under
-     the distribution bar when the move-vote counter is non-zero. */
+  /* "X readers changed their pick after reading the evidence" line,
+     shown under the legend when the move-vote counter is non-zero. */
   .pick-dist-moves {
     margin-top: 6px;
     font-size: 0.6875rem;
@@ -1302,6 +1380,27 @@ og_url: https://marbleheaddata.org/
     letter-spacing: 0.6px;
     color: var(--text-subtle);
     margin-bottom: 2px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .votes-strip-countdown {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+    text-transform: none;
+    color: var(--c-teal);
+    background: color-mix(in srgb, var(--c-teal) 10%, transparent);
+    border-radius: 3px;
+    padding: 1px 5px;
+    white-space: nowrap;
+  }
+  .votes-strip-countdown:empty { display: none; }
+  .votes-strip-countdown.past {
+    color: var(--text-subtle);
+    background: color-mix(in srgb, var(--text-subtle) 10%, transparent);
   }
   .votes-strip-step-what {
     font-size: 14px;
@@ -1666,13 +1765,13 @@ og_url: https://marbleheaddata.org/
       <p class="votes-strip-label">Two votes decide the override</p>
       <div class="votes-strip-steps">
         <div class="votes-strip-step">
-          <div class="votes-strip-step-when">Mon, May 4</div>
+          <div class="votes-strip-step-when">Mon, May 4 <span class="votes-strip-countdown" data-date="2026-05-04"></span></div>
           <div class="votes-strip-step-what">Annual Town Meeting</div>
           <p class="votes-strip-step-desc">Residents vote yes or no on sending the override to the ballot as three tiers, ceiling $15M. A no ends the override here.</p>
         </div>
         <div class="votes-strip-arrow" aria-hidden="true">&rarr;</div>
         <div class="votes-strip-step">
-          <div class="votes-strip-step-when">Tue, Jun 9</div>
+          <div class="votes-strip-step-when">Tue, Jun 9 <span class="votes-strip-countdown" data-date="2026-06-09"></span></div>
           <div class="votes-strip-step-what">Annual Town Election</div>
           <p class="votes-strip-step-desc">If Town Meeting sends it forward, voters pick the tier at the ballot. The highest tier with a majority sets the amount.</p>
         </div>
@@ -1713,6 +1812,23 @@ og_url: https://marbleheaddata.org/
     <div class="explore-question-list" id="questionList">
       <!-- JS builds these from the actual question h1s -->
     </div>
+
+    <div class="explore-tools">
+      <p class="explore-tools-label">Run the numbers yourself</p>
+      <div class="explore-tools-row">
+        <a class="explore-tool-card" href="charts/deficit_model.html">
+          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+          <span class="explore-tool-title">Deficit Model</span>
+          <span class="explore-tool-desc">Set growth rates, toggle tiers, see when the gap reopens</span>
+        </a>
+        <a class="explore-tool-card" href="charts/town_explorer.html">
+          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <span class="explore-tool-title">Town Explorer</span>
+          <span class="explore-tool-desc">Filter, sort, and compare all 351 MA communities</span>
+        </a>
+      </div>
+    </div>
+
     <div class="explore-share-strip" id="shareStrip">
       <button type="button" class="explore-copy-link" data-copy-positions>
         <svg class="icon-link" viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
@@ -2043,6 +2159,9 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Full sustainability projections
         </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Build your own deficit projection
+        </a>
         <a class="evidence-chart-link" href="charts/budget_flow.html">
           Where the money goes: spending by category
         </a>
@@ -2294,6 +2413,9 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Full sustainability projections
         </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Adjust the assumptions and see when the gap reopens
+        </a>
         <p class="evidence-caveat">
           FY28-FY30 are projections (3% revenue growth,
           5% expense growth), not forecasts.
@@ -2399,9 +2521,23 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Enrollment fell 21%, staffing grew</h4>
+        <h4>Enrollment fell 21%; the town's own count shows staffing up 9.6%</h4>
 
-        <div class="chart-wrapper">
+        <div class="chart-wrapper" data-chart-tooltip>
+          <script type="application/json" class="chart-tooltip-data">
+          {
+            "xLabels": ["FY01","FY02","FY03","FY04","FY05","FY06","FY07","FY08","FY09","FY10","FY11","FY12","FY13","FY14","FY15","FY16","FY17","FY18","FY19","FY20","FY21","FY22","FY23","FY24"],
+            "xPositions": [70,93,117,140,164,187,211,234,258,281,305,328,352,375,399,422,446,469,493,516,540,563,587,610],
+            "valueDecimals": 0,
+            "series": [
+              {
+                "name": "Student enrollment",
+                "className": "s-neutral",
+                "values": [2792,2875,2970,3003,3067,3133,3242,3212,3262,3232,3206,3172,3269,3327,3245,3208,3264,3185,3051,2963,2703,2602,2622,2617]
+              }
+            ]
+          }
+          </script>
           <svg class="chart" viewBox="0 0 740 185" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Student enrollment FY2001 to FY2024, peaking at 3,327 in FY2014 and declining to 2,617.">
             <line class="axis-base" x1="70" y1="170" x2="610" y2="170"/>
             <line class="tick" x1="66" y1="156" x2="70" y2="156"/>
@@ -2416,24 +2552,15 @@ og_url: https://marbleheaddata.org/
             <text class="tick-label tick-label--major" x="610" y="184" text-anchor="middle">FY24</text>
           </svg>
         </div>
-        <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 740 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Education FTE FY2001 to FY2024, rising from 400 to 537.">
-            <line class="axis-base" x1="70" y1="140" x2="610" y2="140"/>
-            <line class="tick" x1="66" y1="127" x2="70" y2="127"/>
-            <text class="tick-label" x="63" y="131" text-anchor="end">400</text>
-            <line class="tick" x1="66" y1="60" x2="70" y2="60"/>
-            <text class="tick-label" x="63" y="64" text-anchor="end">500</text>
-            <polyline class="data-line s-marblehead" points="70,127 93,117 117,111 140,109 164,94 187,82 211,77 234,73 258,68 281,68 305,68 328,73 352,67 375,65 399,67 422,67 446,65 469,57 493,71 516,73 540,71 563,72 587,35 610,35"/>
-            <text class="end-label s-marblehead" x="616" y="31">537</text>
-            <text class="tick-label tick-label--major" x="70" y="160" text-anchor="middle">FY01</text>
-            <text class="tick-label tick-label--major" x="352" y="160" text-anchor="middle">FY13</text>
-            <text class="tick-label tick-label--major" x="610" y="160" text-anchor="middle">FY24</text>
-          </svg>
-        </div>
 
         <p class="caption">
-          Enrollment dropped 21% but staff grew. If staffing had tracked
-          enrollment, we'd have fewer positions and lower costs.
+          The ACFR (town financial reports) shows education FTE rising
+          from 490 to 537 since FY15. But DESE (state education data)
+          shows total educator FTE falling from 502 to 432 over the
+          same period. The divergence is driven by a FY23 counting
+          change and different definitions of who counts as "education"
+          staff. <a href="charts/enrollment_vs_staffing.html">See all
+          three measures</a>.
         </p>
       </div>
 
@@ -2469,14 +2596,28 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            Not every staff position scales with total enrollment.
-            Special education, <abbr class="g" title="English Language Learner">ELL</abbr>,
+            The town's <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>
+            is one of three staffing measures, and it is the only one that
+            shows growth. State education data
+            (<abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr>)
+            shows total educator
+            <abbr class="g" title="Full-Time Equivalent">FTE</abbr> down 13.9%
+            and classroom teacher
+            <abbr class="g" title="Full-Time Equivalent">FTE</abbr> down 4.3%
+            over the same period. The
+            <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>
+            is also affected by a
+            <a href="inside-school-staffing.html#the-fy23-mystery">FY23 data
+            discontinuity</a>. Beyond the measurement question, not every
+            staff position scales with total enrollment. Special education,
+            <abbr class="g" title="English Language Learner">ELL</abbr>,
             and mandated compliance roles are driven by student need,
-            not by headcount, and they account for about 60-65% of the
-            added positions. A ratio comparison that treats all
+            not by headcount. A ratio comparison that treats all
             <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>
             as interchangeable obscures what those staff actually do
             and which positions the district can legally reduce.
+            <a href="charts/enrollment_vs_staffing.html">See all three
+            measures</a>.
           </p>
         </div>
       </details>
@@ -2504,43 +2645,61 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Special education needs grew while enrollment fell</h4>
+        <h4>Special education teachers rose as gen-ed teachers fell</h4>
 
-        <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 740 185" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Student enrollment FY2001 to FY2024, peaking at 3,327 in FY2014 and declining to 2,617.">
-            <line class="axis-base" x1="70" y1="170" x2="610" y2="170"/>
-            <line class="tick" x1="66" y1="156" x2="70" y2="156"/>
-            <text class="tick-label" x="63" y="160" text-anchor="end">2,500</text>
-            <line class="tick" x1="66" y1="86" x2="70" y2="86"/>
-            <text class="tick-label" x="63" y="90" text-anchor="end">3,000</text>
-            <polyline class="data-line s-neutral" points="70,115 93,104 117,90 140,86 164,77 187,67 211,52 234,56 258,49 281,54 305,57 328,62 352,48 375,40 399,52 422,57 446,49 469,60 493,79 516,91 540,128 563,142 587,139 610,140"/>
-            <text class="end-label s-neutral" x="616" y="136">2,617</text>
-            <text class="annotation" x="375" y="34" text-anchor="middle">peak: 3,327</text>
-            <text class="tick-label tick-label--major" x="70" y="184" text-anchor="middle">FY01</text>
-            <text class="tick-label tick-label--major" x="352" y="184" text-anchor="middle">FY13</text>
-            <text class="tick-label tick-label--major" x="610" y="184" text-anchor="middle">FY24</text>
+        <div class="chart-wrapper" data-chart-tooltip>
+          <script type="application/json" class="chart-tooltip-data">
+          {
+            "xLabels": ["FY15","FY16","FY17","FY18","FY19","FY20","FY21","FY22","FY23","FY24"],
+            "xPositions": [70,130,190,250,310,370,430,490,550,610],
+            "valueDecimals": 1,
+            "series": [
+              {
+                "name": "Gen-ed teachers",
+                "className": "s-neutral",
+                "values": [210.1,215.3,216.4,210.4,222.2,231.4,223.7,209.6,193.5,184.5]
+              },
+              {
+                "name": "SPED teachers",
+                "className": "s-marblehead",
+                "values": [44.6,43.6,45.5,47.2,31.0,22.9,28.6,41.3,51.8,56.7]
+              }
+            ]
+          }
+          </script>
+          <svg class="chart" viewBox="0 0 740 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Gen-ed teacher FTE declining from 210 to 185 while SPED teacher FTE rises from 45 to 57, FY15 to FY24.">
+            <line class="axis-base" x1="70" y1="130" x2="610" y2="130"/>
+            <!-- Y ticks: scale 0-250, 130px range, factor=0.52 -->
+            <line class="tick" x1="66" y1="104" x2="70" y2="104"/>
+            <text class="tick-label" x="63" y="108" text-anchor="end">50</text>
+            <line class="tick" x1="66" y1="52" x2="70" y2="52"/>
+            <text class="tick-label" x="63" y="56" text-anchor="end">150</text>
+            <!-- Gen ed: 210.1,215.3,216.4,210.4,222.2,231.4,223.7,209.6,193.5,184.5 -->
+            <!-- y = 130 - v*0.52 -->
+            <polyline class="data-line s-neutral"
+                      points="70,21 130,18 190,17 250,21 310,14 370,10 430,14 490,21 550,29 610,34"/>
+            <text class="end-label s-neutral" x="616" y="30">184.5</text>
+            <!-- SPED: 44.6,43.6,45.5,47.2,31.0,22.9,28.6,41.3,51.8,56.7 -->
+            <polyline class="data-line s-marblehead"
+                      points="70,107 130,107 190,106 250,105 310,114 370,118 430,115 490,109 550,103 610,100"/>
+            <text class="end-label s-marblehead" x="616" y="96">56.7</text>
+            <text class="tick-label tick-label--major" x="70"  y="148" text-anchor="middle">FY15</text>
+            <text class="tick-label tick-label--minor" x="310" y="148" text-anchor="middle">FY19</text>
+            <text class="tick-label tick-label--major" x="610" y="148" text-anchor="middle">FY24</text>
           </svg>
         </div>
-        <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 740 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Education FTE FY2001 to FY2024, rising from 400 to 537.">
-            <line class="axis-base" x1="70" y1="140" x2="610" y2="140"/>
-            <line class="tick" x1="66" y1="127" x2="70" y2="127"/>
-            <text class="tick-label" x="63" y="131" text-anchor="end">400</text>
-            <line class="tick" x1="66" y1="60" x2="70" y2="60"/>
-            <text class="tick-label" x="63" y="64" text-anchor="end">500</text>
-            <polyline class="data-line s-marblehead" points="70,127 93,117 117,111 140,109 164,94 187,82 211,77 234,73 258,68 281,68 305,68 328,73 352,67 375,65 399,67 422,67 446,65 469,57 493,71 516,73 540,71 563,72 587,35 610,35"/>
-            <text class="end-label s-marblehead" x="616" y="31">537</text>
-            <text class="tick-label tick-label--major" x="70" y="160" text-anchor="middle">FY01</text>
-            <text class="tick-label tick-label--major" x="352" y="160" text-anchor="middle">FY13</text>
-            <text class="tick-label tick-label--major" x="610" y="160" text-anchor="middle">FY24</text>
-          </svg>
+        <div class="legend">
+          <span class="legend-item s-neutral"><span class="legend-swatch"></span><span class="legend-text">Gen-ed teachers</span></span>
+          <span class="legend-item s-marblehead"><span class="legend-swatch"></span><span class="legend-text">SPED teachers</span></span>
         </div>
-
         <p class="caption">
-          Same chart, different reading: fewer students, but higher needs.
-          High-needs students grew from 27% to 32% of enrollment. Each
+          High-needs students grew from 27% to 32% of enrollment.
+          <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> data shows special education teacher
+          <abbr class="g" title="Full-Time Equivalent">FTE</abbr> rose 27% (44.6 to 56.7) while general education
+          teachers fell 12% (210.1 to 184.5) over FY15 to FY24. Each
           student with an <abbr class="g" title="Individualized Education Program">IEP</abbr> requiring a 1:1 aide adds a full
           position the district must fill.
+          <a href="charts/enrollment_vs_staffing.html">See the full breakdown</a>.
         </p>
       </div>
 
@@ -2730,6 +2889,9 @@ og_url: https://marbleheaddata.org/
           $463K (+9%). Together they consume more than the full 2.5%
           levy increase. Everything else has to come from cuts.
         </p>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Model the gap: drag revenue and expense growth rates yourself
+        </a>
       </div>
 
       <details class="counter-argument">
@@ -2983,6 +3145,23 @@ og_url: https://marbleheaddata.org/
         </a>
       </div>
 
+      <div class="evidence-point">
+        <h4>Lighter than all but 24 of 351 MA communities</h4>
+        <p>
+          Tax bill as a share of household income: Marblehead ranks 327
+          out of 351 Massachusetts communities at 9.6%. Only 24 towns
+          statewide have a lighter tax-to-income burden. Even at full
+          Tier 3 the projected 7.1% would still stay below Swampscott's
+          current 8.5%.
+        </p>
+        <a class="evidence-chart-link" href="charts/statewide_tax_burden.html">
+          Full 351-community ranking
+        </a>
+        <a class="evidence-chart-link" href="charts/town_explorer.html">
+          Compare all 351 communities yourself
+        </a>
+      </div>
+
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
@@ -3030,6 +3209,9 @@ og_url: https://marbleheaddata.org/
         </p>
         <a class="evidence-chart-link" href="charts/four_town_rates.html">
           Bill as share of income
+        </a>
+        <a class="evidence-chart-link" href="charts/town_explorer.html">
+          Build your own peer comparison
         </a>
       </div>
 
@@ -3161,11 +3343,11 @@ og_url: https://marbleheaddata.org/
 
         <div class="chart-wrapper">
           <svg class="chart" viewBox="0 0 560 150" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Horizontal bar chart: annual override cost at average home value. Tier 1 $1,187, Tier 2 $1,587, Tier 3 $1,985.">
-            <text class="tick-label" x="130" y="28" text-anchor="end">Tier 1 (Restore)</text>
+            <text class="tick-label" x="130" y="28" text-anchor="end">Tier 1 (Partial Restore)</text>
             <rect class="data-bar s-tier-1" x="135" y="14" width="179" height="20" rx="2"/>
             <text class="value-label" x="320" y="30">$1,187/yr ($99/mo)</text>
 
-            <text class="tick-label" x="130" y="64" text-anchor="end">Tier 2 (Stabilize)</text>
+            <text class="tick-label" x="130" y="64" text-anchor="end">Tier 2 (Build)</text>
             <rect class="data-bar s-tier-2" x="135" y="50" width="239" height="20" rx="2"/>
             <text class="value-label" x="380" y="66">$1,587/yr ($132/mo)</text>
 
@@ -3377,8 +3559,8 @@ og_url: https://marbleheaddata.org/
         <h2>The size doesn't matter because the answer is no</h2>
         <p class="answer-summary">
           No override of any size should pass until the town demonstrates
-          structural reform. Voting yes at any tier rewards the spending
-          patterns that created the deficit.
+          structural reform. Any tier continues the same spending
+          trajectory that created the deficit.
         </p>
       </div>
     </div>
@@ -3415,6 +3597,9 @@ og_url: https://marbleheaddata.org/
         </a>
         <a class="evidence-chart-link" href="no-override-budget.html">
           What gets cut without an override
+        </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Model how long each tier lasts
         </a>
       </div>
 
@@ -3454,6 +3639,9 @@ og_url: https://marbleheaddata.org/
         </a>
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Revenue vs. expenses forecast
+        </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Toggle tiers on/off and see the crossover year
         </a>
       </div>
 
@@ -3495,7 +3683,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>An override without reform is a blank check</h4>
+        <h4>An override without reform doesn't fix the structure</h4>
         <p>
           Marblehead has not consolidated departments, renegotiated
           health plan design, or moved to
@@ -3507,18 +3695,19 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="charts/healthcare_costs.html">
           Health insurance cost trends
         </a>
-        <a class="evidence-chart-link" href="why-not-elsewhere.html#town-school-consolidation">
-          Town/school administrative consolidation
+        <a class="evidence-chart-link" href="town-school-admin.html">
+          Why two sets of departments?
         </a>
       </div>
 
       <div class="evidence-point">
-        <h4>Voting no is the only real leverage</h4>
+        <h4>A no vote is the strongest available leverage</h4>
         <p>
           Once an override passes, the levy ceiling rises permanently.
-          There is no mechanism for voters to claw it back. Voting no
-          forces the conversation about which services the town can
-          actually afford at its current tax base.
+          There is no mechanism for voters to claw it back. Proponents
+          of this view argue that voting no forces the conversation
+          about which services the town can afford at its current
+          tax base.
         </p>
         <a class="evidence-chart-link" href="what-you-can-do.html#better-oversight">
           Ways to push for reform
@@ -3687,6 +3876,9 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Sustainability projections
         </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Set your own growth rates and watch the gap reopen
+        </a>
       </div>
 
       <div class="evidence-point">
@@ -3748,6 +3940,9 @@ og_url: https://marbleheaddata.org/
         </p>
         <a class="evidence-chart-link" href="what-you-can-do.html#better-oversight">
           Reform options
+        </a>
+        <a class="evidence-chart-link" href="charts/deficit_model.html">
+          Model the gap under different cost-growth scenarios
         </a>
       </div>
 
@@ -3858,6 +4053,9 @@ og_url: https://marbleheaddata.org/
           districts, and zoning constrain development. Rezoning
           takes years.
         </p>
+        <a class="evidence-chart-link" href="charts/town_explorer.html">
+          See how Marblehead's tax base compares to all 351 communities
+        </a>
       </div>
 
       <details class="counter-argument">
@@ -4667,6 +4865,558 @@ og_url: https://marbleheaddata.org/
 
   </section>
 
+  <!-- ═══════════════════════════════════════════════════
+       QUESTION: How does this affect seniors?
+       ═══════════════════════════════════════════════════ -->
+  <section class="question-screen" data-topic="seniors">
+
+    <div class="question-block">
+      <h1>How does this affect seniors and people on fixed incomes?</h1>
+      <p class="question-context">
+        Property taxes are the same whether the household writing the check
+        is a working family or a retiree on Social Security. Marblehead has
+        several relief programs, but they only help if you qualify and apply.
+      </p>
+    </div>
+
+    <div class="answers">
+
+      <div class="answer-card" data-answer="a" data-question="seniors">
+        <p class="answer-label">Answer A</p>
+        <h2>Existing relief meaningfully offsets the increase</h2>
+        <p class="answer-summary">
+          The state Senior Circuit Breaker refunds up to $2,820/year. For
+          a lower-income senior with a modest home, it absorbs a
+          meaningful share of a Tier 3 increase. The programs exist; the
+          problem is low uptake, not low benefit.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="b" data-question="seniors">
+        <p class="answer-label">Answer B</p>
+        <h2>Relief doesn't reach most of the seniors who need it</h2>
+        <p class="answer-summary">
+          Only 418 of roughly 1,158 eligible Marblehead seniors claimed
+          the Circuit Breaker in 2022. For the rest, the override is a
+          straight tax increase with no offset.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="c" data-question="seniors">
+        <p class="answer-label">Answer C</p>
+        <h2>The override is the wrong instrument for targeted relief</h2>
+        <p class="answer-summary">
+          Property taxes tax the home, not the income. Voting yes or no
+          on the override doesn't change fixed-income exposure. Making
+          existing relief easier to access does.
+        </p>
+      </div>
+
+    </div>
+
+    <!-- Evidence A: existing relief offsets it -->
+    <div class="evidence" data-evidence="seniors-a">
+      <div class="evidence-header">
+        <h3>The case for "existing relief offsets it"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The Senior Circuit Breaker is worth up to $2,820/year</h4>
+        <p>
+          The <abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr>
+          Senior Circuit Breaker is a refundable state tax credit for
+          homeowners 65 and older with MA income below $75,000 (single),
+          $94,000 (head of household), or $112,000 (joint), and a home
+          assessed at or below $1,298,000. The credit is the portion of
+          property tax (plus half water and sewer) above 10% of income,
+          capped at $2,820. It's refundable: you get a check even if
+          you owe no state income tax. Social Security income does not
+          disqualify you.
+        </p>
+        <a class="evidence-chart-link" href="senior-tax-relief.html#circuit-breaker">
+          Circuit Breaker walkthrough
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Worked example: $900K home, $60K income</h4>
+        <p>
+          At Marblehead's FY26 tax rate of $8.60 per $1,000: property tax
+          $7,740. Half water and sewer: $750. Total eligible: $8,490. 10%
+          of income: $6,000. Excess: $2,490. That's the credit the state
+          writes you a check for. A full Tier 3 override would add about
+          $1,380 to the tax bill on a $900K home; the Circuit Breaker
+          credit grows by $330 (from $2,490 to the $2,820 cap), leaving
+          the senior paying about $1,050 of the override out of pocket.
+          Seniors who start farther below the cap see a larger share
+          absorbed; seniors already at the cap see none.
+        </p>
+        <a class="evidence-chart-link" href="senior-tax-relief.html">
+          Senior relief calculator
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Additional exemptions stack on top</h4>
+        <p>
+          Veteran exemptions ($400 to full), the senior tax deferral
+          (Clause 41A), the low-income senior exemption (Clause 41C),
+          and the surviving spouse exemption (Clause 17D) all stack with
+          the Circuit Breaker. The Council on Aging also runs a Senior
+          Tax Work-Off Program. The deadline for local exemptions is
+          April 1; Circuit Breaker follows the state tax filing deadline.
+        </p>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            A program that exists and a program that reaches people are
+            different things. In 2022, only 36% of eligible Marblehead
+            seniors claimed the Circuit Breaker, and the average credit
+            received was $1,054 &ndash; far below the $2,820 cap. The
+            relief math works in the abstract; in practice most of the
+            benefit is left on the table every year.
+          </p>
+        </div>
+      </details>
+    </div>
+
+    <!-- Evidence B: relief doesn't reach who needs it -->
+    <div class="evidence" data-evidence="seniors-b">
+      <div class="evidence-header">
+        <h3>The case for "relief doesn't reach who needs it"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>36% uptake of the Circuit Breaker in 2022</h4>
+        <p>
+          418 Marblehead seniors filed Schedule CB and claimed the
+          Circuit Breaker in 2022. The estimated eligible population is
+          roughly 1,158 senior households at or below the $75,000
+          single-filer income limit. That leaves roughly 740 households
+          either unaware of the program, not filing state returns, or
+          facing application friction that blocks them. The credit is
+          worth nothing to a senior who never files.
+        </p>
+        <a class="evidence-chart-link" href="senior-tax-relief.html#how-to-actually-get-this">
+          Uptake data and application steps
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The average claim is $1,054, not $2,820</h4>
+        <p>
+          The average Marblehead Circuit Breaker claim in 2022 was $1,054,
+          about 37% of the $2,820 cap. For seniors who do file, the
+          credit partially offsets an override; for those who don't file
+          at all, the offset is zero.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The local means-tested exemption hasn't taken effect yet</h4>
+        <p>
+          Marblehead Town Meeting passed Article 28 in May 2025 with
+          roughly 93% support. It would add a means-tested local
+          exemption on top of the Circuit Breaker for longtime Marblehead
+          seniors, funded from the tax overlay rather than the operating
+          budget. The enabling state legislation (H.4225) passed the MA
+          House on March 30, 2026, but is still awaiting Senate action.
+          Until it becomes law, the local exemption does not exist for
+          FY27.
+        </p>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer A would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            Low uptake is a distribution problem, not a funding problem.
+            The Circuit Breaker is fully funded by the state, requires no
+            local appropriation, and is waiting to be claimed. Outreach
+            campaigns, Council on Aging assistance, and pre-filled forms
+            could close most of the gap in a year or two. "Not reaching
+            enough people" is a reason to improve the program, not a
+            reason to vote down the override.
+          </p>
+        </div>
+      </details>
+    </div>
+
+    <!-- Evidence C: override is the wrong instrument -->
+    <div class="evidence" data-evidence="seniors-c">
+      <div class="evidence-header">
+        <h3>The case for "override is the wrong instrument"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Property taxes tax the home, not the income</h4>
+        <p>
+          An override raises property tax on the assessed value of a
+          home, regardless of the household's current income. A retiree
+          who bought their house in 1985 and sees it appraised today at
+          $1.2 million pays the same rate as a working professional who
+          bought the same house last year. Any override, any size, any
+          year carries this property-vs-income mismatch &ndash; it's
+          built into property tax as a mechanism.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The relief levers are separate from the override vote</h4>
+        <p>
+          Voting yes or no on the override doesn't change the Circuit
+          Breaker uptake rate, doesn't accelerate H.4225 in the Senate,
+          and doesn't enroll seniors in programs they're not currently
+          using. Those are separate policy levers with separate
+          decision-makers. Pushing for better outreach, automatic
+          enrollment where possible, and state-level caps that scale
+          with home values is the direct path to fixed-income relief,
+          override or no override.
+        </p>
+        <a class="evidence-chart-link" href="what-you-can-do.html#better-oversight">
+          Better oversight and reform options
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The local exemption doesn't compete with services</h4>
+        <p>
+          Article 28's means-tested local exemption is paid from the tax
+          overlay, not the operating budget, which means it does not
+          compete with schools, public safety, or library funding.
+          Whatever happens at the override ballot, pushing for faster
+          Senate action on H.4225 has no tradeoff against service levels.
+        </p>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answers A and B would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            "Use other levers" is a non-answer to "what do I do about
+            this specific tax bill on June 9?" Seniors voting on the
+            override are not in a position to accelerate Senate action
+            on H.4225 or redesign the Circuit Breaker. Saying "the
+            override is the wrong instrument" names the exposure but
+            leaves the voter without a concrete response to it on the
+            actual ballot they are holding.
+          </p>
+        </div>
+      </details>
+    </div>
+
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════
+       QUESTION: What explains the budget growth?
+       ═══════════════════════════════════════════════════ -->
+  <section class="question-screen" data-topic="moneygone">
+
+    <div class="question-block">
+      <h1>What explains the budget growth?</h1>
+      <p class="question-context">
+        Marblehead's General Fund grew from $70.5M (FY15) to $106.2M
+        (FY26), an increase of $35.7M over 11 years. What drove that
+        growth, and did anything grow faster than inflation,
+        enrollment, or service levels would suggest?
+      </p>
+    </div>
+
+    <div class="answers">
+
+      <div class="answer-card" data-answer="a" data-question="moneygone">
+        <p class="answer-label">Answer A</p>
+        <h2>Costs the town can't say no to</h2>
+        <p class="answer-summary">
+          Schools absorbed 48% of the growth, with mandated
+          out-of-district special education one of the drivers. Health
+          insurance, pensions, and debt service are on rate sheets and
+          fixed schedules the town doesn't set. These aren't choices.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="b" data-question="moneygone">
+        <p class="answer-label">Answer B</p>
+        <h2>Some growth ran ahead of any obvious driver</h2>
+        <p class="answer-summary">
+          Enrollment fell 19% while education staff rose 9.6%. The town
+          has balanced the operating budget with one-time free cash
+          for years. Several line items grew faster than any obvious
+          driver.
+        </p>
+      </div>
+
+      <div class="answer-card" data-answer="c" data-question="moneygone">
+        <p class="answer-label">Answer C</p>
+        <h2>Both, depending on which line item</h2>
+        <p class="answer-summary">
+          Different lines tell different stories. Schools, pensions,
+          and health insurance look mandatory. Town Counsel and
+          free-cash patching look discretionary. The same audited
+          numbers support both A and B because both are true for
+          different lines.
+        </p>
+      </div>
+
+    </div>
+
+    <!-- Evidence A: cost pressures -->
+    <div class="evidence" data-evidence="moneygone-a">
+      <div class="evidence-header">
+        <h3>The case for "costs the town can't say no to"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Schools absorbed 48% of total growth</h4>
+        <p>
+          Schools grew from $32.1M (FY15) to $46.2M (FY24), absorbing
+          roughly 48% of the $35.7M total General Fund growth. About
+          $4.6M of the FY26 school budget &ndash; roughly 9% &ndash;
+          pays for out-of-district special education placements that
+          are mandated by the federal
+          <abbr class="g" title="Individuals with Disabilities Education Act">IDEA</abbr>
+          and Massachusetts special education law. The town does not
+          have discretion to stop paying for placements once a
+          student's Individualized Education Program requires them.
+        </p>
+        <a class="evidence-chart-link" href="where-has-the-money-gone.html">
+          Where the money went
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Health insurance is set by the state pool, not the town</h4>
+        <p>
+          The town pays 83% of employee health insurance premiums
+          through the <abbr class="g" title="Group Insurance Commission">GIC</abbr>,
+          Massachusetts's state insurance pool. GIC rates are set by
+          the pool and have grown substantially faster than
+          Proposition 2&frac12;'s 2.5% annual levy cap. The FY27 rate
+          increase alone added roughly $1.65M to the operating budget
+          on a single line item.
+        </p>
+        <a class="evidence-chart-link" href="charts/healthcare_costs.html">
+          Health insurance vs. tax levy
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Pensions and debt service are fixed schedules</h4>
+        <p>
+          Marblehead's pension obligations are on a
+          <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>-certified
+          actuarial schedule rising 8.6% per year through FY35.
+          Voter-approved debt service (Abbot Library, Mary Alley
+          <abbr class="g" title="Heating, Ventilation, and Air Conditioning">HVAC</abbr>,
+          and other capital projects) is contractual. Neither line
+          has meaningful near-term local discretion.
+        </p>
+        <a class="evidence-chart-link" href="charts/budget_flow.html">
+          Full budget flow, by category
+        </a>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer B would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            "Mandated" and "chosen" blur over a 10-year horizon. The
+            83/17 GIC premium split is a contract provision the town
+            chose and can renegotiate at contract renewal. Staffing
+            composition is a policy choice even when specific positions
+            trigger benefits eligibility. Calling growth "external"
+            assumes a 12-week budget-cycle view; the same lines look
+            discretionary on a 5-year view.
+          </p>
+        </div>
+      </details>
+    </div>
+
+    <!-- Evidence B: some growth ran ahead of any obvious driver -->
+    <div class="evidence" data-evidence="moneygone-b">
+      <div class="evidence-header">
+        <h3>The case for "some growth ran ahead of any obvious driver"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Enrollment fell 19%, total education headcount grew 9.6%</h4>
+        <p>
+          Between 2015 and 2024, Marblehead school enrollment fell from
+          3,245 to 2,617 students &ndash; a drop of 628 students, or
+          19%. Classroom teacher headcount dropped about 4% over the
+          same window. But total education headcount (including
+          paraprofessionals, specialists, and administrators) rose by
+          roughly 58 positions to 537
+          <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>,
+          a 9.6% increase. The student-to-teacher ratio fell from 12.6
+          to 10.7, the lowest of Marblehead's four peer towns. Most of
+          that FTE increase lands in a single FY22-to-FY23 jump (483 to
+          537) that the town has not publicly explained; the source may
+          reflect expired federal ESSER positions or a change in
+          reporting methodology, and the number has held at exactly
+          537.0 for two years since.
+        </p>
+        <a class="evidence-chart-link" href="inside-school-staffing.html">
+          Inside school staffing
+        </a>
+        <a class="evidence-chart-link" href="charts/enrollment_vs_staffing.html">
+          Enrollment vs. staffing chart
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Operating budget balanced on free cash for years</h4>
+        <p>
+          Town Meeting appropriated $7.0M of free cash (prior-year
+          surplus) into the FY26 operating budget, $5.5M into FY25,
+          and $10.2M into FY23. The
+          <abbr class="g" title="Finance Committee">FinCom</abbr>'s
+          2022 report described the pattern as a "structural budget
+          challenge" caused by "recurring costs structurally outpacing
+          recurring revenues." The 2025 report noted reserves at only
+          2.5% of the operating budget, below the state-recommended
+          range of 5 to 10%.
+        </p>
+        <a class="evidence-chart-link" href="how-we-got-here.html">
+          Seven years of FinCom warnings
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Town Counsel rose 142% in one year, unexplained</h4>
+        <p>
+          The FY27 Proposed Budget moves Town Counsel from $115,000 to
+          $278,000 &ndash; a one-year increase of $163,000 or 142%.
+          Two FY26 town documents disagree on the starting figure (one
+          lists $115,000, the other $228,000), and the reason for the
+          year-over-year increase and the discrepancy between the two
+          FY26 figures is not publicly documented. The same budget
+          zeros out the town's $250,000 annual
+          <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr>
+          retiree-benefits-trust contribution, so one legal line grew
+          by about two-thirds of the retiree-benefits contribution in
+          the same budget cycle.
+        </p>
+        <a class="evidence-chart-link" href="where-has-the-money-gone.html#what-grew-faster">
+          What grew faster
+        </a>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answer A would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            The peer-town comparison cuts both ways. A 10.7
+            student-teacher ratio is low, but some of the headcount
+            growth reflects mandated special education staffing that
+            rose even as total enrollment fell. Free cash use is a
+            structural concern the Finance Committee has flagged, but
+            it does not by itself prove the underlying spending was
+            discretionary rather than contractually obligated.
+          </p>
+        </div>
+      </details>
+    </div>
+
+    <!-- Evidence C: both, depending on which line item -->
+    <div class="evidence" data-evidence="moneygone-c">
+      <div class="evidence-header">
+        <h3>The case for "both, depending on which line item"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Six independent reviewers check the books every year</h4>
+        <p>
+          Marblehead's books are audited annually by an independent
+          firm (clean opinion every year). The
+          <abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr>
+          certifies the tax rate. PERAC audits the pension fund on a
+          biennial actuarial schedule. The Finance Committee publishes
+          an annual report. The town's outside auditor issues a
+          management letter in most years. These are not self-reported
+          numbers.
+        </p>
+        <a class="evidence-chart-link" href="where-has-the-money-gone.html#who-checks-books">
+          Who has been checking the books
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The source documents are free, public, and long</h4>
+        <p>
+          The
+          <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>
+          publishes every line item, every year, with departmental
+          breakdowns and multi-year trends. The Finance Committee
+          Annual Report summarizes the year's budget process in about
+          40 pages. Both documents are posted on the town website.
+          How many residents read any of them in a given year is a
+          separate question.
+        </p>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Answers A and B read the same numbers differently</h4>
+        <p>
+          The A and B perspectives on this question use the same
+          underlying data &ndash; the same ACFR, the same
+          <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr>
+          enrollment file, the same FinCom reports &ndash; and reach
+          opposite conclusions. Without engaging the source documents,
+          both answers are narratives layered on identical data. The
+          goal of this site is to make verification easier, not to
+          settle which narrative is correct.
+        </p>
+        <a class="evidence-chart-link" href="data/SOURCE_LOOKUP.html">
+          Trace any number to its source
+        </a>
+      </div>
+
+      <details class="counter-argument">
+        <summary>
+          <span class="counter-argument-label">Counter-argument</span>
+          <span class="counter-argument-teaser">Answers A and B would push back</span>
+        </summary>
+        <div class="counter-argument-body">
+          <p>
+            "It's mixed" is a starting point for analysis, not a
+            conclusion to rest on. Voters have to act on some reading
+            of the numbers within a 12-week budget cycle, and a reading
+            that refuses to commit still counts as a vote. The split
+            between "mandatory" and "discretionary" lines is itself a
+            judgment call &ndash; A would draw the line in one place, B
+            in another.
+          </p>
+        </div>
+      </details>
+    </div>
+
+  </section>
+
   <!-- Related questions (JS populates based on current topic) -->
   <div class="related-questions" id="relatedQuestions">
     <div class="related-questions-label">Related questions</div>
@@ -4727,8 +5477,10 @@ og_url: https://marbleheaddata.org/
   (function reorderQuestions() {
     var preferredOrder = [
       'mycost',       // How will this affect my taxes?
+      'seniors',      // How does this affect seniors and fixed-income households?
       'taxrank',      // How does Marblehead's tax burden compare?
       'levy',         // Why don't 2.5% increases keep up?
+      'moneygone',    // What explains the budget growth?
       'size',         // Does the size of the override matter?
       'schools',      // Why did staffing grow while enrollment fell?
       'trash',        // Why is trash collection on the ballot?
@@ -5193,6 +5945,32 @@ og_url: https://marbleheaddata.org/
 
   // Personal view count is now derived from topic views (incremented in switchTopic)
 
+  // Count-up animation for the community totals on initial server response.
+  // Runs once per page load (the first time real server data arrives); later
+  // updates from single-user increments just set textContent directly so a
+  // share of 97 -> 98 doesn't trigger a visible animation.
+  var statsCommunityAnimated = false;
+  var prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  function animateStatCount(el, from, to, duration) {
+    if (!el) return;
+    if (prefersReducedMotion || from === to) { el.textContent = to; return; }
+    var start = null;
+    var diff = to - from;
+    function step(ts) {
+      if (start === null) start = ts;
+      var t = Math.min(1, (ts - start) / duration);
+      // Ease-out cubic: fast at first, slows as it finishes
+      var eased = 1 - Math.pow(1 - t, 3);
+      el.textContent = Math.round(from + diff * eased);
+      if (t < 1) {
+        requestAnimationFrame(step);
+      } else {
+        el.textContent = to;
+      }
+    }
+    requestAnimationFrame(step);
+  }
+
   function updateStatsStrip() {
     var statsEl = document.getElementById('exploreStats');
     var decidedCount = topicOrder.filter(function (t) { return !!selections[t]; }).length;
@@ -5210,8 +5988,17 @@ og_url: https://marbleheaddata.org/
     document.getElementById('statTotal').textContent = totalCount;
     document.getElementById('statYourViews').textContent = getYourViews();
     document.getElementById('statYourShares').textContent = getYourShares();
-    document.getElementById('statAllViews').textContent = allViews;
-    document.getElementById('statAllShares').textContent = allShares;
+    var allViewsEl = document.getElementById('statAllViews');
+    var allSharesEl = document.getElementById('statAllShares');
+    if (!statsCommunityAnimated && (allViews > 0 || allShares > 0)) {
+      // First time real server totals arrive: count up from zero.
+      animateStatCount(allViewsEl, 0, allViews, 1200);
+      animateStatCount(allSharesEl, 0, allShares, 1200);
+      statsCommunityAnimated = true;
+    } else {
+      allViewsEl.textContent = allViews;
+      allSharesEl.textContent = allShares;
+    }
     var pct = totalCount > 0 ? Math.round((decidedCount / totalCount) * 100) : 0;
     document.getElementById('statBar').style.width = pct + '%';
 
@@ -5233,7 +6020,7 @@ og_url: https://marbleheaddata.org/
 
   // Reset button: clears all local data (selections, notes, counters, tutorial)
   document.getElementById('statsReset').addEventListener('click', function () {
-    if (!confirm('Erase all your picks and notes? Nothing about you is stored anywhere except your browser.')) return;
+    if (!confirm('Erase all your picks? Nothing about you is stored anywhere except your browser.')) return;
     // Clear selections
     Object.keys(selections).forEach(function (k) { delete selections[k]; });
     persistSelections();
@@ -5273,6 +6060,10 @@ og_url: https://marbleheaddata.org/
 
   function showTutorial() {
     if (tutorialSeen) return;
+    // Mark as seen immediately on display, not only on "Got it" click.
+    // Otherwise users who ignore the box keep seeing it on every later pick.
+    tutorialSeen = true;
+    localStorage.setItem(TUTORIAL_KEY, '1');
     tutorialEl.classList.add('visible');
   }
 
@@ -5286,9 +6077,11 @@ og_url: https://marbleheaddata.org/
 
   document.getElementById('tutorialDismiss').addEventListener('click', dismissTutorial);
 
-  // Show browse hint on subsequent visits if tutorial was already seen
+  // Show browse hint on subsequent visits if tutorial was already seen.
+  // Suppress it while the tutorial box itself is still on screen -- the
+  // tutorial already contains the same hint, so showing both is redundant.
   function updateBrowseHint(topic) {
-    if (tutorialSeen && selections[topic]) {
+    if (tutorialSeen && selections[topic] && !tutorialEl.classList.contains('visible')) {
       browseHintEl.classList.add('visible');
     } else {
       browseHintEl.classList.remove('visible');
@@ -5327,14 +6120,20 @@ og_url: https://marbleheaddata.org/
 
   /* ── Related questions map ── */
   var relatedMap = {
-    override: ['voteno', 'levy', 'trust'],
-    voteno:   ['override', 'again', 'schools'],
-    schools:  ['override', 'mycost', 'voteno'],
-    levy:     ['taxrank', 'mycost', 'override'],
-    taxrank:  ['levy', 'mycost', 'schools'],
-    mycost:   ['size', 'levy', 'taxrank'],
-    size:     ['mycost', 'again', 'override'],
-    trust:    ['override', 'alternatives', 'voteno']
+    override:     ['voteno', 'levy', 'trust'],
+    voteno:       ['override', 'again', 'schools'],
+    schools:      ['override', 'mycost', 'voteno'],
+    levy:         ['taxrank', 'mycost', 'override'],
+    moneygone:    ['override', 'levy', 'schools'],
+    taxrank:      ['levy', 'mycost', 'schools'],
+    mycost:       ['size', 'levy', 'taxrank'],
+    seniors:      ['mycost', 'override', 'voteno'],
+    size:         ['mycost', 'again', 'override'],
+    again:        ['size', 'override', 'voteno'],
+    alternatives: ['override', 'levy', 'trust'],
+    trash:        ['mycost', 'voteno', 'taxrank'],
+    library:      ['voteno', 'override', 'mycost'],
+    trust:        ['override', 'alternatives', 'voteno']
   };
 
   /* ── Topic order (for progress dots) ── */
@@ -5614,7 +6413,9 @@ og_url: https://marbleheaddata.org/
     alternatives: '<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/>', /* question circle */
     trash:        '<path d="M20 7l-1.2 12.5a2 2 0 0 1-2 1.5H7.2a2 2 0 0 1-2-1.5L4 7"/><path d="M10 11v6m4-6v6M1 7h22M8 7V3.5A1.5 1.5 0 0 1 9.5 2h5A1.5 1.5 0 0 1 16 3.5V7"/>', /* trash */
     library:      '<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>', /* book */
-    trust:        '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>'      /* shield */
+    trust:        '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>',     /* shield */
+    seniors:      '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.87a4 4 0 0 1 0 7.75"/>', /* two people */
+    moneygone:    '<path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/>' /* pie chart */
   };
 
   /* ── Build landing question cards from actual h1s ── */
@@ -5645,14 +6446,23 @@ og_url: https://marbleheaddata.org/
     titleSpan.textContent = h1.textContent;
     btn.appendChild(titleSpan);
 
-    /* Context subtitle */
+    /* Context subtitle. When the reader has picked an answer for this
+       topic, this slot recaps their choice instead of re-explaining
+       the question. We stash the original elaboration text and the
+       per-answer headings so updateLandingCards() can swap between
+       them without re-querying the DOM. */
     var ctxP = screen.querySelector('.question-context');
-    if (ctxP) {
-      var ctxSpan = document.createElement('span');
-      ctxSpan.className = 'explore-card-context';
-      ctxSpan.textContent = ctxP.textContent.trim();
-      btn.appendChild(ctxSpan);
-    }
+    var ctxText = ctxP ? ctxP.textContent.trim() : '';
+    var answerHeadings = {};
+    ['a', 'b', 'c'].forEach(function (pos) {
+      var ac = screen.querySelector('.answer-card[data-answer="' + pos + '"]');
+      var h2 = ac ? ac.querySelector('h2') : null;
+      if (h2) answerHeadings[pos] = h2.textContent.trim();
+    });
+    var ctxSpan = document.createElement('span');
+    ctxSpan.className = 'explore-card-context';
+    ctxSpan.textContent = ctxText;
+    btn.appendChild(ctxSpan);
 
     /* Mini position indicators (a, b, c, u). The 'u' pip is the
        muted "Not sure yet" state -- lights up when the reader's
@@ -5679,7 +6489,14 @@ og_url: https://marbleheaddata.org/
       window.scrollTo(0, 0);
     });
     listEl.appendChild(btn);
-    landingCards[topic] = { el: btn, pips: pips, dist: distEl };
+    landingCards[topic] = {
+      el: btn,
+      pips: pips,
+      dist: distEl,
+      ctxSpan: ctxSpan,
+      ctxText: ctxText,
+      answerHeadings: answerHeadings
+    };
   });
 
   /* Update landing cards to reflect current selections */
@@ -5696,6 +6513,14 @@ og_url: https://marbleheaddata.org/
         hasAny = true;
         if (card.pips[answer]) card.pips[answer].classList.add('picked');
         card.el.classList.add('has-pick');
+        // Recap the reader's pick in the subheader slot. For 'u'
+        // (Not sure yet) there's no answer heading to show, so keep
+        // the original question elaboration -- the muted pip already
+        // signals the unsure state.
+        if (card.ctxSpan) {
+          var recap = card.answerHeadings[answer];
+          card.ctxSpan.textContent = recap || card.ctxText;
+        }
         // Populate community split bar from server counts. 'u' is a
         // real fourth segment; the muted pip keeps it from competing
         // visually with the three real positions.
@@ -5726,6 +6551,7 @@ og_url: https://marbleheaddata.org/
       } else {
         card.el.classList.remove('has-pick');
         if (card.dist) card.dist.innerHTML = '';
+        if (card.ctxSpan) card.ctxSpan.textContent = card.ctxText;
       }
     });
     // Show share buttons if any selections
@@ -5811,6 +6637,10 @@ og_url: https://marbleheaddata.org/
     if (typeof posthog !== 'undefined') {
       posthog.capture('explore_answer_selected', { topic: question, answer: answer });
     }
+    // Capture pre-pick state so we can tell if this is the user's very first
+    // pick. Anything else ("you already have picks, you're just making another")
+    // should not trigger the first-pick tutorial.
+    var wasFirstPick = Object.keys(selections).length === 0;
     // Update checkmark: only the selected card gets .selected
     document.querySelectorAll('.answer-card[data-question="' + question + '"]').forEach(function (c) {
       c.classList.remove('selected');
@@ -5835,8 +6665,8 @@ og_url: https://marbleheaddata.org/
     // Show answer distribution now that the user has picked
     showPickDistribution(question);
 
-    // First-time tutorial
-    if (!tutorialSeen) showTutorial();
+    // First-time tutorial -- only on the user's actual first-ever pick
+    if (wasFirstPick && !tutorialSeen) showTutorial();
 
     // Show browse hint (after tutorial is seen)
     updateBrowseHint(question);
@@ -5939,10 +6769,55 @@ og_url: https://marbleheaddata.org/
   // via the "This resonates" button inside the evidence panel or the
   // checkmark shortcut. "Not sure yet" is the one exception -- it still
   // selects directly since its evidence panel is just a placeholder.
+  //
+  // Touch guard: on mobile, a finger touch that turns into a scroll (or a
+  // tap-to-stop during iOS momentum scroll) can still fire a synthetic
+  // click, which would apply .viewing / .selected to a card the user
+  // didn't mean to pick. We ignore clicks where (a) the finger moved past
+  // the tap slop, (b) the document scrolled between touchstart and click,
+  // or (c) the page was actively scrolling in the moment before the click
+  // (tap-to-stop-momentum case, where scrollY at touchstart and click are
+  // the same because the tap halted the scroll).
+  var TAP_SLOP_PX = 10;
+  var _lastScrollAt = 0;
+  window.addEventListener('scroll', function () {
+    _lastScrollAt = Date.now();
+  }, { passive: true });
   document.querySelectorAll('.answer-card').forEach(function (card) {
+    var tStartX = 0, tStartY = 0, tStartScrollY = 0, tStartAt = 0, tMoved = false;
+    card.addEventListener('touchstart', function (e) {
+      tStartAt = Date.now();
+      if (!e.touches || e.touches.length !== 1) { tMoved = true; return; }
+      tStartX = e.touches[0].clientX;
+      tStartY = e.touches[0].clientY;
+      tStartScrollY = window.pageYOffset || document.documentElement.scrollTop || 0;
+      // If a scroll event fired very recently, the page is mid-momentum
+      // and this touch is likely a stop-scroll gesture, not a tap.
+      tMoved = (tStartAt - _lastScrollAt) < 150;
+    }, { passive: true });
+    card.addEventListener('touchmove', function (e) {
+      if (tMoved || !e.touches || e.touches.length !== 1) return;
+      var dx = Math.abs(e.touches[0].clientX - tStartX);
+      var dy = Math.abs(e.touches[0].clientY - tStartY);
+      if (dx > TAP_SLOP_PX || dy > TAP_SLOP_PX) tMoved = true;
+    }, { passive: true });
     card.addEventListener('click', function (e) {
       // Don't fire if they clicked the checkmark (handled separately)
       if (e.target.closest('.answer-check')) return;
+
+      // Only apply touch-scroll guards when this click actually followed
+      // a recent touchstart. On desktop (mouse clicks) tStartAt stays 0,
+      // so the guards are skipped and scroll position is irrelevant.
+      if (tStartAt && (Date.now() - tStartAt) < 1000) {
+        var nowScrollY = window.pageYOffset || document.documentElement.scrollTop || 0;
+        if (tMoved || Math.abs(nowScrollY - tStartScrollY) > TAP_SLOP_PX) {
+          tMoved = false;
+          tStartAt = 0;
+          return;
+        }
+      }
+      tMoved = false;
+      tStartAt = 0;
 
       var question = this.dataset.question;
       var answer   = this.dataset.answer;


### PR DESCRIPTION
## Summary

Commit cbaaed6 ("Add neighbor verification network with passkey auth") accidentally removed substantial content and UX features from index.html alongside the verification additions. This PR restores everything that was lost while keeping the new verification features intact.

### Content restored
- **Two full question sections** ("How does this affect seniors?" and "What explains the budget growth?") with all evidence, counter-arguments, and source citations
- **"Lighter than all but 24 of 351 MA communities"** evidence point in the tax burden section
- **Gen-ed vs SPED teacher chart** with tooltip data (had been replaced with a duplicate enrollment chart)
- **Detailed ACFR vs DESE staffing comparison** text and counter-argument with links to enrollment_vs_staffing.html
- **Explore Tools row** (Deficit Model + Town Explorer) on the landing page
- **7 deficit model links** and **3 town explorer links** throughout evidence sections
- **Vote date countdown badges** for Town Meeting (May 4) and Town Election (Jun 9)

### UX restored
- **`@media (hover: hover)` guards** on answer cards, checkmarks, and hints (prevents sticky hover on touch devices)
- **Touch-scroll guards** on card clicks (prevents accidental taps during iOS momentum scroll)
- **Count-up animation** for community stats on first server response
- **Landing card answer recap** (shows your pick text in the subheader)
- **First-pick-only tutorial trigger** (was firing on every pick instead of just the first)
- **Browse hint suppression** while tutorial box is visible
- **Related questions map** entries for all topics (seniors, moneygone, again, alternatives, trash, library)
- **Pick distribution legend** styling (gap 14->20px, font 0.6875->0.75rem)

### Editorial fixes (per STYLE_GUIDE neutrality rules)
- "blank check" -> "doesn't fix the structure"
- "only real leverage" -> "strongest available leverage"
- "rewards the spending patterns" -> "continues the same spending trajectory"
- Restored neutral framing on no-vote evidence paragraph
- Tier labels back to official names (Partial Restore, Build)
- town-school-admin.html link restored (had been changed to why-not-elsewhere.html)

## Test plan
- [ ] Verify seniors and budget growth questions appear in the question list and are navigable
- [ ] Verify Deficit Model and Town Explorer cards appear in the "Run the numbers yourself" row on the landing page
- [ ] Verify countdown badges appear next to vote dates (May 4, Jun 9)
- [ ] Test on a touch device: tap an answer card, confirm no sticky hover state
- [ ] Test on a touch device: scroll through answer cards, confirm no accidental selections
- [ ] Pick an answer and return to landing -- confirm the subheader shows your pick text
- [ ] Verify the gen-ed vs SPED chart appears in the schools evidence section (not a duplicate enrollment chart)
- [ ] Verify "Lighter than all but 24" evidence point appears in the taxrank-a evidence
- [ ] Confirm community stats animate on first page load (count up from zero)
- [ ] Verify first pick triggers tutorial; second pick does not

https://claude.ai/code/session_01TESKxUJeh6EUtD9dbqXBRV