### PR TITLE
Fix bar chart: bars fill width at any filter count

### DIFF
--- a/charts/town_explorer.html
+++ b/charts/town_explorer.html
@@ -151,7 +151,7 @@ scripts: [citations]
     overflow: hidden;
   }
   .bar-chart .bar {
-    flex: 1; max-width: 4px; min-width: 1px;
+    flex: 1; min-width: 1px;
     background: var(--text-subtle); opacity: 0.25;
     border-radius: 1px 1px 0 0;
     cursor: pointer; transition: opacity 0.1s;
@@ -159,7 +159,7 @@ scripts: [citations]
   .bar-chart .bar:hover { opacity: 0.6; }
   .bar-chart .bar.bar-mh {
     background: var(--series-marblehead); opacity: 0.85;
-    min-width: 3px; max-width: 6px; flex: 2;
+    min-width: 3px; flex: 2;
   }
   .bar-chart .bar.bar-mh:hover { opacity: 1; }
   .bar-tip {


### PR DESCRIPTION
Bars were capped at 4px wide, so 15 filtered towns huddled in the left corner. Now flex to fill the chart.