### PR TITLE
Clear the pick when "Not for me" is clicked on the selected answer

### DIFF
--- a/assets/explore.js
+++ b/assets/explore.js
@@ -1629,7 +1629,14 @@
     noBtn.className = 'evidence-action evidence-action--no';
     noBtn.textContent = 'Not for me';
     noBtn.addEventListener('click', function () {
-      panel.classList.remove('open');
+      // If this answer is currently the user's pick, "Not for me" should
+      // also clear it, not just hide the evidence. Server tally is left
+      // alone (matches the checkmark-to-unpick flow).
+      if (selections[question] === answer) {
+        deselectAnswer(question);
+      } else {
+        panel.classList.remove('open');
+      }
       // Scroll back to the question so they can try another answer
       var screen = document.querySelector('.question-screen[data-topic="' + question + '"]');
       if (screen) {


### PR DESCRIPTION
## Summary

Previously "Not for me" only closed the evidence panel, so if the user had
already committed via "This resonates" (or the checkmark) and then reopened
the panel and hit "Not for me", the card stayed selected — checkmark, Notes
entry, and distribution vote all persisted. The button's label reads like a
rejection but it was a pure UI dismissal.

Now, if the current pick for this question is this answer, "Not for me"
calls `deselectAnswer(question)`, which clears `.selected`, removes the
selection from localStorage/URL, closes the evidence panel, and hides the
next-question button. The server vote tally is left alone, matching the
existing checkmark-to-unpick flow (`deselectAnswer` doesn't hit
`/api/votes`).

If no pick is set, behavior is unchanged — just close the panel and scroll
back to the question.

## Test plan

- [ ] Open `/explore/`, click a card body to open evidence, click "This resonates" — card shows checkmark, Notes pill updates, distribution bar appears.
- [ ] Reopen the same evidence panel, click "Not for me" — checkmark clears, Notes entry disappears, evidence panel closes, page scrolls back to the question.
- [ ] Click a card body to open evidence without picking, click "Not for me" — panel closes and scrolls; no selection state changes (unchanged behavior).
- [ ] Confirm distribution bar on the server doesn't double-decrement (we intentionally don't retract the vote).

https://claude.ai/code/session_017AV3Z4JFKxNmWnH4oXx37X