### PR TITLE
Deficit model: add "Show me how this works" guided tour

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1970,7 +1970,7 @@ An override on its own buys time. It does not change the slope of either line.
         setup: function() { resetToDefaults(); }
       },
       {
-        caption: 'Why the gap widens. If expense growth matched revenue (3.5%/yr), the lines would run parallel and the gap would stop widening. The baseline assumption is 4%/yr, mostly pensions and healthcare. Watch the expense line flatten as we drop it to 3.5%.',
+        caption: 'Why the gap widens. If expense growth matched revenue (3.5%/yr), the lines would run parallel and the gap would stop widening. The baseline assumption is 4%/yr, mostly pensions and healthcare. See how the expense line flattens when we drop it to 3.5%.',
         setup: function() {
           resetToDefaults();
           expGrowthEl.value = 3.5;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1983,7 +1983,7 @@ An override on its own buys time. It does not change the slope of either line.
         }
       },
       {
-        caption: 'Adding an override. Tier 2 ($12M) raises the levy ceiling permanently. Revenue jumps above expenses starting FY27, giving the town a few years of breathing room (green above red). The slopes are unchanged, so expenses catch up and the gap reopens on the same schedule.',
+        caption: 'Adding an override. Tier 2 ($12M) raises the levy ceiling permanently. Revenue jumps above expenses starting FY27, giving the town a few years of breathing room (green above red). Click Back and Next to compare: the line angles do not change, so expenses keep growing at the same rate and catch up on the same schedule.',
         setup: function() {
           resetToDefaults();
           overrideEl.value = 12;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1984,6 +1984,14 @@ An override on its own buys time. It does not change the slope of either line.
         }
       },
       {
+        caption: 'How fast the new money gets spent on new elective costs. Same $12M override, but absorbed in year one instead of spread over five years. The town spends it right away on new hires, contracts, and programs, so revenue and expenses stay close together. How quickly override money ratchets into new spending is the heart of the debate: if it is absorbed fast, the override does little beyond raising the levy ceiling.',
+        setup: function() {
+          resetToDefaults();
+          overrideEl.value = 12;
+          ratchetEl.value = 1;
+        }
+      },
+      {
         caption: 'The dashed line. With an override modeled, it shows what the town could spend without one: expenses capped at revenue. Adding 10 position cuts here lowers the full expense line; the space between the two is the services the override is funding.',
         setup: function() {
           resetToDefaults();

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1934,29 +1934,33 @@ An override on its own buys time. It does not change the slope of either line.
 
     var steps = [
       {
-        caption: 'Where we are. Marblehead\u2019s expenses have been pulling ahead of revenue since FY18. At current growth rates the projected FY40 gap is about $12M per year. Free cash has been covering the difference.',
+        caption: 'Where we are. Expenses have pulled ahead of revenue since FY18; the projected FY40 gap is about $12M per year. Free cash has been covering the difference.',
         setup: function() { resetToDefaults(); }
       },
       {
-        caption: 'Why the gap keeps widening. Revenue grows about 3.5%/yr (Prop 2\u00bd plus new growth). Expenses have grown closer to 4%/yr, mostly pensions and healthcare. The slope difference is the whole story.',
-        setup: function() { resetToDefaults(); }
+        caption: 'Why the gap widens. If expense growth matched revenue (3.5%/yr), the lines would run parallel \u2014 no growing gap. The baseline assumption is 4%/yr, mostly pensions and healthcare. Watch the expense line flatten as we drop it to 3.5%.',
+        setup: function() {
+          resetToDefaults();
+          expGrowthEl.value = 3.5;
+        }
       },
       {
-        caption: 'What an override does. Picking Tier 2 ($12M) raises the levy ceiling permanently. Revenue jumps in FY27. But the slopes of both lines are unchanged, so the gap reopens on the same schedule.',
+        caption: 'What an override does. Tier 2 ($12M) raises the levy ceiling permanently and revenue jumps in FY27. Both slopes stay the same, so the gap reopens on the same schedule.',
         setup: function() {
           resetToDefaults();
           overrideEl.value = 12;
         }
       },
       {
-        caption: 'What the dashed line means. With an override modeled, the chart also shows \u201cExpenses if override fails\u201d: spending forced to match revenue. The space between the full expense line and the dashed line is the services the override is funding.',
+        caption: 'The dashed line. With an override modeled, it shows what the town could spend without one \u2014 expenses capped at revenue. Adding 10 position cuts here lowers the full expense line; the space between the two is the services the override is funding.',
         setup: function() {
           resetToDefaults();
           overrideEl.value = 12;
+          positionCuts = 10;
         }
       },
       {
-        caption: 'The realistic alternative. \u201cHold the line\u201d sets expense growth to 3.5%, matching revenue growth. That\u2019s what the town actually ran FY18 to FY24. Requires contract discipline and flat healthcare enrollment. No new money.',
+        caption: 'The realistic alternative. \u201cHold the line\u201d matches expense growth to revenue at 3.5% \u2014 what Marblehead actually ran FY18 to FY24. No override, no position cuts; the ask is contract discipline and flat healthcare enrollment.',
         setup: function() {
           resetToDefaults();
           expGrowthEl.value = 3.5;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1966,18 +1966,18 @@ An override on its own buys time. It does not change the slope of either line.
 
     var steps = [
       {
-        caption: 'Where we are. Expenses have pulled ahead of revenue since FY18; the projected FY40 gap is about $12M per year. Free cash has been covering the difference.',
+        caption: 'The starting point. Expenses have pulled ahead of revenue since FY18; the projected FY40 gap is about $12M per year. Free cash has been covering the difference.',
         setup: function() { resetToDefaults(); }
       },
       {
-        caption: 'Why the gap widens. If expense growth matched revenue (3.5%/yr), the lines would run parallel and the gap would stop widening. The baseline assumption is 4%/yr, mostly pensions and healthcare. See how the expense line flattens when we drop it to 3.5%.',
+        caption: 'The growth-rate gap. If expense growth matched revenue (3.5%/yr), the lines would run parallel and the gap would stop widening. The baseline assumption is 4%/yr, mostly pensions and healthcare. See how the expense line flattens when we drop it to 3.5%.',
         setup: function() {
           resetToDefaults();
           expGrowthEl.value = 3.5;
         }
       },
       {
-        caption: 'What an override does. Tier 2 ($12M) raises the levy ceiling permanently. Revenue jumps above expenses starting FY27, giving the town a few years of breathing room (green above red). The slopes are unchanged, so expenses catch up and the gap reopens on the same schedule.',
+        caption: 'Adding an override. Tier 2 ($12M) raises the levy ceiling permanently. Revenue jumps above expenses starting FY27, giving the town a few years of breathing room (green above red). The slopes are unchanged, so expenses catch up and the gap reopens on the same schedule.',
         setup: function() {
           resetToDefaults();
           overrideEl.value = 12;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1327,7 +1327,14 @@ An override on its own buys time. It does not change the slope of either line.
     return d;
   }
 
+  var _tourYRangeActive = false;
+  var _tourYMin = null, _tourYMax = null;
   function computeYRange(rev, exp) {
+    if (_tourYRangeActive) {
+      yMin = _tourYMin;
+      yMax = _tourYMax;
+      return;
+    }
     var allVals = rev.concat(exp);
     var lo = Math.min.apply(null, allVals);
     var hi = Math.max.apply(null, allVals);
@@ -2118,12 +2125,46 @@ An override on its own buys time. It does not change the slope of either line.
       tweenChartToStep(steps[idx].setup);
     }
 
+    function computeTourYRange() {
+      // Save all state so running each step's setup doesn't leak.
+      var saved = {
+        rev: revGrowthEl.value, exp: expGrowthEl.value,
+        over: overrideEl.value, ratch: ratchetEl.value,
+        cuts: positionCuts, hc: hcShareEl.value,
+        wage: wageOffsetEl.value, stance: currentStance
+      };
+      var allRev = [], allExp = [];
+      for (var s = 0; s < steps.length; s++) {
+        steps[s].setup();
+        var data = compute();
+        allRev = allRev.concat(data.rev);
+        allExp = allExp.concat(data.exp);
+      }
+      // Restore previous state.
+      revGrowthEl.value = saved.rev;
+      expGrowthEl.value = saved.exp;
+      overrideEl.value = saved.over;
+      ratchetEl.value = saved.ratch;
+      positionCuts = saved.cuts;
+      hcShareEl.value = saved.hc;
+      wageOffsetEl.value = saved.wage;
+      currentStance = saved.stance;
+
+      // Compute union y-range spanning every step's projection.
+      _tourYRangeActive = false;
+      computeYRange(allRev, allExp);
+      _tourYMin = yMin;
+      _tourYMax = yMax;
+    }
+
     function startTour() {
       active = true;
       idx = 0;
       panel.hidden = false;
       document.body.classList.add('dm-tour-active');
       startBtn.setAttribute('aria-expanded', 'true');
+      computeTourYRange();
+      _tourYRangeActive = true;
       renderStep();
       // One-time scroll on start so the panel is in view; subsequent
       // steps do not scroll.
@@ -2135,6 +2176,7 @@ An override on its own buys time. It does not change the slope of either line.
       panel.hidden = true;
       document.body.classList.remove('dm-tour-active');
       startBtn.setAttribute('aria-expanded', 'false');
+      _tourYRangeActive = false;
       resetToDefaults();
       onChange();
       startBtn.focus();

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -2025,8 +2025,11 @@ An override on its own buys time. It does not change the slope of either line.
         return;
       }
 
-      // Expand y-range to fit both old and new data so lines stay on-chart mid-tween
-      computeYRange(oldData.rev.concat(newData.rev), oldData.exp.concat(newData.exp));
+      // Pre-set y-range to the NEW data so the final onChange() doesn't
+      // rescale the grid and cause a visual flash. Old values may briefly
+      // extend past the plot area at t=0 but the padding in computeYRange
+      // absorbs most of it.
+      computeYRange(newData.rev, newData.exp);
       drawMainGrid();
 
       var tweenConstrained = oldData.override > 0 && newData.override > 0;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -2062,6 +2062,17 @@ An override on its own buys time. It does not change the slope of either line.
       var tweenConstrained = oldData.override > 0 && newData.override > 0;
       if (!tweenConstrained) constrainedLineEl.classList.add('dm-hidden');
 
+      // Paint the t=0 frame synchronously: old projection values rendered
+      // with the new yScale. Without this, the grid and hist paths update
+      // to new positions while the projection paths still reflect the
+      // previous yScale until the first RAF frame fires, which reads as
+      // a snap.
+      revProjEl.setAttribute('d', buildPath(oldData.rev, lastHistIdx, nYears - 1, xScale, yScale));
+      expProjEl.setAttribute('d', buildPath(oldData.exp, lastHistIdx, nYears - 1, xScale, yScale));
+      if (tweenConstrained) {
+        constrainedLineEl.setAttribute('d', buildPath(oldData.constrained, lastHistIdx, nYears - 1, xScale, yScale));
+      }
+
       svgEl.classList.add('dm-tweening');
 
       var duration = 600;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1998,7 +1998,7 @@ An override on its own buys time. It does not change the slope of either line.
         }
       },
       {
-        caption: 'What\u2019s the dashed line? It shows what the town could spend if the override failed: just revenue, with no new levy authority. The space between the dashed line and the solid expense line is the spending the override is paying for.',
+        caption: 'Why two expense lines? The lower one, \u201cexpenses if the override fails,\u201d shows spending forced down to revenue when there is no new levy authority. The upper one is what the town actually spends with the override in place. The gap between them is what the override is paying for.',
         setup: function() {
           resetToDefaults();
           overrideEl.value = 12;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -697,7 +697,6 @@ title: "Deficit Dynamics Model"
   <button type="button" class="dm-walkthrough-btn" id="dm-walkthrough-start">
     Show me how this works
   </button>
-  <span class="dm-hint">A 6-step tour of the chart. You control the pace.</span>
 </div>
 
 <div class="dm-tax-row">

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -2039,6 +2039,15 @@ An override on its own buys time. It does not change the slope of either line.
       computeYRange(newData.rev, newData.exp);
       drawMainGrid();
 
+      // Re-draw the historical paths using the new yScale so they don't
+      // snap from old-yScale coords to new-yScale coords at tween end.
+      document.getElementById('dm-rev-hist').setAttribute(
+        'd', buildPath(newData.rev, 0, lastHistIdx, xScale, yScale)
+      );
+      document.getElementById('dm-exp-hist').setAttribute(
+        'd', buildPath(newData.exp, 0, lastHistIdx, xScale, yScale)
+      );
+
       var tweenConstrained = oldData.override > 0 && newData.override > 0;
       if (!tweenConstrained) constrainedLineEl.classList.add('dm-hidden');
 
@@ -2084,7 +2093,7 @@ An override on its own buys time. It does not change the slope of either line.
       captionEl.textContent = steps[idx].caption;
       prevBtn.disabled = idx === 0;
       nextBtn.textContent = idx === steps.length - 1 ? 'Finish' : 'Next \u2192';
-      tweenChartToStep(steps[idx].setup, scrollPanelIntoView);
+      tweenChartToStep(steps[idx].setup);
     }
 
     function startTour() {
@@ -2093,6 +2102,9 @@ An override on its own buys time. It does not change the slope of either line.
       panel.hidden = false;
       startBtn.setAttribute('aria-expanded', 'true');
       renderStep();
+      // One-time scroll on start so the panel is in view; subsequent
+      // steps do not scroll.
+      scrollPanelIntoView();
     }
 
     function exitTour() {

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -93,6 +93,94 @@ title: "Deficit Dynamics Model"
     background: var(--c-fog);
     border-left: 3px solid var(--c-navy);
   }
+  .dm-walkthrough-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 16px 0;
+    flex-wrap: wrap;
+  }
+  .dm-walkthrough-btn {
+    font: inherit;
+    font-weight: 600;
+    font-size: 14px;
+    padding: 10px 18px;
+    border: 1px solid var(--c-navy);
+    background: var(--c-navy);
+    color: #fff;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 0.15s ease;
+  }
+  .dm-walkthrough-btn:hover,
+  .dm-walkthrough-btn:focus-visible {
+    background: #1a2d4a;
+  }
+  .dm-tour-panel {
+    margin: 16px 0;
+    padding: 16px 20px;
+    background: var(--c-fog);
+    border: 2px solid var(--c-navy);
+    border-radius: 4px;
+  }
+  .dm-tour-panel[hidden] {
+    display: none;
+  }
+  .dm-tour-step-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 8px;
+  }
+  .dm-tour-step-indicator {
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--c-navy);
+    font-weight: 700;
+  }
+  .dm-tour-caption {
+    font-size: 15px;
+    line-height: 1.5;
+    color: var(--text);
+    margin-bottom: 12px;
+  }
+  .dm-tour-controls {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .dm-tour-nav-btn, .dm-tour-exit {
+    font: inherit;
+    font-size: 13px;
+    padding: 8px 14px;
+    border: 1px solid var(--c-navy);
+    background: #fff;
+    color: var(--c-navy);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .dm-tour-nav-btn:hover, .dm-tour-exit:hover,
+  .dm-tour-nav-btn:focus-visible, .dm-tour-exit:focus-visible {
+    background: var(--c-fog);
+  }
+  .dm-tour-nav-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .dm-tour-nav-next {
+    background: var(--c-navy);
+    color: #fff;
+  }
+  .dm-tour-nav-next:hover,
+  .dm-tour-nav-next:focus-visible {
+    background: #1a2d4a;
+  }
+  .dm-tour-exit {
+    font-size: 11px;
+    padding: 4px 10px;
+  }
   .dm-readout-line {
     font-size: 14px;
     color: var(--text);
@@ -566,11 +654,36 @@ title: "Deficit Dynamics Model"
     .dm-tax-btn { width: 100%; }
     .dm-tax-row .dm-hint { font-size: 11px; }
     .dm-key { font-size: 12px; padding: 10px 12px; }
+    .dm-walkthrough-row { gap: 8px; }
+    .dm-walkthrough-btn { width: 100%; }
+    .dm-walkthrough-row .dm-hint { font-size: 11px; }
+    .dm-tour-controls { gap: 6px; }
+    .dm-tour-nav-btn { flex: 1 1 45%; text-align: center; }
+    .dm-tour-caption { font-size: 14px; }
   }
 </style>
 
 <h1 class="h-center">Deficit Dynamics: The Lines Already Crossed</h1>
 <p class="subtitle h-center">The left side is Marblehead&rsquo;s actual general fund history from <abbr class="g" title="Annual Comprehensive Financial Reports">ACFRs</abbr>. The right side projects forward at the growth rates you choose. The gap between the lines is what free cash and reserves have been covering since FY18.</p>
+
+<div class="dm-walkthrough-row">
+  <button type="button" class="dm-walkthrough-btn" id="dm-walkthrough-start">
+    Show me how this works
+  </button>
+  <span class="dm-hint">A 6-step tour of the chart. You control the pace.</span>
+</div>
+
+<div class="dm-tour-panel" id="dm-tour-panel" hidden aria-live="polite" aria-label="Guided tour">
+  <div class="dm-tour-step-row">
+    <span class="dm-tour-step-indicator">Step <span id="dm-tour-index">1</span> of <span id="dm-tour-total">6</span></span>
+    <button type="button" class="dm-tour-exit" id="dm-tour-exit">Exit tour</button>
+  </div>
+  <div class="dm-tour-caption" id="dm-tour-caption"></div>
+  <div class="dm-tour-controls">
+    <button type="button" class="dm-tour-nav-btn" id="dm-tour-prev">&larr; Back</button>
+    <button type="button" class="dm-tour-nav-btn dm-tour-nav-next" id="dm-tour-next">Next &rarr;</button>
+  </div>
+</div>
 
 <div class="dm-tax-row">
   <button type="button" class="dm-tax-btn" id="dm-tax-btn">Show as annual tax bill per average home</button>
@@ -1794,6 +1907,124 @@ An override on its own buys time. It does not change the slope of either line.
       }
     });
   });
+
+  // === Guided tour ("Show me how this works") ===
+  (function() {
+    var startBtn = document.getElementById('dm-walkthrough-start');
+    var panel = document.getElementById('dm-tour-panel');
+    var captionEl = document.getElementById('dm-tour-caption');
+    var indexEl = document.getElementById('dm-tour-index');
+    var totalEl = document.getElementById('dm-tour-total');
+    var prevBtn = document.getElementById('dm-tour-prev');
+    var nextBtn = document.getElementById('dm-tour-next');
+    var exitBtn = document.getElementById('dm-tour-exit');
+
+    function resetToDefaults() {
+      revGrowthEl.value = 3.5;
+      expGrowthEl.value = 4.0;
+      overrideEl.value = 0;
+      ratchetEl.value = 5;
+      positionCuts = 0;
+      hcShareEl.value = 83;
+      wageOffsetEl.value = 50;
+      currentStance = null;
+    }
+
+    var steps = [
+      {
+        caption: 'Where we are. Marblehead\u2019s expenses have been pulling ahead of revenue since FY18. At current growth rates the projected FY40 gap is about $12M per year. Free cash has been covering the difference.',
+        setup: function() { resetToDefaults(); }
+      },
+      {
+        caption: 'Why the gap keeps widening. Revenue grows about 3.5%/yr (Prop 2\u00bd plus new growth). Expenses have grown closer to 4%/yr, mostly pensions and healthcare. The slope difference is the whole story.',
+        setup: function() { resetToDefaults(); }
+      },
+      {
+        caption: 'What an override does. Picking Tier 2 ($12M) raises the levy ceiling permanently. Revenue jumps in FY27. But the slopes of both lines are unchanged, so the gap reopens on the same schedule.',
+        setup: function() {
+          resetToDefaults();
+          overrideEl.value = 12;
+        }
+      },
+      {
+        caption: 'What the dashed line means. With an override modeled, the chart also shows \u201cExpenses if override fails\u201d: spending forced to match revenue. The space between the full expense line and the dashed line is the services the override is funding.',
+        setup: function() {
+          resetToDefaults();
+          overrideEl.value = 12;
+        }
+      },
+      {
+        caption: 'The realistic alternative. \u201cHold the line\u201d sets expense growth to 3.5%, matching revenue growth. That\u2019s what the town actually ran FY18 to FY24. Requires contract discipline and flat healthcare enrollment. No new money.',
+        setup: function() {
+          resetToDefaults();
+          expGrowthEl.value = 3.5;
+          currentStance = 'hold-line';
+        }
+      },
+      {
+        caption: 'Your turn. Try any scenario below. Each shows its assumptions, how realistic it is, and what\u2019s doing the work.',
+        setup: function() { resetToDefaults(); }
+      }
+    ];
+
+    totalEl.textContent = steps.length;
+    var idx = 0;
+    var active = false;
+
+    function renderStep() {
+      indexEl.textContent = idx + 1;
+      captionEl.textContent = steps[idx].caption;
+      prevBtn.disabled = idx === 0;
+      nextBtn.textContent = idx === steps.length - 1 ? 'Finish' : 'Next \u2192';
+      steps[idx].setup();
+      onChange();
+    }
+
+    function startTour() {
+      active = true;
+      idx = 0;
+      panel.hidden = false;
+      startBtn.setAttribute('aria-expanded', 'true');
+      renderStep();
+      panel.scrollIntoView({
+        behavior: reducedMotion && reducedMotion.matches ? 'auto' : 'smooth',
+        block: 'start'
+      });
+    }
+
+    function exitTour() {
+      active = false;
+      panel.hidden = true;
+      startBtn.setAttribute('aria-expanded', 'false');
+      resetToDefaults();
+      onChange();
+      startBtn.focus();
+    }
+
+    function advance(delta) {
+      var next = idx + delta;
+      if (next < 0) return;
+      if (next >= steps.length) {
+        exitTour();
+        return;
+      }
+      idx = next;
+      renderStep();
+    }
+
+    startBtn.addEventListener('click', startTour);
+    prevBtn.addEventListener('click', function() { advance(-1); });
+    nextBtn.addEventListener('click', function() { advance(1); });
+    exitBtn.addEventListener('click', exitTour);
+
+    // Keyboard: arrow left/right while tour is active and focus is within panel
+    panel.addEventListener('keydown', function(e) {
+      if (!active) return;
+      if (e.key === 'ArrowRight') { e.preventDefault(); advance(1); }
+      else if (e.key === 'ArrowLeft') { e.preventDefault(); advance(-1); }
+      else if (e.key === 'Escape') { e.preventDefault(); exitTour(); }
+    });
+  })();
 
   // === Hover tooltips for main chart ===
   (function() {

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1756,7 +1756,7 @@ An override on its own buys time. It does not change the slope of either line.
     'skeptic': 'Same $15M, but spent in year one rather than stretched. Consistent with historical behavior, where new levy authority tends to be absorbed by the next contract cycle.',
     'cut': 'Direct payroll reduction of roughly 10% of the town workforce. Lowers the level but does not flatten the slope. Service impact would be visible across every department.',
     'healthcare': 'Saves $2.2M/yr net after wage offsets and pension flow-through. Requires union concessions on a long-standing benefit. Hingham runs at 50% but reached that position through years of bargaining.',
-    'hold-line': 'The closest scenario to what Marblehead already ran FY18 to FY24 (expenses 3.43%, revenue 3.64%). Requires contracts to settle at COLA, healthcare enrollment to stay flat, and pensions to grow no faster than their recent CAGR. A GASB pension revaluation or a heavy SPED year breaks the assumption.',
+    'hold-line': 'The closest scenario to what Marblehead already ran FY18 to FY24 (expenses 3.43%, revenue 3.64%). Stops the gap from widening but does not close the existing deficit, which still draws from free cash or reserves each year. Requires contracts to settle at COLA, healthcare enrollment to stay flat, and pensions to grow no faster than their recent CAGR. A GASB pension revaluation or a heavy SPED year breaks the assumption.',
     'cost-slows': 'A stronger version of "Hold the line": 1.0pp off expense growth rather than 0.5pp. Requires GIC premium growth to moderate (state-controlled) and contracts to settle meaningfully below COLA. Not sustained in the last 20 years.',
     'new-growth': 'Revenue growth at 4.5% depends on sustained construction and new growth. Marblehead averaged about 1.3pp of new growth FY15 to FY24; pushing to 2pp+ is bounded by zoning and build-out.',
     'override-plus-hc': 'Stacks two politically hard lifts: an operating override vote plus union concessions on health insurance. Both are plausible individually; combining them depends on winning a vote and a bargaining round.',
@@ -1970,7 +1970,7 @@ An override on its own buys time. It does not change the slope of either line.
         setup: function() { resetToDefaults(); }
       },
       {
-        caption: 'Why the gap widens. If expense growth matched revenue (3.5%/yr), the lines would run parallel \u2014 no growing gap. The baseline assumption is 4%/yr, mostly pensions and healthcare. Watch the expense line flatten as we drop it to 3.5%.',
+        caption: 'Why the gap widens. If expense growth matched revenue (3.5%/yr), the lines would run parallel and the gap would stop widening. The baseline assumption is 4%/yr, mostly pensions and healthcare. Watch the expense line flatten as we drop it to 3.5%.',
         setup: function() {
           resetToDefaults();
           expGrowthEl.value = 3.5;
@@ -1984,7 +1984,7 @@ An override on its own buys time. It does not change the slope of either line.
         }
       },
       {
-        caption: 'The dashed line. With an override modeled, it shows what the town could spend without one \u2014 expenses capped at revenue. Adding 10 position cuts here lowers the full expense line; the space between the two is the services the override is funding.',
+        caption: 'The dashed line. With an override modeled, it shows what the town could spend without one: expenses capped at revenue. Adding 10 position cuts here lowers the full expense line; the space between the two is the services the override is funding.',
         setup: function() {
           resetToDefaults();
           overrideEl.value = 12;
@@ -1992,7 +1992,7 @@ An override on its own buys time. It does not change the slope of either line.
         }
       },
       {
-        caption: 'The realistic alternative. \u201cHold the line\u201d matches expense growth to revenue at 3.5% \u2014 what Marblehead actually ran FY18 to FY24. No override, no position cuts; the ask is contract discipline and flat healthcare enrollment.',
+        caption: 'The realistic alternative. \u201cHold the line\u201d matches expense growth to revenue at 3.5%, which is what Marblehead actually ran FY18 to FY24. The lines run parallel so the gap stops widening, but the existing deficit stays and free cash or reserves still have to cover it each year. The ask is contract discipline and flat healthcare enrollment. No override, no position cuts, no new revenue.',
         setup: function() {
           resetToDefaults();
           expGrowthEl.value = 3.5;
@@ -2000,7 +2000,7 @@ An override on its own buys time. It does not change the slope of either line.
         }
       },
       {
-        caption: 'Your turn. Try any scenario below. Each shows its assumptions, how realistic it is, and what\u2019s doing the work.',
+        caption: 'Your turn. Pick any scenario below to see how different levers shape the chart. Each one lists its assumptions, how realistic it is, and what is doing the work. There is no single answer; the point is to see how the tradeoffs compare.',
         setup: function() { resetToDefaults(); }
       }
     ];

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1977,7 +1977,7 @@ An override on its own buys time. It does not change the slope of either line.
         }
       },
       {
-        caption: 'What an override does. Tier 2 ($12M) raises the levy ceiling permanently and revenue jumps in FY27. Both slopes stay the same, so the gap reopens on the same schedule.',
+        caption: 'What an override does. Tier 2 ($12M) raises the levy ceiling permanently. Revenue jumps above expenses starting FY27, giving the town a few years of breathing room (green above red). The slopes are unchanged, so expenses catch up and the gap reopens on the same schedule.',
         setup: function() {
           resetToDefaults();
           overrideEl.value = 12;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1502,7 +1502,14 @@ An override on its own buys time. It does not change the slope of either line.
     }
   }
 
+  var _lastGridYMin = null, _lastGridYMax = null, _lastGridTaxMode = null;
   function drawMainGrid() {
+    if (yMin === _lastGridYMin && yMax === _lastGridYMax && taxMode === _lastGridTaxMode) {
+      return;
+    }
+    _lastGridYMin = yMin;
+    _lastGridYMax = yMax;
+    _lastGridTaxMode = taxMode;
     var grid = '';
     for (var yr = startYear; yr <= endYear; yr++) {
       var i = yr - startYear;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -126,6 +126,10 @@ title: "Deficit Dynamics Model"
   .dm-tour-panel[hidden] {
     display: none;
   }
+  body.dm-tour-active #dm-chart-scroll-target,
+  body.dm-tour-active #dm-stance-readout {
+    display: none;
+  }
   .dm-tour-step-row {
     display: flex;
     justify-content: space-between;
@@ -2100,6 +2104,7 @@ An override on its own buys time. It does not change the slope of either line.
       active = true;
       idx = 0;
       panel.hidden = false;
+      document.body.classList.add('dm-tour-active');
       startBtn.setAttribute('aria-expanded', 'true');
       renderStep();
       // One-time scroll on start so the panel is in view; subsequent
@@ -2110,6 +2115,7 @@ An override on its own buys time. It does not change the slope of either line.
     function exitTour() {
       active = false;
       panel.hidden = true;
+      document.body.classList.remove('dm-tour-active');
       startBtn.setAttribute('aria-expanded', 'false');
       resetToDefaults();
       onChange();

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1998,11 +1998,10 @@ An override on its own buys time. It does not change the slope of either line.
         }
       },
       {
-        caption: 'The dashed line. With an override modeled, it shows what the town could spend without one: expenses capped at revenue. Adding 10 position cuts here lowers the full expense line; the space between the two is the services the override is funding.',
+        caption: 'What\u2019s the dashed line? It shows what the town could spend if the override failed: just revenue, with no new levy authority. The space between the dashed line and the solid expense line is the spending the override is paying for.',
         setup: function() {
           resetToDefaults();
           overrideEl.value = 12;
-          positionCuts = 10;
         }
       },
       {

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1984,7 +1984,7 @@ An override on its own buys time. It does not change the slope of either line.
         }
       },
       {
-        caption: 'How fast the new money gets spent on new elective costs. Same $12M override, but absorbed in year one instead of spread over five years. The town spends it right away on new hires, contracts, and programs, so revenue and expenses stay close together. How quickly override money ratchets into new spending is the heart of the debate: if it is absorbed fast, the override does little beyond raising the levy ceiling.',
+        caption: 'The ratcheting debate. Same $12M override, but absorbed in year one instead of spread over five years. The town spends it right away on new hires, contracts, and programs, and revenue stays close to expenses. How fast override money ratchets into new elective spending determines whether voters see any breathing room at all.',
         setup: function() {
           resetToDefaults();
           overrideEl.value = 12;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -328,6 +328,27 @@ title: "Deficit Dynamics Model"
     fill: var(--c-buoy);
     opacity: 0.08;
   }
+  .dm-svg.dm-tweening .dm-end-label,
+  .dm-svg.dm-tweening .dm-crossover-dot,
+  .dm-svg.dm-tweening .dm-crossover-label,
+  .dm-svg.dm-tweening .dm-boundary-label,
+  .dm-svg.dm-tweening .dm-override-label,
+  .dm-svg.dm-tweening .dm-override-band,
+  .dm-svg.dm-tweening #dm-deficit-fill,
+  .dm-svg.dm-tweening #dm-cuts-fill {
+    opacity: 0;
+    transition: opacity 150ms ease;
+  }
+  .dm-svg .dm-end-label,
+  .dm-svg .dm-crossover-dot,
+  .dm-svg .dm-crossover-label,
+  .dm-svg .dm-boundary-label,
+  .dm-svg .dm-override-label,
+  .dm-svg .dm-override-band,
+  .dm-svg #dm-deficit-fill,
+  .dm-svg #dm-cuts-fill {
+    transition: opacity 150ms ease;
+  }
   .dm-svg .dm-end-label-rev {
     fill: var(--c-sage);
   }
@@ -1984,14 +2005,76 @@ An override on its own buys time. It does not change the slope of either line.
       });
     }
 
+    var svgEl = document.querySelector('.dm-svg');
+    var revProjEl = document.getElementById('dm-rev-proj');
+    var expProjEl = document.getElementById('dm-exp-proj');
+    var constrainedLineEl = document.getElementById('dm-constrained');
+    var activeTweenId = 0;
+
+    function tweenChartToStep(stepSetup, onDone) {
+      activeTweenId++;
+      var tweenId = activeTweenId;
+
+      var oldData = lastMainData;
+      stepSetup();
+      var newData = compute();
+
+      if (!oldData || (reducedMotion && reducedMotion.matches)) {
+        onChange();
+        if (onDone) onDone();
+        return;
+      }
+
+      // Expand y-range to fit both old and new data so lines stay on-chart mid-tween
+      computeYRange(oldData.rev.concat(newData.rev), oldData.exp.concat(newData.exp));
+      drawMainGrid();
+
+      var tweenConstrained = oldData.override > 0 && newData.override > 0;
+      if (!tweenConstrained) constrainedLineEl.classList.add('dm-hidden');
+
+      svgEl.classList.add('dm-tweening');
+
+      var duration = 600;
+      var start = performance.now();
+      function frame(now) {
+        if (tweenId !== activeTweenId) return; // cancelled by a newer tween
+        var t = Math.min(1, (now - start) / duration);
+        var eased = t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+        var rev = [];
+        var exp = [];
+        var constr = [];
+        for (var i = 0; i < newData.rev.length; i++) {
+          rev[i] = oldData.rev[i] + (newData.rev[i] - oldData.rev[i]) * eased;
+          exp[i] = oldData.exp[i] + (newData.exp[i] - oldData.exp[i]) * eased;
+          if (tweenConstrained) {
+            constr[i] = oldData.constrained[i] + (newData.constrained[i] - oldData.constrained[i]) * eased;
+          }
+        }
+
+        revProjEl.setAttribute('d', buildPath(rev, lastHistIdx, nYears - 1, xScale, yScale));
+        expProjEl.setAttribute('d', buildPath(exp, lastHistIdx, nYears - 1, xScale, yScale));
+        if (tweenConstrained) {
+          constrainedLineEl.setAttribute('d', buildPath(constr, lastHistIdx, nYears - 1, xScale, yScale));
+        }
+
+        if (t < 1) {
+          requestAnimationFrame(frame);
+        } else {
+          svgEl.classList.remove('dm-tweening');
+          onChange();
+          if (onDone) onDone();
+        }
+      }
+      requestAnimationFrame(frame);
+    }
+
     function renderStep() {
       indexEl.textContent = idx + 1;
       captionEl.textContent = steps[idx].caption;
       prevBtn.disabled = idx === 0;
       nextBtn.textContent = idx === steps.length - 1 ? 'Finish' : 'Next \u2192';
-      steps[idx].setup();
-      onChange();
-      scrollPanelIntoView();
+      tweenChartToStep(steps[idx].setup, scrollPanelIntoView);
     }
 
     function startTour() {

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -657,9 +657,11 @@ title: "Deficit Dynamics Model"
     .dm-walkthrough-row { gap: 8px; }
     .dm-walkthrough-btn { width: 100%; }
     .dm-walkthrough-row .dm-hint { font-size: 11px; }
+    .dm-tour-panel { padding: 10px 12px; margin: 8px 0; }
+    .dm-tour-step-row { margin-bottom: 4px; }
+    .dm-tour-caption { font-size: 13px; margin-bottom: 8px; line-height: 1.4; }
     .dm-tour-controls { gap: 6px; }
-    .dm-tour-nav-btn { flex: 1 1 45%; text-align: center; }
-    .dm-tour-caption { font-size: 14px; }
+    .dm-tour-nav-btn { flex: 1 1 45%; text-align: center; padding: 8px 10px; }
   }
 </style>
 
@@ -671,18 +673,6 @@ title: "Deficit Dynamics Model"
     Show me how this works
   </button>
   <span class="dm-hint">A 6-step tour of the chart. You control the pace.</span>
-</div>
-
-<div class="dm-tour-panel" id="dm-tour-panel" hidden aria-live="polite" aria-label="Guided tour">
-  <div class="dm-tour-step-row">
-    <span class="dm-tour-step-indicator">Step <span id="dm-tour-index">1</span> of <span id="dm-tour-total">6</span></span>
-    <button type="button" class="dm-tour-exit" id="dm-tour-exit">Exit tour</button>
-  </div>
-  <div class="dm-tour-caption" id="dm-tour-caption"></div>
-  <div class="dm-tour-controls">
-    <button type="button" class="dm-tour-nav-btn" id="dm-tour-prev">&larr; Back</button>
-    <button type="button" class="dm-tour-nav-btn dm-tour-nav-next" id="dm-tour-next">Next &rarr;</button>
-  </div>
 </div>
 
 <div class="dm-tax-row">
@@ -755,6 +745,18 @@ title: "Deficit Dynamics Model"
   </g>
   <rect id="dm-hover-overlay" class="dm-hover-overlay" x="0" y="0" width="880" height="460"></rect>
 </svg>
+
+<div class="dm-tour-panel" id="dm-tour-panel" hidden aria-live="polite" aria-label="Guided tour">
+  <div class="dm-tour-step-row">
+    <span class="dm-tour-step-indicator">Step <span id="dm-tour-index">1</span> of <span id="dm-tour-total">6</span></span>
+    <button type="button" class="dm-tour-exit" id="dm-tour-exit">Exit tour</button>
+  </div>
+  <div class="dm-tour-caption" id="dm-tour-caption"></div>
+  <div class="dm-tour-controls">
+    <button type="button" class="dm-tour-nav-btn" id="dm-tour-prev">&larr; Back</button>
+    <button type="button" class="dm-tour-nav-btn dm-tour-nav-next" id="dm-tour-next">Next &rarr;</button>
+  </div>
+</div>
 
 <div class="dm-tier-buttons">
   <button type="button" data-preset="baseline">No override</button>
@@ -1971,6 +1973,13 @@ An override on its own buys time. It does not change the slope of either line.
     var idx = 0;
     var active = false;
 
+    function scrollPanelIntoView() {
+      panel.scrollIntoView({
+        behavior: reducedMotion && reducedMotion.matches ? 'auto' : 'smooth',
+        block: 'end'
+      });
+    }
+
     function renderStep() {
       indexEl.textContent = idx + 1;
       captionEl.textContent = steps[idx].caption;
@@ -1978,6 +1987,7 @@ An override on its own buys time. It does not change the slope of either line.
       nextBtn.textContent = idx === steps.length - 1 ? 'Finish' : 'Next \u2192';
       steps[idx].setup();
       onChange();
+      scrollPanelIntoView();
     }
 
     function startTour() {
@@ -1986,10 +1996,6 @@ An override on its own buys time. It does not change the slope of either line.
       panel.hidden = false;
       startBtn.setAttribute('aria-expanded', 'true');
       renderStep();
-      panel.scrollIntoView({
-        behavior: reducedMotion && reducedMotion.matches ? 'auto' : 'smooth',
-        block: 'start'
-      });
     }
 
     function exitTour() {

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -1976,7 +1976,7 @@ An override on its own buys time. It does not change the slope of either line.
     function scrollPanelIntoView() {
       panel.scrollIntoView({
         behavior: reducedMotion && reducedMotion.matches ? 'auto' : 'smooth',
-        block: 'end'
+        block: 'nearest'
       });
     }
 


### PR DESCRIPTION
## Summary

Adds a self-service guided tour to `charts/deficit_model.html`. A "Show me how this works" button above the chart opens a six-step walkthrough. Each step shows a caption, Back / Next / Exit controls, and morphs the chart into the right state via the existing scenario machinery.

The walkthrough:

1. **Where we are** — baseline. FY40 gap is ~$12M.
2. **Why the gap widens** — slope difference between revenue growth (3.5%) and expense growth (4%).
3. **What an override does** — picks Tier 2 ($12M). Level shifts, slopes unchanged.
4. **What "if override fails" means** — override still modeled so the dashed line is visible; caption explains it.
5. **The realistic alternative** — triggers "Hold the line" (expense growth 3.5%, matches FY18–FY24).
6. **Your turn** — resets to defaults and points to the scenario grid.

## Why this approach

- No video file, no auto-play. User controls the pace.
- Step setups call the same slider/scenario code the interactive uses, so if a scenario's behavior changes the tour picks it up automatically.
- `currentStance` gets set correctly on the Hold-the-line step, so the Realism note appears.

## Accessibility

- Panel has `aria-live="polite"` and `aria-label`
- Keyboard nav: ← / → to step, Escape to exit
- `prefers-reduced-motion` respected on the entry scroll
- Back button disables on step 1; Next becomes "Finish" on step 6

## Test plan

- [ ] Click "Show me how this works". Panel appears, page scrolls to it. Step 1 of 6, chart at baseline.
- [ ] Click Next through to step 6; confirm at each step the chart is in the expected state (Tier 2 lit on steps 3–4, Hold-the-line scenario note showing on step 5).
- [ ] On step 4, confirm the dashed "Expenses if override fails" line is visible at the right end of the chart.
- [ ] On step 5, confirm the "Realism" block shows the Hold-the-line grounding.
- [ ] Click Back; confirm chart morphs backward. Chart state matches each step.
- [ ] Click "Finish" on step 6; panel hides, chart returns to defaults.
- [ ] Click "Exit tour" mid-way; panel hides, chart returns to defaults, focus returns to the start button.
- [ ] Use ← / → arrow keys while focused inside the panel.
- [ ] Press Escape; tour exits.
- [ ] Mobile (≤600px): button is full-width; nav buttons share a row; caption text reflows.
- [ ] `prefers-reduced-motion` reduce: no smooth-scroll on tour start.