### PR TITLE
Add voluntary municipal contribution research notes

### DIFF
--- a/data/voluntary_contribution_precedents.md
+++ b/data/voluntary_contribution_precedents.md
@@ -1,0 +1,107 @@
+---
+body_class: doc-page
+title: Voluntary Municipal Contribution Precedents
+exclude_from_nav: true
+---
+
+# Voluntary Municipal Contribution Precedents
+
+Research on whether towns can raise meaningful voluntary revenue from
+residents, and what donors get in return.
+
+## The baseline: generic "pay more" fails
+
+Massachusetts has offered a **voluntary higher income tax rate** (5.85%
+vs 5.0%) since 2002. About 1,200 of 3.5 million filers check the box
+each year (0.03%), raising roughly $250K against a $40B state budget.
+When there is no tangible return, almost nobody opts in.
+
+## Models that generate real revenue
+
+### Federal and state tax deductibility
+
+Under IRC 170(c)(1), donations to a political subdivision (town, city,
+county) for exclusively public purposes are deductible as charitable
+contributions -- the town does not need 501(c)(3) status. Massachusetts
+also allows a state charitable deduction that does not require federal
+itemization. A household in the 24% federal bracket + 5% MA rate
+effectively pays about $710 per $1,000 donated.
+
+### Earmarking to a visible purpose
+
+The MA tax-return checkoff for the Natural Heritage & Endangered Species
+Fund pulls roughly $312K/year from about 23,000 contributors -- 20x the
+participation rate of the generic "pay more" box. People give when they
+can see where the money goes. Nationally, 433 state checkoff programs
+exist; New York has raised over $51M total since 1983.
+
+### Municipal gift funds (MGL c.44 s.53A)
+
+Massachusetts law authorizes any town to accept gifts of money.
+Restricted gifts (e.g. "for the fire department") stay in a dedicated
+account and can be spent by the accepting department with selectboard
+approval. Unrestricted gifts require town meeting appropriation.
+
+### Physical recognition programs
+
+Common in MA suburbs:
+
+- **Brookline:** Park bench $5K--$10K with bronze plaque; ornamental
+  tree $1K; specimen tree $2K
+- **Newton:** Memorial bench $2,500--$2,800 with cast bronze plaque
+- **Salisbury:** Engraved memorial brick $150--$200
+
+Modest per-unit revenue but steady and self-sustaining.
+
+### Education foundations
+
+Wealthy MA towns run independent 501(c)(3) nonprofits that channel
+voluntary donations back to public schools:
+
+- **Brookline Education Foundation:** Over $6M distributed since 1981
+- **Lexington Education Foundation:** $250K/year pledged in grants
+- **Needham Education Foundation:** ~$28K per grant cycle
+
+Donors get the charitable deduction plus event and website recognition.
+
+### Community Preservation Act (CPA)
+
+201 MA towns (57% of municipalities) have adopted CPA, raising $3.7B
+total statewide across 18,742 projects. The surcharge is up to 3% of the
+property tax levy, voted in by town ballot. The state provides a partial
+match funded by Registry of Deeds fees (currently about 17%).
+
+Marblehead has not adopted CPA.
+
+### Civic crowdfunding with government match
+
+Michigan's Public Spaces Community Places program matches civic
+crowdfunding campaigns up to $50K. Since 2014: $14M+ invested across 421
+projects with a 97% success rate. The match makes each dollar feel like
+two.
+
+### Boston PILOT (Payments in Lieu of Taxes)
+
+Requests voluntary payments from tax-exempt nonprofits at 25% of what
+they would owe if taxable. FY2025: requested $133.6M, received $102.1M
+(76% compliance). The return for institutions is goodwill and avoiding
+the political risk of mandatory PILOT legislation.
+
+## Summary
+
+| Model | Participation | What donors get |
+|-------|--------------|-----------------|
+| Generic "pay more tax" (MA 5.85%) | 0.03% of filers | Nothing |
+| Earmarked tax checkoff (MA wildlife) | ~23K filers | Visible purpose |
+| Bench/plaque programs | Steady | Physical memorial + deduction |
+| Education foundations | Community-wide | Deduction + recognition |
+| CPA surcharge (town vote) | 201 MA towns | Open space, housing, preservation |
+| Civic crowdfunding + match | Project-specific | Leverage via matching |
+| Boston PILOT | 40+ institutions | Goodwill, avoid legislation |
+
+Voluntary contributions to government generate trivial revenue when they
+offer nothing tangible. Revenue scales with earmarking, deductibility,
+physical recognition, and matching. The generic "donate to the town"
+pitch reliably fails; the specific "fund this bench / this school program
+/ this open space parcel and here is your tax receipt" pitch reliably
+works.


### PR DESCRIPTION
## Summary
- Research on whether towns can raise meaningful voluntary revenue from residents
- Covers MA's 5.85% voluntary tax rate (0.03% participation), gift funds, bench/plaque programs, education foundations, CPA, civic crowdfunding, and Boston PILOT
- Stored in `data/` as a reference doc for override discussion prep

## Test plan
- [ ] Confirm markdown renders correctly on GitHub Pages with `doc-page` body class

🤖 Generated with [Claude Code](https://claude.com/claude-code)