### PR TITLE
Wrap 10 bare municipal-finance acronyms per STYLE_GUIDE

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@ og_url: https://marbleheaddata.org/
 
         <p class="caption">
           The levy and your tax bill grew about 53-55% since FY12.
-          Inflation grew 37%. Prop 2&frac12; caps the annual levy
+          Inflation (<abbr class="g" title="Consumer Price Index for All Urban Consumers">CPI-U</abbr>) grew 37%. Prop 2&frac12; caps the annual levy
           increase at 2.5%, so the town can't raise revenue faster
           even when costs jump.
         </p>
@@ -436,7 +436,7 @@ og_url: https://marbleheaddata.org/
         <h4>Rate paid and value received move together</h4>
         <p>
           Across peer communities, the towns paying more in school tax effort
-          generally receive more on the DESE accountability and outcomes
+          generally receive more on the <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> accountability and outcomes
           side. Marblehead sits on that curve; preserving the position
           takes sustained revenue.
         </p>
@@ -917,7 +917,7 @@ og_url: https://marbleheaddata.org/
         </div>
 
         <p class="caption">
-          The ACFR (town financial reports) shows education FTE rising
+          The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> (town financial reports) shows education FTE rising
           from 490 to 537 since FY15. But DESE (state education data)
           shows total educator FTE falling from 502 to 432 over the
           same period. The divergence is driven by a FY23 counting
@@ -1368,7 +1368,7 @@ og_url: https://marbleheaddata.org/
             negotiable at each contract cycle.
           </li>
           <li>
-            <strong>Budget discipline.</strong> Requesting an MA DOR DLS
+            <strong>Budget discipline.</strong> Requesting an MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr>
             review is free and has never been requested. Line-item
             transparency in the budget reporting format is also a town
             choice.
@@ -1516,7 +1516,7 @@ og_url: https://marbleheaddata.org/
         <p class="answer-label">Answer C</p>
         <h2>I compare by share of income, which matches what households can afford</h2>
         <p class="answer-summary">
-          Divide the median bill by Marblehead ACS median household income
+          Divide the median bill by Marblehead <abbr class="g" title="American Community Survey">ACS</abbr> median household income
           and the result sits closer to the middle of the peer set. Per-capita
           levy is a related view but income is the denominator that reflects
           what taxes cost households, not just homes.
@@ -1896,7 +1896,7 @@ og_url: https://marbleheaddata.org/
           chose. That is roughly three years after full phase-in.
         </p>
         <a class="evidence-chart-link" href="what-is-the-override.html#mou-commitments">
-          Full MOU terms
+          Full <abbr class="g" title="Memorandum of Understanding">MOU</abbr> terms
         </a>
         <p class="evidence-caveat">
           The MOU is a public statement of intent, not a binding
@@ -2493,7 +2493,7 @@ og_url: https://marbleheaddata.org/
         <p class="answer-label">Answer A</p>
         <h2>No: near-term levers don't scale to the FY27 gap</h2>
         <p class="answer-summary">
-          Commercial tax base, state aid, and CIP shifts either don't
+          Commercial tax base, state aid, and <abbr class="g" title="Capital Improvement Plan">CIP</abbr> shifts either don't
           exist in Marblehead or don't move fast or big enough. On a
           12-week horizon, nothing but new revenue or cuts closes $8.47M.
         </p>
@@ -3111,7 +3111,7 @@ og_url: https://marbleheaddata.org/
         <p>
           Every Marblehead household uses or sees the library. Cutting
           it 43% produces a reaction in a way that cutting a planning
-          position or a DPW laborer does not. If your goal is to make
+          position or a <abbr class="g" title="Department of Public Works">DPW</abbr> laborer does not. If your goal is to make
           the no-override scenario feel painful, the library is the
           most effective place to concentrate cuts.
         </p>
@@ -3142,7 +3142,7 @@ og_url: https://marbleheaddata.org/
             realistic alternatives and chose not to use them. But
             the list of departments without union contracts or state
             mandates is short: the library, community development,
-            COA, recreation, and cemetery. Community development is
+            <abbr class="g" title="Council on Aging">COA</abbr>, recreation, and cemetery. Community development is
             already cut 59%. Spreading $636K evenly across those
             departments would cripple all of them instead of deeply
             cutting one. The skeptic's challenge is to name a
@@ -3816,7 +3816,7 @@ og_url: https://marbleheaddata.org/
           to 10.7, the lowest of Marblehead's four peer towns. Most of
           that FTE increase lands in a single FY22-to-FY23 jump (483 to
           537) that the town has not publicly explained; the source may
-          reflect expired federal ESSER positions or a change in
+          reflect expired federal <abbr class="g" title="Elementary and Secondary School Emergency Relief">ESSER</abbr> positions or a change in
           reporting methodology, and the number has held at exactly
           537.0 for two years since.
         </p>


### PR DESCRIPTION
## Summary

Flagged on the preview: "CIP" on `/?q=alternatives` had no tooltip. A site-wide first-use audit on `index.html` found 10 bare municipal-finance or governance acronyms that weren't wrapped in `<abbr class="g" title="...">`. STYLE_GUIDE requires first use on a page to carry the wrapper so the glossary tooltip works (hover on desktop, long-press on mobile).

## Wrapped

| Acronym | Expansion | Where |
|---|---|---|
| CIP | Capital Improvement Plan | Q9 alternatives, card A |
| ACS | American Community Survey | Q5 taxrank, card C |
| CPI-U | Consumer Price Index for All Urban Consumers | Q1 override, evidence A caption |
| DESE | Department of Elementary and Secondary Education | Q15 servicelevel, evidence A |
| DOR | Department of Revenue | Q4 levy, evidence B levers list |
| DLS | Division of Local Services | Q4 levy, evidence B levers list |
| DPW | Department of Public Works | Q11 library, evidence C counter |
| MOU | Memorandum of Understanding | Q7 size, evidence A link |
| ESSER | Elementary and Secondary School Emergency Relief | Q14 moneygone, evidence B |
| ACFR | Annual Comprehensive Financial Report | Q3 schools, evidence A caption |
| COA | Council on Aging | Q11 library, evidence C counter |

## What I didn't wrap

- **SVG chart labels** (where CPI and DESE appear a few lines earlier than the body-prose first use): `<abbr>` tooltips don't render reliably inside SVG text elements, and each chart is accompanied by a caption paragraph that carries the wrapper.
- **Subsequent uses** of each acronym on the page stay bare per convention.

## Test plan

- [ ] `/?q=alternatives` shows CIP with dotted underline and tooltip "Capital Improvement Plan"
- [ ] All other first uses on the page show tooltips on hover (desktop) and long-press (mobile)
- [ ] Preview and smoke CI pass

https://claude.ai/code/session_012TvKEt2eJmwG3MfETLenWq