### PR TITLE
WIP: DLS Schedule A scraper for peer town deficit curves

### DIFF
--- a/docs/superpowers/plans/2026-04-16-peer-deficit-curves.md
+++ b/docs/superpowers/plans/2026-04-16-peer-deficit-curves.md
@@ -1,0 +1,76 @@
+# Peer Town Deficit Curves: Research Status
+
+**Goal:** Build deficit dynamics charts (revenue vs expense lines crossing)
+for 14 peer towns, matching the Marblehead model at
+`/charts/deficit_model.html`.
+
+## What we have
+
+- **Override vote history** for 14 towns is done and merged
+  (`/charts/override_history.html`, PR #531).
+- **Marblehead** general fund budgetary data (FY15-FY24) from ACFRs is in
+  `data/general_fund_budgetary_FY15-24.csv`.
+
+## What we need
+
+Per-town general fund **total revenues** and **total expenditures** for
+FY2002-FY2025 from the DOR DLS Schedule A reports.
+
+## Data source
+
+**DOR DLS Schedule A General Fund**
+- URL: `https://dls-gw.dor.state.ma.us/reports/rdPage.aspx?rdReport=ScheduleA.GenFund_MAIN`
+- Content loads in an iframe (`#subGenFund`) pointing to `ScheduleA.GeneralFund`
+- The iframe has:
+  - Municipality checkboxes (`input[name="iclMuni"]`) with 351 towns
+  - Year checkboxes (`input[name="islYear"]`) for FY2002-FY2025
+  - Revenue/Expenditure dropdown (`<select>`)
+  - Submit button (image input)
+- Data table ID: `xtGenFund`, paginated at 40 rows per page (~9 pages for all 351 towns)
+- Columns (Revenue view): DOR Code, Municipality, Fiscal Year, Taxes,
+  Service Charges, Licenses and Permits, Federal Revenue, State Revenue,
+  Revenue from Other Governments, Special Assessments, Fines and
+  Forfeitures, Miscellaneous, Other Financing Sources, Transfers,
+  **Total Revenues**
+- Expenditure view has similar structure with different categories and
+  **Total Expenditures**
+
+## Scraper status
+
+`pull_schedule_a.mjs` is a working Playwright scraper that:
+1. Navigates to the Schedule A page
+2. Enters the iframe
+3. Loops through each year, selecting it and submitting
+4. Paginates through the `xtGenFund` table
+5. Filters to 14 peer towns and saves CSV
+
+**Known issue:** After the first form submission, pagination does not
+properly reset to page 1 when the year changes. The `<<` reset click
+was added but the second run was interrupted before completing.
+
+### To fix and run
+
+1. Run `node pull_schedule_a.mjs` and watch the output
+2. Verify that each year gets ~351 rows (all towns) not ~32 (stuck on
+   last page)
+3. If pagination is still stuck, try reloading the full page URL for
+   each year instead of just changing the year dropdown
+4. Alternative: click the `<<` link, wait longer, then verify page 1
+   is showing before scraping
+
+### Peer towns (14)
+
+Arlington, Brookline, Cohasset, Framingham, Hingham, Lexington,
+Marblehead, Melrose, Natick, Needham, Stoneham, Swampscott, Wellesley,
+Winchester
+
+## Next steps after data is collected
+
+1. Save as `data/peer_schedule_a_revenues.csv` and
+   `data/peer_schedule_a_expenditures.csv`
+2. Build combined `data/peer_gf_rev_exp_summary.csv` with columns:
+   municipality, fiscal_year, total_revenues, total_expenditures
+3. Add a new chart page (or extend `/charts/override_history.html`) with
+   per-town deficit curves
+4. Each town gets a small-multiple: revenue line vs expense line, with
+   override votes marked as annotations

--- a/pull_schedule_a.mjs
+++ b/pull_schedule_a.mjs
@@ -1,0 +1,203 @@
+import { chromium } from 'playwright';
+import { writeFileSync } from 'fs';
+
+const URL = 'https://dls-gw.dor.state.ma.us/reports/rdPage.aspx?rdReport=ScheduleA.GenFund_MAIN';
+
+const TOWNS = new Set([
+  'Arlington', 'Brookline', 'Cohasset', 'Framingham', 'Hingham',
+  'Lexington', 'Marblehead', 'Melrose', 'Natick', 'Needham',
+  'Stoneham', 'Swampscott', 'Wellesley', 'Winchester'
+]);
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+  });
+  await context.addInitScript(() => {
+    Object.defineProperty(navigator, 'webdriver', { get: () => false });
+  });
+  const page = await context.newPage();
+
+  console.log('Loading Schedule A General Fund page...');
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForTimeout(8000);
+
+  const frame = page.frames().find(f => f.url().includes('ScheduleA.GeneralFund'));
+  if (!frame) throw new Error('Could not find Schedule A iframe');
+
+  // Discover available years
+  const years = await frame.evaluate(() => {
+    const result = [];
+    const cbs = document.querySelectorAll('input[name="islYear"]');
+    for (const cb of cbs) {
+      if (cb.id.includes('All')) continue;
+      const label = document.querySelector('label[for="' + cb.id + '"]');
+      if (label) result.push({ id: cb.id, year: label.textContent.trim() });
+    }
+    return result;
+  });
+  console.log('Available years:', years.map(y => y.year).join(', '));
+
+  // For each view (Revenues, Expenditures), for each year, scrape data
+  const allRevRows = [];
+  const allExpRows = [];
+
+  for (const view of ['Revenues', 'Expenditures']) {
+    console.log('\n========== ' + view.toUpperCase() + ' ==========');
+    const allRows = view === 'Revenues' ? allRevRows : allExpRows;
+
+    for (const yearInfo of years) {
+      const yr = yearInfo.year;
+      console.log('\n--- ' + view + ' FY' + yr + ' ---');
+
+      // Select only this year (uncheck all, check this one)
+      await frame.evaluate((yearId) => {
+        const allCb = document.querySelector('input[id="islYear_rdListAll"]');
+        if (allCb && allCb.checked) allCb.click();
+        // Uncheck everything
+        const cbs = document.querySelectorAll('input[name="islYear"]');
+        for (const cb of cbs) {
+          if (cb.checked && !cb.id.includes('All')) cb.click();
+        }
+        // Check just this year
+        const target = document.getElementById(yearId);
+        if (target && !target.checked) target.click();
+      }, yearInfo.id);
+
+      // Select the view (Revenues or Expenditures)
+      await frame.evaluate((viewName) => {
+        const selects = document.querySelectorAll('select');
+        for (const sel of selects) {
+          for (const opt of sel.options) {
+            if (opt.text.includes(viewName)) {
+              sel.value = opt.value;
+              sel.dispatchEvent(new Event('change'));
+              return;
+            }
+          }
+        }
+      }, view);
+
+      // Submit
+      await frame.evaluate(() => {
+        const buttons = document.querySelectorAll('input[type="submit"], input[type="image"]');
+        for (const btn of buttons) {
+          const text = (btn.value || btn.alt || '').toLowerCase();
+          if (text.includes('submit') || btn.type === 'image') {
+            btn.click();
+            return;
+          }
+        }
+      });
+      await frame.waitForTimeout(4000);
+
+      // Reset to page 1 (pagination sticks on last page after re-submit)
+      await frame.evaluate(() => {
+        const links = document.querySelectorAll('a');
+        for (const a of links) {
+          if (a.textContent.trim() === '<<') { a.click(); return; }
+        }
+      });
+      await frame.waitForTimeout(2500);
+
+      // Scrape all pages for this year
+      const rows = await scrapeAllPages(frame);
+      console.log('  Total rows for FY' + yr + ': ' + rows.length);
+      for (const row of rows) allRows.push(row);
+    }
+  }
+
+  // Filter to peer towns and save
+  saveCSV(allRevRows, 'data/peer_schedule_a_revenues.csv', 'revenues');
+  saveCSV(allExpRows, 'data/peer_schedule_a_expenditures.csv', 'expenditures');
+
+  // Also save combined summary
+  buildSummary(allRevRows, allExpRows);
+
+  await browser.close();
+}
+
+function saveCSV(rows, filename, label) {
+  if (rows.length === 0) {
+    console.log('No ' + label + ' data to save.');
+    return;
+  }
+  // Filter to peer towns (municipality is column index 1)
+  const filtered = rows.filter(r => TOWNS.has(r[1]));
+  console.log('\n' + label + ': ' + rows.length + ' total rows, ' + filtered.length + ' peer town rows');
+
+  const lines = [];
+  // Use first row pattern for header
+  lines.push('dor_code,municipality,fiscal_year,taxes,service_charges,licenses_permits,federal_revenue,state_revenue,other_govt_revenue,special_assessments,fines,miscellaneous,other_financing,transfers,total');
+  for (const r of filtered) {
+    lines.push(r.map(c => '"' + c.replace(/"/g, '""') + '"').join(','));
+  }
+  writeFileSync(filename, lines.join('\n'));
+  console.log('Saved to ' + filename);
+}
+
+function buildSummary(revRows, expRows) {
+  // Build a simple town/year -> total revenue/expenditure lookup
+  const revMap = {};
+  for (const r of revRows) {
+    if (!TOWNS.has(r[1])) continue;
+    const key = r[1] + '|' + r[2];
+    revMap[key] = r[r.length - 1]; // last column = Total
+  }
+  const expMap = {};
+  for (const r of expRows) {
+    if (!TOWNS.has(r[1])) continue;
+    const key = r[1] + '|' + r[2];
+    expMap[key] = r[r.length - 1];
+  }
+
+  // Build combined CSV
+  const lines = ['municipality,fiscal_year,total_revenues,total_expenditures'];
+  const keys = new Set([...Object.keys(revMap), ...Object.keys(expMap)]);
+  const sorted = Array.from(keys).sort();
+  for (const key of sorted) {
+    const [town, fy] = key.split('|');
+    lines.push([town, fy, revMap[key] || '', expMap[key] || ''].join(','));
+  }
+  writeFileSync('data/peer_gf_rev_exp_summary.csv', lines.join('\n'));
+  console.log('Saved summary to data/peer_gf_rev_exp_summary.csv');
+}
+
+async function scrapeAllPages(frame) {
+  const allRows = [];
+
+  for (let pg = 1; pg <= 20; pg++) {
+    const rows = await frame.evaluate(() => {
+      const table = document.getElementById('xtGenFund');
+      if (!table) return [];
+      const trs = table.querySelectorAll('tr');
+      const result = [];
+      for (let i = 1; i < trs.length; i++) { // skip header row
+        const cells = trs[i].querySelectorAll('td');
+        if (cells.length >= 3) {
+          result.push(Array.from(cells).map(c => c.textContent.trim()));
+        }
+      }
+      return result;
+    });
+
+    if (rows.length === 0) break;
+    for (const row of rows) allRows.push(row);
+
+    const hasNext = await frame.evaluate(() => {
+      const links = document.querySelectorAll('a');
+      for (const a of links) {
+        if (a.textContent.trim() === '>') { a.click(); return true; }
+      }
+      return false;
+    });
+
+    if (!hasNext) break;
+    await frame.waitForTimeout(2500);
+  }
+
+  return allRows;
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- Playwright scraper (`pull_schedule_a.mjs`) for MA DOR DLS Schedule A General Fund data
- Plan doc with full research findings on the DLS page structure, data schema, and next steps
- Targets 14 peer towns, FY2002-FY2025, both revenues and expenditures

## Status: WIP
The scraper works but has a **pagination reset bug**: after changing the year dropdown and resubmitting, the table stays on the last page instead of resetting to page 1. The `<<` reset click was added but needs testing. Each year should return ~351 rows (all towns); if it returns ~32, pagination is stuck.

## What this enables
Once the scraper pulls clean data, we can build deficit dynamics curves (revenue vs expense lines) for each peer town, annotated with their override vote history. This shows what the fiscal trajectory looked like when towns chose to override (or not).

## Next session
1. Fix pagination reset in the scraper
2. Run and collect data into `data/peer_schedule_a_revenues.csv` and `data/peer_schedule_a_expenditures.csv`
3. Build the chart page

🤖 Generated with [Claude Code](https://claude.com/claude-code)