### PR TITLE
Fix two confusing behaviors in the question flow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -51,16 +51,22 @@ jobs:
           gem install 'jekyll:3.10.0' kramdown-parser-gfm
           jekyll build
 
-      # Idempotent: creates the Pages project on first run, no-ops after.
-      # The API returns 200 on create and a 4xx with errorcode 8000007 when
-      # the project already exists. We treat "exists" as success and fail
-      # loudly on anything else so token/account issues surface here, not
-      # deep inside wrangler.
+      # Idempotent: GET first to see if the project exists, POST to create
+      # it if not. This avoids guessing which error code CF returns when a
+      # project already exists (the code has shifted across API versions).
       - name: Ensure Pages project exists
         env:
           CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CF_TOKEN: ${{ secrets.CLOUDFLARE_API_KEY }}
         run: |
+          status=$(curl -sS -o /tmp/cf-get.json -w "%{http_code}" \
+            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT}/pages/projects/marbleheaddata-preview" \
+            -H "Authorization: Bearer ${CF_TOKEN}")
+          if [ "$status" = "200" ]; then
+            echo "Project already exists."
+            exit 0
+          fi
+          echo "Project not found (HTTP $status). Creating..."
           body=$(curl -sS -X POST \
             "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT}/pages/projects" \
             -H "Authorization: Bearer ${CF_TOKEN}" \
@@ -68,13 +74,11 @@ jobs:
             --data '{"name":"marbleheaddata-preview","production_branch":"main"}')
           echo "$body"
           success=$(echo "$body" | jq -r '.success')
-          exists=$(echo "$body" | jq -r '.errors // [] | map(select(.code == 8000007)) | length')
-          if [ "$success" = "true" ] || [ "$exists" != "0" ]; then
-            echo "Project ready."
-          else
+          if [ "$success" != "true" ]; then
             echo "Project create failed."
             exit 1
           fi
+          echo "Project created."
 
       - name: Deploy to Cloudflare Pages
         id: deploy

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -822,15 +822,10 @@
       // Show pick distribution if already decided
       showPickDistribution(topic);
     } else {
-      // No pick yet: auto-open a random answer's evidence so the user
-      // lands on data instead of a blank state with just card summaries.
-      var cards = document.querySelectorAll(
-        '.answer-card[data-question="' + topic + '"]'
-      );
-      if (cards.length) {
-        var rand = cards[Math.floor(Math.random() * cards.length)];
-        viewEvidence(topic, rand.dataset.answer);
-      }
+      // No pick yet: leave all evidence panels closed so the reader
+      // chooses what to expand. Auto-opening a random answer's
+      // evidence reads as the site endorsing that answer, which
+      // violates the "let the reader form their own opinion" stance.
     }
     updateBrowseHint(topic);
   }
@@ -848,9 +843,13 @@
     writeURL(null, null);
   }
 
-  /* ── Nav back button ── */
+  /* ── Nav back button ──
+     "All questions" must always return to the landing/list view.
+     history.back() picked the previous URL entry, which after a few
+     question switches lands on a different question, not the list. */
   document.getElementById('navBack').addEventListener('click', function () {
-    history.back();
+    showLanding();
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   });
 
   /* ── Inject "Next question" buttons ── */


### PR DESCRIPTION
## Summary

Two small UX bugs in the question flow, both surfaced while reviewing #551 on the new Cloudflare Pages preview.

### 1. "All questions" button now actually goes to All questions
`#navBack` was wired to `history.back()`, so after navigating through several questions the button sent the reader to the previous question instead of the landing list. Now calls `showLanding()` (the same thing the "Back to all questions" button at the bottom of each question already does).

### 2. Drop the random answer auto-highlight
On entering a question with no pick, the code was rolling a random answer and auto-opening its evidence panel ("so the user lands on data instead of a blank state with just card summaries"). That reads as the site endorsing whichever answer got rolled, which doesn't fit the editorial stance. Card summaries are already visible without expanding; the reader chooses what to open.

### Bonus: workflow fix carried over from #551
First commit re-applies the GET-first project-check fix from #551 so this PR's own preview works (#551 hasn't merged yet, so main still has the brittle POST-only version). Same change, two paths to main &mdash; whichever lands first wins; the other PR's commit just no-ops on rebase.

## Test plan

- [ ] Open the preview URL.
- [ ] Tap a question card from the landing &rarr; question screen, no answer pre-highlighted, no evidence panel auto-opened.
- [ ] Tap an answer card &rarr; that card's evidence panel opens.
- [ ] Use the "Next question" button to navigate through 2-3 questions.
- [ ] Tap "&larr; All questions" at the top &rarr; returns to the landing/list view (not the previous question).
- [ ] CI smoke tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)