### PR TITLE
Add Cloudflare Pages PR preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,18 +5,18 @@ name: PR Preview
 # the change in a browser without pulling the branch locally.
 #
 # Setup (one-time, outside this workflow):
-#   1. In the Cloudflare dashboard, create a Pages project named
-#      "marbleheaddata-preview" (Direct Upload, no Git integration).
-#   2. Create an API token with "Cloudflare Pages - Edit" permission.
-#   3. Add two repo secrets:
-#        CLOUDFLARE_API_KEY     - the scoped API token from step 2
+#   1. Create an API token with "Cloudflare Pages - Edit" permission.
+#   2. Add two repo secrets:
+#        CLOUDFLARE_API_KEY     - the scoped API token from step 1
 #                                 (named API_KEY for historical reasons;
 #                                 the value is a scoped token, not the
 #                                 legacy Global API Key)
 #        CLOUDFLARE_ACCOUNT_ID  - your Cloudflare account ID
 #
-# With those secrets in place, every PR gets a preview URL posted as
-# a sticky comment on the PR. New pushes update the same comment.
+# The workflow creates the "marbleheaddata-preview" Pages project via
+# the Cloudflare API on first run; no dashboard click-through needed.
+# Every PR gets a preview URL posted as a sticky comment, updated
+# in place on each new push.
 
 on:
   pull_request:
@@ -50,6 +50,31 @@ jobs:
         run: |
           gem install 'jekyll:3.10.0' kramdown-parser-gfm
           jekyll build
+
+      # Idempotent: creates the Pages project on first run, no-ops after.
+      # The API returns 200 on create and a 4xx with errorcode 8000007 when
+      # the project already exists. We treat "exists" as success and fail
+      # loudly on anything else so token/account issues surface here, not
+      # deep inside wrangler.
+      - name: Ensure Pages project exists
+        env:
+          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_KEY }}
+        run: |
+          body=$(curl -sS -X POST \
+            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT}/pages/projects" \
+            -H "Authorization: Bearer ${CF_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data '{"name":"marbleheaddata-preview","production_branch":"main"}')
+          echo "$body"
+          success=$(echo "$body" | jq -r '.success')
+          exists=$(echo "$body" | jq -r '.errors // [] | map(select(.code == 8000007)) | length')
+          if [ "$success" = "true" ] || [ "$exists" != "0" ]; then
+            echo "Project ready."
+          else
+            echo "Project create failed."
+            exit 1
+          fi
 
       - name: Deploy to Cloudflare Pages
         id: deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,70 @@
+name: PR Preview
+
+# Build the Jekyll site for each pull request and deploy it to a
+# Cloudflare Pages preview URL so reviewers (and the author) can see
+# the change in a browser without pulling the branch locally.
+#
+# Setup (one-time, outside this workflow):
+#   1. In the Cloudflare dashboard, create a Pages project named
+#      "marbleheaddata-preview" (Direct Upload, no Git integration).
+#   2. Create an API token with "Cloudflare Pages - Edit" permission.
+#   3. Add two repo secrets:
+#        CLOUDFLARE_API_TOKEN   - the token from step 2
+#        CLOUDFLARE_ACCOUNT_ID  - your Cloudflare account ID
+#
+# With those secrets in place, every PR gets a preview URL posted as
+# a sticky comment on the PR. New pushes update the same comment.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+# A single deploy per PR; a new push cancels an in-flight run so the
+# comment always reflects the latest commit.
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Needed so the "post preview URL" step can comment on the PR.
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Build site with Jekyll
+        run: |
+          gem install 'jekyll:3.10.0' kramdown-parser-gfm
+          jekyll build
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # --branch uses the PR branch name so Cloudflare gives each
+          # branch a stable alias URL (e.g. claude-review-debate-flow).
+          command: pages deploy _site --project-name=marbleheaddata-preview --branch=${{ github.head_ref }} --commit-dirty=true
+
+      - name: Post preview URL to PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: preview-url
+          message: |
+            ### Preview
+            **Branch URL:** ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+            **This commit:** ${{ steps.deploy.outputs.deployment-url }}
+
+            Updated for commit ${{ github.event.pull_request.head.sha }}.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,7 +9,10 @@ name: PR Preview
 #      "marbleheaddata-preview" (Direct Upload, no Git integration).
 #   2. Create an API token with "Cloudflare Pages - Edit" permission.
 #   3. Add two repo secrets:
-#        CLOUDFLARE_API_TOKEN   - the token from step 2
+#        CLOUDFLARE_API_KEY     - the scoped API token from step 2
+#                                 (named API_KEY for historical reasons;
+#                                 the value is a scoped token, not the
+#                                 legacy Global API Key)
 #        CLOUDFLARE_ACCOUNT_ID  - your Cloudflare account ID
 #
 # With those secrets in place, every PR gets a preview URL posted as
@@ -52,7 +55,7 @@ jobs:
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_KEY }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           # --branch uses the PR branch name so Cloudflare gives each
           # branch a stable alias URL (e.g. claude-review-debate-flow).


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds the Jekyll site on every PR and deploys it to a Cloudflare Pages preview URL, then posts that URL as a sticky comment on the PR.

Solves the "how do I preview this from iOS / from another machine / without pulling the branch?" problem &mdash; reviewers click the link in the PR comment and see the actual rendered site.

### How it works

- Fires on `pull_request` against `main` (`opened` / `synchronize` / `reopened`).
- Concurrency group per PR, with `cancel-in-progress: true`, so a new push cancels any in-flight deploy and the sticky comment always reflects the latest commit.
- Uses `cloudflare/wrangler-action@v3` (the `cloudflare/pages-action` repo is archived) and deploys via `wrangler pages deploy _site --project-name=marbleheaddata-preview --branch=<PR head ref>`.
- Uses `marocchino/sticky-pull-request-comment@v2` to edit a single comment rather than spamming a new one on each push.

### One-time setup required before this works

1. In the Cloudflare dashboard, create a Pages project named **`marbleheaddata-preview`** (Direct Upload, no Git integration needed).
2. Create a Cloudflare API token with the **`Cloudflare Pages:Edit`** permission.
3. Add two repo secrets under Settings &rarr; Secrets and variables &rarr; Actions:
   - `CLOUDFLARE_API_TOKEN` &mdash; the token from step 2
   - `CLOUDFLARE_ACCOUNT_ID` &mdash; your Cloudflare account ID (visible in the dashboard sidebar on any Workers/Pages page)

If you want a different project name, edit `--project-name=` in the workflow &mdash; that's the only place it's used.

### What it does not do

- Doesn't replace the staging worker for verified-neighbor (`marblehead-community-pulse-staging...`). That's a separate system for the worker-inlined pages.
- Doesn't touch production deploy. `marbleheaddata.org` still serves from GitHub Pages on the `main` branch.
- Doesn't preview against real community-pulse data &mdash; reactions/picks hit the production worker (which has `ALLOWED_ORIGIN` set), so some counts may not populate on the preview URL. That's fine for UX/visual review.

## Test plan

- [ ] Merge this PR.
- [ ] Add the two repo secrets + create the Cloudflare Pages project.
- [ ] Push any commit to an open PR (e.g. #551) to trigger the workflow.
- [ ] Confirm the sticky preview comment appears with working URLs (branch alias + this-commit URL).
- [ ] Push a second commit &mdash; confirm the sticky comment updates in place rather than creating a new comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)