### PR TITLE
Wrap subsequent uses of municipal-finance acronyms on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,7 +506,7 @@ og_url: https://marbleheaddata.org/
         <p>
           Most public materials describe the override as "preventing cuts."
           A Tier 3 override also funds spending the no-override budget does
-          not: restored positions, OPEB contributions, capital room.
+          not: restored positions, <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr> contributions, capital room.
           Calling it loss-avoidance hides the preservation-plus-improvement
           option on the ballot.
         </p>
@@ -830,15 +830,15 @@ og_url: https://marbleheaddata.org/
       <h1>Did school staffing grow while enrollment fell?</h1>
       <p class="question-context">
         Marblehead enrollment peaked at 3,327 and fell to 2,617, a 21%
-        decline. The <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> FTE series
+        decline. The <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> <abbr class="g" title="Full-Time Equivalent">FTE</abbr> series
         over the same period tells more than one story, depending on which
         of four lines you read.
       </p>
       <p class="story-filter">
-        The chart lets you toggle four FTE series: total, instructional,
-        non-instructional, and special-education. Enrollment is DESE
-        October 1 headcount; FTE is the DESE End-of-Year Report. FY23
-        has a known DESE reporting-method change that looks like a single-year
+        The chart lets you toggle four <abbr class="g" title="Full-Time Equivalent">FTE</abbr> series: total, instructional,
+        non-instructional, and special-education. Enrollment is <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr>
+        October 1 headcount; <abbr class="g" title="Full-Time Equivalent">FTE</abbr> is the <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> End-of-Year Report. FY23
+        has a known <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> reporting-method change that looks like a single-year
         hire but isn't.
       </p>
     </div>
@@ -848,7 +848,7 @@ og_url: https://marbleheaddata.org/
         <p class="answer-label">Answer A</p>
         <h2>Yes: the staffing-to-enrollment ratio is a choice I'd reverse</h2>
         <p class="answer-summary">
-          Enrollment fell 21% but FTEs grew. The student-to-staff ratio
+          Enrollment fell 21% but <abbr class="g" title="Full-Time Equivalents">FTEs</abbr> grew. The student-to-staff ratio
           is the lowest among peer towns. That gap is a choice, not a
           mandate.
         </p>
@@ -856,22 +856,22 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="schools">
         <p class="answer-label">Answer B</p>
-        <h2>No: three of four FTE series tell a different story</h2>
+        <h2>No: three of four <abbr class="g" title="Full-Time Equivalent">FTE</abbr> series tell a different story</h2>
         <p class="answer-summary">
           Special education, <abbr class="g" title="English Language Learner">ELL</abbr>, and compliance requirements drove most of
           the growth. You cannot cut an <abbr class="g" title="Individualized Education Program">IEP</abbr>-required aide without violating
-          federal law. Read as total FTEs, the picture looks overstaffed;
+          federal law. Read as total <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>, the picture looks overstaffed;
           read by series, it doesn't.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="schools">
         <p class="answer-label">Answer C</p>
-        <h2>Both are in the data; it depends on which FTE series you read</h2>
+        <h2>Both are in the data; it depends on which <abbr class="g" title="Full-Time Equivalent">FTE</abbr> series you read</h2>
         <p class="answer-summary">
           <abbr class="g" title="Special Education">SPED</abbr> and <abbr class="g" title="English Language Learner">ELL</abbr> growth are mandated. Instructional coaches,
           additional administrators, and co-teachers are district choices.
-          My read on "overstaffed" depends on which FTE series is on.
+          My read on "overstaffed" depends on which <abbr class="g" title="Full-Time Equivalent">FTE</abbr> series is on.
         </p>
       </div>
     </div>
@@ -917,9 +917,9 @@ og_url: https://marbleheaddata.org/
         </div>
 
         <p class="caption">
-          The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> (town financial reports) shows education FTE rising
-          from 490 to 537 since FY15. But DESE (state education data)
-          shows total educator FTE falling from 502 to 432 over the
+          The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> (town financial reports) shows education <abbr class="g" title="Full-Time Equivalent">FTE</abbr> rising
+          from 490 to 537 since FY15. But <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> (state education data)
+          shows total educator <abbr class="g" title="Full-Time Equivalent">FTE</abbr> falling from 502 to 432 over the
           same period. The divergence is driven by a FY23 counting
           change and different definitions of who counts as "education"
           staff. <a href="charts/enrollment_vs_staffing.html">See all
@@ -1332,7 +1332,7 @@ og_url: https://marbleheaddata.org/
         </div>
 
         <p class="caption">
-          The levy grew 53% from FY12 to FY24 while CPI-U grew 37%.
+          The levy grew 53% from FY12 to FY24 while <abbr class="g" title="Consumer Price Index for All Urban Consumers">CPI-U</abbr> grew 37%.
           Property taxes have been rising faster than general inflation,
           because the 2.5% cap compounds to ~34.5% over twelve years and
           new growth (new construction added to the grand list) adds the
@@ -1439,7 +1439,7 @@ og_url: https://marbleheaddata.org/
         <p class="caption">
           An override bridges the gap once. But as long as costs grow at
           5% and revenue grows at 2.5%, the gap reopens. Structural
-          levers on the cost side (GIC premium splits, staffing model,
+          levers on the cost side (<abbr class="g" title="Group Insurance Commission">GIC</abbr> premium splits, staffing model,
           total compensation) are what change the slope.
         </p>
         <a class="evidence-chart-link" href="charts/sustainability.html">
@@ -1486,7 +1486,7 @@ og_url: https://marbleheaddata.org/
       <p class="story-filter">
         Peers are Melrose, Swampscott, and Stoneham, picked for comparable
         population (~20K-30K), North Shore geography, and service mix; all
-        four share the MA DOR DLS reporting. The Town Explorer page lets
+        four share the MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr> reporting. The Town Explorer page lets
         you build a different cohort from all 351 MA communities.
       </p>
     </div>
@@ -1675,7 +1675,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Bill as share of ACS median household income</h4>
+        <h4>Bill as share of <abbr class="g" title="American Community Survey">ACS</abbr> median household income</h4>
         <p>
           Marblehead 6.1%. Stoneham 7.1%. Melrose 7.3%. Swampscott 8.5%.
           Dividing the median single-family bill by median household
@@ -1723,7 +1723,7 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            ACS median income carries wide error margins (roughly
+            <abbr class="g" title="American Community Survey">ACS</abbr> median income carries wide error margins (roughly
             <abbr class="g" title="plus or minus">&plusmn;</abbr>$28K for
             Marblehead) and includes renters who don't pay property
             tax directly, so share-of-income is best read as relative
@@ -1785,7 +1785,7 @@ og_url: https://marbleheaddata.org/
         <p class="answer-label">Answer C</p>
         <h2>Share of income: a fraction of median household earnings</h2>
         <p class="answer-summary">
-          Annual override cost divided by Marblehead ACS median household
+          Annual override cost divided by Marblehead <abbr class="g" title="American Community Survey">ACS</abbr> median household
           income gives me a share-of-income figure. It's the framing that
           matches affordability across households with similar homes but
           different earnings.
@@ -1899,7 +1899,7 @@ og_url: https://marbleheaddata.org/
           Full <abbr class="g" title="Memorandum of Understanding">MOU</abbr> terms
         </a>
         <p class="evidence-caveat">
-          The MOU is a public statement of intent, not a binding
+          The <abbr class="g" title="Memorandum of Understanding">MOU</abbr> is a public statement of intent, not a binding
           contract; a two-thirds vote of all three boards could
           deviate. It covers general operating overrides only, not
           debt exclusions. At the April 8, 2026 meeting the School
@@ -1981,7 +1981,7 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            ACS median household income has wide error margins (roughly
+            <abbr class="g" title="American Community Survey">ACS</abbr> median household income has wide error margins (roughly
             <abbr class="g" title="plus or minus">&plusmn;</abbr>$28K
             for Marblehead) and includes renters, who don't pay property
             tax directly. A specific household's share-of-income depends
@@ -2533,7 +2533,7 @@ og_url: https://marbleheaddata.org/
         <p>
           95.5% of the tax levy comes from residential property, the
           highest in a 21-town peer set. There's almost no commercial
-          base to shift burden onto. A CIP split on 4.5% commercial
+          base to shift burden onto. A <abbr class="g" title="Capital Improvement Plan">CIP</abbr> split on 4.5% commercial
           property produces trivial revenue.
         </p>
         <a class="evidence-chart-link" href="why-not-elsewhere.html">
@@ -2608,7 +2608,7 @@ og_url: https://marbleheaddata.org/
       <div class="evidence-point">
         <h4>Budget transparency is free</h4>
         <p>
-          The state offers free independent budget reviews (DLS
+          The state offers free independent budget reviews (<abbr class="g" title="Division of Local Services">DLS</abbr>
           Financial Management Review). The town has never requested
           one. Publishing school-level budget detail is a format
           choice, not a policy change.
@@ -3325,7 +3325,7 @@ og_url: https://marbleheaddata.org/
             <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>,
             the FY27 budget, the
             <abbr class="g" title="Finance Committee">FinCom</abbr>
-            reports, and the DOR filings are public, and residents
+            reports, and the <abbr class="g" title="Department of Revenue">DOR</abbr> filings are public, and residents
             who want to fact-check a claim can. "Hard to use" isn't
             the same as "not transparent" &ndash; it's a usability
             problem, and usability can be improved without a ballot
@@ -3409,9 +3409,9 @@ og_url: https://marbleheaddata.org/
         covers non-senior fixed-income relief in its own section.
       </p>
       <p class="story-filter">
-        Share-of-income uses ACS 65+ median household income as the
-        denominator. Claim figures are MA DOR 2022 tax-year data, the
-        most recent available; eligibility estimates use ACS income
+        Share-of-income uses <abbr class="g" title="American Community Survey">ACS</abbr> 65+ median household income as the
+        denominator. Claim figures are MA <abbr class="g" title="Department of Revenue">DOR</abbr> 2022 tax-year data, the
+        most recent available; eligibility estimates use <abbr class="g" title="American Community Survey">ACS</abbr> income
         distributions and may undercount.
       </p>
     </div>
@@ -3749,7 +3749,7 @@ og_url: https://marbleheaddata.org/
         <p>
           The town pays 83% of employee health insurance premiums
           through the <abbr class="g" title="Group Insurance Commission">GIC</abbr>,
-          Massachusetts's state insurance pool. GIC rates are set by
+          Massachusetts's state insurance pool. <abbr class="g" title="Group Insurance Commission">GIC</abbr> rates are set by
           the pool and have grown substantially faster than
           Proposition 2&frac12;'s 2.5% annual levy cap. The FY27 rate
           increase alone added roughly $1.65M to the operating budget
@@ -3784,7 +3784,7 @@ og_url: https://marbleheaddata.org/
         <div class="counter-argument-body">
           <p>
             "Mandated" and "chosen" blur over a 10-year horizon. The
-            83/17 GIC premium split is a contract provision the town
+            83/17 <abbr class="g" title="Group Insurance Commission">GIC</abbr> premium split is a contract provision the town
             chose and can renegotiate at contract renewal. Staffing
             composition is a policy choice even when specific positions
             trigger benefits eligibility. Calling growth "external"
@@ -3814,7 +3814,7 @@ og_url: https://marbleheaddata.org/
           <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>,
           a 9.6% increase. The student-to-teacher ratio fell from 12.6
           to 10.7, the lowest of Marblehead's four peer towns. Most of
-          that FTE increase lands in a single FY22-to-FY23 jump (483 to
+          that <abbr class="g" title="Full-Time Equivalent">FTE</abbr> increase lands in a single FY22-to-FY23 jump (483 to
           537) that the town has not publicly explained; the source may
           reflect expired federal <abbr class="g" title="Elementary and Secondary School Emergency Relief">ESSER</abbr> positions or a change in
           reporting methodology, and the number has held at exactly
@@ -3898,7 +3898,7 @@ og_url: https://marbleheaddata.org/
           Marblehead's books are audited annually by an independent
           firm (clean opinion every year). The
           <abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr>
-          certifies the tax rate. PERAC audits the pension fund on a
+          certifies the tax rate. <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr> audits the pension fund on a
           biennial actuarial schedule. The Finance Committee publishes
           an annual report. The town's outside auditor issues a
           management letter in most years. These are not self-reported
@@ -3927,7 +3927,7 @@ og_url: https://marbleheaddata.org/
         <h4>Answers A and B read the same numbers differently</h4>
         <p>
           The A and B perspectives on this question use the same
-          underlying data &ndash; the same ACFR, the same
+          underlying data &ndash; the same <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>, the same
           <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr>
           enrollment file, the same FinCom reports &ndash; and reach
           opposite conclusions. Without engaging the source documents,


### PR DESCRIPTION
## Summary

Follow-up to #575 per reviewer feedback. STYLE_GUIDE: *"The tooltip is the minimum. On pages where an acronym is central to the topic... still wrap the acronym in `<abbr class="g">` so the tooltip is available on subsequent uses."*

The question-screen reveal model on `index.html` shows one topic at a time, so a reader landing mid-flow via `?q=<topic>` may see an acronym without having seen the earlier-in-DOM "first use." Wrapping every prose instance makes the tooltip available everywhere.

## Wrapped

All remaining prose occurrences on `index.html`:

- **FTE / FTEs** &ndash; Q3 cards and evidence, Q14 evidence
- **DESE** &ndash; Q3 story-filter and caption
- **DLS** &ndash; Q5 story-filter, Q9 evidence
- **DOR** &ndash; Q5 story-filter, Q12 counter, Q13 story-filter
- **CIP** &ndash; Q9 evidence second use
- **MOU** &ndash; Q7 evidence caveat
- **GIC** &ndash; Q4 evidence, Q14 evidence, Q14 counter
- **OPEB** &ndash; Q15 evidence
- **PERAC** &ndash; Q14 evidence
- **ACS** &ndash; Q5 evidence &times;2, Q6 evidence &times;2, Q13 story-filter &times;2
- **ACFR** &ndash; Q14 evidence
- **CPI-U** &ndash; Q4 evidence caption

Scope: 33 wrap additions, surgical edits, no content changes.

## Deliberately skipped

- **SVG chart labels** (`<text class="end-label">+37% CPI</text>`) &ndash; abbr tooltips don't render reliably in SVG text elements. Each chart is accompanied by a caption paragraph that carries the wrapper.
- **SVG aria-labels** containing CPI, FTE, SPED, etc. &ndash; these are screen-reader-only strings, not visible text.
- **JSON tooltip-data blocks** in `<script type="application/json" class="chart-tooltip-data">` &ndash; data labels consumed by the chart-tooltip JS, not rendered as prose.

## Test plan

- [ ] Hover any acronym on any question screen: dotted underline + tooltip appears
- [ ] `/?q=alternatives` tooltip works on CIP (both occurrences)
- [ ] `/?q=schools` tooltips work on FTE, DESE, ACFR anywhere they appear
- [ ] Mobile long-press on any acronym shows the tooltip
- [ ] CI passes

https://claude.ai/code/session_012TvKEt2eJmwG3MfETLenWq