### PR TITLE
Move "Not sure yet" button directly under the answer cards

### DIFF
--- a/assets/explore.css
+++ b/assets/explore.css
@@ -705,7 +705,7 @@
 
   /* ── "Not sure yet" pill directly under the answer cards ── */
   .unsure-row {
-    margin: 14px 0 4px;
+    margin: 16px 0 20px;
     text-align: center;
   }
   .unsure-btn {

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -711,30 +711,44 @@
   .unsure-btn {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 7px 16px;
-    background: transparent;
-    border: 1px dashed var(--border);
+    gap: 8px;
+    padding: 8px 18px;
+    background: color-mix(in srgb, var(--text-faint) 10%, transparent);
+    border: 1.5px solid color-mix(in srgb, var(--text-faint) 45%, var(--border));
     border-radius: 999px;
     cursor: pointer;
     font-family: inherit;
     font-size: 13px;
+    font-weight: 500;
+    color: var(--text);
+    transition: background 0.15s, border-color 0.15s;
+  }
+  .unsure-btn::before {
+    content: '?';
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--text-faint) 30%, transparent);
     color: var(--text-muted);
-    transition: border-color 0.15s, color 0.15s;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
   }
   .unsure-btn:hover {
+    background: color-mix(in srgb, var(--text-faint) 18%, transparent);
     border-color: var(--text-muted);
-    border-style: solid;
-    color: var(--text);
   }
   .unsure-btn.selected {
-    border-style: solid;
+    background: color-mix(in srgb, var(--text-faint) 22%, transparent);
     border-color: var(--text-muted);
-    color: var(--text);
   }
   .unsure-btn.selected::before {
     content: '\2713';
-    font-size: 11px;
+    background: var(--text-faint);
+    color: var(--surface);
   }
 
   /* ── Pick distribution bar ── */

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -703,12 +703,15 @@
     margin: 0;
   }
 
-  /* ── "Not sure yet" pill below the answer cards ── */
+  /* ── "Not sure yet" pill directly under the answer cards ── */
+  .unsure-row {
+    margin: 14px 0 4px;
+    text-align: center;
+  }
   .unsure-btn {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    margin-top: 4px;
     padding: 7px 16px;
     background: transparent;
     border: 1px dashed var(--border);

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -51,31 +51,6 @@
     });
   })();
 
-  /* ── Inject "Not sure yet" button below the answer cards ── */
-  (function injectUnsureButton() {
-    document.querySelectorAll('.question-screen').forEach(function (screen) {
-      var topic = screen.dataset.topic;
-      var answersEl = screen.querySelector('.answers');
-      if (!answersEl) return;
-
-      var btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = 'unsure-btn';
-      btn.dataset.answer = 'u';
-      btn.dataset.question = topic;
-      btn.textContent = 'Not sure yet';
-      answersEl.parentNode.insertBefore(btn, answersEl.nextSibling);
-
-      btn.addEventListener('click', function () {
-        var q = btn.dataset.question;
-        if (selections[q] === 'u') return; // already unsure
-        selectAnswer(q, 'u');
-        updateNotesPill();
-        updateNotesPanel();
-      });
-    });
-  })();
-
   /* ── Inject pick prompt below each question's answers ── */
   (function injectPickPrompt() {
     document.querySelectorAll('.question-screen').forEach(function (screen) {
@@ -900,6 +875,38 @@
       screen.appendChild(wrap);
     }
   });
+
+  /* ── Inject "Not sure yet" button directly under the answer cards ──
+     Runs after the next-question injection so it ends up as the element
+     immediately after .answers (centered, above the Next question CTA). */
+  (function injectUnsureButton() {
+    document.querySelectorAll('.question-screen').forEach(function (screen) {
+      var topic = screen.dataset.topic;
+      var answersEl = screen.querySelector('.answers');
+      if (!answersEl) return;
+
+      var row = document.createElement('div');
+      row.className = 'unsure-row';
+
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'unsure-btn';
+      btn.dataset.answer = 'u';
+      btn.dataset.question = topic;
+      btn.textContent = 'Not sure yet';
+      row.appendChild(btn);
+
+      answersEl.parentNode.insertBefore(row, answersEl.nextSibling);
+
+      btn.addEventListener('click', function () {
+        var q = btn.dataset.question;
+        if (selections[q] === 'u') return; // already unsure
+        selectAnswer(q, 'u');
+        updateNotesPill();
+        updateNotesPanel();
+      });
+    });
+  })();
 
   /* ── Inject social proof bar + share button into each question screen ── */
   document.querySelectorAll('.question-screen').forEach(function (screen) {


### PR DESCRIPTION
## Summary

- The "Not sure yet" pill was floating in the bottom-left of each question screen, below the "Next question" CTA and the next-question preview text. It read like it belonged to the *next* question rather than the current one.
- Root cause: it was injected first, and every subsequent inject (pick prompt, next-question, social bar) used `insertBefore(el, answersEl.nextSibling)`, so each new element pushed the unsure button further down.
- Fix: wrap it in a centered `.unsure-row` and move the inject call to run after the next-question inject, so it lands immediately after `.answers` — centered under A/B/C, above the "Next question" button.

## Test plan

- [ ] Load an explore question screen and confirm "Not sure yet" appears centered directly below the three answer cards, above the "Next question →" button.
- [ ] Click "Not sure yet" and confirm it toggles `.selected`, records the 'u' pick, opens the evidence placeholder, and reveals the next-question CTA.
- [ ] After picking A/B/C, confirm the unsure pill stays visible but un-selected and does not interfere with the distribution bar or social strip.
- [ ] Run `node tests/smoke-test.mjs` — the `.unsure-btn` existence / "outside `.answers`" check should still pass (button is now inside `.unsure-row`, which is outside `.answers`).

_Note: I wasn't able to start a dev server from this environment to visually verify the new layout — worth a quick eyeball before merging._

https://claude.ai/code/session_014Xy9H2GuTbWaSDcn2KxJSw