### PR TITLE
Scroll to tapped card, not past it to evidence

### DIFF
--- a/index.html
+++ b/index.html
@@ -6712,14 +6712,17 @@ og_url: https://marbleheaddata.org/
       }
     });
 
-    // Scroll so the user sees the evidence they just revealed.
-    // Only scroll if the panel top is below the viewport bottom,
-    // so we don't yank users away from content already visible.
-    if (openedPanel) {
+    // Scroll the tapped card to the top of the viewport so the user
+    // sees their pick confirmed, with evidence visible below it.
+    // Only scroll if the card isn't already near the top.
+    var tappedCard = document.querySelector(
+      '.answer-card[data-question="' + question + '"][data-answer="' + answer + '"]'
+    );
+    if (tappedCard) {
       setTimeout(function () {
-        var rect = openedPanel.getBoundingClientRect();
-        if (rect.top > window.innerHeight - 80) {
-          openedPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        var rect = tappedCard.getBoundingClientRect();
+        if (rect.top < 0 || rect.top > window.innerHeight * 0.4) {
+          tappedCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
       }, 120);
     }


### PR DESCRIPTION
## Summary
- After tapping an answer card, scrolls the **card itself** to the top of the viewport instead of jumping down to the evidence panel
- User sees their pick confirmed at the top with evidence visible below it
- Only scrolls if the card is off-screen or below 40% of the viewport

## Test plan
- [ ] Tap a card on mobile -- card scrolls to top, evidence visible below
- [ ] Tap a card already near the top -- no scroll happens
- [ ] "Not for me" still scrolls back to question top

🤖 Generated with [Claude Code](https://claude.com/claude-code)