### PR TITLE
Rewrite 45 cards in voter-stance voice, add Q15 servicelevel, absorb synthesis panel

### DIFF
--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -58,6 +58,8 @@
       <!-- JS builds these from the actual question h1s -->
     </div>
 
+    {% include explore-synthesis.html %}
+
     <div class="explore-tools">
       <p class="explore-tools-label">Run the numbers yourself</p>
       <div class="explore-tools-row">

--- a/_includes/explore-synthesis.html
+++ b/_includes/explore-synthesis.html
@@ -1,0 +1,37 @@
+<!-- "Where you landed" synthesis panel.
+     Hidden until the reader has picked enough answers. JS populates the
+     themed recap, the still-open list, and the shared-view copy swap. -->
+<section class="where-you-landed" id="whereYouLanded" aria-live="polite" hidden>
+  <div class="wyl-head">
+    <h2 class="wyl-title" id="wylTitle">Where you landed</h2>
+    <p class="wyl-sub" id="wylSub">Your picks so far, grouped by theme.</p>
+    <p class="wyl-progress" id="wylProgress"></p>
+  </div>
+
+  <div class="wyl-themes" id="wylThemes"></div>
+
+  <div class="wyl-open" id="wylOpen" hidden>
+    <h3 class="wyl-open-title">Still open</h3>
+    <p class="wyl-open-sub">Questions you haven't decided yet.</p>
+    <ul class="wyl-open-list" id="wylOpenList"></ul>
+  </div>
+
+  <div class="wyl-next">
+    <h3 class="wyl-next-title">Your two votes</h3>
+    <p class="wyl-next-body">
+      <strong>Mon, May 4</strong> &ndash; Annual Town Meeting.
+      <strong>Tue, Jun 9</strong> &ndash; Annual Town Election.
+      Either vote can end the override.
+      <a href="what-you-can-do.html#your-two-votes">How the two votes work together &rarr;</a>
+    </p>
+  </div>
+
+  <div class="wyl-actions">
+    <button type="button" class="wyl-action wyl-action--primary" data-copy-positions>
+      <svg class="icon-link" viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+      <svg class="icon-copied" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"/></svg>
+      <span>Copy link to your positions</span>
+    </button>
+    <button type="button" class="wyl-action wyl-action--ghost" id="wylStartOver">Clear my picks</button>
+  </div>
+</section>

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -1700,3 +1700,270 @@
     .explore-stats-detail-left { gap: 10px; }
     .explore-tutorial { font-size: 12px; padding: 12px 14px; }
   }
+
+  /* ─── Story-filter caption on question-block ──────────────────────
+     Neutral italic note that names the framing choice the strongest
+     evidence chart is making (time range, peers, metric). Written as
+     context, not disclaimer. */
+  .question-block .story-filter {
+    margin: 10px 0 0;
+    padding: 10px 14px;
+    font-size: 13.5px;
+    line-height: 1.5;
+    color: var(--c-text-mid);
+    background: var(--c-fog);
+    border-left: 3px solid var(--c-border);
+    border-radius: 0 6px 6px 0;
+    font-style: italic;
+  }
+
+  /* ─── Evidence-block cross-link to a related question ──────────── */
+  .evidence-cross-link {
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid var(--c-border);
+  }
+  .evidence-cross-link p {
+    margin: 0;
+    font-size: 13.5px;
+    color: var(--c-text-mid);
+  }
+  .evidence-cross-link a {
+    color: var(--c-teal);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+
+  /* ─── One-time reset notice on the landing head ────────────────── */
+  .explore-reset-notice {
+    margin: 12px 0 0;
+    padding: 10px 14px;
+    font-size: 13.5px;
+    line-height: 1.5;
+    color: var(--c-text);
+    background: var(--c-fog);
+    border: 1px solid var(--c-border);
+    border-radius: 6px;
+  }
+
+  /* ─── "Where you landed" synthesis panel ──────────────────────────
+     Shown inside .explore-landing once the reader has picked >= 3
+     answers. Pure readback: themed list of picked answers, still-open
+     list, vote-date reminder. Neutral styling on purpose -- no
+     yes/no color cues. */
+  .where-you-landed {
+    margin: 24px 0 8px;
+    padding: 20px 22px;
+    background: var(--c-surface);
+    border: 1px solid var(--c-border);
+    border-radius: 10px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.03);
+  }
+  .where-you-landed[hidden] { display: none; }
+  .wyl-head { margin-bottom: 16px; }
+  .wyl-title {
+    margin: 0 0 6px;
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--c-text);
+  }
+  .wyl-sub {
+    margin: 0 0 4px;
+    font-size: 14px;
+    color: var(--c-text-mid);
+    line-height: 1.5;
+  }
+  .wyl-progress {
+    margin: 0;
+    font-size: 13px;
+    color: var(--c-text-sub);
+    font-variant-numeric: tabular-nums;
+  }
+  .wyl-themes { display: flex; flex-direction: column; gap: 22px; }
+  .wyl-theme { padding-top: 18px; border-top: 1px solid var(--c-border); }
+  .wyl-theme:first-child { border-top: 0; padding-top: 0; }
+  .wyl-theme-title {
+    margin: 0 0 8px;
+    font-size: 12px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--c-text-mid);
+  }
+  .wyl-theme-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .wyl-theme-item { margin: 0; }
+  .wyl-topic-link {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 6px 12px;
+    align-items: baseline;
+    width: 100%;
+    padding: 10px 10px;
+    margin: 0;
+    background: transparent;
+    border: 0;
+    border-radius: 6px;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition: background 0.12s ease;
+  }
+  .wyl-topic-link:hover { background: var(--c-fog); }
+  .wyl-topic-link:focus-visible {
+    background: var(--c-fog);
+    outline: 2px solid var(--c-teal);
+    outline-offset: -2px;
+  }
+  .wyl-topic-link:active { background: var(--c-divider); }
+  .wyl-topic-label {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--c-text);
+    line-height: 1.3;
+  }
+  .wyl-topic-chev {
+    color: var(--c-text-faint);
+    font-size: 18px;
+    line-height: 1;
+    transition: color 0.12s ease, transform 0.12s ease;
+  }
+  .wyl-topic-link:hover .wyl-topic-chev,
+  .wyl-topic-link:focus-visible .wyl-topic-chev {
+    color: var(--c-teal);
+    transform: translateX(2px);
+  }
+  .wyl-topic-detail {
+    grid-column: 1 / -1;
+    padding-left: 0;
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--c-text-mid);
+  }
+  .wyl-topic-detail--unsure { font-style: italic; color: var(--c-text-sub); }
+  .wyl-open {
+    margin-top: 16px;
+    padding-top: 12px;
+    border-top: 1px solid var(--c-border);
+  }
+  .wyl-open[hidden] { display: none; }
+  .wyl-open-title {
+    margin: 0 0 4px;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--c-text);
+  }
+  .wyl-open-sub {
+    margin: 0 0 8px;
+    font-size: 13px;
+    color: var(--c-text-mid);
+  }
+  .wyl-open-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 8px;
+  }
+  .wyl-topic-link--open {
+    display: inline-flex;
+    padding: 6px 10px;
+    background: var(--c-fog);
+    border: 1px solid var(--c-border);
+    font-size: 13px;
+    color: var(--c-text);
+    width: auto;
+  }
+  .wyl-topic-link--open:hover,
+  .wyl-topic-link--open:focus-visible {
+    background: var(--c-surface);
+    border-color: var(--c-text-mid);
+  }
+  .wyl-next {
+    margin-top: 16px;
+    padding: 12px 14px;
+    background: var(--c-fog);
+    border-radius: 8px;
+  }
+  .wyl-next-title {
+    margin: 0 0 4px;
+    font-size: 13px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--c-text-mid);
+  }
+  .wyl-next-body {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--c-text);
+  }
+  .wyl-next-body a { color: var(--c-teal); }
+  .wyl-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 14px;
+  }
+  .wyl-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border-radius: 6px;
+    border: 1px solid var(--c-border);
+    background: var(--c-surface);
+    color: var(--c-text);
+    font: inherit;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .wyl-action:hover,
+  .wyl-action:focus-visible {
+    background: var(--c-fog);
+    outline: none;
+  }
+  .wyl-action--primary {
+    background: var(--c-navy);
+    color: #fff;
+    border-color: var(--c-navy);
+  }
+  .wyl-action--primary:hover,
+  .wyl-action--primary:focus-visible {
+    background: var(--c-teal);
+    border-color: var(--c-teal);
+  }
+  .wyl-action--primary .icon-copied,
+  .wyl-action--primary.copied .icon-link { display: none; }
+  .wyl-action--primary .icon-link,
+  .wyl-action--primary.copied .icon-copied { display: inline-block; }
+  .wyl-action--primary svg {
+    width: 14px;
+    height: 14px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .wyl-action--ghost { background: transparent; }
+
+  .explore-landing.shared-mode .wyl-action--ghost { display: none; }
+
+  @media (max-width: 599px) {
+    .where-you-landed { padding: 16px 14px; }
+    .wyl-title { font-size: 18px; }
+    .wyl-topic-label { font-size: 14.5px; }
+    .wyl-topic-detail { font-size: 13.5px; }
+  }

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -20,20 +20,21 @@
      the section elements is enough. */
   (function reorderQuestions() {
     var preferredOrder = [
-      'mycost',       // How will this affect my taxes?
-      'seniors',      // How does this affect seniors and fixed-income households?
+      'mycost',       // What would the override cost my household?
+      'servicelevel', // What level of service do I want from Marblehead?
+      'seniors',      // How does this affect seniors?
       'taxrank',      // How does Marblehead's tax burden compare?
-      'levy',         // Why don't 2.5% increases keep up?
+      'levy',         // How can town income keep up with cost growth?
       'moneygone',    // What explains the budget growth?
-      'size',         // Does the size of the override matter?
-      'schools',      // Why did staffing grow while enrollment fell?
-      'trash',        // Why is trash collection on the ballot?
-      'library',      // Why would the library be the heaviest cut?
-      'alternatives', // What else could we do instead?
-      'again',        // Will we be back here in 5 years?
-      'voteno',       // What happens if we vote no?
-      'override',     // Is the override necessary, or wasteful spending?
-      'trust'         // How do we trust the decision-makers?
+      'size',         // What does each tier get us?
+      'schools',      // Did school staffing grow while enrollment fell?
+      'trash',        // Should we pay for trash through property taxes or a flat fee?
+      'library',      // Why does the library take the heaviest cut?
+      'alternatives', // Do any of the town's levers have enough impact?
+      'again',        // How soon would we come back for another override?
+      'voteno',       // What will happen if we vote no?
+      'override',     // Does an override buy time, and for what?
+      'trust'         // Should I trust the town with more revenue?
     ];
     var parent = document.querySelector('.explore-stage');
     if (!parent) return;
@@ -1128,7 +1129,208 @@
       });
       cards.forEach(function (c) { listEl.appendChild(c); });
     }
+    updateSynthesis();
   }
+
+  /* ── "Where you landed" synthesis panel ──
+     Reads back the reader's picks grouped by theme once they've made
+     enough of them (>= WYL_THRESHOLD). Pure readback: no scoring, no
+     implied "yes/no" label, no advocacy. Still-open questions are
+     surfaced at the bottom so a partial flow has a clear nudge. */
+  var WYL_THRESHOLD = 3;
+  var WYL_THEMES = [
+    { key: 'preference',     label: 'What I want from the town',          topics: ['servicelevel', 'mycost', 'seniors'] },
+    { key: 'money',          label: 'Money and taxes',                    topics: ['taxrank', 'levy'] },
+    { key: 'structure',      label: 'Why the gap exists',                 topics: ['moneygone', 'size'] },
+    { key: 'services',       label: 'Services on the table',              topics: ['schools', 'trash', 'library'] },
+    { key: 'futures',        label: 'Paths not taken, and what comes next', topics: ['alternatives', 'again'] },
+    { key: 'interpretation', label: 'Reading the choice',                 topics: ['voteno', 'override', 'trust'] }
+  ];
+  // Short, scannable titles for the recap. The full h1 on each question
+  // screen is a sentence; these are the nouns that sentence is about.
+  var WYL_TOPIC_LABELS = {
+    mycost:       'What the override would cost',
+    servicelevel: 'Service level I want',
+    seniors:      'Impact on seniors',
+    taxrank:      'Where Marblehead ranks',
+    levy:         'Income vs. cost growth',
+    moneygone:    'What drove budget growth',
+    size:         'What each tier gets us',
+    schools:      'Staffing vs. enrollment',
+    trash:        'Property tax vs. flat fee',
+    library:      'Heaviest cut without an override',
+    alternatives: 'Do the levers scale',
+    again:        'How soon we come back',
+    voteno:       'If the override fails',
+    override:     'What an override buys',
+    trust:        'Trusting the decision-makers'
+  };
+
+  // Pull the answer-card's own summary text -- the actual case the reader
+  // read when they picked. This is the right "why" for revisit.
+  var _answerSummaryCache = {};
+  function getAnswerSummary(topic, answer) {
+    var key = topic + '-' + answer;
+    if (key in _answerSummaryCache) return _answerSummaryCache[key];
+    var card = document.querySelector(
+      '.answer-card[data-question="' + topic + '"][data-answer="' + answer + '"]'
+    );
+    var summary = card && card.querySelector('.answer-summary');
+    if (!summary) { _answerSummaryCache[key] = null; return null; }
+    var text = (summary.textContent || '').replace(/\s+/g, ' ').trim();
+    _answerSummaryCache[key] = text || null;
+    return _answerSummaryCache[key];
+  }
+
+  function updateSynthesis() {
+    var panel = document.getElementById('whereYouLanded');
+    if (!panel) return;
+
+    var decided = topicOrder.filter(function (t) { return !!selections[t]; });
+    var total = topicOrder.length;
+    if (decided.length < WYL_THRESHOLD) {
+      panel.hidden = true;
+      return;
+    }
+    panel.hidden = false;
+
+    var titleEl = document.getElementById('wylTitle');
+    var subEl = document.getElementById('wylSub');
+    var clearBtn = document.getElementById('wylStartOver');
+    if (isSharedView) {
+      if (titleEl) titleEl.textContent = 'Where they landed';
+      if (subEl) subEl.textContent = 'The positions in the link you followed. Tap Start fresh at the top to pick your own.';
+      if (clearBtn) clearBtn.hidden = true;
+    } else {
+      if (titleEl) titleEl.textContent = 'Where you landed';
+      if (subEl) subEl.textContent = 'Your picks so far, grouped by theme.';
+      if (clearBtn) clearBtn.hidden = false;
+    }
+
+    var progressEl = document.getElementById('wylProgress');
+    if (progressEl) {
+      var remaining = total - decided.length;
+      progressEl.textContent = remaining === 0
+        ? 'All ' + total + ' questions answered.'
+        : decided.length + ' of ' + total + ' questions answered. ' + remaining + ' still open below.';
+    }
+
+    var themesEl = document.getElementById('wylThemes');
+    if (themesEl) {
+      themesEl.innerHTML = '';
+      WYL_THEMES.forEach(function (theme) {
+        var answeredInTheme = theme.topics.filter(function (t) { return !!selections[t]; });
+        if (answeredInTheme.length === 0) return;
+
+        var group = document.createElement('div');
+        group.className = 'wyl-theme';
+        group.dataset.theme = theme.key;
+
+        var h = document.createElement('h3');
+        h.className = 'wyl-theme-title';
+        h.textContent = theme.label;
+        group.appendChild(h);
+
+        var ul = document.createElement('ul');
+        ul.className = 'wyl-theme-list';
+        answeredInTheme.forEach(function (topic) {
+          var li = document.createElement('li');
+          li.className = 'wyl-theme-item';
+          var ans = selections[topic];
+
+          var btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'wyl-topic-link';
+          btn.dataset.topic = topic;
+          btn.addEventListener('click', function () {
+            switchTopic(topic);
+            window.scrollTo(0, 0);
+          });
+
+          var label = document.createElement('span');
+          label.className = 'wyl-topic-label';
+          label.textContent = WYL_TOPIC_LABELS[topic] || topic;
+          btn.appendChild(label);
+
+          var chev = document.createElement('span');
+          chev.className = 'wyl-topic-chev';
+          chev.setAttribute('aria-hidden', 'true');
+          chev.textContent = '\u203A';
+          btn.appendChild(chev);
+
+          var detail = document.createElement('span');
+          detail.className = 'wyl-topic-detail';
+          if (ans === 'u') {
+            detail.classList.add('wyl-topic-detail--unsure');
+            detail.textContent = 'Marked not sure yet.';
+          } else {
+            var summary = getAnswerSummary(topic, ans);
+            detail.textContent = summary
+              || (landingCards[topic]
+                  && landingCards[topic].answerHeadings
+                  && landingCards[topic].answerHeadings[ans])
+              || ('Picked ' + ans.toUpperCase());
+          }
+          btn.appendChild(detail);
+
+          li.appendChild(btn);
+          ul.appendChild(li);
+        });
+        group.appendChild(ul);
+        themesEl.appendChild(group);
+      });
+    }
+
+    var openEl = document.getElementById('wylOpen');
+    var openListEl = document.getElementById('wylOpenList');
+    var unanswered = topicOrder.filter(function (t) { return !selections[t]; });
+    if (openEl && openListEl) {
+      if (unanswered.length === 0) {
+        openEl.hidden = true;
+      } else {
+        openEl.hidden = false;
+        openListEl.innerHTML = '';
+        unanswered.forEach(function (topic) {
+          var li = document.createElement('li');
+          li.className = 'wyl-open-item';
+          var btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'wyl-topic-link wyl-topic-link--open';
+          btn.dataset.topic = topic;
+          btn.textContent = WYL_TOPIC_LABELS[topic] || topic;
+          btn.addEventListener('click', function () {
+            switchTopic(topic);
+            window.scrollTo(0, 0);
+          });
+          li.appendChild(btn);
+          openListEl.appendChild(li);
+        });
+      }
+    }
+  }
+
+  // "Clear my picks" in the synthesis panel reuses the existing Delete-my-data
+  // confirm + reset path, keeping one place that wipes local state.
+  (function wireSynthesisActions() {
+    var clearBtn = document.getElementById('wylStartOver');
+    var resetBtn = document.getElementById('statsReset');
+    if (clearBtn && resetBtn) {
+      clearBtn.addEventListener('click', function () { resetBtn.click(); });
+    }
+  })();
+
+  // Cross-links in evidence blocks use <a href="#" data-topic="slug">; intercept
+  // and route through switchTopic so the reader jumps to the related question
+  // without a page reload.
+  document.addEventListener('click', function (e) {
+    var a = e.target.closest && e.target.closest('a[data-topic]');
+    if (!a) return;
+    var topic = a.getAttribute('data-topic');
+    if (!topic) return;
+    e.preventDefault();
+    switchTopic(topic);
+    window.scrollTo(0, 0);
+  });
 
   /* ── Copy-link buttons (top + bottom) ── */
   var shareTopEl = document.getElementById('shareTop');
@@ -1770,19 +1972,57 @@
   // Restore notes badges on load
   updateCardBadges();
 
-  // Restore selections from localStorage
+  // Restore selections from localStorage. The 45-card rewrite changed card
+  // semantics (not just copy) on most questions, so selections saved under
+  // a prior version would silently misrepresent the reader's position.
+  // Bumping SELECTIONS_VERSION wipes stale picks and posts a one-time notice.
+  var SELECTIONS_VERSION = '2026-04-rewrite';
+  var VERSION_KEY = 'explore-selections-version';
+  var savedVersion = null;
+  try { savedVersion = localStorage.getItem(VERSION_KEY); } catch (e) {}
   var savedSelections = null;
-  try { savedSelections = JSON.parse(localStorage.getItem('explore-selections')); } catch (e) {}
+  if (savedVersion === SELECTIONS_VERSION) {
+    try { savedSelections = JSON.parse(localStorage.getItem('explore-selections')); } catch (e) {}
+  } else {
+    // Stale or missing version: drop prior picks. If the reader had any,
+    // surface a one-time banner so they know to revisit.
+    var hadPriorPicks = false;
+    try {
+      var prior = JSON.parse(localStorage.getItem('explore-selections'));
+      hadPriorPicks = prior && Object.keys(prior).length > 0;
+    } catch (e) {}
+    try {
+      localStorage.removeItem('explore-selections');
+      localStorage.setItem(VERSION_KEY, SELECTIONS_VERSION);
+    } catch (e) {}
+    if (hadPriorPicks) {
+      try { sessionStorage.setItem('explore-reset-notice', '1'); } catch (e) {}
+    }
+  }
   if (savedSelections) {
     Object.keys(savedSelections).forEach(function (topic) {
       selections[topic] = savedSelections[topic];
     });
     updateNotesPill();
   }
+  // Surface the one-time reset notice on the landing page.
+  (function showResetNoticeIfAny() {
+    var show = false;
+    try { show = sessionStorage.getItem('explore-reset-notice') === '1'; } catch (e) {}
+    if (!show) return;
+    try { sessionStorage.removeItem('explore-reset-notice'); } catch (e) {}
+    var head = document.querySelector('.explore-landing-head');
+    if (!head) return;
+    var notice = document.createElement('p');
+    notice.className = 'explore-reset-notice';
+    notice.textContent = 'Questions were updated. Please revisit to record your stances.';
+    head.appendChild(notice);
+  })();
 
   // Persist selections
   function persistSelections() {
     localStorage.setItem('explore-selections', JSON.stringify(selections));
+    try { localStorage.setItem(VERSION_KEY, SELECTIONS_VERSION); } catch (e) {}
   }
 
   /* ── Restore state on load ── */

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -961,6 +961,7 @@
   /* Lucide-based icons, 24x24 viewBox */
   var topicIcons = {
     override:     '<circle cx="12" cy="12" r="10"/><line x1="12" y1="6" x2="12" y2="18"/><path d="M15.5 9.5a3 3 0 0 0-3-2h-1a3 3 0 0 0 0 6h1a3 3 0 0 1 0 6h-1a3 3 0 0 1-3-2"/>',  /* coin with $ */
+    servicelevel: '<line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/><circle cx="9" cy="7" r="2"/><circle cx="15" cy="12" r="2"/><circle cx="7" cy="17" r="2"/>', /* three sliders with handles */
     voteno:       '<ellipse cx="12" cy="6" rx="7" ry="3.5"/><ellipse cx="12" cy="13" rx="7" ry="3.5"/><ellipse cx="12" cy="20" rx="7" ry="3.5"/>', /* three ballot ovals */
     schools:      '<path d="M22 10v6M2 10l10-5 10 5-10 5z"/><path d="M6 12v5c0 1.1 2.7 3 6 3s6-1.9 6-3v-5"/>', /* graduation cap */
     levy:         '<path d="M3 3v18h18"/><path d="M7 16l4-4 4 4 5-7"/>',          /* trending up */

--- a/charts/four_town_rates.html
+++ b/charts/four_town_rates.html
@@ -35,7 +35,7 @@ scripts: [chart-tooltip]
     <li><strong>Lowest tax burden relative to income</strong>: only 24 of 350 MA communities have a lighter ratio</li>
   </ul>
 
-  <h2 class="h-center">Tax rate, per $1,000 assessed value</h2>
+  <h2 class="h-center" id="tax-rate">Tax rate, per $1,000 assessed value</h2>
 
   <div class="legend">
     <div class="legend-item s-marblehead"><span class="legend-swatch"></span><span class="legend-text">Marblehead</span></div>
@@ -143,7 +143,7 @@ scripts: [chart-tooltip]
 
   <p class="caption">Even at full Tier 3 ($15M), Marblehead's rate ($10.06) would remain the lowest of the four. The Melrose FY26 spike reflects its $13.5M override (November 2025). Dashed lines assume 2.5% levy growth and constant assessed values.</p>
 
-  <h2 class="h-center">Average single-family tax bill</h2>
+  <h2 class="h-center" id="average-bill">Average single-family tax bill</h2>
 
   <div class="chart-wrapper" data-chart-tooltip>
     <script type="application/json" class="chart-tooltip-data">
@@ -235,7 +235,7 @@ scripts: [chart-tooltip]
 
   <p class="caption">With any override tier, Marblehead's average bill would surpass Swampscott's. Without an override, Marblehead ($11,055) remains second behind Swampscott ($11,478). The difference is home values: Marblehead's median assessed value is $1,010,100.</p>
 
-  <h2 class="h-center">Tax bill as share of household income</h2>
+  <h2 class="h-center" id="share-of-income">Tax bill as share of household income</h2>
 
   <div class="chart-wrapper">
     <svg class="chart" viewBox="0 0 600 330" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar chart: tax bill as percentage of median household income. Swampscott 8.5%, Melrose 7.3%, Stoneham 7.1%, Marblehead 6.1% (lowest). With override, Marblehead reaches 6.7-7.1%, still below Swampscott.">

--- a/index.html
+++ b/index.html
@@ -1898,13 +1898,13 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Each tier adds roughly 0.6 to 1.0 percentage points</h4>
+        <h4>Tier 1 adds ~0.6 points; Tier 3 adds ~1.0</h4>
         <p>
           At full phase-in, the average-home override cost (~$1,188/yr
           at Tier 1, ~$1,985/yr at Tier 3) works out to roughly 0.65%
-          to 1.09% of the ACS median household income. Expressed as
-          the combined bill, Marblehead reaches about 6.7% at Tier 1
-          and 7.1% at Tier 3.
+          of ACS median household income for Tier 1 and 1.09% for
+          Tier 3. The combined bill/income ratio moves from 6.1%
+          today to about 6.7% at Tier 1 or 7.1% at Tier 3.
         </p>
         <a class="evidence-chart-link" href="charts/override_calculator.html">
           Override calculator: reprice for your home and income

--- a/index.html
+++ b/index.html
@@ -846,7 +846,7 @@ og_url: https://marbleheaddata.org/
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="schools">
         <p class="answer-label">Answer A</p>
-        <h2>Yes — the staffing-to-enrollment ratio is a choice I'd reverse</h2>
+        <h2>Yes: the staffing-to-enrollment ratio is a choice I'd reverse</h2>
         <p class="answer-summary">
           Enrollment fell 21% but FTEs grew. The student-to-staff ratio
           is the lowest among peer towns. That gap is a choice, not a
@@ -856,7 +856,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="schools">
         <p class="answer-label">Answer B</p>
-        <h2>No — three of four FTE series tell a different story</h2>
+        <h2>No: three of four FTE series tell a different story</h2>
         <p class="answer-summary">
           Special education, <abbr class="g" title="English Language Learner">ELL</abbr>, and compliance requirements drove most of
           the growth. You cannot cut an <abbr class="g" title="Individualized Education Program">IEP</abbr>-required aide without violating
@@ -2242,7 +2242,7 @@ og_url: https://marbleheaddata.org/
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="again">
         <p class="answer-label">Answer A</p>
-        <h2>Not soon — a sized-well override holds for several years</h2>
+        <h2>Not soon: a sized-well override holds for several years</h2>
         <p class="answer-summary">
           The tiers were designed as a multi-year correction, and the
           higher ones build capacity to absorb future cost growth without
@@ -2252,7 +2252,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="again">
         <p class="answer-label">Answer B</p>
-        <h2>Soon — the math pulls ahead of any tier within a year or two</h2>
+        <h2>Soon: the math pulls ahead of any tier within a year or two</h2>
         <p class="answer-summary">
           Health insurance and pensions don't stop growing when the
           override passes. Even Tier 3 bridges the gap briefly before
@@ -2263,7 +2263,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="c" data-question="again">
         <p class="answer-label">Answer C</p>
-        <h2>Depends — it turns on what reform happens while the override runs</h2>
+        <h2>Depends: it turns on what reform happens while the override runs</h2>
         <p class="answer-summary">
           The override buys time. Whether that time turns into slope-bending
           reform (benefits, commercial growth, staffing) or just gets
@@ -2491,7 +2491,7 @@ og_url: https://marbleheaddata.org/
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="alternatives">
         <p class="answer-label">Answer A</p>
-        <h2>No — near-term levers don't scale to the FY27 gap</h2>
+        <h2>No: near-term levers don't scale to the FY27 gap</h2>
         <p class="answer-summary">
           Commercial tax base, state aid, and CIP shifts either don't
           exist in Marblehead or don't move fast or big enough. On a
@@ -2501,7 +2501,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="alternatives">
         <p class="answer-label">Answer B</p>
-        <h2>Yes — the slope-bending levers are what actually end the cycle</h2>
+        <h2>Yes: the slope-bending levers are what actually end the cycle</h2>
         <p class="answer-summary">
           Benefits reform (especially the 83% health-insurance employer
           share), economic development, and long-run staffing reduce the
@@ -2512,7 +2512,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="c" data-question="alternatives">
         <p class="answer-label">Answer C</p>
-        <h2>Only together — override bridges, slope-benders end the cycle</h2>
+        <h2>Only together: override bridges, slope-benders end the cycle</h2>
         <p class="answer-summary">
           Nothing closes $8.47M by June. An override plus explicit
           slope-bending work during the bridge is the combination that
@@ -3177,7 +3177,7 @@ og_url: https://marbleheaddata.org/
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="trust">
         <p class="answer-label">Answer A</p>
-        <h2>Yes — the checks I can use are in place</h2>
+        <h2>Yes: the checks I can use are in place</h2>
         <p class="answer-summary">
           Elected boards, public meetings, independent audits, state
           oversight, and the Town Meeting vote all exist. The information
@@ -3188,7 +3188,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="trust">
         <p class="answer-label">Answer B</p>
-        <h2>No — transparency exists on paper but not in practice</h2>
+        <h2>No: transparency exists on paper but not in practice</h2>
         <p class="answer-summary">
           Meetings are poorly attended, budgets are presented as
           take-it-or-leave-it, and few residents have the time to audit
@@ -3199,7 +3199,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="c" data-question="trust">
         <p class="answer-label">Answer C</p>
-        <h2>Depends — I'll extend trust when the town shows the work</h2>
+        <h2>Depends: I'll extend trust when the town shows the work</h2>
         <p class="answer-summary">
           The question isn't whether officials are honest but whether the
           system makes it easy for me to verify claims independently. I'll

--- a/index.html
+++ b/index.html
@@ -1589,7 +1589,7 @@ og_url: https://marbleheaddata.org/
           8.5%. But if your income is below the median, the bite is
           proportionally bigger.
         </p>
-        <a class="evidence-chart-link" href="charts/four_town_rates.html">
+        <a class="evidence-chart-link" href="charts/four_town_rates.html#share-of-income">
           Bill as share of income
         </a>
         <a class="evidence-chart-link" href="charts/town_explorer.html">
@@ -1632,7 +1632,7 @@ og_url: https://marbleheaddata.org/
           and different household earnings, which rate and bill alone
           cannot.
         </p>
-        <a class="evidence-chart-link" href="charts/four_town_rates.html">
+        <a class="evidence-chart-link" href="charts/four_town_rates.html#share-of-income">
           Bill as share of income, all four towns
         </a>
       </div>
@@ -1892,7 +1892,7 @@ og_url: https://marbleheaddata.org/
           four-town peer set. That's the baseline the override adds to,
           regardless of which tier passes.
         </p>
-        <a class="evidence-chart-link" href="charts/four_town_rates.html">
+        <a class="evidence-chart-link" href="charts/four_town_rates.html#share-of-income">
           Bill as share of income, peer comparison
         </a>
       </div>

--- a/index.html
+++ b/index.html
@@ -1257,11 +1257,12 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Two line items eat the entire 2.5% increase</h4>
+        <h4>Insurance and pensions eat nearly all of the FY27 levy growth</h4>
         <p>
           Health insurance goes up $1.65M (+11%). Pensions go up
-          $463K (+9%). Together they consume more than the full 2.5%
-          levy increase. Everything else has to come from cuts.
+          $463K (+9%). Together that's $2.11M &ndash; roughly 97% of the
+          $2.18M in levy growth FY27 produces from the 2.5% cap plus new
+          growth combined. Everything else competes for the residual.
         </p>
         <a class="evidence-chart-link" href="charts/deficit_model.html">
           Model the gap: drag revenue and expense growth rates yourself
@@ -1320,8 +1321,11 @@ og_url: https://marbleheaddata.org/
 
         <p class="caption">
           The levy grew 53% from FY12 to FY24 while CPI-U grew 37%.
-          Property taxes have been rising faster than general inflation.
-          Without the 2.5% cap, spending growth would face fewer constraints.
+          Property taxes have been rising faster than general inflation,
+          because the 2.5% cap compounds to ~34.5% over twelve years and
+          new growth (new construction added to the grand list) adds the
+          rest. The cap bounds the per-year increase, not the long-run
+          total.
         </p>
         <a class="evidence-chart-link" href="charts/levy_vs_bill.html">
           Full levy, bill, and inflation chart
@@ -1386,10 +1390,10 @@ og_url: https://marbleheaddata.org/
         </div>
 
         <p class="caption">
-          An override closes the gap once. But as long as costs grow at
+          An override bridges the gap once. But as long as costs grow at
           5% and revenue grows at 2.5%, the gap reopens. Structural
-          reforms to the cost drivers (insurance negotiation, staffing
-          model, pension funding) are what change the slope.
+          levers on the cost side (GIC premium splits, staffing model,
+          total compensation) are what change the slope.
         </p>
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Full sustainability projections

--- a/index.html
+++ b/index.html
@@ -1616,50 +1616,71 @@ og_url: https://marbleheaddata.org/
       </details>
     </div>
 
-    <!-- Evidence C: per-capita -->
+    <!-- Evidence C: share of income -->
     <div class="evidence" data-evidence="taxrank-c">
       <div class="evidence-header">
-        <h3>The case for "per-capita levy is fairest"</h3>
+        <h3>The case for "share of income is the comparison"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
       <div class="evidence-point">
-        <h4>Tax collected per person (FY26)</h4>
+        <h4>Bill as share of ACS median household income</h4>
         <p>
-          Swampscott: $4,207. Marblehead: $4,144. Melrose: $3,416.
-          Stoneham: $3,117. This cuts through rate vs. bill debates
-          by asking: how much does the town actually collect per
-          resident?
+          Marblehead 6.1%. Stoneham 7.1%. Melrose 7.3%. Swampscott 8.5%.
+          Dividing the median single-family bill by median household
+          income normalizes across towns with different home values
+          and different household earnings, which rate and bill alone
+          cannot.
+        </p>
+        <a class="evidence-chart-link" href="charts/four_town_rates.html">
+          Bill as share of income, all four towns
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Even at full Tier 3, Marblehead stays below Swampscott</h4>
+        <p>
+          A Tier 3 override moves Marblehead's bill/income ratio to
+          roughly 7.1%, still under Swampscott's current 8.5% and
+          comparable to Stoneham and Melrose today. Statewide, only
+          24 of 350 MA communities have a lighter bill/income ratio
+          than Marblehead at baseline.
+        </p>
+        <a class="evidence-chart-link" href="charts/statewide_tax_burden.html">
+          Statewide bill/income ratio, 350 MA communities
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Per-capita levy is a related view, but a different question</h4>
+        <p>
+          Tax collected per resident (Swampscott $4,207, Marblehead
+          $4,144, Melrose $3,416, Stoneham $3,117) describes what the
+          town collects, not what households can afford. Share of
+          income answers the affordability question; per-capita levy
+          answers the collection question.
         </p>
         <a class="evidence-chart-link" href="charts/per_capita_levy.html">
           Per-capita levy chart
         </a>
       </div>
 
-      <div class="evidence-point">
-        <h4>Two tiers: Marblehead/Swampscott vs. Melrose/Stoneham</h4>
-        <p>
-          Marblehead and Swampscott are $63 apart. Both collect about
-          $1,000 more per person than Melrose or Stoneham. Higher
-          property values, higher service expectations, or both.
-        </p>
-      </div>
-
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Answer B would push back</span>
+          <span class="counter-argument-teaser">Answers A and B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
-            Per-capita levy averages across residents, which smooths
-            over how the burden actually lands on individual
-            households. What a retiree on a fixed income pays is the
-            bill on their specific home, not a per-capita figure. A
-            household whose home has appreciated past their salary
-            years feels the median bill, not the average. Which
-            metric is "fairest" depends on whose perspective is being
-            asked.
+            ACS median income carries wide error margins (roughly
+            <abbr class="g" title="plus or minus">&plusmn;</abbr>$28K for
+            Marblehead) and includes renters who don't pay property
+            tax directly, so share-of-income is best read as relative
+            across towns, not as a precise measure of any one
+            homeowner's burden. A retiree whose income is below the
+            median feels a heavier bite than the town-wide ratio
+            implies, which is the same specific-household objection
+            answer B raises.
           </p>
         </div>
       </details>
@@ -1858,49 +1879,67 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence C: compare to what you lose -->
     <div class="evidence" data-evidence="mycost-c">
       <div class="evidence-header">
-        <h3>The case for "compare it to what you lose"</h3>
+        <h3>The case for "share of income"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
       <div class="evidence-point">
-        <h4>The cuts are specific and published</h4>
+        <h4>Marblehead's bill is already 6.1% of median household income</h4>
         <p>
-          Library -43%. Community development -59%. Retiree health
-          trust zeroed. 22 town positions and 18 school positions
-          eliminated. These are in the published FY27 budget.
+          Dividing the median single-family bill (~$8,677) by
+          Marblehead <abbr class="g" title="American Community Survey">ACS</abbr>
+          median household income (~$182,132) gives 6.1%, lowest of the
+          four-town peer set. That's the baseline the override adds to,
+          regardless of which tier passes.
         </p>
-        <a class="evidence-chart-link" href="no-override-budget.html#town-side-reductions">
-          No-override budget, line by line
+        <a class="evidence-chart-link" href="charts/four_town_rates.html">
+          Bill as share of income, peer comparison
         </a>
       </div>
 
       <div class="evidence-point">
-        <h4>Other towns that voted no came back with larger overrides</h4>
+        <h4>Each tier adds roughly 0.6 to 1.0 percentage points</h4>
         <p>
-          Melrose rejected $7.7M in June 2024, then passed $13.5M
-          (+75%) in November 2025. Stoneham rejected $14.6M in April
-          2025, then passed $9.3M in December 2025 after losing staff
-          to higher-paying districts.
+          At full phase-in, the average-home override cost (~$1,188/yr
+          at Tier 1, ~$1,985/yr at Tier 3) works out to roughly 0.65%
+          to 1.09% of the ACS median household income. Expressed as
+          the combined bill, Marblehead reaches about 6.7% at Tier 1
+          and 7.1% at Tier 3.
         </p>
-        <a class="evidence-chart-link" href="data/case_studies">
-          Override case studies
+        <a class="evidence-chart-link" href="charts/override_calculator.html">
+          Override calculator: reprice for your home and income
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Even at Tier 3, the ratio stays below Swampscott</h4>
+        <p>
+          Swampscott's current bill/income ratio is 8.5%. Stoneham
+          is 7.1% and Melrose 7.3% today. Marblehead at Tier 3 (7.1%)
+          lands roughly where Stoneham already sits and stays below
+          Swampscott. Statewide context is available on the
+          bill/income chart for 350 MA communities.
+        </p>
+        <a class="evidence-chart-link" href="charts/statewide_tax_burden.html">
+          Statewide bill/income ratio, 350 MA communities
         </a>
       </div>
 
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
-          <span class="counter-argument-teaser">Answer B would push back</span>
+          <span class="counter-argument-teaser">Answers A and B would push back</span>
         </summary>
         <div class="counter-argument-body">
           <p>
-            Comparing the tax cost to the published cuts only frames
-            the choice for voters who accept the current FY26
-            spending baseline as the appropriate floor. Residents
-            who believe the budget had room for discipline see the
-            no-override cut list as an opening bid, not the only
-            alternative. "Your cost vs. what you lose" hides that
-            assumption inside the framing.
+            ACS median household income has wide error margins (roughly
+            <abbr class="g" title="plus or minus">&plusmn;</abbr>$28K
+            for Marblehead) and includes renters, who don't pay property
+            tax directly. A specific household's share-of-income depends
+            on its own income, not the town median. For the household
+            writing the check, the monthly number and the ten-year
+            compounded number are the figures that actually describe
+            what the override costs them.
           </p>
         </div>
       </details>

--- a/index.html
+++ b/index.html
@@ -867,7 +867,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="c" data-question="schools">
         <p class="answer-label">Answer C</p>
-        <h2>Both are in the data; I read it by line, not in aggregate</h2>
+        <h2>Both are in the data; I weigh it line by line, not in aggregate</h2>
         <p class="answer-summary">
           <abbr class="g" title="Special Education">SPED</abbr> and <abbr class="g" title="English Language Learner">ELL</abbr> growth are mandated. Instructional coaches,
           additional administrators, and co-teachers are district choices.
@@ -1711,7 +1711,7 @@ og_url: https://marbleheaddata.org/
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="mycost">
         <p class="answer-label">Answer A</p>
-        <h2>Monthly: I read the cost as $99 / $132 / $165 at the average home</h2>
+        <h2>Monthly: $99 / $132 / $165 at the average home</h2>
         <p class="answer-summary">
           Tier 1 adds about $99/mo, Tier 2 adds $132/mo, Tier 3 adds $165/mo
           at full phase-in. That's the cash-flow framing I can compare to
@@ -1721,7 +1721,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="mycost">
         <p class="answer-label">Answer B</p>
-        <h2>Ten-year: I read the cost as $20K-$24K compounded</h2>
+        <h2>Ten-year: $20K-$24K compounded at the average home</h2>
         <p class="answer-summary">
           An override permanently raises the levy. Tier 3 at the average
           home is roughly $1,985/year every year going forward, so the
@@ -1732,7 +1732,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="c" data-question="mycost">
         <p class="answer-label">Answer C</p>
-        <h2>Share of income: I read the cost as a fraction of median household earnings</h2>
+        <h2>Share of income: a fraction of median household earnings</h2>
         <p class="answer-summary">
           Annual override cost divided by Marblehead ACS median household
           income gives me a share-of-income figure. It's the framing that
@@ -2195,7 +2195,7 @@ og_url: https://marbleheaddata.org/
         <p class="answer-summary">
           The tiers were designed as a multi-year correction, and the
           higher ones build capacity to absorb future cost growth without
-          a near-term return to voters. I read the bridge as durable.
+          a near-term return to voters. The bridge looks durable to me.
         </p>
       </div>
 
@@ -2672,7 +2672,7 @@ og_url: https://marbleheaddata.org/
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="trash">
         <p class="answer-label">Answer A</p>
-        <h2>Levy: I read it as fairer because it scales with value</h2>
+        <h2>Levy: fairer because it scales with value</h2>
         <p class="answer-summary">
           Below the ~$1.21M break-even, the levy route saves my household
           money. The median home ($1.01M) saves about $46/yr; a $500K
@@ -2683,7 +2683,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="trash">
         <p class="answer-label">Answer B</p>
-        <h2>Flat fee: I read it as fairer because service is the same</h2>
+        <h2>Flat fee: fairer because the service is the same</h2>
         <p class="answer-summary">
           Above the ~$1.21M break-even the flat fee saves money, and the
           fairness principle I'd apply is that every household gets the
@@ -2890,7 +2890,7 @@ og_url: https://marbleheaddata.org/
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="library">
         <p class="answer-label">Answer A</p>
-        <h2>I read it as building and operating being separate budgets</h2>
+        <h2>Building and operating are separate budgets</h2>
         <p class="answer-summary">
           The $8.5M was a debt exclusion for construction. Staff,
           materials, and hours come from the general fund. A new building
@@ -2900,7 +2900,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="library">
         <p class="answer-label">Answer B</p>
-        <h2>I read it as law and contracts leaving almost nowhere else</h2>
+        <h2>Law and contracts leave almost nowhere else</h2>
         <p class="answer-summary">
           Pensions are state-mandated. Police, fire, and teacher pay are
           locked by union contracts. Health-insurance rates are set by the
@@ -2912,7 +2912,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="c" data-question="library">
         <p class="answer-label">Answer C</p>
-        <h2>I read it as a cut designed to pressure a yes vote</h2>
+        <h2>A cut designed to pressure a yes vote</h2>
         <p class="answer-summary">
           The library is visible and sympathetic. Officials could spread
           the pain differently but concentrated it where residents feel it
@@ -3369,17 +3369,18 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="a" data-question="seniors">
         <p class="answer-label">Answer A</p>
-        <h2>I read existing relief as offsetting the increase if claimed</h2>
+        <h2>Existing relief offsets the increase for seniors who claim it</h2>
         <p class="answer-summary">
           The state Senior Circuit Breaker refunds up to $2,820/year. For a
-          lower-income senior with a modest home, it absorbs a meaningful
-          share of a Tier 3 increase. The problem is uptake, not benefit.
+          lower-income senior with a modest home, claiming it absorbs a
+          meaningful share of a Tier 3 increase. The program is calibrated
+          to help the seniors most exposed to a tax bump.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="seniors">
         <p class="answer-label">Answer B</p>
-        <h2>I read it as uptake being so low that most seniors feel the full increase</h2>
+        <h2>Uptake is too low, so most seniors feel the full increase</h2>
         <p class="answer-summary">
           Only 418 of roughly 1,158 eligible Marblehead seniors claimed the
           Circuit Breaker in 2022. For the rest, the override is a straight
@@ -3390,7 +3391,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="c" data-question="seniors">
         <p class="answer-label">Answer C</p>
-        <h2>I read the override as the wrong lever for targeted relief</h2>
+        <h2>The override is the wrong lever for targeted relief</h2>
         <p class="answer-summary">
           Voting yes or no on the override doesn't change fixed-income
           exposure directly. Making existing relief easier to access does.
@@ -3619,8 +3620,8 @@ og_url: https://marbleheaddata.org/
         Marblehead's General Fund grew from $70.5M (FY15) to $106.2M
         (FY26), an increase of $35.7M over 11 years. The split between
         "unavoidable" and "discretionary" within that growth is the
-        priors question: it shapes how I read the override, the tiers,
-        and the alternatives.
+        priors question: it shapes how readers weigh the override, the
+        tiers, and the alternatives.
       </p>
       <p class="story-filter">
         Growth is measured FY15 to FY26 in nominal dollars. Inflation
@@ -3633,7 +3634,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="a" data-question="moneygone">
         <p class="answer-label">Answer A</p>
-        <h2>I read it as mostly costs the town can't say no to</h2>
+        <h2>Mostly costs the town can't say no to</h2>
         <p class="answer-summary">
           Schools absorbed 48% of the growth, with mandated out-of-district
           special education one of the drivers. Health insurance, pensions,
@@ -3644,7 +3645,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="moneygone">
         <p class="answer-label">Answer B</p>
-        <h2>I read it as growth running ahead of obvious drivers</h2>
+        <h2>Some lines grew ahead of any obvious driver</h2>
         <p class="answer-summary">
           Enrollment fell 19% while education staff rose 9.6%. The town
           balanced the operating budget with one-time free cash for years.
@@ -3655,7 +3656,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="c" data-question="moneygone">
         <p class="answer-label">Answer C</p>
-        <h2>I read it as both, depending on which line item</h2>
+        <h2>Both, depending on the line item</h2>
         <p class="answer-summary">
           Different lines tell different stories. Schools, pensions, and
           health insurance look mandatory. Town Counsel and free-cash

--- a/index.html
+++ b/index.html
@@ -405,7 +405,7 @@ og_url: https://marbleheaddata.org/
         <p class="answer-summary">
           An override should deliver something beyond preservation, whether
           that's stronger staffing ratios, restored hours, or service quality
-          peer towns already provide. Loss-aversion framing understates what's
+          peer towns provide today. Loss-aversion framing understates what's
           on offer.
         </p>
       </div>
@@ -474,12 +474,12 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>The no-override budget is already the smaller-service scenario</h4>
+        <h4>The no-override budget is the smaller-service scenario</h4>
         <p>
           If "smaller services for lower taxes" is what I want, the
           published no-override budget is roughly the first year of that
           outcome. Voting no selects that baseline directly; no override
-          is the lever I'd already be pulling.
+          is the lever I'd be pulling.
         </p>
         <a class="evidence-chart-link" href="no-override-budget.html">
           No-override budget details
@@ -1642,7 +1642,7 @@ og_url: https://marbleheaddata.org/
         <p>
           A Tier 3 override moves Marblehead's bill/income ratio to
           roughly 7.1%, still under Swampscott's current 8.5% and
-          comparable to Stoneham and Melrose today. Statewide, only
+          comparable to Stoneham and Melrose today. Statewide,
           24 of 350 MA communities have a lighter bill/income ratio
           than Marblehead at baseline.
         </p>
@@ -2914,10 +2914,10 @@ og_url: https://marbleheaddata.org/
         <p class="answer-label">Answer C</p>
         <h2>A cut designed to pressure a yes vote</h2>
         <p class="answer-summary">
-          The library is visible and sympathetic. Officials could spread
-          the pain differently but concentrated it where residents feel it
-          most, making the no-override outcome feel unacceptable. That's
-          an editorial reading of the choice, not a structural one.
+          The library is visible and sympathetic. Officials could have
+          spread the pain differently but concentrated it where residents
+          feel it most, making the no-override outcome feel unacceptable.
+          The shape of the cut is a choice, not just what contracts leave.
         </p>
       </div>
     </div>
@@ -3126,7 +3126,7 @@ og_url: https://marbleheaddata.org/
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="trust">
         <p class="answer-label">Answer A</p>
-        <h2>Yes — the checks I can use are already in place</h2>
+        <h2>Yes — the checks I can use are in place</h2>
         <p class="answer-summary">
           Elected boards, public meetings, independent audits, state
           oversight, and the Town Meeting vote all exist. The information

--- a/index.html
+++ b/index.html
@@ -1898,7 +1898,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Tier 1 adds ~0.6 points; Tier 3 adds ~1.0</h4>
+        <h4>Tier 1 adds ~0.6 percentage points of income; Tier 3 adds ~1.0</h4>
         <p>
           At full phase-in, the average-home override cost (~$1,188/yr
           at Tier 1, ~$1,985/yr at Tier 3) works out to roughly 0.65%

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ og_url: https://marbleheaddata.org/
       <!-- Answer A -->
       <div class="answer-card" data-answer="a" data-question="override">
         <p class="answer-label">Answer A</p>
-        <h2>I'll fund the bridge and trust the town to use the time</h2>
+        <h2>I'll fund the override and trust the town with the time</h2>
         <p class="answer-summary">
           Costs ran ahead of the levy for a decade. An override buys
           multi-year breathing room so the town can plan without emergency
@@ -52,7 +52,7 @@ og_url: https://marbleheaddata.org/
       <!-- Answer B -->
       <div class="answer-card" data-answer="b" data-question="override">
         <p class="answer-label">Answer B</p>
-        <h2>I need reform before I fund a bridge</h2>
+        <h2>I need reform before I fund an override</h2>
         <p class="answer-summary">
           Structural issues, staffing choices, and the 83% health-insurance
           premium split were set long before FY27. I want benefits reform or
@@ -63,7 +63,7 @@ og_url: https://marbleheaddata.org/
       <!-- Answer C -->
       <div class="answer-card" data-answer="c" data-question="override">
         <p class="answer-label">Answer C</p>
-        <h2>I'll fund the bridge only if reform runs alongside it</h2>
+        <h2>I'll fund the override only if reform runs alongside it</h2>
         <p class="answer-summary">
           The gap is part structure, part choices. My yes depends on a visible
           commitment to slope-bending reform while the override runs, so we
@@ -846,7 +846,7 @@ og_url: https://marbleheaddata.org/
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="schools">
         <p class="answer-label">Answer A</p>
-        <h2>Yes — the ratio is a choice I'd reverse</h2>
+        <h2>Yes — the staffing-to-enrollment ratio is a choice I'd reverse</h2>
         <p class="answer-summary">
           Enrollment fell 21% but FTEs grew. The student-to-staff ratio
           is the lowest among peer towns. That gap is a choice, not a
@@ -867,7 +867,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="c" data-question="schools">
         <p class="answer-label">Answer C</p>
-        <h2>Both are in the data; I weigh it line by line, not in aggregate</h2>
+        <h2>Both are in the data; it depends on which FTE series you read</h2>
         <p class="answer-summary">
           <abbr class="g" title="Special Education">SPED</abbr> and <abbr class="g" title="English Language Learner">ELL</abbr> growth are mandated. Instructional coaches,
           additional administrators, and co-teachers are district choices.
@@ -2212,7 +2212,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="c" data-question="again">
         <p class="answer-label">Answer C</p>
-        <h2>Depends — it turns on what reform happens during the bridge</h2>
+        <h2>Depends — it turns on what reform happens while the override runs</h2>
         <p class="answer-summary">
           The override buys time. Whether that time turns into slope-bending
           reform (benefits, commercial growth, staffing) or just gets
@@ -2693,7 +2693,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="c" data-question="trash">
         <p class="answer-label">Answer C</p>
-        <h2>I'll decide Question 2 on its own, but the carve-out still needs an answer</h2>
+        <h2>I'll decide Question 2 on its own, but the trash-budget carve-out still needs an answer</h2>
         <p class="answer-summary">
           Trash was already in the budget. The Select Board carved it out,
           freeing $1.15M for other spending. My Q2 vote is about the

--- a/index.html
+++ b/index.html
@@ -1269,6 +1269,17 @@ og_url: https://marbleheaddata.org/
         </a>
       </div>
 
+      <div class="evidence-point">
+        <h4>New growth doesn't close the difference either</h4>
+        <p>
+          Marblehead's five-year average new growth rate is 0.54%, the
+          lowest in the peer set. Peninsula geography, historic districts,
+          and zoning limit new construction; rezoning takes years.
+          2.5% + 0.54% is the ceiling on annual revenue growth, and
+          health insurance alone grows faster than that.
+        </p>
+      </div>
+
       <details class="counter-argument">
         <summary>
           <span class="counter-argument-label">Counter-argument</span>
@@ -1280,8 +1291,9 @@ og_url: https://marbleheaddata.org/
             annual overrides. What varies isn't the presence of the
             costs, it's the local choices about premium splits,
             staffing composition, and total compensation that
-            determine how much of the 2.5% is already spoken for. The
-            cap exposes those choices; it doesn't create them.
+            determine how much of the 2.5% plus new growth is
+            spoken for. The cap exposes those choices; it doesn't
+            create them.
           </p>
         </div>
       </details>
@@ -1329,6 +1341,41 @@ og_url: https://marbleheaddata.org/
         </p>
         <a class="evidence-chart-link" href="charts/levy_vs_bill.html">
           Full levy, bill, and inflation chart
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The spending levers the town actually controls</h4>
+        <p>
+          The cap constrains revenue; cost growth is where discipline
+          has to happen. Levers the town sets locally, not the state:
+        </p>
+        <ul>
+          <li>
+            <strong>Health-insurance premium split.</strong> Marblehead
+            pays 83% of employee premiums. State law allows 50-99%;
+            Hingham pays 50%. Moving to 75% would save roughly $1M/yr.
+          </li>
+          <li>
+            <strong>Staffing composition.</strong> Student-to-staff ratio
+            is the lowest among peer towns. Office and administrative
+            staff run well above peer averages.
+          </li>
+          <li>
+            <strong>Total compensation.</strong> Teacher salary runs
+            below peers; total compensation runs above, because of the
+            premium split plus benefits structure. The package is
+            negotiable at each contract cycle.
+          </li>
+          <li>
+            <strong>Budget discipline.</strong> Requesting an MA DOR DLS
+            review is free and has never been requested. Line-item
+            transparency in the budget reporting format is also a town
+            choice.
+          </li>
+        </ul>
+        <a class="evidence-chart-link" href="what-has-the-town-done.html">
+          What has the town already done to save?
         </a>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -1898,13 +1898,13 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Tier 1 adds ~0.6 percentage points of income; Tier 3 adds ~1.0</h4>
+        <h4>Tier 1 moves it from 6.1% to 6.7%; Tier 3 moves it to 7.1%</h4>
         <p>
-          At full phase-in, the average-home override cost (~$1,188/yr
-          at Tier 1, ~$1,985/yr at Tier 3) works out to roughly 0.65%
-          of ACS median household income for Tier 1 and 1.09% for
-          Tier 3. The combined bill/income ratio moves from 6.1%
-          today to about 6.7% at Tier 1 or 7.1% at Tier 3.
+          At full phase-in, the average-home override costs about
+          $1,188/yr at Tier 1 and $1,985/yr at Tier 3. Added to the
+          current $8,677 bill and divided by the $182,132 median
+          household income, Tier 1 lifts the share from 6.1% to
+          roughly 6.7% and Tier 3 lifts it to about 7.1%.
         </p>
         <a class="evidence-chart-link" href="charts/override_calculator.html">
           Override calculator: reprice for your home and income
@@ -1912,13 +1912,11 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Even at Tier 3, the ratio stays below Swampscott</h4>
+        <h4>At Tier 3, the share sits where Stoneham sits today</h4>
         <p>
-          Swampscott's current bill/income ratio is 8.5%. Stoneham
-          is 7.1% and Melrose 7.3% today. Marblehead at Tier 3 (7.1%)
-          lands roughly where Stoneham already sits and stays below
-          Swampscott. Statewide context is available on the
-          bill/income chart for 350 MA communities.
+          Today: Marblehead 6.1%, Stoneham 7.1%, Melrose 7.3%,
+          Swampscott 8.5%. At full Tier 3 Marblehead lands at about
+          7.1%, roughly where Stoneham is now, and below Swampscott.
         </p>
         <a class="evidence-chart-link" href="charts/statewide_tax_burden.html">
           Statewide bill/income ratio, 350 MA communities

--- a/index.html
+++ b/index.html
@@ -1884,7 +1884,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Marblehead's bill is already 6.1% of median household income</h4>
+        <h4>Marblehead's bill is 6.1% of median household income</h4>
         <p>
           Dividing the median single-family bill (~$8,677) by
           Marblehead <abbr class="g" title="American Community Survey">ACS</abbr>

--- a/index.html
+++ b/index.html
@@ -270,8 +270,8 @@ og_url: https://marbleheaddata.org/
         <p>
           The deficit is partly structural (health insurance, pensions)
           and partly the result of choices (staffing, compensation). Both
-          can be true. The override closes the gap; reform changes how
-          the next gap forms.
+          can be true. The override bridges the FY27 gap; reform changes
+          how the next gap forms.
         </p>
       </div>
 
@@ -311,8 +311,8 @@ og_url: https://marbleheaddata.org/
         <p class="caption">
           Without an override, the gap between expenses and revenue grows
           from roughly $1M (FY24) to $18M by FY30. Even Tier 3 ($15M)
-          briefly closes the gap in FY29 but reopens to roughly $4M by FY30
-          as expenses outpace the fixed override levy.
+          briefly bridges the gap in FY29, then reopens to roughly $4M by
+          FY30 as expenses outpace the fixed override levy.
         </p>
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Full sustainability projections
@@ -761,7 +761,7 @@ og_url: https://marbleheaddata.org/
         <p class="caption">
           Without an override, the gap between what the town spends and
           what it collects grows to $18M by FY30. Even Tier 3 ($15M)
-          only closes it briefly before expenses pull ahead again. The
+          only bridges it briefly before expenses pull ahead again. The
           override buys time; it doesn't change the trend.
         </p>
         <a class="evidence-chart-link" href="charts/sustainability.html">
@@ -2032,7 +2032,7 @@ og_url: https://marbleheaddata.org/
         <p class="answer-label">Answer B</p>
         <h2>Tier 3: I want the fuller bridge and fewer revisits</h2>
         <p class="answer-summary">
-          Tier 1 barely closes the current gap. Without the full ceiling,
+          Tier 1 barely bridges the current gap. Without the full ceiling,
           the deficit reopens within a year or two as health insurance,
           pensions, and contracts keep growing. I'd rather vote once for
           more than twice for less.
@@ -2095,7 +2095,7 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            Tier 1 closes the gap for one year. Health insurance rose 11%
+            Tier 1 bridges the gap for one year. Health insurance rose 11%
             for FY27 alone. Without the additional capacity from Tiers 2
             and 3, the town will face the same deficit by FY29 and need
             another override vote, as happened in Melrose and Stoneham.
@@ -2255,7 +2255,7 @@ og_url: https://marbleheaddata.org/
         <h2>Soon — the math pulls ahead of any tier within a year or two</h2>
         <p class="answer-summary">
           Health insurance and pensions don't stop growing when the
-          override passes. Even Tier 3 closes the gap briefly before
+          override passes. Even Tier 3 bridges the gap briefly before
           expenses pull ahead again, so I expect the next vote sooner
           than the tier label suggests.
         </p>
@@ -2298,8 +2298,8 @@ og_url: https://marbleheaddata.org/
         <p>
           The FinCom's three-year forecast shows structural deficits
           only if the override fails. At Tier 2 or 3, the near-term
-          gap closes and the town doesn't need to come back to voters
-          for several years.
+          gap is bridged and the town doesn't need to come back to
+          voters for several years.
         </p>
         <a class="evidence-chart-link" href="how-we-got-here.html">
           How we got here
@@ -2317,7 +2317,7 @@ og_url: https://marbleheaddata.org/
             <abbr class="g" title="Finance Committee">FinCom</abbr>'s
             projections. Health insurance premiums rose 11% for FY27
             alone, well above the 5%/year assumption in the
-            sustainability chart. Even Tier 3 only closes the gap
+            sustainability chart. Even Tier 3 only bridges the gap
             briefly in the published projection before reopening by
             FY30, so the multi-year cushion may be thinner than the
             tier framing suggests.
@@ -2577,8 +2577,8 @@ og_url: https://marbleheaddata.org/
             FY26/27/28 as the projected deficit years in its 2025
             transmittal. Treating the current calendar as the only
             frame implicitly forgives years of not pursuing the
-            longer-horizon levers that could have closed part of the
-            gap by now.
+            longer-horizon levers that could have reduced the gap
+            by now.
           </p>
         </div>
       </details>
@@ -2636,7 +2636,7 @@ og_url: https://marbleheaddata.org/
         <div class="counter-argument-body">
           <p>
             Each alternative named takes years to produce savings
-            and none of them close FY27's $8.47M by June. "Chosen
+            and none of them cover FY27's $8.47M by June. "Chosen
             not to pursue" reads as motive, but the actual
             constraint is collective bargaining cycles, zoning
             processes, and state-level reform, all of which move on

--- a/index.html
+++ b/index.html
@@ -3359,7 +3359,7 @@ og_url: https://marbleheaddata.org/
       </p>
       <p class="story-filter">
         Share-of-income uses ACS 65+ median household income as the
-        denominator. Uptake figures are MA DOR 2022 tax-year data, the
+        denominator. Claim figures are MA DOR 2022 tax-year data, the
         most recent available; eligibility estimates use ACS income
         distributions and may undercount.
       </p>
@@ -3380,7 +3380,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="seniors">
         <p class="answer-label">Answer B</p>
-        <h2>Uptake is too low, so most seniors feel the full increase</h2>
+        <h2>Most eligible seniors don't claim it, so they feel the full increase</h2>
         <p class="answer-summary">
           Only 418 of roughly 1,158 eligible Marblehead seniors claimed the
           Circuit Breaker in 2022. For the rest, the override is a straight
@@ -3395,7 +3395,8 @@ og_url: https://marbleheaddata.org/
         <p class="answer-summary">
           Voting yes or no on the override doesn't change fixed-income
           exposure directly. Making existing relief easier to access does.
-          The decision I'd focus on is uptake, not the levy.
+          The decision I'd focus on is getting eligible seniors to file,
+          not the levy.
         </p>
       </div>
 
@@ -3482,7 +3483,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>36% uptake of the Circuit Breaker in 2022</h4>
+        <h4>Only 36% of eligible Marblehead seniors claimed it in 2022</h4>
         <p>
           418 Marblehead seniors filed Schedule CB and claimed the
           Circuit Breaker in 2022. The estimated eligible population is
@@ -3493,7 +3494,7 @@ og_url: https://marbleheaddata.org/
           worth nothing to a senior who never files.
         </p>
         <a class="evidence-chart-link" href="senior-tax-relief.html#how-to-actually-get-this">
-          Uptake data and application steps
+          Claim rates and application steps
         </a>
       </div>
 
@@ -3528,7 +3529,7 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            Low uptake is a distribution problem, not a funding problem.
+            Low claim rates are a distribution problem, not a funding problem.
             The Circuit Breaker is fully funded by the state, requires no
             local appropriation, and is waiting to be claimed. Outreach
             campaigns, Council on Aging assistance, and pre-filled forms
@@ -3564,7 +3565,7 @@ og_url: https://marbleheaddata.org/
         <h4>The relief levers are separate from the override vote</h4>
         <p>
           Voting yes or no on the override doesn't change the Circuit
-          Breaker uptake rate, doesn't accelerate H.4225 in the Senate,
+          Breaker claim rate, doesn't accelerate H.4225 in the Senate,
           and doesn't enroll seniors in programs they're not currently
           using. Those are separate policy levers with separate
           decision-makers. Pushing for better outreach, automatic

--- a/index.html
+++ b/index.html
@@ -21,10 +21,18 @@ og_url: https://marbleheaddata.org/
   <section class="question-screen" data-topic="override">
 
     <div class="question-block">
-      <h1>Is this override necessary, or the result of wasteful spending?</h1>
+      <h1>Does an override buy time, and for what?</h1>
       <p class="question-context">
-        The proposed $8.47M override would be the largest in Marblehead's history.
-        Was the deficit inevitable, or could it have been avoided?
+        The proposed $8.47M override is a bridge, not a structural fix.
+        It can carry the budget for a few years before the expense slope
+        reopens the gap. The voter decision is a package: fund the bridge,
+        and commit to what has to happen during it.
+      </p>
+      <p class="story-filter">
+        The deficit model defaults the ratchet slider (how fast override
+        revenue gets absorbed into new spending) to five years and treats
+        FY18 as the baked-in gap-start year. Both are editorial choices
+        the chart lets you change.
       </p>
     </div>
 
@@ -33,32 +41,33 @@ og_url: https://marbleheaddata.org/
       <!-- Answer A -->
       <div class="answer-card" data-answer="a" data-question="override">
         <p class="answer-label">Answer A</p>
-        <h2>Years of underfunding made this inevitable</h2>
+        <h2>I'll fund the bridge and trust the town to use the time</h2>
         <p class="answer-summary">
-          Costs grew faster than revenue for over a decade. Health insurance,
-          pensions, and contractual obligations left almost no room to cut.
+          Costs ran ahead of the levy for a decade. An override buys
+          multi-year breathing room so the town can plan without emergency
+          cuts, and I'm willing to let that time be used as the town sees fit.
         </p>
       </div>
 
       <!-- Answer B -->
       <div class="answer-card" data-answer="b" data-question="override">
         <p class="answer-label">Answer B</p>
-        <h2>There is real waste they could cut first</h2>
+        <h2>I need reform before I fund a bridge</h2>
         <p class="answer-summary">
-          Staffing held steady while enrollment fell 21%, total compensation
-          exceeds peer towns, and the budget process lacks the scrutiny
-          residents deserve.
+          Structural issues, staffing choices, and the 83% health-insurance
+          premium split were set long before FY27. I want benefits reform or
+          an independent review on the table before I add revenue.
         </p>
       </div>
 
       <!-- Answer C -->
       <div class="answer-card" data-answer="c" data-question="override">
         <p class="answer-label">Answer C</p>
-        <h2>Both are true, but the gap is too large to close with cuts alone</h2>
+        <h2>I'll fund the bridge only if reform runs alongside it</h2>
         <p class="answer-summary">
-          Some spending was avoidable. But even aggressive cuts would not
-          close an $8.47M deficit without service losses most residents
-          would not accept.
+          The gap is part structure, part choices. My yes depends on a visible
+          commitment to slope-bending reform while the override runs, so we
+          don't just defer the same vote.
         </p>
       </div>
 
@@ -344,6 +353,192 @@ og_url: https://marbleheaddata.org/
   </section>
 
   <!-- ═══════════════════════════════════════════════════
+       QUESTION 15: What level of service do I want?
+       (Added per audit #550; orthogonal preference axis)
+       ═══════════════════════════════════════════════════ -->
+  <section class="question-screen" data-topic="servicelevel">
+
+    <div class="question-block">
+      <h1>What level of service do I want from Marblehead?</h1>
+      <p class="question-context">
+        The override debate tends to anchor on loss aversion: pay more to
+        prevent cuts. The question underneath is a preference one: what do
+        I actually want the town to deliver? Residents legitimately disagree,
+        and the same override dollar can fund preservation or improvement.
+      </p>
+      <p class="story-filter">
+        This is a preference question, not a factual one. The linked charts
+        show what tax effort buys (rate vs. value, peer compensation) and
+        what the published no-override baseline looks like; none of them
+        tell you what service level is "right."
+      </p>
+    </div>
+
+    <div class="answers">
+
+      <!-- Answer A -->
+      <div class="answer-card" data-answer="a" data-question="servicelevel">
+        <p class="answer-label">Answer A</p>
+        <h2>I want to preserve the current service level</h2>
+        <p class="answer-summary">
+          What I pay for today is roughly what I want. Schools, library,
+          public safety at their current footprint are worth maintaining,
+          and I'd accept a levy increase to hold that line.
+        </p>
+      </div>
+
+      <!-- Answer B -->
+      <div class="answer-card" data-answer="b" data-question="servicelevel">
+        <p class="answer-label">Answer B</p>
+        <h2>I'd accept smaller services for lower taxes</h2>
+        <p class="answer-summary">
+          I'd rather pay less now even if it means a smaller library, fewer
+          non-teaching school positions, or leaner town departments. The
+          current service level is more than I need.
+        </p>
+      </div>
+
+      <!-- Answer C -->
+      <div class="answer-card" data-answer="c" data-question="servicelevel">
+        <p class="answer-label">Answer C</p>
+        <h2>I'd pay more for improvements, not just to avoid cuts</h2>
+        <p class="answer-summary">
+          An override should deliver something beyond preservation, whether
+          that's stronger staffing ratios, restored hours, or service quality
+          peer towns already provide. Loss-aversion framing understates what's
+          on offer.
+        </p>
+      </div>
+
+    </div>
+
+    <!-- Evidence A -->
+    <div class="evidence" data-evidence="servicelevel-a">
+      <div class="evidence-header">
+        <h3>The case for "preserve the current service level"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The no-override baseline shows what "smaller" actually means</h4>
+        <p>
+          The town's own FY27 balanced budget cuts the library 43%, removes
+          22 town positions and 18.25 school <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>, and zeros out the
+          <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr> trust. That's the shape of "smaller" on the table.
+          Preserving today's service level requires new revenue.
+        </p>
+        <a class="evidence-chart-link" href="no-override-budget.html">
+          The no-override budget line by line
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Rate paid and value received move together</h4>
+        <p>
+          Across peer communities, the towns paying more in school tax effort
+          generally receive more on the DESE accountability and outcomes
+          side. Marblehead sits on that curve; preserving the position
+          takes sustained revenue.
+        </p>
+        <a class="evidence-chart-link" href="charts/rate_value_schools.html">
+          Rate paid vs. value received for schools
+        </a>
+      </div>
+
+      <div class="evidence-cross-link">
+        <p>
+          Related: <a href="#" data-topic="override">Does an override buy time, and for what?</a>
+          and <a href="#" data-topic="mycost">What would the override cost my household?</a>
+        </p>
+      </div>
+    </div>
+
+    <!-- Evidence B -->
+    <div class="evidence" data-evidence="servicelevel-b">
+      <div class="evidence-header">
+        <h3>The case for "smaller services, lower taxes"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Total compensation is high relative to the peer set</h4>
+        <p>
+          Marblehead's 83% health-insurance premium split and total
+          teacher compensation ($122,702) both sit above Melrose and
+          Stoneham. Leaner staffing or a lower employer-share ratio
+          would reduce cost without shrinking classrooms to unusable size.
+        </p>
+        <a class="evidence-chart-link" href="charts/peer_compensation.html">
+          Peer compensation chart
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>The no-override budget is already the smaller-service scenario</h4>
+        <p>
+          If "smaller services for lower taxes" is what I want, the
+          published no-override budget is roughly the first year of that
+          outcome. Voting no selects that baseline directly; no override
+          is the lever I'd already be pulling.
+        </p>
+        <a class="evidence-chart-link" href="no-override-budget.html">
+          No-override budget details
+        </a>
+      </div>
+
+      <div class="evidence-cross-link">
+        <p>
+          Related: <a href="#" data-topic="voteno">What will happen if we vote no?</a>
+          and <a href="#" data-topic="alternatives">Do any of the town's levers have enough impact?</a>
+        </p>
+      </div>
+    </div>
+
+    <!-- Evidence C -->
+    <div class="evidence" data-evidence="servicelevel-c">
+      <div class="evidence-header">
+        <h3>The case for "pay more for improvements"</h3>
+        <button class="evidence-close">Collapse</button>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Override framing anchors on loss, not gain</h4>
+        <p>
+          Most public materials describe the override as "preventing cuts."
+          A Tier 3 override also funds spending the no-override budget does
+          not: restored positions, OPEB contributions, capital room.
+          Calling it loss-avoidance hides the preservation-plus-improvement
+          option on the ballot.
+        </p>
+        <a class="evidence-chart-link" href="where-has-the-money-gone.html">
+          Where the money has gone, and what the tiers would add
+        </a>
+      </div>
+
+      <div class="evidence-point">
+        <h4>Peers buy more with similar tax effort</h4>
+        <p>
+          The rate-value comparison shows peer towns with similar or lower
+          effective rates achieving comparable or stronger outcomes on
+          specific measures. An override sized for improvement aims for
+          that position, not just for holding ground.
+        </p>
+        <a class="evidence-chart-link" href="charts/rate_value_schools.html">
+          Rate paid vs. value received for schools
+        </a>
+      </div>
+
+      <div class="evidence-cross-link">
+        <p>
+          Related: <a href="#" data-topic="size">What does each tier get us?</a>
+          and <a href="#" data-topic="moneygone">What explains the budget growth?</a>
+        </p>
+      </div>
+    </div>
+
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════
        QUESTION 2: What happens if we vote no?
        ═══════════════════════════════════════════════════ -->
   <section class="question-screen" data-topic="voteno">
@@ -351,39 +546,49 @@ og_url: https://marbleheaddata.org/
     <div class="question-block">
       <h1>What will happen if we vote no?</h1>
       <p class="question-context">
-        The town has published a no-override balanced budget. It cuts
-        22 town positions, 18.25 school <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>, and reduces the library 43%.
-        What does that actually look like?
+        The town has published a no-override balanced budget: 22 town
+        positions cut, 18.25 school <abbr class="g" title="Full-Time Equivalents">FTEs</abbr> cut, the library at 43% of its
+        prior funding. That is the published baseline for a no vote.
+      </p>
+      <p class="story-filter">
+        Where those cuts land is a Select Board allocation choice, not
+        a mathematical necessity. A different board could have spread
+        the same dollar reduction differently. Peer-town outcomes after a
+        no vote come from four MA towns whose no votes are at least five
+        years old so post-vote effects are observable.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="voteno">
         <p class="answer-label">Answer A</p>
-        <h2>Services get cut, but the town adjusts</h2>
+        <h2>I accept the published no-override budget as the baseline</h2>
         <p class="answer-summary">
-          The no-override budget is painful but balanced. Marblehead has
-          operated without overrides before. Towns adapt.
+          The balanced FY27 budget is the town's own document. I'll take it
+          on its terms, accept the service reductions it describes, and
+          treat it as the consequence of voting no rather than assuming
+          worse outcomes follow.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="voteno">
         <p class="answer-label">Answer B</p>
-        <h2>The cuts trigger losses that are hard to reverse</h2>
+        <h2>I think the cuts set off losses the budget understates</h2>
         <p class="answer-summary">
           Staff leave for higher-paying districts, institutional knowledge
-          is lost, and the next override ends up larger. Other towns
-          learned this the hard way.
+          walks out with them, and the next override ends up larger. Peer
+          towns that voted no saw effects the first-year budget did not
+          price in.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="voteno">
         <p class="answer-label">Answer C</p>
-        <h2>Voting no is the only way to force structural reform</h2>
+        <h2>I'm voting no because it's the only pressure for reform</h2>
         <p class="answer-summary">
-          Approving the override removes the pressure to fix the spending
-          patterns that created the deficit. A no vote forces the
-          conversation the town has been avoiding.
+          I'd rather accept the published cuts than approve an override
+          that lets the cost-driver conversation get deferred again. A no
+          vote is the lever I have to force that conversation.
         </p>
       </div>
     </div>
@@ -622,18 +827,26 @@ og_url: https://marbleheaddata.org/
   <section class="question-screen" data-topic="schools">
 
     <div class="question-block">
-      <h1>Why did school staffing grow while enrollment fell?</h1>
+      <h1>Did school staffing grow while enrollment fell?</h1>
       <p class="question-context">
-        Marblehead employs 430 school staff for 2,389 students, a ratio
-        of 5.6 students per staff member. Enrollment fell 21% since
-        its peak, but staffing did not shrink with it.
+        Marblehead enrollment peaked at 3,327 and fell to 2,617, a 21%
+        decline. The <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> FTE series
+        over the same period tells more than one story, depending on which
+        of four lines you read.
+      </p>
+      <p class="story-filter">
+        The chart lets you toggle four FTE series: total, instructional,
+        non-instructional, and special-education. Enrollment is DESE
+        October 1 headcount; FTE is the DESE End-of-Year Report. FY23
+        has a known DESE reporting-method change that looks like a single-year
+        hire but isn't.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="schools">
         <p class="answer-label">Answer A</p>
-        <h2>Yes, staffing should have tracked enrollment down</h2>
+        <h2>Yes — the ratio is a choice I'd reverse</h2>
         <p class="answer-summary">
           Enrollment fell 21% but FTEs grew. The student-to-staff ratio
           is the lowest among peer towns. That gap is a choice, not a
@@ -643,21 +856,22 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="schools">
         <p class="answer-label">Answer B</p>
-        <h2>Most of the growth is legally mandated</h2>
+        <h2>No — three of four FTE series tell a different story</h2>
         <p class="answer-summary">
-          Special education, <abbr class="g" title="English Language Learner">ELL</abbr>, and compliance requirements drove
-          60-65% of the staffing increase. You cannot cut an <abbr class="g" title="Individualized Education Program">IEP</abbr>-required
-          aide without violating federal law.
+          Special education, <abbr class="g" title="English Language Learner">ELL</abbr>, and compliance requirements drove most of
+          the growth. You cannot cut an <abbr class="g" title="Individualized Education Program">IEP</abbr>-required aide without violating
+          federal law. Read as total FTEs, the picture looks overstaffed;
+          read by series, it doesn't.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="schools">
         <p class="answer-label">Answer C</p>
-        <h2>The mandates are real, but not every position is mandated</h2>
+        <h2>Both are in the data; I read it by line, not in aggregate</h2>
         <p class="answer-summary">
-          <abbr class="g" title="Special Education">SPED</abbr> and <abbr class="g" title="English Language Learner">ELL</abbr> growth are required. Instructional coaches,
-          additional administrators, and co-teachers are district
-          choices. Both things are true.
+          <abbr class="g" title="Special Education">SPED</abbr> and <abbr class="g" title="English Language Learner">ELL</abbr> growth are mandated. Instructional coaches,
+          additional administrators, and co-teachers are district choices.
+          My read on "overstaffed" depends on which FTE series is on.
         </p>
       </div>
     </div>
@@ -955,39 +1169,50 @@ og_url: https://marbleheaddata.org/
   <section class="question-screen" data-topic="levy">
 
     <div class="question-block">
-      <h1>Why don't annual 2.5% tax increases keep up?</h1>
+      <h1>How can town income keep up with cost growth?</h1>
       <p class="question-context">
-        Prop 2&frac12; caps the levy increase at 2.5% per year. But health
-        insurance, pensions, and contracted salaries grow faster. Where
-        does the gap come from?
+        Town income grows through two channels: the Prop 2&frac12; levy cap
+        (2.5%/year) and new growth (new construction and renovations added
+        to the tax base). Health insurance, pensions, and contracted
+        salaries grow faster than the cap, and new growth in Marblehead
+        is small enough that it doesn't close the difference on its own.
+      </p>
+      <p class="story-filter">
+        The healthcare-costs chart is titled in a way that foregrounds the
+        growth rate, which is the strongest version of answer A's case.
+        The same data supports answer B if read against spending choices
+        rather than against the cap.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="levy">
         <p class="answer-label">Answer A</p>
-        <h2>The cap was never designed for the cost structure towns face today</h2>
+        <h2>I want new revenue because costs outrun 2.5% structurally</h2>
         <p class="answer-summary">
-          Health insurance grows 7-11% per year. Pensions grow 9%. A 2.5%
-          revenue cap cannot keep up with costs the town does not control.
+          Health insurance grows 7-11% per year, pensions ~9%. A 2.5%
+          revenue cap plus modest new growth cannot keep up with costs the
+          town does not set, so overrides are the mechanism the law leaves.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="levy">
         <p class="answer-label">Answer B</p>
-        <h2>The cap is the only check on spending growth</h2>
+        <h2>I want spending brought down to what 2.5% plus new growth supports</h2>
         <p class="answer-summary">
-          Without the cap, spending would grow unchecked. The pressure it
-          creates is the point: it forces the town to prioritize.
+          The cap is the only structural check. Instead of raising revenue to
+          match cost growth, I'd rather reshape the spending that outruns the
+          cap, starting with the levers the town actually controls.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="levy">
         <p class="answer-label">Answer C</p>
-        <h2>The math is real, but so is the need for reform</h2>
+        <h2>I want both: override now, and reform before the next one</h2>
         <p class="answer-summary">
-          The structural gap is not the town's fault. But closing it with
-          overrides alone, without fixing cost drivers, is not sustainable.
+          The mechanics are real, but a yes should not let the slope issues
+          drift. New revenue plus benefits reform and new-growth work is
+          the package I'd accept.
         </p>
       </div>
     </div>
@@ -1202,40 +1427,48 @@ og_url: https://marbleheaddata.org/
     <div class="question-block">
       <h1>How does Marblehead's tax burden compare to similar towns?</h1>
       <p class="question-context">
-        Marblehead has the lowest tax rate of four comparable North Shore
-        towns. But high home values mean a high median bill. Which
-        number matters more?
+        Marblehead has the lowest residential tax rate among four
+        comparable North Shore towns, a high median bill in dollars, and
+        a roughly middle position when the bill is expressed as a share
+        of median household income. Each lens is a legitimate comparison.
+      </p>
+      <p class="story-filter">
+        Peers are Melrose, Swampscott, and Stoneham, picked for comparable
+        population (~20K-30K), North Shore geography, and service mix; all
+        four share the MA DOR DLS reporting. The Town Explorer page lets
+        you build a different cohort from all 351 MA communities.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="taxrank">
         <p class="answer-label">Answer A</p>
-        <h2>The rate is what matters, and ours is the lowest</h2>
+        <h2>I compare by rate, and Marblehead's is the lowest</h2>
         <p class="answer-summary">
-          At $8.59 per $1,000, Marblehead's tax rate is lower than
-          Swampscott ($12.00), Melrose ($11.41), and Stoneham ($11.10).
-          Even at Tier 3, the rate stays lowest.
+          At $8.59 per $1,000, Marblehead's rate sits below Swampscott
+          ($12.00), Melrose ($11.41), and Stoneham ($11.10). Even at
+          Tier 3 the rate stays lowest. That's the lens I trust.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="taxrank">
         <p class="answer-label">Answer B</p>
-        <h2>The bill is what you pay, and ours is high</h2>
+        <h2>I compare by bill, and ours is high in dollars</h2>
         <p class="answer-summary">
-          The median Marblehead tax bill is ~$8,677. That is more than
-          Swampscott ($7,549) in absolute dollars because our homes are
-          worth more.
+          The median Marblehead bill is ~$8,677, more than Swampscott
+          ($7,549) in absolute dollars because our homes are worth more.
+          The dollars I actually write a check for are the ones I count.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="taxrank">
         <p class="answer-label">Answer C</p>
-        <h2>Per-capita levy is the fairest comparison</h2>
+        <h2>I compare by share of income, which matches what households can afford</h2>
         <p class="answer-summary">
-          Total tax collected per resident: Swampscott $4,207, Marblehead
-          $4,144, Melrose $3,416, Stoneham $3,117. Marblehead is in line
-          with its closest peer.
+          Divide the median bill by Marblehead ACS median household income
+          and the result sits closer to the middle of the peer set. Per-capita
+          levy is a related view but income is the denominator that reflects
+          what taxes cost households, not just homes.
         </p>
       </div>
     </div>
@@ -1440,42 +1673,50 @@ og_url: https://marbleheaddata.org/
   <section class="question-screen" data-topic="mycost">
 
     <div class="question-block">
-      <h1>How will this affect my taxes?</h1>
+      <h1>What would the override cost my household?</h1>
       <p class="question-context">
-        The override has three tiers. Each adds a different amount to
-        your annual tax bill based on your home's assessed value.
+        There are three honest framings of "what does it cost." Per month
+        at the average home, compounded over ten years, or as a share of
+        median household income. None is wrong; they answer slightly
+        different questions.
+      </p>
+      <p class="story-filter">
+        Monthly figures use FY26 average assessed value ($1,291,507) at
+        full phase-in (Year 3). Re-enter your own assessment on the
+        override calculator to reprice any framing.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="mycost">
         <p class="answer-label">Answer A</p>
-        <h2>At the average home value, Tier 3 adds ~$166/month at full phase-in</h2>
+        <h2>Monthly: I read the cost as $99 / $132 / $165 at the average home</h2>
         <p class="answer-summary">
-          The average assessed value in Marblehead is $1,291,507.
-          Tier 1 adds $99/mo, Tier 2 adds $132/mo, Tier 3 adds $165/mo
-          at full phase-in (Year 3).
+          Tier 1 adds about $99/mo, Tier 2 adds $132/mo, Tier 3 adds $165/mo
+          at full phase-in. That's the cash-flow framing I can compare to
+          other household line items.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="mycost">
         <p class="answer-label">Answer B</p>
-        <h2>It compounds: $20K-$24K over ten years</h2>
+        <h2>Ten-year: I read the cost as $20K-$24K compounded</h2>
         <p class="answer-summary">
           An override permanently raises the levy. Tier 3 at the average
-          home costs roughly $1,985/year every year going forward, not
-          just for three years.
+          home is roughly $1,985/year every year going forward, so the
+          real number I'm evaluating is the compounded decade, not the
+          three-year phase-in.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="mycost">
         <p class="answer-label">Answer C</p>
-        <h2>Compare it to what you lose without it</h2>
+        <h2>Share of income: I read the cost as a fraction of median household earnings</h2>
         <p class="answer-summary">
-          The no-override budget cuts 22 town positions, 18.25 school
-          <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>,
-          and the library 43%. The cost of the override is real, but so
-          is the cost of not having one.
+          Annual override cost divided by Marblehead ACS median household
+          income gives me a share-of-income figure. It's the framing that
+          matches affordability across households with similar homes but
+          different earnings.
         </p>
       </div>
     </div>
@@ -1673,43 +1914,50 @@ og_url: https://marbleheaddata.org/
   <section class="question-screen" data-topic="size">
 
     <div class="question-block">
-      <h1>Does the size of the override matter?</h1>
+      <h1>What does each tier get us?</h1>
       <p class="question-context">
         The ballot has three tiers: Tier 1 ($9M), Tier 2 ($12M), and
-        Tier 3 ($15M). Each passes or fails independently. Is the full
-        amount necessary, or would a smaller override be enough?
+        Tier 3 ($15M). Each passes or fails independently. The three
+        stances here are Tier 1, Tier 3, and none. Tier 2 is a middle
+        position; the comparison matrix is the right view for it.
+      </p>
+      <p class="story-filter">
+        The tier projections hold current cost-growth rates constant (health,
+        pensions, salaries) and assume no structural reform. A tier
+        comparison matrix chart is the right place to evaluate Tier 2;
+        it's scoped as a follow-up to this rewrite.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="size">
         <p class="answer-label">Answer A</p>
-        <h2>Fund the essentials, skip the rest</h2>
+        <h2>Tier 1: I want the minimum bridge, and I'll accept coming back sooner</h2>
         <p class="answer-summary">
           Tier 1 restores cuts and avoids layoffs. Tiers 2 and 3 add
-          cushion and new spending that the town hasn't proven it needs.
-          A smaller override is easier to sustain long-term.
+          cushion and new spending I'm not convinced the town has earned.
+          I'll accept another vote sooner in exchange for the smaller ask now.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="size">
         <p class="answer-label">Answer B</p>
-        <h2>The full amount is already the minimum</h2>
+        <h2>Tier 3: I want the fuller bridge and fewer revisits</h2>
         <p class="answer-summary">
-          Tier 1 barely closes the current gap. Without Tiers 2 and 3,
-          the deficit reopens within a year as health insurance, pensions,
-          and contracts keep growing. Passing only Tier 1 guarantees
-          another override vote soon.
+          Tier 1 barely closes the current gap. Without the full ceiling,
+          the deficit reopens within a year or two as health insurance,
+          pensions, and contracts keep growing. I'd rather vote once for
+          more than twice for less.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="size">
         <p class="answer-label">Answer C</p>
-        <h2>The size doesn't matter because the answer is no</h2>
+        <h2>None: no override at any tier until reform is on the table</h2>
         <p class="answer-summary">
-          No override of any size should pass until the town demonstrates
-          structural reform. Any tier continues the same spending
-          trajectory that created the deficit.
+          Any tier continues the same spending trajectory that created the
+          deficit. I'd rather take the published no-override baseline than
+          fund a bridge without a reform commitment to go with it.
         </p>
       </div>
     </div>
@@ -1888,41 +2136,51 @@ og_url: https://marbleheaddata.org/
   <section class="question-screen" data-topic="again">
 
     <div class="question-block">
-      <h1>Will we be back here in 5 years?</h1>
+      <h1>How soon would we come back for another override?</h1>
       <p class="question-context">
-        If the override passes, does the problem go away or does the
-        same pressure rebuild?
+        An override bridges the gap; it does not end the cycle. Whether
+        the next vote is soon, later, or not needed depends on both
+        tier size and on what changes inside the bridging period.
+      </p>
+      <p class="story-filter">
+        The deficit model's ratchet slider controls how quickly override
+        revenue gets absorbed into new spending. At the default five years
+        the bridge feels durable; at one year the gap reopens almost
+        immediately. Both are plausible; historical ratcheting analysis
+        is tracked as companion work.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="again">
         <p class="answer-label">Answer A</p>
-        <h2>The override is sized to last several years</h2>
+        <h2>Not soon — a sized-well override holds for several years</h2>
         <p class="answer-summary">
-          The three tiers were designed as a multi-year correction.
-          Tier 2 and 3 build capacity to absorb future cost growth
-          without coming back to voters immediately.
+          The tiers were designed as a multi-year correction, and the
+          higher ones build capacity to absorb future cost growth without
+          a near-term return to voters. I read the bridge as durable.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="again">
         <p class="answer-label">Answer B</p>
-        <h2>The math says we will</h2>
+        <h2>Soon — the math pulls ahead of any tier within a year or two</h2>
         <p class="answer-summary">
           Health insurance and pensions don't stop growing when the
-          override passes. Even Tier 3 closes the gap for about one
-          year before expenses pull ahead again.
+          override passes. Even Tier 3 closes the gap briefly before
+          expenses pull ahead again, so I expect the next vote sooner
+          than the tier label suggests.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="again">
         <p class="answer-label">Answer C</p>
-        <h2>It depends on whether reform happens during the breathing room</h2>
+        <h2>Depends — it turns on what reform happens during the bridge</h2>
         <p class="answer-summary">
-          The override buys time. Whether that time gets used for
-          structural changes or just defers the problem is a choice,
-          not a certainty.
+          The override buys time. Whether that time turns into slope-bending
+          reform (benefits, commercial growth, staffing) or just gets
+          ratcheted into new spending is the variable that decides when the
+          next vote is needed.
         </p>
       </div>
     </div>
@@ -2125,42 +2383,52 @@ og_url: https://marbleheaddata.org/
   <section class="question-screen" data-topic="alternatives">
 
     <div class="question-block">
-      <h1>What else could we do instead of an override?</h1>
+      <h1>Do any of the town's levers have enough impact?</h1>
       <p class="question-context">
-        Is it really override-or-cuts, or are there other options
-        nobody is talking about?
+        Override alternatives fall into two groups. Bridge-style levers
+        (one-time cuts, reserves, fee carve-outs) can close part of the
+        FY27 $8.47M gap for a year or two. Slope-benders (benefits reform,
+        commercial base, long-run staffing) can reduce the growth
+        differential by roughly half a point per year, compounding.
+        Scale is the question.
+      </p>
+      <p class="story-filter">
+        Near-term scoring is against the FY27 $8.47M gap on a 12-week
+        horizon. Longer horizons, or a smaller remaining gap after an
+        override, unlock different levers. A levers-magnitude panel is
+        tracked as follow-up work.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="alternatives">
         <p class="answer-label">Answer A</p>
-        <h2>There are no short-term alternatives that close an $8.47M gap</h2>
+        <h2>No — near-term levers don't scale to the FY27 gap</h2>
         <p class="answer-summary">
-          The levers other towns use (commercial tax base, state aid,
-          CIP shift) either don't exist in Marblehead or don't scale.
-          Nothing else works in 12 weeks.
+          Commercial tax base, state aid, and CIP shifts either don't
+          exist in Marblehead or don't move fast or big enough. On a
+          12-week horizon, nothing but new revenue or cuts closes $8.47M.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="alternatives">
         <p class="answer-label">Answer B</p>
-        <h2>There are alternatives the town has chosen not to pursue</h2>
+        <h2>Yes — the slope-bending levers are what actually end the cycle</h2>
         <p class="answer-summary">
-          Benefits reform, economic development, and budget
-          transparency are all possible. They take longer, but that's
-          the point: the override is being asked for instead of the
-          harder work.
+          Benefits reform (especially the 83% health-insurance employer
+          share), economic development, and long-run staffing reduce the
+          growth differential structurally. They don't close FY27 alone,
+          but they're the only levers that change the trend line.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="alternatives">
         <p class="answer-label">Answer C</p>
-        <h2>12-week alternatives don't exist, but 5-year ones do</h2>
+        <h2>Only together — override bridges, slope-benders end the cycle</h2>
         <p class="answer-summary">
-          Nothing closes $8.47M by June. But the override should come
-          with a commitment to the structural changes that prevent the
-          next one.
+          Nothing closes $8.47M by June. An override plus explicit
+          slope-bending work during the bridge is the combination that
+          matches the gap at both timescales.
         </p>
       </div>
     </div>
@@ -2350,42 +2618,50 @@ og_url: https://marbleheaddata.org/
   <section class="question-screen" data-topic="trash">
 
     <div class="question-block">
-      <h1>Why is trash collection on the ballot?</h1>
+      <h1>Should we pay for trash through property taxes or a flat fee?</h1>
       <p class="question-context">
         Question 2 asks for $2.3M to fund curbside trash through
-        property taxes. If it fails, a flat $281/household fee kicks
-        in instead. Either way, you pay for trash.
+        property taxes. If it fails, a flat $281/household fee kicks in
+        instead. Either way you pay; the choice is how the cost is split.
+      </p>
+      <p class="story-filter">
+        Break-even uses the FY27 proposed $281 flat fee against the
+        $2.3M levy spread across the grand list at current rates. A
+        break-even-by-home-value chart with reference markers at $500K,
+        $1.01M, $1.21M, $1.29M, $2M, and $3M is tracked as a follow-up.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="trash">
         <p class="answer-label">Answer A</p>
-        <h2>Vote yes: the levy scales with home value</h2>
+        <h2>Levy: I read it as fairer because it scales with value</h2>
         <p class="answer-summary">
-          If your home is assessed below the ~$1.21M break-even, you
-          save by voting yes. The median home ($1.01M) saves $46/yr;
-          a $500K home saves $165/yr.
+          Below the ~$1.21M break-even, the levy route saves my household
+          money. The median home ($1.01M) saves about $46/yr; a $500K
+          home saves ~$165/yr. Value-scaled payment is the fairness
+          principle I'd apply.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="trash">
         <p class="answer-label">Answer B</p>
-        <h2>Vote no: everyone uses the same service</h2>
+        <h2>Flat fee: I read it as fairer because service is the same</h2>
         <p class="answer-summary">
-          If your home is assessed above the ~$1.21M break-even, you
-          save by voting no. A $2M home saves $184/yr; a $3M home
-          saves $417/yr.
+          Above the ~$1.21M break-even the flat fee saves money, and the
+          fairness principle I'd apply is that every household gets the
+          same pickup. A $2M home saves ~$184/yr; a $3M home ~$417/yr.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="trash">
         <p class="answer-label">Answer C</p>
-        <h2>The real question is what happened to the money</h2>
+        <h2>I'll decide Question 2 on its own, but the carve-out still needs an answer</h2>
         <p class="answer-summary">
-          Trash was already in the budget. The Select Board carved it
-          out, freeing $1.15M for other spending. Question 2 is about
-          whether to backfill that with new taxes.
+          Trash was already in the budget. The Select Board carved it out,
+          freeing $1.15M for other spending. My Q2 vote is about the
+          levy-vs-fee split; where the $1.15M went is a separate
+          trust-and-transparency question.
         </p>
       </div>
     </div>
@@ -2559,45 +2835,52 @@ og_url: https://marbleheaddata.org/
   <section class="question-screen" data-topic="library">
 
     <div class="question-block">
-      <h1>Why would the library be the heaviest cut without an override?</h1>
+      <h1>Why does the library take the heaviest cut without an override?</h1>
       <p class="question-context">
         Marblehead approved $8.5M to renovate Abbot Library in 2021.
-        Now the no-override budget cuts library operations 43%, the
-        deepest reduction of any department. What explains that?
+        The no-override budget cuts library operations 43%, the deepest
+        reduction of any department. The cut is in a published document,
+        not hypothetical.
+      </p>
+      <p class="story-filter">
+        "Heaviest" here is a percentage framing. In absolute dollars the
+        library is not the biggest reduction; in share-of-department it is.
+        A fixed-vs-discretionary view of each department's budget is
+        tracked as a follow-up.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="library">
         <p class="answer-label">Answer A</p>
-        <h2>The building and the operating budget are different things</h2>
+        <h2>I read it as building and operating being separate budgets</h2>
         <p class="answer-summary">
           The $8.5M was a debt exclusion for construction. Staff,
-          materials, and hours come from the general fund. A new
-          building doesn't change what it costs to keep it open.
+          materials, and hours come from the general fund. A new building
+          doesn't change what it costs to keep it open.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="library">
         <p class="answer-label">Answer B</p>
-        <h2>Law and contracts leave almost nowhere else to cut</h2>
+        <h2>I read it as law and contracts leaving almost nowhere else</h2>
         <p class="answer-summary">
-          Pensions are state-mandated. Police, fire, and teacher pay
-          are locked by union contracts. Health insurance rates are
-          set by the GIC. The library has no union, no state funding
-          floor, and voluntary accreditation. The 43% isn't a
-          preference. It's what's left.
+          Pensions are state-mandated. Police, fire, and teacher pay are
+          locked by union contracts. Health-insurance rates are set by the
+          <abbr class="g" title="Group Insurance Commission">GIC</abbr>.
+          The library has no union, no state funding floor, and voluntary
+          accreditation. 43% is what's structurally left, not a preference.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="library">
         <p class="answer-label">Answer C</p>
-        <h2>The town is cutting the library to pressure a yes vote</h2>
+        <h2>I read it as a cut designed to pressure a yes vote</h2>
         <p class="answer-summary">
-          The library is visible and sympathetic. Officials could
-          spread the pain differently but are concentrating it where
-          residents will feel it most, to make the no-override
-          outcome feel unacceptable.
+          The library is visible and sympathetic. Officials could spread
+          the pain differently but concentrated it where residents feel it
+          most, making the no-override outcome feel unacceptable. That's
+          an editorial reading of the choice, not a structural one.
         </p>
       </div>
     </div>
@@ -2790,41 +3073,50 @@ og_url: https://marbleheaddata.org/
   <section class="question-screen" data-topic="trust">
 
     <div class="question-block">
-      <h1>How do we trust the people making these decisions?</h1>
+      <h1>Should I trust the town with more revenue?</h1>
       <p class="question-context">
         Elected and appointed boards set the budget and propose overrides.
-        What oversight exists, and is it enough?
+        The question is what oversight exists, where its limits are, and
+        whether that's enough for me to accept a budget I didn't build.
+      </p>
+      <p class="story-filter">
+        This is a process question, not a data question. Linked pages show
+        the audit trail (verify) and this site's own framing choices
+        (bias audit). No chart fills a trust gap directly.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="trust">
         <p class="answer-label">Answer A</p>
-        <h2>The system has real checks and transparency</h2>
+        <h2>Yes — the checks I can use are already in place</h2>
         <p class="answer-summary">
           Elected boards, public meetings, independent audits, state
-          oversight, and Town Meeting vote. The information is there
-          if you look for it.
+          oversight, and the Town Meeting vote all exist. The information
+          is there if I look, and that's enough for me to accept the
+          override as proposed.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="trust">
         <p class="answer-label">Answer B</p>
-        <h2>Transparency exists on paper but not in practice</h2>
+        <h2>No — transparency exists on paper but not in practice</h2>
         <p class="answer-summary">
           Meetings are poorly attended, budgets are presented as
-          take-it-or-leave-it, and few residents have the time to
-          audit 200-page financial reports.
+          take-it-or-leave-it, and few residents have the time to audit
+          200-page financial reports. I don't feel the existing oversight
+          is enough to justify more revenue.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="trust">
         <p class="answer-label">Answer C</p>
-        <h2>Trust is earned by showing the work, not asking for faith</h2>
+        <h2>Depends — I'll extend trust when the town shows the work</h2>
         <p class="answer-summary">
-          The question is not whether officials are honest but whether
-          the system makes it easy for residents to verify claims
-          independently.
+          The question isn't whether officials are honest but whether the
+          system makes it easy for me to verify claims independently. I'll
+          extend trust where the work is visible and withhold it where it
+          isn't.
         </p>
       </div>
     </div>
@@ -3020,11 +3312,19 @@ og_url: https://marbleheaddata.org/
   <section class="question-screen" data-topic="seniors">
 
     <div class="question-block">
-      <h1>How does this affect seniors and people on fixed incomes?</h1>
+      <h1>How does this affect seniors?</h1>
       <p class="question-context">
-        Property taxes are the same whether the household writing the check
-        is a working family or a retiree on Social Security. Marblehead has
-        several relief programs, but they only help if you qualify and apply.
+        Property taxes tax the home, not the income. Marblehead has
+        relief programs, but they only help if a household qualifies and
+        applies. This question is scoped to seniors; the
+        <a href="senior-tax-relief.html">senior-tax-relief page</a>
+        covers non-senior fixed-income relief in its own section.
+      </p>
+      <p class="story-filter">
+        Share-of-income uses ACS 65+ median household income as the
+        denominator. Uptake figures are MA DOR 2022 tax-year data, the
+        most recent available; eligibility estimates use ACS income
+        distributions and may undercount.
       </p>
     </div>
 
@@ -3032,32 +3332,32 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="a" data-question="seniors">
         <p class="answer-label">Answer A</p>
-        <h2>Existing relief meaningfully offsets the increase</h2>
+        <h2>I read existing relief as offsetting the increase if claimed</h2>
         <p class="answer-summary">
-          The state Senior Circuit Breaker refunds up to $2,820/year. For
-          a lower-income senior with a modest home, it absorbs a
-          meaningful share of a Tier 3 increase. The programs exist; the
-          problem is low uptake, not low benefit.
+          The state Senior Circuit Breaker refunds up to $2,820/year. For a
+          lower-income senior with a modest home, it absorbs a meaningful
+          share of a Tier 3 increase. The problem is uptake, not benefit.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="seniors">
         <p class="answer-label">Answer B</p>
-        <h2>Relief doesn't reach most of the seniors who need it</h2>
+        <h2>I read it as uptake being so low that most seniors feel the full increase</h2>
         <p class="answer-summary">
-          Only 418 of roughly 1,158 eligible Marblehead seniors claimed
-          the Circuit Breaker in 2022. For the rest, the override is a
-          straight tax increase with no offset.
+          Only 418 of roughly 1,158 eligible Marblehead seniors claimed the
+          Circuit Breaker in 2022. For the rest, the override is a straight
+          tax increase with no offset, and the relief programs don't reach
+          the households they're designed for.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="seniors">
         <p class="answer-label">Answer C</p>
-        <h2>The override is the wrong instrument for targeted relief</h2>
+        <h2>I read the override as the wrong lever for targeted relief</h2>
         <p class="answer-summary">
-          Property taxes tax the home, not the income. Voting yes or no
-          on the override doesn't change fixed-income exposure. Making
-          existing relief easier to access does.
+          Voting yes or no on the override doesn't change fixed-income
+          exposure directly. Making existing relief easier to access does.
+          The decision I'd focus on is uptake, not the levy.
         </p>
       </div>
 
@@ -3280,9 +3580,15 @@ og_url: https://marbleheaddata.org/
       <h1>What explains the budget growth?</h1>
       <p class="question-context">
         Marblehead's General Fund grew from $70.5M (FY15) to $106.2M
-        (FY26), an increase of $35.7M over 11 years. What drove that
-        growth, and did anything grow faster than inflation,
-        enrollment, or service levels would suggest?
+        (FY26), an increase of $35.7M over 11 years. The split between
+        "unavoidable" and "discretionary" within that growth is the
+        priors question: it shapes how I read the override, the tiers,
+        and the alternatives.
+      </p>
+      <p class="story-filter">
+        Growth is measured FY15 to FY26 in nominal dollars. Inflation
+        context is available on the levy-vs-bill chart but is not the
+        primary lens here; the primary lens is line-item attribution.
       </p>
     </div>
 
@@ -3290,35 +3596,34 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="a" data-question="moneygone">
         <p class="answer-label">Answer A</p>
-        <h2>Costs the town can't say no to</h2>
+        <h2>I read it as mostly costs the town can't say no to</h2>
         <p class="answer-summary">
-          Schools absorbed 48% of the growth, with mandated
-          out-of-district special education one of the drivers. Health
-          insurance, pensions, and debt service are on rate sheets and
-          fixed schedules the town doesn't set. These aren't choices.
+          Schools absorbed 48% of the growth, with mandated out-of-district
+          special education one of the drivers. Health insurance, pensions,
+          and debt service sit on rate sheets and fixed schedules the town
+          doesn't set.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="moneygone">
         <p class="answer-label">Answer B</p>
-        <h2>Some growth ran ahead of any obvious driver</h2>
+        <h2>I read it as growth running ahead of obvious drivers</h2>
         <p class="answer-summary">
           Enrollment fell 19% while education staff rose 9.6%. The town
-          has balanced the operating budget with one-time free cash
-          for years. Several line items grew faster than any obvious
-          driver.
+          balanced the operating budget with one-time free cash for years.
+          Several lines grew faster than any obvious driver, and that
+          looks like a set of choices I'd question.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="moneygone">
         <p class="answer-label">Answer C</p>
-        <h2>Both, depending on which line item</h2>
+        <h2>I read it as both, depending on which line item</h2>
         <p class="answer-summary">
-          Different lines tell different stories. Schools, pensions,
-          and health insurance look mandatory. Town Counsel and
-          free-cash patching look discretionary. The same audited
-          numbers support both A and B because both are true for
-          different lines.
+          Different lines tell different stories. Schools, pensions, and
+          health insurance look mandatory. Town Counsel and free-cash
+          patching look discretionary. The same audited numbers support
+          both reads because both are true for different lines.
         </p>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -3369,7 +3369,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="a" data-question="seniors">
         <p class="answer-label">Answer A</p>
-        <h2>Existing relief offsets the increase for seniors who claim it</h2>
+        <h2>Existing relief offsets the increase for seniors who file for it</h2>
         <p class="answer-summary">
           The state Senior Circuit Breaker refunds up to $2,820/year. For a
           lower-income senior with a modest home, claiming it absorbs a
@@ -3380,7 +3380,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="seniors">
         <p class="answer-label">Answer B</p>
-        <h2>Most eligible seniors don't claim it, so they feel the full increase</h2>
+        <h2>Most eligible seniors don't file for relief, so they feel the full increase</h2>
         <p class="answer-summary">
           Only 418 of roughly 1,158 eligible Marblehead seniors claimed the
           Circuit Breaker in 2022. For the rest, the override is a straight

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence A -->
     <div class="evidence" data-evidence="override-a">
       <div class="evidence-header">
-        <h3>The case for "underfunding made this inevitable"</h3>
+        <h3>The case for "fund the bridge and trust the town with the time"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
@@ -181,7 +181,7 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence B -->
     <div class="evidence" data-evidence="override-b">
       <div class="evidence-header">
-        <h3>The case for "there is real waste"</h3>
+        <h3>The case for "reform before funding an override"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
@@ -245,7 +245,7 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence C -->
     <div class="evidence" data-evidence="override-c">
       <div class="evidence-header">
-        <h3>The case for "both, but the gap is real"</h3>
+        <h3>The case for "fund only if reform runs alongside"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
@@ -596,7 +596,7 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence A: town adjusts -->
     <div class="evidence" data-evidence="voteno-a">
       <div class="evidence-header">
-        <h3>The case for "the town adjusts"</h3>
+        <h3>The case for "accept the published baseline"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
@@ -1220,7 +1220,7 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence A: cap can't keep up -->
     <div class="evidence" data-evidence="levy-a">
       <div class="evidence-header">
-        <h3>The case for "the cap can't keep up"</h3>
+        <h3>The case for "the cap plus new growth can't keep up"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
@@ -1302,7 +1302,7 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence B: cap is the check -->
     <div class="evidence" data-evidence="levy-b">
       <div class="evidence-header">
-        <h3>The case for "the cap is the check"</h3>
+        <h3>The case for "reshape spending, not the cap"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
@@ -1402,7 +1402,7 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence C: math is real but reform needed -->
     <div class="evidence" data-evidence="levy-c">
       <div class="evidence-header">
-        <h3>The case for "the math is real, but so is reform"</h3>
+        <h3>The case for "override now, reform before the next one"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
@@ -2587,7 +2587,7 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence B: alternatives exist -->
     <div class="evidence" data-evidence="alternatives-b">
       <div class="evidence-header">
-        <h3>The case for "alternatives exist"</h3>
+        <h3>The case for "slope-benders end the cycle"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 


### PR DESCRIPTION
## Summary

Implements the 45-card rewrite PR scoped in the consolidated audit on [issue #550](https://github.com/agbaber/marblehead/issues/550#issuecomment-4264570569), in a single focused pass. Absorbs [#551](https://github.com/agbaber/marblehead/pull/551) (the Where-you-landed synthesis panel) so the panel ships against cleaned copy, not stale stance wording.

### Content rewrite

All 42 existing answer cards rewritten to first-person voter-stance voice so each card stands alone when lifted into the synthesis panel or a shared link. Contested-premise h1s reframed per the audit:

| Topic | Before | After |
|---|---|---|
| `override` | Is this override necessary, or the result of wasteful spending? | Does an override buy time, and for what? |
| `schools` | Why did school staffing grow while enrollment fell? | Did school staffing grow while enrollment fell? |
| `levy` | Why don't annual 2.5% tax increases keep up? | How can town income keep up with cost growth? |
| `mycost` | How will this affect my taxes? | What would the override cost my household? |
| `size` | Does the size of the override matter? | What does each tier get us? |
| `again` | Will we be back here in 5 years? | How soon would we come back for another override? |
| `alternatives` | What else could we do instead of an override? | Do any of the town's levers have enough impact? |
| `trash` | Why is trash collection on the ballot? | Should we pay for trash through property taxes or a flat fee? |
| `library` | Why *would* the library be the heaviest cut without an override? | Why *does* the library take the heaviest cut without an override? |
| `trust` | How do we trust the people making these decisions? | Should I trust the town with more revenue? |
| `seniors` | How does this affect seniors and people on fixed incomes? | How does this affect seniors? |

- **Q6 `mycost`** cards shift from stances to three framings: monthly at the average home, ten-year compounding, and share of ACS median household income.
- **Q7 `size`** cards shift to Tier&nbsp;1 / Tier&nbsp;3 / None; Tier&nbsp;2 is matrix-only per the audit.
- **Q5 `taxrank`** card C replaces per-capita levy with share-of-income.
- **Q2, Q11** surface the Select Board's cut-allocation choice and the percentage framing on "heaviest cut" as story-filter context, not editorial claim.

### Q15 `servicelevel` added

New question-screen inserted immediately after Q1 in display order. Three stances (preserve / shrink / pay for improvement), evidence blocks linking `rate_value_schools.html`, `peer_compensation.html`, and `no-override-budget.html`. Grows the total to 45 cards.

### Story-filter captions

Neutral italic note on each question-block naming the framing choice the linked chart makes (ratchet default, FY18 gap-start, peer-set selection criteria, DESE FTE reporting-method jump, etc). Context, not disclaimer.

### Synthesis panel absorbed (#551)

- `_includes/explore-synthesis.html` &ndash; the Where-you-landed panel skeleton.
- `_includes/explore-landing.html` &ndash; includes the panel before `.explore-tools`.
- `assets/explore.js` &ndash; `updateSynthesis()`, a new `preference` theme covering `servicelevel`/`mycost`/`seniors`, `WYL_TOPIC_LABELS` keyed to the rewritten h1s, and a document-level click handler that routes `data-topic` cross-links through `switchTopic()`.
- `assets/explore.css` &ndash; scoped `.where-you-landed` styles.

### State reset

`explore.js` bumps a `SELECTIONS_VERSION` key. On mismatch or absence, prior picks are cleared and a one-time notice ("Questions were updated. Please revisit to record your stances.") appears on the landing head. `persistSelections()` writes the version alongside picks so future changes only need another bump.

### Cross-navigation

`preferredOrder` moves `servicelevel` to slot 2 (right after `mycost`) so Q15 shapes reads on the downstream questions as the audit intends. Q15's evidence blocks include cross-links to Q1/Q2/Q6/Q7/Q9/Q14. Other cross-navigation flows through the synthesis panel.

### Scope held

Follow-up chart and research issues from the audit (#555 through #564, #549) are out of scope for this PR.

## Test plan

- [ ] Homepage renders 15 question cards on the landing grid
- [ ] Each question screen has exactly 3 answer cards
- [ ] Q15 `servicelevel` appears in slot 2 after `mycost` in the landing order
- [ ] Picking 3+ answers reveals the Where-you-landed panel between the question list and tools
- [ ] Picked rows show the answer-card summary text (first-person voice)
- [ ] The panel's "Clear my picks" routes through the existing `#statsReset` confirm flow
- [ ] `?positions=override:a,servicelevel:c,trust:b` shared view swaps title to "Where they landed" and hides Clear
- [ ] Local-storage picks saved before this deploy are wiped; the reset notice appears once on the landing head
- [ ] `data-topic` cross-links in Q15 evidence blocks jump to the target question without a full reload
- [ ] Story-filter captions render as italic/offset notes below each `.question-context`
- [ ] CI smoke tests pass against the built site

https://claude.ai/code/session_012TvKEt2eJmwG3MfETLenWq