### PR TITLE
Fix "None is wrong" -> "None are wrong" in Q6 mycost context

### DIFF
--- a/index.html
+++ b/index.html
@@ -1749,7 +1749,7 @@ og_url: https://marbleheaddata.org/
       <p class="question-context">
         There are three honest framings of "what does it cost." Per month
         at the average home, compounded over ten years, or as a share of
-        median household income. None is wrong; they answer slightly
+        median household income. None are wrong; they answer slightly
         different questions.
       </p>
       <p class="story-filter">


### PR DESCRIPTION
## Summary

Changes "None is wrong" to "None are wrong" in the Q6 mycost question-context.

When "none" refers to a collective set (the three framings: monthly, ten-year, share-of-income), modern usage and most contemporary style guides (Chicago, AP) prefer plural agreement. "None is" treats it as "not a single one is," which is grammatically defensible but stilted for plain site copy.

## Test plan

- [ ] `?q=mycost` renders "None are wrong" in the context paragraph
- [ ] CI passes

https://claude.ai/code/session_012TvKEt2eJmwG3MfETLenWq