### PR TITLE
Ingest April 15 Select Board override deck (FINAL)

### DIFF
--- a/data/2026-04-15_Override_Presentation_FINAL.txt
+++ b/data/2026-04-15_Override_Presentation_FINAL.txt
@@ -1,0 +1,327 @@
+     MARBLEHEAD
+    MASSACHUSETTS
+     ESTABLISHED
+                           OVERRIDE
+         1649
+
+                           THREE-TIER
+                           OVERRIDE
+TOWN OF MARBLEHEAD
+                           3-YEAR OVERRIDE TIERS AND PURPOSE
+    SELECT BOARD
+
+                                  TIER 1            TIER 2      TIER 3
+
+        FY 2027                $9M                $12M         $15M
+     Annual Town Meeting       Partial Restore       Build      Invest
+THREE-TIER OVERRIDE
+Understanding Tier Options
+
+
+
+1      TIER 1 — PARTIAL RESTORE                     2     TIER 2 — BUILD                              3     TIER 3 — INVEST
+
+
+
+$9 Million                                          $12 Million                                       $15 Million
+Partially restores previously reduced services to   Adds staff, creates a maintenance division, and   Comprehensive investment combining all
+ensure baseline functionality across key            expands Recreation and Council on Aging           restorations, enhancements, mental health
+departments.                                        services.                                         funding & capital.
+
+•     Restores 15 positions cut in FY27             •     All Tier 1 restorations included
+      balanced budget                               •     Fully restores Library and Materials and
+•     Allows Library to apply for accreditation           +1 PT Assistant Librarian + expenses        •     All Tier 1 & 2 investments included
+      waiver                                        •     +2 Firefighters + 1 Police Officer          •     +2 Firefighters + 1 Police Officer
+•     Brings back Police SRO position               •     +1 IT Director +1 Budget Analyst            •     +1 Foreman +1 Specialized HEO
+•     Restores DPW, Rec & Park, COA, Public         •     + 1 PT Social Worker +1 GIS position        •     +1 Grants Writer
+      Buildings, Finance
+                                                    •     $450K maintenance to public buildings       •     $60K for mental health counseling
+•     Partial restore of Community                        for buildings and rail trail
+      Development and Laborer in Cemetery                                                             •     $1M recurring capital investment
+                                                    •     Restores 1 Special Clerk and 1 Assistant
+•     Restores Long-Term Financial Health                 Planner (former Sustainability) and 1
+      contributions                                       Conservation Agent (former Grants)
+
+
+                                                           Town of Marblehead | FY2027 Override
+HOW A THREE-TIER OVERRIDE WORKS                                                                                                                                     MHD
+                                                                                                                                                                    1649
+
+
+
+
+One question on the ballot. Three tiers. Vote YES on any or all tiers — the tier with highest $ amount and majority vote is approved.
+                                      ▲
+
+                                   TIER 1                                             TIER 1 — $9M | PARTIAL RESTORE
+                                                                                      Library partial restore +4 • Police SRO • DPW HEO, Laborer, and PT Clerk + asphalt •
+                                   $9M                                                Public Buildings 2 Custodians • Rec & Park Groundskeeper • COA Nutrition Coordinator
+                                                                                      and Temp Clerk • Finance Senior Clerk • Comm Dev Director • Cemetery Laborer • Other
+                            PARTIAL RESTORE
+                                                                                      Gen Govt Stabilization, OPEB, Workers Comp Funding
+
+                                   TIER 2                                             TIER 2 — $12M | BUILD (all of Tier 1, plus:)
+                + Tier 1
+                                 $12M                                                 +1 Police Officer • +2 Firefighters • 1 Special Clerk restore • +1 IT Director +1 Budget
+                                                                                      Analyst Finance • +1 GIS DPW • +1 Social Worker COA • 1 Asst. Planner & 1 Conservation
+                                   BUILD                                              Agent • $450K Building Maintenance • Fully restore Library
+
+                                   TIER 3                                             TIER 3 — $15M | INVEST (all of Tiers 1 & 2, plus:)
+           + Tiers 1 & 2
+                                 $15M                                                 +1 Police Officer • +2 Firefighters • $60K Mental Health • +1 Grant Writer • $1M
+                                                                                      Recurring Capital • +1 Specialized HEO • +1 Foreman
+                                   INVEST
+
+
+
+
+HO W RESIDENT VO T E W O RKS
+
+            Vote YES on Tier 1 only                            Vote YES on Tier 2 (Tiers 1 & 2)                     Vote YES on Tier 3 (1 & 2 plus Tier 3 adds)
+
+                                                                                                                 -> $15M enacted — Tier 1 restore & Tier 2 additions
+-> $9M enacted — Tier 1 restorations take effect       -> $12M enacted — Tier 1 restore & Tier 2 additions
+                                                                                                                 plus Tier 3 additions
+ IF NO OVERRIDE PASSES
+ Loss of Town Services by Department
+
+
+LIBRARY                                 POLICE                                       RECREATION & PARKS                      PUBLIC WORKS
+
+Loses certification                     No SRO in schools                            No Groundskeeper                        2.5 positions Cut & Asphalt Cut
+                                                                                     No Trash pickup for 186 public trash   No Laborer, Heavy Equipment
+                                        School Resource Officer eliminated                                                  Operator, and PT Clerk; $60K Asphalt
+Open only 3 days/week ; No                                                           barrels
+Evenings and No Weekends; 8.5           FIRE                                         TOWN CLERK                             CEMETERY
+positions cut
+                                        Overtime costs spike; Down 1 full            No Special Clerk ; reduced services     No Laborer
+                                        shift
+
+
+
+COUNCIL ON AGING                        FINANCE                                    I PUBLIC BUILDINGS                       nCAPITAL
+Key staff cut                           Senior Clerk cut and IT
+                                                                                     2 Custodians cut                        Zero capital FY2027
+                                        equipment and Training cut
+No Nutrition Coordinator/Labor and                                                   Facility upkeep diminished for Mary    No equipment, Public Buildings
+Temporary Clerk ;                       No Senior Clerk causing Treasurers           Alley and Abbot Hall.                  improvements
+ COMM DEV & PLANNING                    Office to be understaffed; IT               BUILDING INSPECTIONS                     FINANCIAL HEALTH
+                                        replacement equipment & training
+No Community Development                                                             Cut Other Professional and Technical    No Stabilization Fund
+                                        for new staff eliminated                                                             or OPEB liability ($250K each);
+Director, Sustainability Coordinator,                                                Expense which funds OpenGov
+and Grants Coordinator;                                                              Subscription & Copier Maintenance       Cut FinCom Reserve by $26K;
+                                                                                                                             cut $97,662 Workers Comp
+
+
+
+                                                               Town of Marblehead | FY2027 Override
+COMPARISON: NO OVERRIDE vs. TIERS 1–3
+                                     No Override                            Tier 1 – Partial Restore                                Tier 2 - Build                                            Tier 3 - Invest
+
+
+                                                                                                                                                                                                    ✓
+                          Lose Accreditation; Operates only             Allows Waiver for Accreditation;               Fully Restored; 8.5 positions and library
+       Library            3 days per week; No evenings or           No evenings/weekend hours; 4 positions                 materials; +1 Part-time Librarian
+                            weekends; 8.5 positions cut                           restored                                 and increase expenses funding
+                         No School Resource Officer (SRO)          Fully restored SRO but Police staffing level                                                      1 Police Officer added for a total of 3 with SRO brings Police
+  Police Department                                                                                                  Fully Restored SRO +1 Police Officer Added
+                            brings staffing to 29 officers                    at historically low level                                                              Staffing Level to 33 Officers in line with historic staffing level
+
+                        No staff cuts to contain overtime (OT)
+   Fire Department                                                                                                               2 Firefighters added                 2 Firefighters added for a total of 4 to reduce overtime costs
+                         expense; currently down 1 full shift
+                        2.5 positions cut; $60,000 reduction in    Fully restored 1 PT General Clerk, 1 Heavy                                                       In addition to the 3 positions restored and the new GIS position
+    Department of
+                                        asphalt;                       Equipment Operator, 1 Laborer and            1 GIS position added; Improved service levels      in tier 2, Adding1 Foreman position & 1 Specialized HEO;
+    Public Works
+                               reduced services levels             Asphalt,; service levels at historic low level                                                   significantly improved service levels in line with past staff levels
+
+                                                                                                                                                                                                    ✓
+                        Cut Groundskeeper; No trash pick up        Fully restored 1 Groundskeeper to pickup          Maintenance & Materials budget increased
+ Recreation & Parks
+                             for 187 public trash barrels                         trash barrels                         $25,000; Utilities increased $17,000
+
+
+                                                                                                                                                                                                    ✓
+                        Nutrition Coordinator/General Labor &             Fully restored 1 Nutritional               1 Part time Social Worker added; Building
+  Council on Aging
+                                Temp Special Clerk cut                Coordinator/Labor and 1 Temp Clerk            maintenance $15K added; Improved Service
+    Community                                                          Director restored only; Currently the        1 Asst. Planner & 1 Conservation Agent added              In addition to full restore and 2 tier positions
+                         Cuts include Director, Sustainability
+   Development &                                                   Director is also the interim Planner; Lost 2          (replacing Sustainability Coordinator                  Adding 1 Grant Writer position to bring in
+                         Coordinator, and Grant Coordinator
+     Planning                                                      employees (planner & sustainability) FY26.                    & Grant Coordinator)                            additional grant revenue for the Town.
+
+                                                                                                                                                                                                    ✓
+                        Senior Clerk cut; Computer equipment       Fully restored 1 Senior Clerk, IT equipment
+                                                                                                                     1 Town IT director added; 1 Budget Analyst
+ Finance Department     and Staff training cut; Treasurer Office    identified for replacement, and training for
+                                                                                                                        added to improve IT and operations
+                         under staffed and need IT equipment          new staff hired along with certifications
+
+                                                                                                                                                                                                    ✓
+                         Cut 2 Special Labor Custodians that
+                                                                   Fully restored 2 Special Labor Custodians          Establish a $450,000 maintenance budget
+   Public Buildings       service Mary Alley and Abbot Hall.
+                                                                     that serve Mary Alley and Abbot Hall.               for buildings townwide and rail trail
+                         Impacts cleaning, meetings, & more.
+
+                                                                                                                                          ✓                                                         ✓
+                           Cut OpenGov subscription and             Fully restored OpenGov subscription and
+ Building Inspections
+                                copier maintenance.                copier maintenance needed for operations.
+                                                                                                                                                                      Double funding to Mental Health with $60,000 investment in
+                          Level funded Health despite need
+ Health Department                                                                                                                                                                             mental
+                             for additional mental health
+                                                                                                                                                                                          health counseling
+
+     Town Clerk
+                        Cut 1 special clerk reducing the office
+                         from 3 employees to 2 employees
+                                                                                                                            Fully restored 1 Special Clerk                                          ✓
+
+      Cemetery
+                        Reduce dept. head to part time; Cut 1
+                                      laborer
+                                                                                Restore 1 laborer                                         ✓                                                         ✓
+                            No Capital for FY2027 except
+                                                                                                                                                                                $1 million capital for recurring leases,
+                                  contractual Leases;
+  Recurring Capital                                                                                                                                                 equipment, and building improvements (3 articles seen annually
+                          1 of 3 recurring Capital Articles on
+                                                                                                                                                                                         on the Town Warrant)
+                                    warrant funded.
+                         No contribution to Stabilization Fund     Fully restored annual stabilization transfer,
+                                                                                                                                          ✓                                                         ✓
+      Long Term            or OPEB liability ($250K each);         OPEB transfer, FinCom Reserve restored
+   Financial Health        Cut FinCom Reserve by $26K;              to 440K, and workers comp restored to
+                             cut $97,662 Workers Comp                     cover any unexpected claims.
+                                                                                                                          Restores another 6.5 positions;
+    FTE Summary                  Cuts 21.5 Positions                         Restores 15 Positions                                                                               Adds an additional 6 New Positions
+                                                                                                                              Adds 7 New Positions
+WHAT DOES IT COST?
+Tax impact on the Median $998,600 Marblehead homeowner
+
+
+             Overrides are phased in over 3 years. The amounts below reflect the estimated annual property tax increase per household.
+
+
+
+    TIER 1 — Partial Restore                                         TIER 2 — Build                                                 TIER 3 — Invest
+
+
+
+
+          $9M                                                     $12M                                                              $15M
+              Override Total                                               Override Total                                              Override Total
+
+
+ Year 1                           ~$130                Year 1                                       ~$280                  Year 1                       ~$430
+
+ Year 2                           ~$533                Year 2                                       ~$676                  Year 2                       ~$720
+
+ Year 3                           ~$256                Year 3                                       ~$274                  Year 3                       ~$388
+
+                                   $919                                                              $1,230                                             $1,538
+
+
+                                          Estimates based on median assessed home value. Actual amounts will vary by property.
+                                                               Town of Marblehead | FY2027 Override
+WHAT DOES IT COST?
+Tax impact on the Average $1,291,507 Marblehead homeowner
+
+
+             Overrides are phased in over 3 years. The amounts below reflect the estimated annual property tax increase per household.
+
+
+
+    TIER 1 — Partial Restore                                         TIER 2 — Build                                                  TIER 3 — Invest
+
+
+
+
+          $9M                                                     $12M                                                               $15M
+              Override Total                                                Override Total                                              Override Total
+
+
+ Year 1                           ~$168                 Year 1                                       ~$362                  Year 1                       ~$556
+
+ Year 2                           ~$689                 Year 2                                       ~$875                  Year 2                       ~$931
+
+ Year 3                           ~$331                 Year 3                                       ~$353                  Year 3                       ~$502
+
+                                  $1,188                                                             $1,590                                              $1,989
+
+
+                                          Estimates based on average assessed home value. Actual amounts will vary by property.
+                                                                Town of Marblehead | FY2027 Override
+  OVERRIDE TAX IMPACT (CUMULATIVE AT END OF 3 YEARS)                                                                                                                 MHD
+                                                                                                                                                                     1649
+
+
+★ Median home value: $998,600 (current tax bill ~$8,548/yr) | Average home value: $1,291,507 (current tax bill ~$11,055/yr) | Current Tax Rate $8.56
+
+   Annual cost per household based on assessed home value. Rate: $0.10 per $1,000. Chart shows increase if full costs in year one rather than phased over 3 years.
+
+
+          Home Value                      Tier 1 — $9M                     Tier 2 — $12M                     Tier 3 — $15M                      Monthly (Tier 3)
+
+  $500,000                                     $450                              $600                             $750                               $63/mo
+
+  $600,000                                     $540                              $720                             $900                               $75/mo
+
+  $700,000                                     $630                              $840                            $1,050                              $88/mo
+
+  $800,000                                     $720                              $960                            $1,200                             $100/mo
+
+  $900,000                                     $810                             $1,080                           $1,350                             $113/mo
+
+  $998,600 ★ MEDIAN                            $899                            $1,198                            $1,498                             $125/mo
+
+  $1,100,000                                   $990                             $1,320                           $1,650                             $138/mo
+
+  $1,200,000                                  $1,080                            $1,440                           $1,800                             $150/mo
+
+  $1,291,507 ★ AVG                            $1,162                           $1,550                            $1,937                             $161/mo
+
+  $1,400,000                                  $1,260                            $1,680                           $2,100                             $175/mo
+
+  $1,500,000                                  $1,350                            $1,800                           $2,250                             $188/mo
+MEMORANDUM OF UNDERSTANDING (MOU)                                                                                                                      MHD
+                                                                                                                                                       1649
+
+
+
+
+A public commitment among the Select Board, School Committee, and Finance Committee governing fiscal discipline through FY2030.
+
+
+                                                                                    62%–38% unrestricted revenue split formalized along with
+ No override at least through FY2030
+                                                                                    benefits allocation
+
+  Select Board, School Committee, and Finance Committee commits                      Establishes clear allocation of revenues and benefits between
+  to not pursuing another override at least through fiscal year 2030.                schools and the town.
+
+
+
+
+ Quarterly joint financial review                                                   Reduce reliance on Free Cash
+
+  Quarterly finance reviews and annual public updates from Town                      Shift to structural budgeting and phase out use of Free Cash to
+  Administrator and School Superintendent                                            balance the budget.
+
+
+
+
+ Build Stabilization Fund to 5% of Operating Budget
+  Establishes a target reserve level that provides a meaningful financial cushion for the town against future volatility and unexpected costs in line with
+  financial policy.
+
+
+
+
+                          This MOU is a public promise — accountability to Marblehead residents.
+

--- a/data/SOURCE_LOOKUP.md
+++ b/data/SOURCE_LOOKUP.md
@@ -118,6 +118,7 @@ Document links below point at the [primary source archive](archive), a GitHub re
 
 ## Override Tier Amounts and Tax Impact
 - Primary: [Town Administrator's Override Presentation, April 8, 2026](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-08_Override_Presentation.pdf)
+- Updated: [Select Board Override Presentation (FINAL), April 15, 2026](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-15_Override_Presentation_FINAL.pdf) &ndash; adds median-home tax impact, home-value-to-cost table, MOU terms, and explicit service-loss-without-override summary.
 - Summary: Marblehead Independent, ["Kezer presents $9M-to-$15M tiered override plan"](https://www.marbleheadindependent.com/kezer-presents-9m-to-15m-tiered-override-plan-and-separate-2-2m-trash-tax-option/)
 
 Extracted into:

--- a/data/archive.md
+++ b/data/archive.md
@@ -58,6 +58,7 @@ Annual reports from the Marblehead Finance Committee, transmitted ahead of each 
 
 - [2026 State of the Town](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026_State_of_the_Town.pdf) &ndash; Town Administrator's January 2026 presentation with revenue and expense projections and the FY27 deficit framing.
 - [April 8, 2026 Override Presentation](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-08_Override_Presentation.pdf) &ndash; town slide deck on the three-tier override and Question 2.
+- [April 15, 2026 Override Presentation (FINAL)](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-15_Override_Presentation_FINAL.pdf) &ndash; Select Board's final voter-facing deck. Adds per-household tax impact at median ($998,600) and average ($1,291,507) values, a home-value-to-cost lookup table, the MOU terms between Select Board, School Committee, and FinCom, and a "no override" service loss summary. Does not cover Question 2 (trash).
 - [Financial Policies (2023)](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/Financial_Policies_2023.pdf) &ndash; adopted town financial policies.
 - [FY22 Management Letter](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY22_Management_Letter.pdf) &ndash; audit management letter to the Select Board.
 - [FY23 Management Letter](https://github.com/agbaber/marblehead/releases/download/source-archive-v1/FY23_Management_Letter.pdf)


### PR DESCRIPTION
## Summary
- Adds plain-text extract of the 2026-04-15 voter-facing override deck to `data/` (PDF already in `source-archive-v1` release).
- Cross-links the new deck from `data/archive.md` and `data/SOURCE_LOOKUP.md`.
- Renamed the release asset from `2026-04-15-Override-Presentation-FINAL-.pdf` (trailing hyphen from upstream URL) to `2026-04-15_Override_Presentation_FINAL.pdf` for consistency with the April 8 asset.

## What's new vs the April 8 deck
- Median home tax impact table ($998,600) — April 8 only had average
- Home-value-to-cost lookup ($500K–$1.5M in $100K steps)
- MOU terms: no override through FY30, 62/38 unrestricted revenue split, quarterly joint financial reviews, 5% stabilization target, phase out Free Cash to balance budget
- Explicit per-department "no override" service-loss summary
- Drops Question 2 (trash) entirely

## Test plan
- [ ] Confirm release asset URL resolves: https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026-04-15_Override_Presentation_FINAL.pdf
- [ ] Archive page renders the new link