### PR TITLE
Deficit model: explain the dashed lower expense line

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -469,6 +469,16 @@ title: "Deficit Dynamics Model"
     opacity: 0.18;
     height: 14px;
   }
+  .dm-key-swatch-constrained {
+    background: repeating-linear-gradient(
+      to right,
+      var(--c-buoy) 0 3px,
+      transparent 3px 6px
+    );
+    height: 3px;
+    margin-top: 8px;
+    opacity: 0.6;
+  }
   .dm-key-text strong {
     color: var(--text);
   }
@@ -579,6 +589,10 @@ title: "Deficit Dynamics Model"
   <div class="dm-key-row">
     <span class="dm-key-swatch dm-key-swatch-gap"></span>
     <span class="dm-key-text"><strong>Shaded gap</strong> &ndash; the deficit free cash, cuts, or an override has to close.</span>
+  </div>
+  <div class="dm-key-row">
+    <span class="dm-key-swatch dm-key-swatch-constrained"></span>
+    <span class="dm-key-text"><strong>Expenses if override fails</strong> &ndash; only appears when an override is modeled. Shows what the town could spend without it: expenses capped at revenue. The space between this line and the full expense line is what the override is funding.</span>
   </div>
 </div>
 
@@ -1321,7 +1335,7 @@ An override on its own buys time. It does not change the slope of either line.
       endConstrainedEl.setAttribute('x', xScale(li) + 6);
       endConstrainedEl.setAttribute('y', cEndY);
       endConstrainedEl.setAttribute('text-anchor', 'start');
-      endConstrainedEl.textContent = fmtEnd(constrained[li]) + ' (if cut)';
+      endConstrainedEl.textContent = fmtEnd(constrained[li]) + ' (if override fails)';
       endConstrainedEl.classList.remove('dm-hidden');
     } else {
       endConstrainedEl.classList.add('dm-hidden');


### PR DESCRIPTION
## Summary

The dashed lower expense line that appears when you model an override was labeled "(if cut)" with no entry in the chart key. That made it read as "expenses if you cut 50 positions" — but the line is actually `Math.min(expenses, revenue)`: expenses forced to match revenue because the override failed. The gap between this line and the full expense line is what the override is funding.

## What changed

- End label "(if cut)" → "(if override fails)"
- New 4th row in the chart key: **Expenses if override fails** — only appears under an override scenario, caps expenses at revenue, and the space between this and the full expense line is the services the override is funding.
- Added a dashed key swatch (repeating linear-gradient) so it visually matches the dashed SVG line.

## Test plan

- [ ] `/charts/deficit_model.html` at baseline (no override): key shows 4 rows; dashed line does not appear on the chart.
- [ ] Pick any override scenario: dashed line appears, labeled "$XXm (if override fails)" at the right end.
- [ ] Key swatch for "Expenses if override fails" renders as a dashed line (not a solid bar).
- [ ] Mobile: key rows reflow; text wraps cleanly.