### PR TITLE
Fix character-by-character link wrapping in doc-page tables

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1360,8 +1360,13 @@ body.doc-page .page li {
 body.doc-page .page li > p { margin: 0 0 6px; }
 body.doc-page .page li strong { color: var(--text); }
 
-/* Long URLs in source lists should wrap, not overflow */
-body.doc-page .page a { overflow-wrap: anywhere; word-break: break-word; }
+/* Long URLs in source lists should wrap, not overflow.
+   Excludes links inside table cells: `overflow-wrap: anywhere` tells the
+   browser the min-content width is a single character, which collapses
+   narrow table columns into character-per-line wrapping. */
+body.doc-page .page :not(td):not(th) > a,
+body.doc-page .page li a,
+body.doc-page .page p a { overflow-wrap: anywhere; word-break: break-word; }
 
 /* Inline code */
 body.doc-page .page code {


### PR DESCRIPTION
## Summary

- The `body.doc-page .page a { overflow-wrap: anywhere; word-break: break-word }` rule in `assets/site.css` was intended for long URLs in source lists, but applied to every link — including short link text inside table cells.
- `overflow-wrap: anywhere` lets the browser treat each character as a valid break point for min-content sizing, so the changelog's narrow "See" column collapsed and rendered "Override tiers" as "Ove rride tiers" and "MOU commitments" as "MO U com mit men ts".
- Scope the rule to `li a`, `p a`, and non-cell direct parents so URLs still wrap in lists and paragraphs but table links size normally.

## Test plan

- [ ] Load `/data/changelog.html` and confirm the "See" column of the April 15, 2026 table shows "Override tiers" and "MOU commitments" on one line each (or word-wrapped, not character-wrapped).
- [ ] Load `/data/SOURCE_LOOKUP.md` (or any doc-page markdown with long URLs in lists) and confirm long URLs still wrap within list items instead of overflowing horizontally on narrow viewports.
- [ ] Check mobile viewport (~375px) for both pages.

https://claude.ai/code/session_01N5obRHX9MMX5fjtjEKGyxP