### PR TITLE
Scroll back to the question on "This resonates"

### DIFF
--- a/assets/explore.js
+++ b/assets/explore.js
@@ -1719,6 +1719,14 @@
       selectAnswer(question, answer);
       updateNotesPill();
       updateNotesPanel();
+      // Scroll back to the question so the reader can see the selected
+      // state on the answer card, the Next question button, and (on a
+      // first pick) the tutorial -- all of which live above the evidence
+      // panel and would otherwise be off-screen. Mirrors "Not for me".
+      var screen = document.querySelector('.question-screen[data-topic="' + question + '"]');
+      if (screen) {
+        screen.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
     });
 
     var noBtn = document.createElement('button');


### PR DESCRIPTION
## Summary

Clicking "This resonates" from inside an evidence panel silently records the pick and leaves the reader scrolled to the bottom of the evidence. The feedback &ndash; `.selected` state on the answer card, the "Next question" button, and the first-pick tutorial &ndash; all live above the evidence panel, so a reader committing from the bottom sees nothing change and reports "nothing seems to happen."

"Not for me" already scrolls back to the top of the question-screen on click. This makes "This resonates" do the same, so confirming a pick lands the reader back where the selected state is visible.

Surfaced by the new featured-Q onboarding (#574): tapping a featured answer smooth-scrolls straight to the evidence panel, so the reader is even further from the answer cards than before when they click "This resonates."

## Test plan

- [ ] From landing, tap the featured Q's Answer A &rarr; scrolls to evidence &rarr; click "This resonates" &rarr; page smooth-scrolls up; selected teal border is visible on Answer A; "Next question" button is visible; first-pick tutorial box is visible.
- [ ] Same flow for Answer B and Answer C.
- [ ] Second pick on a different question: "This resonates" still scrolls, tutorial does NOT re-show.
- [ ] "Not for me" behavior unchanged.
- [ ] `prefers-reduced-motion` respected (scrollIntoView honors it automatically in modern browsers).

https://claude.ai/code/session_01LvnoZzoCGtUDKJkKrgaRoZ