### PR TITLE
Make Marblehead bar same width as others

### DIFF
--- a/charts/town_explorer.html
+++ b/charts/town_explorer.html
@@ -159,7 +159,6 @@ scripts: [citations]
   .bar-chart .bar:hover { opacity: 0.6; }
   .bar-chart .bar.bar-mh {
     background: var(--series-marblehead); opacity: 0.85;
-    min-width: 3px; flex: 2;
   }
   .bar-chart .bar.bar-mh:hover { opacity: 1; }
   .bar-tip {


### PR DESCRIPTION
Navy color is enough to identify it. Double width was visually misleading.