### PR TITLE
Add FY26 vendor payments snapshot from Open Finance portal

### DIFF
--- a/data/DATA_CATALOG.md
+++ b/data/DATA_CATALOG.md
@@ -136,6 +136,18 @@ All data compiled April 2026 from primary public sources. Every number is either
 - **Source:** DESE Teacher Salaries Report (school year 2023-24, updated Feb 2026) and DESE Per Pupil Expenditure Report (FY2024)
 - **Confidence:** High. Official state data from district end-of-year financial reports.
 
+### FY26 Vendor Payments (YTD snapshot)
+- **File:** `open_finance_vendor_payments_FY26_snapshot_2026-04-17.csv`
+- 1,965 vendors paid by the Town in FY26 through 2026-04-17, with cumulative dollars each. Ranges from $15.94M (Commonwealth of MA) down to $0.00 (vendors set up in the ledger but unpaid so far this year). Full total $84,709,576.43 matches the Open Finance dashboard headline. Top 5 vendors = 55% of spend; top 100 = 90.4%.
+- **Source:** Town of Marblehead Open Finance portal (Tyler/Socrata), `townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026`. Fed from the Town's MUNIS ledger and updated at the end of each business day.
+- **Caveats:**
+  - Unaudited running totals, not ACFR figures. For historical or audited numbers, use the ACFRs instead.
+  - Spans tax-funded and enterprise-fund spending together. Berkshire Wind Power ($11.80M, rank 2) is Municipal Light Department purchased power, self-funded by ratepayers, not the tax levy. Do not cite it as a tax-supported cost.
+  - "Commonwealth of MA" ($15.94M, rank 1) aggregates unrelated state charges (MBTA assessment, charter school tuition, state retirement, etc.). The Cherry Sheet / FY27 Proposed Budget breaks these out line by line.
+  - Only FY26 is available in the spending portal; earlier fiscal years return zero. For multi-year vendor trends, this file is insufficient.
+  - Snapshot captured 2026-04-17 (FY26 Q3). A later snapshot would include year-end payments and reclassifications.
+- **Confidence:** High for vendor identities and dollar amounts at the snapshot instant. Low for year-end interpretation (8-10 weeks of FY26 still to post).
+
 ## What We Don't Have (identified gaps)
 
 1. **Annual total headcount (not FTE)** - only have FY25: 1,185 (from Marblehead Independent). Public records request filed.

--- a/data/open_finance_vendor_payments_FY26_snapshot_2026-04-17.csv
+++ b/data/open_finance_vendor_payments_FY26_snapshot_2026-04-17.csv
@@ -1,0 +1,1966 @@
+rank,vendor_name,amount_ytd_usd,fiscal_year,coverage_start,coverage_end,snapshot_date,source_url
+1,COMMONWEALTH OF MA,15939878.12,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+2,BERKSHIRE WIND POWER COOPERATIVE CORP,11796056.32,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+3,U.S. BANK,9128822.41,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+4,MARBLEHEAD CONTRIBUTORY RETIREMENT SYSTEM,6536597.57,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+5,SOUTH ESSEX SEWERAGE DISTRICT,3267244.87,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+6,MASSACHUSETTS WATER RESOURCES AUTHORITY,2791850.20,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+7,D & R GENERAL CONTRACTING INC,1297918.20,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+8,MARBLEHEAD LIGHT DEPT,1180239.78,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+9,DELULIS BROTHERS CONSTRUCTION CO INC,1173788.65,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+10,N GRANESE & SONS INC,1151366.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+11,ONE TIME PAY,1101251.83,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+12,MIIA HEALTH BENEFITS TRUST,1037373.19,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+13,MYERS CONTROLLED POWER LLC,1011083.82,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+14,RAYMOND DESIGN ASSOCIATES INC,838310.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+15,NICKS LUXURY TRANSPORTATION INC,830327.49,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+16,WASTE MANAGEMENT OF MA INC.,825279.15,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+17,MDM ENGINEERING COMPANY INC,823141.27,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+18,REPUBLIC SERVICES INC,787345.91,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+19,FISCHBACH & MOORE ELECTRIC GROUP LCC,691205.84,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+20,ESSEX NS AGRIC & TECHN SCHOOL DISTR,627323.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+21,WILLIAM E MUNSON COMPANY INC,606445.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+22,NATIONAL GRID,493364.98,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+23,BOSTON HIGASHI SCHOOL INC,461424.60,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+24,RAFFAELE CONSTRUCTION,434582.15,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+25,"HALEY WARD, INC",411865.70,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+26,HOMER CONTRACTING IN,399000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+27,NV5,392568.26,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+28,MELMARK NEW ENGLAND,369668.54,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+29,PERFORMANCE FOODSERVICE NORTHCENTER FOODS,369510.32,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+30,TYLER TECHNOLOGIES INC,354118.59,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+31,LANDMARK SCHOOL,335080.10,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+32,"ALTUS DENTAL INSURANCE COMPANY, INC",324222.67,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+33,VOYA HOLDINGS INC,282856.78,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+34,MAYER TREE SERVICE,269229.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+35,RIVERVIEW SCHOOL,256883.23,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+36,NORTH READING-LYNNFIELD TAXI,240474.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+37,NORTHSHORE EDUCATION CONSORTIUM,227357.53,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+38,NEW ENGLAND ACADEMY LLC,217864.59,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+39,RICHARD D AMBROSIA INC,216911.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+40,JUSTICE RESOURCE INSTITUTE INC,205615.15,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+41,DENNIS K BURKE INC,203424.81,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+42,FUTURE TECHNOLOGIES GROUP LLC,202958.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+43,LEFTFIELD LLC,192949.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+44,TJ'S PLUMBING & HEATING INC,189334.35,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+45,COMM TRACT CORP,188216.06,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+46,DEPARTMENT OF THE TREASURY,175214.84,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+47,AMAZON CAPITAL SERVICES INC,165237.12,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+48,WOODARD & CURRAN INC,164418.87,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+49,NRG BUSINESS MARKETING LLC,163161.43,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+50,MEAD TALERMAN & COSTA LLC,156379.16,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+51,NEW DIRECTION SOLUTIONS LLC,147128.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+52,CLIFTON LARSON ALLEN LLP,144795.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+53,EASTERN MINERALS INC,143229.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+54,MARBLEHEAD WATER AND SEWER,140996.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+55,ALL AMERICAN INVESTMENT GROUP LLC,134209.04,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+56,HOPEFUL JOURNEYS EDUCATIONAL CENTER INC,132995.21,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+57,NORTHERN DATA SYSTEMS INC,127135.95,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+58,KITTREDGE EQUIPMENT CO,125609.89,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+59,LEARNING SKILLS ACADEMY,125058.45,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+60,SUBLIME INC,124500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+61,AKBAR OLIA,123500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+62,CLOUGH HARBOUR & ASSOCIATES LLP,121699.01,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+63,PURVIS SYSTEMS INC,120000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+64,"AMERICAN SERVICE CO., INC",116067.35,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+65,TOOLE DESIGN GROUP LLC,115832.57,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+66,DESIGN BUILTLLC,115782.38,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+67,MARCOTTE FORD SALES INC,115640.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+68,CARING CHOICE TRANSPORTATION,114817.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+69,LIGHTHOUSE SCHOOL INC,113099.94,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+70,EMBREE ELEVATOR,109661.65,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+71,CORPORATE BILLING LLC,109620.62,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+72,NATIONAL GRAND BANK OF MARBLEHEAD,108083.77,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+73,CREST COLLABORATIVE,105547.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+74,MCLEAN HOSPITAL,105137.83,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+75,BEVERLY SCHOOL FOR THE DEAF,103937.22,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+76,CDW GOVERNMENT INC,102628.59,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+77,MCGRAW-HILL SCHOOL EDUCATION,98125.34,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+78,COAST MAINTENANCE SUPPLY CO,97176.49,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+79,INFRA-RED BUILDING & POWER SERVICE INC,96545.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+80,JUDGE BAKER CHILDREN'S CENTER,96413.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+81,EVERY SPECIAL CHILD LLC,95378.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+82,BOSTON COLLEGE CAMPUS SCHOOL,92810.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+83,LA  MANAGEMENT INC,90352.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+84,IMAGINE LEARNING LLC,89056.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+85,BOSTON MUTUAL LIFE INS,86713.58,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+86,"VALERIO DOMINELLO & HILLMAN, LLC",84997.97,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+87,CN FINANCING INC,84752.86,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+88,AGRESOURCE,81760.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+89,OPENGOV INC,79202.46,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+90,LEAH GOODMAN,78910.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+91,WESCO,77580.03,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+92,LEARNING PREP SCHOOL,77101.01,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+93,"RICOH USA, INC",74015.63,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+94,NOBLE INC,69450.06,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+95,SEALCOATING INC  ( DBA INDUS),67833.35,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+96,"PZA GROUP, LLC",66663.74,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+97,CATALIS TAX & CAMA INC,66245.86,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+98,WINTER ST. ARCHITECTS INC,65955.76,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+99,DELANDE SUPPLY CO INC,64980.14,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+100,FRANCIS VADALA,64949.24,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+101,"NEW ENGLAND SCHOOL SERVICES, INC",63750.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+102,GRAYBAR ELECTRIC CO INC,63300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+103,CLEARWAY SCHOOL,62433.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+104,BMC CORP,61145.96,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+105,PLM ELECTRIC POWER ENGINEERING,60423.03,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+106,EVERETT J PRESCOTT INC,59726.11,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+107,ARBITERPAY TRUST ACCOUNT,57030.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+108,R B ALLEN CO INC,56247.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+109,JOHN DEERE FINANCIAL,55994.97,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+110,ALL COMM TECHNOLOGIES INC,55646.91,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+111,PYROTECNICO FIREWORKS INC,54407.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+112,NORTHEAST PUBLIC POWER ASSOC,54157.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+113,NEXGRID,53379.33,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+114,HEALEY BUS INC,52623.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+115,X2 DEVELOPMENT CORPORATION,52517.56,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+116,E AMANTI & SONS INC,52334.49,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+117,AMANDA TRIPP HAYES,51400.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+118,DAGLE ELECTRICAL CONSTRUCTION CORP,49978.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+119,OCEAN STATE SIGNAL LLC,48020.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+120,MARBLEHEAD MARINE CONS INC,47846.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+121,CLEARGOV INC,47730.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+122,TAYLOR PRICE,46689.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+123,WINDHAM WOODS SCHOOL,45945.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+124,CURRICULUM ASSOCIATES LLC,44873.89,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+125,MARBLEHEAD COUNSELING CENTER,43411.74,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+126,SALEM OVERHEAD DOOR CO INC,42977.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+127,VERIZON INC,42611.89,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+128,AMRIZE NORTHEAST INC,41247.26,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+129,ENOME INC,39270.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+130,ST ANN'S HOME INC,38710.45,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+131,NORTH EAST TECHNOLOGY,38703.38,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+132,AMERICAN REFRIGERATION COMPANY LLC,38417.83,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+133,UNIVEST CAPITAL INC,38305.07,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+134,NATIONAL GRID COMPANY,37708.74,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+135,K5 CORPORATION,37470.86,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+136,"PREMIER FENCE, LLC",37463.35,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+137,METROPOLITAN AREA PLANNING COUNCIL,36777.41,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+138,INGRAM LIBRARY SERVICES LLC,36245.98,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+139,"FITCHBURG, LEOMINSTER, LANCASTER, & CLINTON ED COL",35834.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+140,SWAMPSCOTT PUBLIC SCHOOLS,35651.67,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+141,HAM ELECTRIC LLC,35290.12,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+142,"WELLS FARGO BANK, N.A.",35039.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+143,CHRISTOPHER GALLO,35000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+144,LAHEY CLINIC INC,34523.01,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+145,MYSTERY SCIENCE INC,34335.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+146,W W GRAINGER INC,34292.52,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+147,SINCLAIR CLEANING SERVICES,33642.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+148,STANDARD & POOR'S,33100.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+149,"KP LAW, PC",32944.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+150,MATT CORREIA,32767.20,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+151,HD SUPPLY INC,32581.22,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+152,THE HUNTINGTON NATIONAL BANK,32206.92,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+153,CARLTON ELECTRICAL COSTRUCTION,31980.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+154,CURRENT CENTER LLC,31600.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+155,MASS MUNIFIN INC,31547.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+156,NORTHEAST BEHAVIORAL HEALTH CORPORATION,31063.35,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+157,CHARLES GAMBALE,30750.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+158,COMBUSTION SERVICE CO OF NE,30392.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+159,UTEC INC,30254.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+160,DAVID PERRY,30122.24,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+161,W B MASON CO INC,30114.53,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+162,FRONTLINE TECHNOLOGIES GROUP LLC,29726.54,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+163,"NUTTALL & MACAVOY, P.C.",29413.68,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+164,VARSITY BRANDS INC,28785.44,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+165,COMCAST,28262.78,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+166,RAMON RIJOS,27936.35,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+167,RICHEY & CLAPPER INC,27611.84,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+168,SPRAGUE ENERGY CORP,27361.63,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+169,CAPTUREPOINT,27335.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+170,ARTHUR J HURLEY CO INC,27266.10,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+171,SALEM STATE UNIVERSITY,26200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+172,ZAINALI HUSSIAN,26017.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+173,MPOWER TECHNOLOGIES INC,25963.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+174,PUBLIC UTILITY MUTUAL INSURANCE COMPANY (PUMIC RRG,25912.34,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+175,CARAHSOFT TECHNOLOGY CORPORATION,25642.11,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+176,THE HILLER COMPANIES LLC,25501.02,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+177,PARE CORPORATION,25380.21,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+178,METASOURCE LLC,25360.39,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+179,AMAZON CAPITAL SERVICES,25357.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+180,THE HILB GROUP OF NEW ENGLAND LLC,25000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+181,THE PENNSYLVANIA GLOBE,24970.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+182,SCOTT LAVOIE,24476.31,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+183,BLACK EARTH COMPOST LLC,23847.92,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+184,FIRST AMERICAN COMMERCIAL BANCORP INC,23759.97,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+185,SAWYER ENTERPRISES,23148.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+186,VIKING CONTROLS INC,23091.30,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+187,IXL LEARNING,23066.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+188,TINA FOX,22803.84,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+189,TRITECH SOFTWARE SYSTEMS,22733.06,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+190,A-1 EXTERMINATORS,22694.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+191,ALLIANCE TECHNICAL GROUP LLC,22550.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+192,UNIVERSITY OF MASSACHUSETTS,22515.69,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+193,"COMFORTZONES COMMUNICATIONS, INC",22249.79,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+194,"TMDE CALIBRATION LAB,INC",22110.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+195,MARY C DELAI,21730.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+196,"EDTECH SOLUTIONS, LLC",21662.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+197,FORD MOTOR COMPANY,21158.74,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+198,MPS,20959.28,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+199,COLLINS ENGINEERS INC,20925.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+200,HOME DEPOT CREDIT SERVICES,20855.41,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+201,FOCUS TECHNOLOGY SOLUTIONS LLC,20794.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+202,CENTER FOR RESPONSIVE SCHOOLS,20546.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+203,WILSON LANGUAGE TRAINING,20402.30,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+204,GORMAN RICHARDSON LEWIS ARCHITECTS INC,20376.70,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+205,DANIEL M SULLIVAN,20340.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+206,PEARSON EDUCATION,20268.60,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+207,STUART C IRBY CO,20158.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+208,SCHOOL SPECIALTY LLC,20125.62,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+209,BONSAI LOGIC LLC,19981.73,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+210,TOWN OF DANVERS,19976.32,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+211,BAYSTATE INTERPRETERS INC,19814.23,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+212,STAPLES BUSINESS ADVANTAGE,19810.48,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+213,UNITED CONSTRUCTION & FORESTRY LLC,19706.97,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+214,COLLINS OVERHEAD DOOR INC,19611.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+215,ONLINE MOORING LLC,19500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+216,NATIONAL SHINE CLEANING CORP,19500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+217,MIDWEST TAPE EXCHANGE,19128.76,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+218,"AVIDEX INDUSTRIES, LLC",19121.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+219,J HARLEN COMPANY INC,19115.97,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+220,GML UTILITY SERVICES COOPERATIVE LLC,19018.54,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+221,BCM CONTROLS CORP,19006.78,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+222,NORTHEAST TRAILWORKS LLP,19000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+223,HASAN FARYABI,18641.60,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+224,NEW GENERATION LANDSCAPING & FENCE INC,18500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+225,"TENTINDO,KENDALL,CANNIFF & KEEFE LLP",18310.08,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+226,BETH ISRAEL LAHEY HEALTH PRIMARY,18304.03,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+227,JCR CONSTRUCTION CO INC,17976.05,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+228,KOPPERS INC.,17737.84,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+229,OCKERS COMPANY,17563.65,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+230,PARTNERS HEALTHCARE,17550.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+231,JOHNSON CONTROLS FIRE PROTECTION LP,17202.91,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+232,HTS ENGINEERING INC,17026.95,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+233,DUFF & PHELPS HOLDINGS CORPORATION,16950.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+234,ADVANTAGE SPORT & FITNESS INC,16717.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+235,R&Z PETROLEUM INC,16647.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+236,YMCA OF THE NORTH SHORE,16409.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+237,JATHEON TECHNOLGIES INC,16167.61,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+238,GILBERT & COLE,16033.46,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+239,HOLLY HANNAWAY,16002.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+240,EI US LLC,15798.15,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+241,MICHAEL SILVER,15734.38,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+242,PATRICK KEVIN BUGLER,15543.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+243,MARCH & MARTIN INC,15519.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+244,KELLEY & RYAN ASSOCIATES INC,15505.61,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+245,HAYES PUMP INC,15415.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+246,THE PITNEY BOWES RESERVE ACCOUNT,15288.39,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+247,INGRAM LIBRARY SERVICES,15149.52,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+248,NORTHEASTERN CONFERENCE,15053.07,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+249,MICHAEL C BRICHER,14925.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+250,"TIGHE & BOND, INC",14875.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+251,MEDFORD WELLINGTON SERVICE CO INC,14807.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+252,C & C AUTO PARTS,14806.98,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+253,ROUND STAR LLC,14664.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+254,POWERSCHOOL CORPORATION,14587.92,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+255,BLOOM ED INC,14500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+256,HAYDENS SAFE & LOCK CO. INC.,14480.45,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+257,TIMECLOCK  PLUS LLC,14448.86,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+258,HENRI INC,14315.67,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+259,AT&T MOBILITY LLC,14264.45,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+260,TALTY FLOORS INC,14234.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+261,GOULET SALVIDO & ASS PC,14000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+262,COMCAST HOLDINGS CORPORATION,13928.87,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+263,STAPLES CREDIT PLAN   691,13878.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+264,SEEM COLLABORATIVE,13820.84,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+265,CARTWHEEL HEALTH SERVICES P C,13750.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+266,"INCIDENT IQ, LLC",13744.04,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+267,FISHER AUTO PARTS INC,13394.13,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+268,OVERDRIVE INC,13371.43,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+269,J'S AUTOMOTIVE WAREHOUSE INC,13347.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+270,"F & S HARDWARE, INC",13278.77,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+271,T MOBILE USA INC,13164.14,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+272,PEARSON,13052.27,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+273,HECTORY H DUARTE,12900.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+274,CHRISTOPHER FIELDS,12761.28,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+275,ONSOLVE INTERMEDIATE HOLDING COMPANY,12662.74,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+276,AAA POLICE SUPPLY,12430.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+277,BRIGHTER HORIZONS ENVIRONMENTAL CORPORATION,12261.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+278,UNLIMITED PROMOTIONS,12120.24,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+279,ST PIERRE MANUFACTURING CORP,12045.84,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+280,MIIA INC,11950.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+281,TI-SALES INC,11891.86,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+282,ATHLETIC FACILITY SOLUTIONS LLC,11863.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+283,"UTILITY SERVICES OF VERMONT, LLC",11790.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+284,NORTH EAST DATA GROUP LLC,11759.64,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+285,CENTURY TIRE OF PEABODY,11758.58,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+286,HARTFORD FIRE INSURANCE CO,11749.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+287,MCGILL HOSE & COUPLING INC,11734.61,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+288,SIMONS UNIFORMS,11719.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+289,AMERICAN PUBLIC POWER ASSOCIATION,11633.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+290,JAMF HOLDINGS INC & SUBSIDIARIES,11445.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+291,JOHN HOADLEY AND SONS INC,11432.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+292,ACTIVE INTERNET TECHNOLOGIES LLC,11421.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+293,CAM OFFICE SERVICES INC,11124.23,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+294,D3LOGIC INC,11108.07,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+295,"SERVICE TIRE TRUCK CENTERS, INC",11103.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+296,KIMBERLY ANNE CROWLEY,11100.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+297,PJC ORGANIC,11054.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+298,ODYSSEY ADVISORS INC,10950.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+299,SUNBELT STUFFING LLC,10800.28,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+300,HART HALSEY LLC,10777.31,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+301,CHUBB AND SON,10689.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+302,TRIDENT ENVIRONMENTAL GROUP LLC,10672.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+303,DEMOULAS SUPER MARKET,10500.06,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+304,FANTINI BAKING CO INC,10319.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+305,J C MADIGAN INC,10224.13,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+306,JOHN GUILFOIL,10192.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+307,SEAN FLYNN,10189.07,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+308,SCENARIO LEARNING LLC,10184.08,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+309,THURSTON FOODS INC,10175.38,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+310,CENGAGE LEARNING,10175.70,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+311,GRANT MACLEAN,9980.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+312,UNLIMITED AUTO & TRUCK REPAIR,9876.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+313,JOHN B MENDONCA,9844.97,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+314,US TELEPACIFIC CORP,9842.39,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+315,ROBERT H LORD COMPANY,9779.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+316,TRAVELERS INDEMNITY AND AFFILIATES,9702.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+317,VILLAGE GREEN RESTORATION INC,9700.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+318,SPORTS MEDICINE NORTH,9503.74,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+319,JOHN D CLEMSON,9500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+320,LBK TRANSPORTATION CO INC,9410.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+321,BRATT EMERY,9400.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+322,THE CLARKE SCHOOL FOR THE DEAF,9320.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+323,HOUGHTON MIFFLIN COMPANY,9268.08,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+324,KONICA - MINOLTA BUSINESS SOLUTIONS USA INC,9163.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+325,CORE & MAIN LP,9116.53,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+326,F W WEBB CO,9048.39,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+327,FRANKLIN PAINT CO,8924.35,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+328,NEARMAP US INC,8910.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+329,PERKINS SCHOOLFOR THE BLIND,8828.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+330,AARON MOSESON,8800.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+331,"FIFTH ASSET, INC",8750.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+332,ARXED,8750.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+333,"ALICE TRAINING INSTITUTE, LLC",8741.81,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+334,MASS MUNICIPAL ASSN,8691.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+335,ATLANTIC ASPHALT & EQUIPMENT CO INC,8537.76,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+336,ORION ENERGY SYSTEMS INC,8525.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+337,FRASCO INC,8522.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+338,SANOFI PASTEUR INC,8390.31,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+339,"WILLIAMS SCOTSMAN, INC",8318.23,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+340,ABH SERVICES INC,8250.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+341,BOSTON GREEN FUEL CO INC,8078.27,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+342,WILLIS IANNARELLI,8022.29,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+343,"INSIGHTATLAST, LLC",7978.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+344,MARBLEHEAD COLLISION,7967.12,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+345,BAKER & TAYLOR BOOKS - 510486,7876.06,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+346,PROJECT WAYFINDER INC,7866.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+347,PITNEY BOWES GLOBAL FINANCIAL SERVICES LLC,7848.06,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+348,R DILISIO CO INC,7845.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+349,NRICH INC,7841.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+350,TEQUIPMENT INC,7826.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+351,MICHAEL R HORSCH SALES INC,7795.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+352,NORTH SHORE CHILDREN'S THEATRE,7790.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+353,MEGAN WHITE,7736.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+354,PHILIP B SOMERBY,7662.10,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+355,KIDS REFERENCE COMPANY INC,7638.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+356,STILES CO INC,7589.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+357,FREDERICK B HAGGETT,7560.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+358,WILLARD & SON INC,7542.32,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+359,CICORIA TREE SERVICE,7500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+360,ANNESE ELECTRICAL SERVICES INC,7488.41,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+361,SIMPLY WINDOWS LLC,7448.53,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+362,SCHOOL FOOD SERVICES OF NEW ENGLAND INC,7440.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+363,SUPERIOR LANDSCAPING,7269.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+364,SCHOLASTIC INC,7254.23,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+365,METROPOLITAN FOODS,7246.87,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+366,SITEONE LANDSCAPE SUPPLY,7221.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+367,MANSFIELD PAPER CO INC,7212.79,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+368,PITNEY BOWES,7200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+369,HANCOCK ASSOCIATES,7169.55,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+370,TYNDALE COMPANY INC,7139.45,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+371,"MCGRAW-HILL GLOBAL EDUCATIONAL HOLDINGS, LLC",7095.36,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+372,JEFFREY CHELGREN,7094.22,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+373,AMERICAN ALARM & COMMUNICATIONS INC,7018.57,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+374,INTRASYSTEMS LLC,7000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+375,CHESS WIZARDS,6997.20,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+376,S & S ABATEMENT LLC,6975.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+377,WALNUT PRINTING SPEC INC,6898.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+378,EDPUZZLE INC,6885.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+379,PERMA-LINE CORP OF NEW ENGLAND,6876.27,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+380,MASS INTERSCHOL ATH ASSN,6870.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+381,DILISIO GOLF RANGE,6809.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+382,SCHERBON CONSOLIDATED,6809.44,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+383,CELLCO PARTNERSHIP D/B/A VERIZON WIRELESS,6696.39,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+384,BRAKE & CLUTCH INC,6669.82,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+385,QUADRANT HEALTH STRATEGIES INC,6657.52,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+386,S & D PETROLEUM INC,6625.26,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+387,ONBOARD INTERIORS LLC,6610.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+388,RMG ENTERPRISE LLC,6603.91,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+389,EJ USA INC,6543.60,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+390,PALMER SPRING COMPANY,6540.14,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+391,KEVIN HUSSON,6531.84,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+392,MARBLEHEAD MUSEUM & HISTORICAL SOCIETY,6500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+393,ENVIRONMENTAL PARTNERS GROUP LLC,6500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+394,DAIS INC,6500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+395,HEALTH TRAINING EDUCATIONAL SERVICES INC,6442.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+396,STONEHAM MOTORS COLLISION CENTER,6410.85,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+397,R.P. O'CONNELL INC,6382.74,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+398,THE PAPPAS COMPANY INC,6380.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+399,SUNDANCE SCREENPRINTS,6359.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+400,AUGUSTIN A SERINO,6283.95,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+401,WINDHAM INJURY MANAGEMENT GROUP INC,6258.47,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+402,TOWN OF MIDDLETON,6254.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+403,EMS LINQ LLC,6207.61,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+404,NORTHEASTERN FENCE & SUPPLY CORP,6161.48,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+405,ZOOM VIDEO COMMUNICATIONS INC,6141.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+406,GYMNASIUM FLOORS INC,6070.10,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+407,W T COX SUBSCRIPTIONS INC,6056.20,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+408,CARA J TYRRELL,6042.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+409,ALLEGIANCE TRUCKS LLC,6015.33,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+410,LIGHTSPEED TECHNOLOGIES INC,6008.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+411,"NE ASSOCIATION OF SCHOOLS & COLLEGES, IN",5995.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+412,BOB PAPPAS WELDING,5976.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+413,DTS,5933.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+414,GLOBAL ASSESSMENTS INC,5927.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+415,BLICK ART MATERIAL,5926.13,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+416,WILLIAM F MANN,5924.22,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+417,JORDANS MARINE INC,5919.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+418,QUIZIZZ INC,5896.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+419,NORTHEAST HOSPITAL CORP,5894.41,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+420,ATHENAK12 EDUCATIONAL CONSULTING LLC,5875.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+421,"LAWSON PRODUCTS, INC.",5872.22,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+422,WINER BROS,5870.18,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+423,BRADY INDUSTRIES LLC,5828.35,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+424,ACHIEVE RENEWABLE ENERGY LLC,5760.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+425,"EDUCATION, TRAINING & RESEARCH ASSOCIATES",5745.35,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+426,LHS ASSOCIATES INC,5600.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+427,TNC INDUSTRIES INC,5595.26,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+428,CAVICCHIO GREENHOUSES,5591.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+429,B & H PHOTO,5588.93,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+430,WILDFISH LLC,5582.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+431,SECURE LOCK & SAFE LLC,5561.76,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+432,"FOLLETT SCHOOL SOLUTIONS, INC",5508.12,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+433,NORTHEASTERN MASSACHUSETTS LAW ENFORCEMENT COUNCIL,5500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+434,FALLON TREE CARE,5500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+435,AMERICAN COMMERCIAL APPLIANCE INC,5421.70,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+436,THOMAS RUBANO,5400.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+437,MASS SCHOOL ADMIN ASSOC,5360.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+438,EVERWAY HOLDCO LLC,5350.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+439,ELECTRIC LIGHT CO INC,5332.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+440,JAMES A KILEY CO,5322.38,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+441,SHOWER TOWER,5309.59,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+442,"A & R CONSTRUCTION, INC",5300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+443,ROBERT L BALLARD JR,5273.24,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+444,BIDDOCS ONLINE,5250.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+445,LIMINEX INC,5226.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+446,UTS OF MASSACHUSETTS INC,5225.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+447,TIMOTHY D BOWEN,5220.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+448,CENTRALSQUARE TECHNOLOGIES LLC,5220.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+449,SCOTT M SANDERS,5211.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+450,SALEM SOUND COASTWATCH,5200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+451,KASEYA US LLC,5200.20,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+452,TOP SECRET KIDS CORPORATION,5175.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+453,POLAR CORPORATION,5169.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+454,SCOPE MEDICAL LLC,5150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+455,DIG SAFE SYSTEM INC,5122.09,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+456,PETES TIRE BARN,5115.98,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+457,SHEA CONCRETE PRODUCTS INC,5100.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+458,TD&I,5060.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+459,OFFICE FURNITURE DISTRIBUTORS OF NE,5057.06,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+460,HIGHLAND SHREDDING LLC,5045.60,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+461,Q-MATION INC,5034.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+462,POLICY CONFLUENCE INC,5000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+463,AUTISM HIGHER EDUCATION FOUNDATION,5000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+464,ACENTECH,5000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+465,NORTHEAST ATHLETIC & TROPHIES,4994.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+466,CAMBIUM LEARNING INC,4985.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+467,"LAND N SEA DISTRIBUTING, INC",4968.62,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+468,THE GREAT BOOKS FOUN,4952.63,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+469,KAREN JANCSY,4950.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+470,N E SCHOOL DEVELOP COUNCIL,4874.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+471,LIBRARY IDEAS LLC,4873.06,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+472,STEVE NUGENT'S KARATE INC,4860.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+473,ZOHO CORPORATION,4838.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+474,THE WANDERLUST GROUP INC,4791.93,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+475,GAIL PERRY BORDEN,4744.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+476,VALSTONE CORPORATION INC,4725.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+477,"BOSTON DOCUMENT SYSTEMS, INC",4723.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+478,MICHAEL HALL,4686.44,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+479,JOSHUA D GERRARD,4650.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+480,G/J TOWING INC,4617.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+481,CHARLES J GAMBALE JR,4600.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+482,RAPTOR TECHNOLOGIES LLC,4549.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+483,CITY HALL SYSTEMS INC,4549.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+484,PROQUEST-CSA LLC,4537.73,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+485,CITY OF SALEM,4484.41,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+486,BRAIN POP LLC,4480.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+487,APPLE COMPUTER INC,4478.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+488,CENTURY-TYWOOD J3 CORP,4467.71,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+489,DONALD L ORNE JR,4462.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+490,ANDCO INC,4445.88,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+491,THE NEW ENGLAND CENTER FOR CHILDREN INC,4403.70,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+492,KATHLEEN KRAMER,4394.20,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+493,"SCHOOL DATEBOOKS, INC",4319.48,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+494,CROWLEY COTTRELL LLC,4300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+495,BERGERON PROTECTIVE CLOTHING,4293.16,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+496,DEPENDABLE SECURITY SYS INC,4258.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+497,MORPHO USA INC,4196.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+498,MUNICIPAL ELECTRIC ASSOC OF MA,4169.76,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+499,AMERICAN PLATE & AUTO GLAS,4157.69,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+500,L J BOUCHARD & SON INC,4146.34,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+501,NORTH SHORE PHYSICIANS GROUP,4125.13,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+502,GENUINE PARTS COMPANY INC,4113.33,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+503,BRIGHAM WOMENS PHISICIAN ORGANIZATION,4099.09,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+504,SKI BLUE HILLS MANAGEMENT,4095.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+505,STERICYCLE,4089.94,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+506,MICHELLE SIMONS,4084.62,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+507,FASTENAL,4046.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+508,RUSTIC FIRE PROTECTION INC,4015.82,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+509,"LITIX, INC.",4000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+510,HAWC HEALING ABUSE WORKING FOR CHANGE,4000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+511,APPLE INC,4000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+512,WAYSIDE RENTALS & LEASING,3995.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+513,"BOSTON FREIGHTLINER, INC",3951.49,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+514,EVELYN FESSENDEN,3900.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+515,TOSHIBA AMERICA BUSINESS SOLUTIONS INC,3899.88,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+516,PENWORTHY COMPANY,3898.83,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+517,JOHN COSTANTINO,3852.14,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+518,SYSTEMS DESIGN AND TECHNOLOGY LLC,3812.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+519,"M.E. O'BRIEN & SONS, INC",3777.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+520,VALLEY COMMUNICATIONS,3766.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+521,WALLINGFORD'S INC,3750.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+522,LAHEY CLINIC HOSPITAL,3747.59,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+523,ARBITERSPORTS LLC,3725.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+524,S.V. MOFFETT CO. INC.,3725.38,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+525,ULINE INC,3724.55,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+526,TRAVELERS INSURANCE,3704.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+527,CAROLINA BIOLOGICAL SUPPLY CO,3701.86,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+528,WALTER HOMAN,3694.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+529,EASTERN PROPANE GAS INC,3687.29,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+530,COMMON CENTS EMS SUPPLY LLC,3632.61,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+531,MARBLEHEAD NEWS GROUP,3600.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+532,MASS ASSO OF SCH BUSINESS OFF,3599.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+533,SPLASHTOP INC,3577.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+534,LEARNING A-Z,3548.67,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+535,WALTER E HOMAN,3547.63,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+536,NORTH SHORE FIRE APPLIANCE CO,3521.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+537,JANET LEE GEORGE,3500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+538,"DONOVAN EQUIPMENT CO., INC",3494.34,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+539,HILLTOP SECURITIES INC.,3450.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+540,E J PRESCOTT INC,3440.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+541,DELTA BECKWITH ELEVATOR CO,3408.12,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+542,VIVIEN CLAIRE CONSALVO,3400.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+543,THE THRONE DEPOT,3370.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+544,DEMCO,3343.58,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+545,GOLD STAR FOODS INC,3341.52,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+546,MASSACHUSETTS POLICE ACCREDITATION COMMISSION INC,3333.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+547,INFRA RED ANALYZER INC,3290.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+548,WAYNE ALARM SYSTEM,3273.83,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+549,FIRE TECH & SAFETY,3261.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+550,SPAULDING REHAB HOSPITAL CORP,3254.64,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+551,AIRGAS USA LLC,3252.04,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+552,SHAMROCK SHINERS INC,3250.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+553,ENERGY NEW ENGLAND LLC,3240.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+554,EDWARD MONTONE,3240.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+555,KEANE FIRE & SAFETY EQUIP CO INC,3237.13,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+556,GOPHER SPORT,3221.03,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+557,SEACOAST MOTORCYCLES,3190.15,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+558,O'REILLY AUTO ENTERPRISES LLC,3182.37,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+559,BAIYUN TAO,3180.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+560,TIGHTROPE MEDIA SYSTEMS INC,3175.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+561,ENE SECURITY LLC,3160.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+562,PATRICIA EILEEN SULLIVAN,3150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+563,JW PEPPER & SON INC,3118.89,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+564,LEE WAYNE CORP,3045.38,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+565,C N WOOD LLC,3040.56,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+566,"CONCORP, INC",3027.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+567,INSTITUTE FOR ENVIRONMENTAL EDUCATION,3025.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+568,VERMEULEN'S INC,3000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+569,KERRI MCDONALD-SCHAUB,3000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+570,"HUDL, INC.",3000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+571,ASAP DRAINS INC,3000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+572,DONALD W MACOMBER,2999.05,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+573,KECHES LAW GROUP P.C.,2982.42,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+574,"CANON SOLUTIONS AMERICA, INC",2962.95,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+575,SMARTPASS INC,2957.76,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+576,AIR CLEANING SPECIALISTS LLC,2955.82,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+577,ASSABET INTERACTIVE,2950.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+578,DARA VANREMOORTEL,2935.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+579,"STADIUM OIL HEAT, INC",2934.77,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+580,NORTHEAST NURSERY INC,2926.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+581,BBE CORPORATION,2910.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+582,MT LIBRARY SERVICES,2898.74,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+583,THE LEARNING CENTER FOR DEAF,2882.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+584,MA LIBRARY SYSTEM ILL DEPT,2874.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+585,READ NATURALLY INC,2860.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+586,PROQUEST INFORMATION AND,2856.37,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+587,TODISCO SERVICES INC,2850.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+588,JOEL A LEDERMAN,2820.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+589,ESSEX COUNTY FIRE CHIEFS ASS0CIATION,2814.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+590,DICK BLICK,2766.35,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+591,MASTER LIBRARY LLC,2760.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+592,AMERICAN TEST CENTER,2760.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+593,XEROX CORPORATION,2754.36,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+594,VERNIER SOFTWARE & TECHNOLOGY INC,2752.55,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+595,JEFFREY BIRTHWISTLE,2736.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+596,"GREENWOOD INDUSTRIES, INC",2715.22,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+597,MUSIC THEATRE INTERNATIONAL,2700.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+598,KATE ANSLINGER,2700.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+599,HOWMEDICA OSTEONICS CORP,2641.38,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+600,DAVE & BUSTER'S ENTERTAINMENT INC,2622.16,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+601,ARA SAKAYAN,2618.51,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+602,DECKER INC,2613.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+603,SPIRIT PRO CHEER LLC,2600.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+604,AMERICAN DOOR SALES LLC,2594.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+605,STACIE NARDIZZI,2580.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+606,"CUSTOMIZED DATA SERVICES, INC.",2572.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+607,ENVIRONMENTAL SYSTEMS RESEARCH INST,2554.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+608,BOWDOIN B CROWNINSHIELD,2542.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+609,BOSTON YACHT CLUB,2539.54,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+610,EDCLUB INC,2533.05,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+611,CHRIS O TELSON,2520.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+612,SECI,2520.86,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+613,WILSON CONTROLS LLC,2508.70,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+614,POSM SOFTWARE LLC,2500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+615,GLOVER'S MARBLEHEAD REGIMENT INC,2500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+616,QBS LLC,2497.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+617,H T BERRY COMPANY LLC A BRADYPLUS COMPANY,2489.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+618,E. CRESSEY & SON,2442.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+619,CENTRAL FAN CO INC,2435.20,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+620,CATHERINE LANDERGAN,2434.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+621,KERNWOOD COUNTRY CLUB,2434.86,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+622,RELAVENT SYSTEMS INC,2400.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+623,MASSACHUSETTS PARTNERSHIP YOUTH,2394.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+624,FACILITY MANAGEMENT CORP,2392.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+625,LAURIE MEAGHER,2389.44,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+626,PERMA-BOUND,2383.20,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+627,RECYCLE AMERICA HOLDINGS INC,2365.84,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+628,SLOWEY MCMANUS COMMUNICATIONS,2306.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+629,DAVID MESSINGER,2292.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+630,WIND RIVER ENVIRONMENTAL LLC,2281.87,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+631,SARAH CROSBIE,2255.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+632,RAIS,2255.48,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+633,STANLEY STEEMER INTERNATIONAL INC,2250.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+634,WOODIE'S TIRE SERVICE,2246.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+635,MMEA - ND,2225.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+636,SCHOOL HEALTH CORP,2222.63,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+637,JOHN NICASTRO,2215.44,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+638,ENCORE FIRE PROTECTION,2205.86,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+639,PRO-ED INC,2203.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+640,CRAIG SIMONETTI,2200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+641,BUREAU OF EDUC & RESEARCH INC,2200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+642,ADAM J HATFIELD,2195.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+643,PRIORITY CARE BLOCKER INC,2173.04,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+644,FLINN SCIENTIFIC INC,2164.15,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+645,PM ENVIRONMENTAL INC,2150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+646,DAVID WILKINS,2150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+647,EMERGE PRODUCTS LLC,2144.18,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+648,BOSTON RED SOX BASEBALL CLUB LP,2142.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+649,TUCKER'S WHARF CONDO TRUST,2140.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+650,TCI INCORPORATED,2135.28,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+651,INCREDIFLIX INC,2130.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+652,GREATER BOSTON POLICE COUNCIL,2125.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+653,WEST MARINE PRODUCTS INC,2117.38,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+654,THOMAS J SCALA,2102.33,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+655,KUTA SOFTWARE,2080.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+656,MAAO,2079.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+657,LANES COVEN THEATER COMPANY INCLANES COVEN THEATER,2040.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+658,EVERSOURCE ENERGY SERVICE,2021.21,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+659,RED WING SHOE STORE,2018.36,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+660,AT&T,2016.38,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+661,AT&T SUPPOENA CENTER,2014.09,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+662,RECOLOR PAINTS LLC,2008.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+663,LAURA M LUNA,2000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+664,JOHN ROBIDOUX,2000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+665,VISTA HIGHER LEARNING INC,1979.62,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+666,"GEM MECHANICAL SERVICES, LLC",1975.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+667,HERTZ FURNITURE SYSTEMS LLC,1969.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+668,"NEW ENGLAND INDUSTRIAL TRUCK, INC",1964.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+669,LOUANN STRANGIE,1960.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+670,SSC SERVICES INC,1959.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+671,TAYLOR & LLOYD INC,1952.91,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+672,MARY ELLEN SHEA,1949.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+673,MARBLEHEAD MARINE INC,1941.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+674,SONEPAR DISTRIBUTION NEW ENGLAND INC,1929.69,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+675,BLACKSTONE PUBLISHING,1917.29,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+676,JOHNSON CONTROLS SECURITY SOLUTIONS INC,1916.70,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+677,EJ ORFANOS PAINTING INC,1900.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+678,KATHERINE CAMERON HOFFMAN,1870.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+679,SKI WARD INC,1856.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+680,MASS CHIEFS OF POLICE ASSOC,1856.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+681,NORTHERN BUSINESS MACHINE INC,1850.02,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+682,YOUR CHOICE BRANDS TRUST,1839.47,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+683,JULIE BERMAN,1827.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+684,DILISIO BROS LANDSCAPE & MAS SUPPLY,1810.77,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+685,DIFFIT INC,1800.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+686,DEBBIE LEIBOWITZ,1800.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+687,EMG,1798.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+688,ERIC F S CHISHOLM,1796.54,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+689,MA COUNCIL ON AGING ASSOC,1790.04,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+690,4ALLPROMOS LLC,1782.58,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+691,B & B ENGINEERING CORP,1781.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+692,"MODUGO, LLC",1770.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+693,REHABMART LLC,1770.64,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+694,SCOTT MURRAY,1764.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+695,MASS STATE TRACK COACHES ASSOCIATION,1762.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+696,JOHN LEQUIN JR,1758.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+697,FUSS & O'NEILL INC,1750.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+698,ARIHANT SREENIVASA,1750.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+699,LIVING FIT LLC,1740.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+700,BASSETT MECHANICAL SERVICES,1725.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+701,MASS ASSN OF SCHOOL COMMITTEES,1720.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+702,THE PD COLLAB,1719.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+703,RENT ALL,1718.60,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+704,BUSINESS & PROFESSIONAL EXCHANGE INC,1701.20,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+705,GREGG MCLAUGHLIN,1690.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+706,BRITT DECKER,1686.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+707,NCS PEARSON INC,1681.04,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+708,GEMPLERS,1669.23,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+709,WILLIAM V MACGILL & CO,1665.13,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+710,DAMON PIGNATO,1650.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+711,WEST MUSIC CO,1650.98,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+712,KATHERINE DEELY,1638.03,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+713,JUDITH MESSINGER,1638.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+714,COLLEEN INGLIS,1632.15,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+715,THE W W WILLIAMS COMPANY LLC,1620.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+716,CENTRAL STEEL SUPPLY CO INC,1604.95,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+717,NEW ENGLAND MOUNTAIN BIKE ASSOCIATION,1600.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+718,PMAM CORPORATION,1595.21,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+719,HANRAHAN CONSULTING LLC,1575.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+720,"NEW ENGLAND HYDRAULIC SERVICE CO., INC",1568.13,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+721,ITHAKA HARBORS INC,1561.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+722,BERGERON HEALTH CARE,1559.87,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+723,ANSWERNET,1554.55,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+724,NASSCO INC,1550.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+725,KARL MAYER,1526.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+726,DEMATOS LANDSCAPING INC,1520.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+727,TRANSUNION RISK & ALTERNATIVE DATA SOLUTIONS INC.,1504.35,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+728,STEVE MCCLURE,1500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+729,ARRAY EDUCATION INC,1500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+730,UNITED STATES POSTAL SERVICE,1498.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+731,BOUND TREE MEDICAL LLC,1491.43,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+732,MILES KEDEX COMPANY INC,1482.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+733,VEOLIA ES TECHNICAL SOLUTIONS,1480.16,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+734,"CARTOGRAPHIC ASSOCIATES, INC",1479.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+735,4IMPRINT,1457.36,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+736,GOODTIME PEDIATRICS,1456.07,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+737,BOB'S TIRE CO,1454.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+738,"QBS, INC",1438.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+739,HAVERHILL PUBLIC SCHOOLS,1433.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+740,CRAFT HOT SAUCE LLC,1432.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+741,EVERYDAY SPEECH LLC,1419.96,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+742,CAMI IANNARELLI,1417.46,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+743,JAMES KEATING,1416.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+744,FERGUSON US HOLDINGS INC,1411.95,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+745,MERIDIAN ASSOCIATES INC,1400.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+746,DEBRA CHRISTENSEN,1389.61,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+747,BATESVILLE INC,1374.76,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+748,OLSON'S LANDSCAPE & TURF IRRIGATION CO,1370.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+749,CHRISTOPHER DUNBAR,1369.18,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+750,JAMES R ROSENCRANTZ & SON INC,1367.58,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+751,NEW YORK TIMES SALES INC,1364.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+752,"MASS ASSN OF SCHOOL SUPT, INC",1350.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+753,FORMAX,1345.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+754,TERMINAL SUPPLY COMPANY,1333.33,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+755,STERICYCLE INC,1332.22,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+756,ERC WIPING PRODUCTS INC,1315.30,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+757,GLOUCESTER MARITIME HERITAGE CENTER INC,1311.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+758,FRANK H JAMES JR,1310.84,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+759,DRY AIR SYSTEMS INC,1309.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+760,PUBLIC UTILITIES RISK MANAGEMENT,1300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+761,FAGONE MECHANICAL,1300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+762,KYLE PETTINELLI,1296.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+763,EDYNAMIC HOLDINGS LP,1295.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+764,DYAR SALES & MACHINERY CO,1289.88,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+765,JOSEPH KING,1286.56,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+766,LANGUAGE TESTING INT'L INC,1285.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+767,CHARLES DALFERRO,1280.66,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+768,DAVID FRENCH MUSIC CO INC,1279.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+769,HOWIES HOCKEY INC,1275.81,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+770,THE TRANZONIC COMPANIES,1263.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+771,EAST COAST CRANE & AERIAL SERVICES LLC,1260.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+772,ANTHONY LUCIANO,1260.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+773,MIIA PROPERTY & CASUALTY GR INC,1251.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+774,"NE LEAGUE OF MIDDLE   SCHOOLS, INC",1250.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+775,SOUTHWORTH-MILTON INC,1246.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+776,RAINWATER CORP,1242.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+777,JOSEPH KOWALIK,1236.37,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+778,"CJ'S TRANSPORTATION, INC",1232.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+779,WOBURN CONCRETE & MASONRY SUPPLIES,1231.74,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+780,PROPER LIVING LLC,1230.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+781,JOHN WRIGHT,1228.86,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+782,M & P BUSINESS PRODUCTS,1218.58,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+783,HAND2MIND INC,1215.05,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+784,B & B PEST CONTROL,1200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+785,STUKENT INC,1195.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+786,RIDDELL/ALL AMERICAN SPORTS CORP,1195.14,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+787,ZIZI MAYER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+788,WILLIAM S HASKELL JR,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+789,WILLIAM SANO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+790,WILLIAM R STANTON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+791,WILLIAM MONTGOMERY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+792,WILLIAM L LARACY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+793,WILLIAM LITTLE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+794,WILLIAM LARIOS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+795,WILLIAM JANCSY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+796,WILLIAM HOWARD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+797,WILLIAM HASKELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+798,WILLIAM BUONOPANE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+799,WENDY ZIMMER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+800,WAYNE ATTRIDGE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+801,WANDA CUMMINGS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+802,WALTER KELSEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+803,WALTER CONRAD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+804,VIRGINIA WILLIAMS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+805,VIRGINIA PALMER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+806,VIRGINIA BOWEN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+807,VIRGINIA BENJAMIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+808,VINCENT TENTINDO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+809,VALERIE PETERSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+810,TUULA SNOW,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+811,TRACEY ANDERSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+812,TINA WEBB SWEET,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+813,TIMOTHY RILEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+814,TIMOTHY KANNALLY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+815,TIMOTHY C GERAGHTY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+816,THOMAS TUCKER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+817,THOMAS MURRAY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+818,THOMAS KEHOE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+819,THOMAS GETZ,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+820,THOMAS ANTONUCCI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+821,THERESA NATTI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+822,TERESA HUYCK,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+823,TERESA BATES,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+824,TERENCE CRISWELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+825,SYLVIA GOODWIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+826,SUZANNE E QUIGLEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+827,SUSAN SPEAR,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+828,SUSAN ROPER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+829,SUSAN PILLSBURY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+830,SUSAN PICKARD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+831,SUSAN DONAHUE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+832,SUSAN BUONOPANE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+833,SUSAN BABINE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+834,SUSAN ANDERS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+835,SUDHA D NEWMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+836,STEVEN RYAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+837,STEVEN ARST,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+838,STEPHEN WEBSTER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+839,STEPHEN WARE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+840,STEPHEN VENEZIA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+841,STEPHEN RYAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+842,STEPHEN QUIGLEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+843,STEPHEN PIERCE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+844,STEPHEN LOUISOS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+845,STEPHEN KRITEMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+846,STEPHEN HULL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+847,STEPHEN FEINS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+848,STEPHEN A ANDREWS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+849,STEPHANIE COLBY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+850,SPENCER MOORE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+851,SONJA KNIGHT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+852,SONDRA MARTIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+853,SHIRLEY GINSBERG,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+854,SHELLY KAMIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+855,SHEILA KEATING,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+856,SHEILA HAMOND,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+857,SHARON SHATTUCK,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+858,SHARON PINGREE-RUSSELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+859,SHARON PAQUETTE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+860,SCOTT EDWARDS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+861,SANDY CARNEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+862,SANDRA WINTER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+863,SANDRA ROTMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+864,SANDRA LEFLEUR,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+865,SANDRA DIXEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+866,SALVATORE PANGALLO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+867,SALLY SHAW,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+868,SALLY POLLARD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+869,RUTH H CURTIS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+870,ROY HAMSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+871,ROSEMARY CROSBY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+872,ROSEMARIE CAREY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+873,ROSE KERNUSKY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+874,RONALD PLOTKA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+875,RONALD J MARKS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+876,RONALD BORDEN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+877,ROGER TUVESON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+878,ROGER DALTON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+879,ROGER BEAULIEU,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+880,ROCHELLE BARTLETT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+881,ROBIN BERG,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+882,ROBERT WILLIAMS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+883,ROBERT V JOLLY JR,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+884,ROBERT PETERSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+885,ROBERT PAQUETTE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+886,ROBERT NICKOLAU,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+887,ROBERT NEWMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+888,ROBERT MURRAY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+889,ROBERT LAKIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+890,ROBERT JENKINS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+891,ROBERT IVES JR,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+892,ROBERT HOMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+893,ROBERT HARVEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+894,ROBERT HALEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+895,ROBERT GLABICKY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+896,ROBERT DANE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+897,ROBERT DANA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+898,ROBERT COYNE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+899,ROBERT CLAYMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+900,ROBERT BELLUCCI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+901,ROBERT BALBONI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+902,ROBERTA ROGERS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+903,ROBERTA MCCLELLAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+904,ROBERTA  A CODY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+905,R KEITH MCCLELLAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+906,RITA DANA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+907,RICHARD PATCH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+908,RICHARD MILLER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+909,RICHARD MACE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+910,RICHARD LOMBARD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+911,RICHARD LAMBY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+912,RICHARD KELLEHER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+913,RICHARD HOLMES,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+914,RICHARD HALEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+915,RICHARD BARTLETT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+916,RHONDA PREMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+917,REBECCA SAGER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+918,REBECCA DULAC,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+919,RAYMOND J PHILLIPS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+920,RAYMOND CURRAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+921,RANDY GUTHARTZ,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+922,RALPH SEVINOR,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+923,RALPH HULL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+924,PRUGH ROESER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+925,PRISCILLA HARRIS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+926,PHYLLIS SMITH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+927,PHILO WAHTERA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+928,PHILLIP LEGRO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+929,PHILIP BOURGEAULT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+930,PETER REARDON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+931,PETER LAWTON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+932,PETER HERMANN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+933,PETER HALKS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+934,PETER FADDEN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+935,PETER CASTOLDI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+936,PAUL WENTZELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+937,PAUL SURETTE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+938,PAUL SPILLANE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+939,PAUL NEILSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+940,PAUL MURBER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+941,PAUL LYNESS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+942,PAUL JALBERT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+943,PAULINE MORGAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+944,PAULETTE RAIMO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+945,PAUL CASSELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+946,PAULA NEILSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+947,PAULA IVES,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+948,PAULA BELYEA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+949,PAT ROBERTS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+950,PATRICIA SAAL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+951,PATRICIA ROGERS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+952,PATRICIA PITTORE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+953,PATRICIA MURRAY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+954,PATRICIA LAUSIER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+955,PATRICIA KELLY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+956,PATRICIA ELLISON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+957,PATRICIA CHARBONNIER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+958,PATRICIA BROSQUE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+959,PATRICE CLOUGH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+960,PAT MAGEE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+961,PASQUALE LUISE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+962,PASCALE QUEVAL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+963,PAMELA WILLIAMS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+964,PAMELA CAMPBELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+965,OREON SCOTT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+966,NORMAN POWERS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+967,NORMAN COLBY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+968,NORMA COLBY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+969,NICHOLAS ECONOMOU,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+970,NEAL ROGERS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+971,NANCY WILLIAMS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+972,NANCY HAMSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+973,NANCY FOSS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+974,NANCY ELDER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+975,NANCY DUPONT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+976,NANCY CALDARONE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+977,NANCY BREED,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+978,MITCHELL LEVINE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+979,MIRIAM SULLIVAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+980,MIKE TUMULTY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+981,MICHELENE RYAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+982,MICHAEL PISANI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+983,MICHAEL NEWBERG,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+984,MICHAEL MUSTO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+985,MICHAEL MINAYEV,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+986,MICHAEL MAGLIARO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+987,MERYL SEVINOR,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+988,MEREDITH REARDON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+989,MELODY WORTHY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+990,MELISSA HUMPHREY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+991,MELISSA ELICKER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+992,MAUREEN SPINA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+993,MAUREEN NICKOLAU,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+994,MAUREEN DARCI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+995,MATHEW ANTONIELLO JR,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+996,MARY VALLE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+997,MARY SHAPIRO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+998,MARY MARTIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+999,MARY MARCIA WILLIAMS LORD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1000,MARYLYN JONES-TENTINDO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1001,MARY LEVINE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1002,MARY HALEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1003,MARY ELLEN RANTA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1004,MARY ELLEN HART,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1005,MARY ECONOMOU,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1006,MARY DEVLIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1007,MARY COBBETT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1008,MARY CASSELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1009,MARY BREED,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1010,MARY ANTONIELLO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1011,MARY ANN MILLETT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1012,MARYANN LARACY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1013,MARYANN CRISWELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1014,MARTIN GINSBERG,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1015,MARTHA WOODFIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1016,MARTHA CROCKER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1017,MARTHA  ANDERSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1018,MARLA GEARHEART,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1019,MARK SWEENEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1020,MARK SHAPIRO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1021,MARK PILLSBURY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1022,MARK MILLS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1023,MARK GREENMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1024,MARK FULTON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1025,MARK FADER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1026,MARK DUGAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1027,MARK ATKINS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1028,MARJORIE SLATTERY SUMNER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1029,MARION KEATING,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1030,MARILYN WOLFGRAM,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1031,MARILYN HURWITZ,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1032,MARILYN DOANE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1033,MARILYN DAY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1034,MARILYN BROWN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1035,MARIBETH R BARRELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1036,MARIAN GASKELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1037,MARIA MICHAUD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1038,MARIA LYDON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1039,MARGUERITE WALKER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1040,MARGARET POWERS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1041,MARC DARISSE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1042,MADELON BURES,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1043,MADELEINE CORMIER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1044,LYLE MORGAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1045,LUANN GLABICKY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1046,LUANA LITTLE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1047,LOUIS GEOFFRION,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1048,LOUISE HALEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1049,LORNA VENEZIA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1050,LORI KELLEHER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1051,LOIS MICHELSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1052,LOIS FALLON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1053,LISA QUILLEN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1054,LIONEL LECLERC,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1055,LIONEL ANTHONY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1056,LINDA MAURAIS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1057,LINDA MATTHEWS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1058,LINDA LEVY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1059,LINDA JOLLY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1060,LINDA CARROLL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1061,LINDA CAREY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1062,LINDA BELANGER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1063,LINDA ARST,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1064,LILLIAN BARRY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1065,LESLIE SWEENEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1066,LESLIE GILL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1067,LESLEY JOHNSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1068,LESLEY DEXTER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1069,LEROY MILLETT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1070,LEONARD KAVANAGH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1071,LEONARD ELLIS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1072,LEIGH WEBSTER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1073,LEE ANN FAIRBANKS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1074,LAWRENCE R ROSS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1075,LAWRENCE MURPHY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1076,LAURIE JENKIN-BURT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1077,LAURIE BLAISDELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1078,LAURA NASH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1079,LAURA LOVELY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1080,LARRY SWEAZY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1081,KILMER SWEAZY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1082,KEVIN WILSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1083,KEVIN MURRAY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1084,KEVIN MICHAUD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1085,KEN SWEET,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1086,KENNETH WARREN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1087,KENNETH STOLL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1088,KENNETH STEADMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1089,KENNETH RYDZEWSKI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1090,KENNETH PORTNOY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1091,KENNETH NICKERSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1092,KENNETH KING,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1093,KENNETH BURES,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1094,KENNETH ANDERSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1095,KAY EISENHOWER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1096,KATHY TERPOS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1097,KATHY SMITH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1098,KATHY GALLAGHER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1099,KATHY EDWARDS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1100,KATHY ATTRIDGE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1101,KATHLEEN SNOW,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1102,KATHLEEN ROESER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1103,KATHLEEN HENNESSEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1104,KATHLEEN HARVEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1105,KATHLEEN CROWLEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1106,KATHERINE PIERCE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1107,KATHERINE MILLETT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1108,KARL PERSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1109,KAREN TUCKER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1110,KAREN O'SHAUGHNESSY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1111,KAREN LEHMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1112,KAREN GARRETT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1113,KAREN EDELSTEIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1114,KAREN BOURGEAULT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1115,JULIE MCGINN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1116,JULIANNA MURBER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1117,JUDY LUISE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1118,JUDITH O'LEARY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1119,JUDITH MITCHELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1120,JUDITH HALKS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1121,JUDITH BEAULIEU,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1122,JUDITH BAILEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1123,JUANITA LAMBY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1124,JOY PURDIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1125,JOYCE PREBLE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1126,JOYCE EVANS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1127,JOSEPH HOMAN JR.,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1128,JOSEPH GEANEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1129,JOSEPH COONEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1130,JOSEPH BROPHY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1131,JONATHAN RANDOLPH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1132,JOHN W HAZELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1133,JOHN STOMATUCK,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1134,JOHN SKALABAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1135,JOHN PAYNE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1136,JOHN PALMER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1137,JOHN MCGINN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1138,JOHN JOHNSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1139,JOHN BRADSHAW,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1140,JOHN BLAISDELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1141,JOHN ANDERSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1142,JOAN YOUNGER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1143,JOAN STOMATUK,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1144,JOAN SHERMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1145,JOAN RILEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1146,JOANNE STEADMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1147,JOANNE BRIGGS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1148,JOANNE BRENNAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1149,JOAN KAVANAGH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1150,JOAN CUTLER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1151,JOAN C GEARY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1152,JILL COPPI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1153,JESSICA RANDOLPH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1154,JERILYN MORGAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1155,JEFFREY CLOUGH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1156,JEAN WHITE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1157,JEAN WENTZELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1158,JEAN PLOTKA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1159,JEANNIE ROMBACH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1160,JEANNETTE BAKER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1161,JEAN MACASKILL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1162,JEAN ELDRIDGE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1163,JAY ROBBINS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1164,JANIS MCDONALD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1165,JANINE GLABICKY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1166,JANICE WILSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1167,JANICE STANDLEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1168,JANICE SKALABAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1169,JANICE PELLETIER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1170,JANICE MCLAUGHLIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1171,JANICE MAGNO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1172,JANICE KNOWLES,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1173,JANICE IANNARELLI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1174,JANE TRICOMI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1175,JANET QUIGLEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1176,JANET M SMITH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1177,JANET CASWELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1178,JANET BACH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1179,JANET AUCELLO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1180,JANE GRANT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1181,JANE DANE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1182,JAMES SPINA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1183,JAMES MCDONALD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1184,JAMES LANDERGAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1185,JAMES IVERS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1186,JAMES HAZELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1187,JAMES FARRELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1188,JAMES DEWING,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1189,JAMES CARNEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1190,IRIS ORLEN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1191,IRENE LANDRY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1192,HENRY CURRIER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1193,HELEN TIBBETTS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1194,HELEN DIXEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1195,HELEN COYNE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1196,HEATHER KENT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1197,HARRY ECONOMOU,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1198,HARRIET PAGE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1199,HARRIET NOTTINGHAM,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1200,HAROLD SCHWARTZ,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1201,GREGORY QUILLEN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1202,GREGORY LORD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1203,GREGORY BURT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1204,GREG DANA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1205,G PAUL DULAC,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1206,GORDON MCLEAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1207,GERARD RIENZO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1208,GERALD ORLEN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1209,GERALD GRANT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1210,GEORGE SNOW,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1211,GEORGE GEARHART,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1212,GEORGE CONNOLLY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1213,GEORGE BONTAITES,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1214,GEORGE BARKER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1215,GAYLE STOLL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1216,GAYLE LOUISOS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1217,GARY MICHELSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1218,GARY EISENHOWER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1219,GARY BARTLETT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1220,FREDERIC DEXTER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1221,FRANK MONAHAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1222,FRANK LORD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1223,FRANCIS GRAY JR,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1224,FRANCIS GLAVIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1225,FRANCES BURRIDGE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1226,FOSTER SOULE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1227,EVELYN ELLIS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1228,ETHAN DEXTER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1229,ESTHER LARIOS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1230,ERIK NATTI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1231,ENID WOOD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1232,EMERSON GRAVES,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1233,ELLIOT EDELSTEIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1234,ELLEN M DRUMMOND,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1235,ELLEN MCKINNON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1236,ELLEN FINN-WELCH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1237,ELLEN CAMERON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1238,ELLEN BECKER-GRAY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1239,ELIZABETH WARREN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1240,ELIZABETH MCCOLLUM,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1241,ELIZABETH LEAVITT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1242,ELIZABETH KING,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1243,ELIZABETH DIXEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1244,ELIZABETH DAWES,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1245,ELIZABETH CHARBONNIER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1246,ELIZABETH BAKER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1247,ELENA MINAYEVA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1248,ELAINE MAGLIARO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1249,EDWARD WALIACKAS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1250,EDWARD ROMBACH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1251,EDWARD FUTCHER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1252,EARLE BROWN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1253,EARL BETHUNE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1254,DULCE WILLIAMSON JENKINS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1255,DRUEDELL HALL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1256,DR PHILIP DEVAUX,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1257,DOUGLAS W SAAL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1258,DOUGLAS PROTO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1259,DOUGLAS GORDON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1260,DOUG BATES,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1261,DONNA ZAESKE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1262,DONNA SINCLAIR,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1263,DONNA POPPEL - NOVEMBER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1264,DONNA LAUSIER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1265,DONNA CAREY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1266,DONALD KELLY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1267,DONALD HUMPHREY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1268,DONALD DENNIS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1269,DONALD DECKER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1270,DONALD BRENNAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1271,DIANNE MCCARTHY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1272,DIANE LEVINSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1273,DIANE GLAVIN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1274,DIANE DALFERRO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1275,DIANE CURRAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1276,DENNIS O'NEIL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1277,DENISE MUSTO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1278,DEBRA LONG,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1279,DEBRA GEANEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1280,DEBORAH PERSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1281,DEBORAH PAPPS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1282,DEBORAH MCNULTY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1283,DEBORAH HAZELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1284,DEBORAH HASKELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1285,DEBORAH FRONGILLO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1286,DEBORAH FADDEN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1287,DEBORAH CROKE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1288,DEBORAH ANTONUCCI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1289,DEARA BARTLETT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1290,DAWN MURRAY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1291,DAVID SHAW,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1292,DAVID RODGERS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1293,DAVID PREMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1294,DAVID MILLETT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1295,DAVID MCKINNON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1296,DAVID HOOKS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1297,DAVID ELDER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1298,DAVID DONAHUE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1299,DAVID ADDIS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1300,DARCIS PARKSIDE INN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1301,DAN WILLIAMS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1302,DANIEL ROADS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1303,DANA RICHARDSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1304,DANA KIERNAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1305,DANA CAMPBELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1306,DALE NICHOLSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1307,CRAIG SAGER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1308,CONSTANCE HAZELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1309,CONSTANCE COONEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1310,CONSTANCE A ROSS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1311,C MICHAEL LANE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1312,CLIFFORD SMITH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1313,CLAUDETTE SOULE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1314,CLARA HASTINGS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1315,CLAIRE NICKERSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1316,CHRISTOPHER ROPER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1317,CHRISTOPHER G BUTLER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1318,CHRISTOPHER BERG,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1319,CHRISTINE SHERWOOD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1320,CHRISTINE KROM,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1321,CHRISTINE EVANS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1322,CHRISTINE ALLEN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1323,CHRISTIE GETZ,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1324,CHERYL WOLFF-VARIAM,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1325,CHERYL KRITEMAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1326,CHERYL CONRAD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1327,CHARLOTTE TOWLE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1328,CHARLOTTE CARLSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1329,CHARLES THOMAS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1330,CHARLES R MCCOLLUM,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1331,CHARLES QUIGLEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1332,CHARLES NEWHALL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1333,CHARLES MORGAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1334,CHARLES MAURAIS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1335,CHARLES MANEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1336,CHARLES D SINCLAIR,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1337,CHARLES CODY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1338,CHARLES CAREY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1339,CHARLES ANDERS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1340,CHARLES ALLEN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1341,CELIA GATCHELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1342,CATHERINE PROTO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1343,CATHERINE JAMIESON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1344,CATHERINE GAZZOLA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1345,CATHERINE CULHANE-HERMANN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1346,CATHERINE CASTOLDI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1347,CAROLYN KNIGHT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1348,CAROL REAGAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1349,CAROL JOHNSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1350,CAROL HASKELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1351,CAROL GRAY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1352,CAROLE BAKER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1353,CAROL APRIL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1354,CAROLAN PAGE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1355,CAROL ANDERSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1356,CARMEN DARISSE,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1357,CALVIN POWERS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1358,BRYN EVANS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1359,BRUCE SMITH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1360,BRUCE MARSTON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1361,BRUCE COLLINS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1362,BRUCE BUCKLEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1363,BRIAN OTA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1364,BRIAN FUMAROLA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1365,BRIAN DRUMMOND,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1366,BRIAN CROWLEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1367,BRET GIFFORD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1368,BRENDA PERRONI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1369,BRENDA MINOR,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1370,BRADLEE CAREY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1371,BRADFORD R SMITH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1372,BETSY GAY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1373,BENJAMIN AYER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1374,BARRY DIXEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1375,BARBARA WESTON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1376,BARBARA THOMAS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1377,BARBARA TAVERNA - DENNIS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1378,BARBARA SCHWARTZ,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1379,BARBARA PERRY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1380,BARBARA PEACH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1381,BARBARA LONERGAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1382,BARBARA KULEVICH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1383,BARBARA KIERNAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1384,BARBARA KELLEY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1385,BARBARA HOWARD,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1386,BARBARA HAWLENA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1387,BARBARA GRANT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1388,BARBARA COLLINS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1389,BARBARA BELLLUCCI,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1390,ARTHUR G GRAVES,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1391,ARLENE WILSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1392,ARLENE ADDIS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1393,ARIE GUTHARTZ,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1394,ANTHONY SHEA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1395,ANTHONY SASSO,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1396,ANN WRIGHT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1397,ANN WORRICK,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1398,ANN LYNESS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1399,ANNE STEPHENSON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1400,ANNE SCOTT,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1401,ANNE ROBBINS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1402,ANNE M GERAGHTY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1403,ANNE LYONS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1404,ANNE KHATCHADURIAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1405,ANNE HAMILTON,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1406,ANNE BONTAITES,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1407,ANN DAVIS-ALLAN,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1408,ANITA DANA,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1409,ANITA ANTHONY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1410,ANDREW LOVELY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1411,ANDREA PORTNOY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1412,ALLEN GASKELL,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1413,ALLEN BREED,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1414,ALISON MURRAY,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1415,ALICE DOW,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1416,ALEXIS KRITIKOS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1417,ALEXANDER KULEVICH,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1418,ALAN NOVEMBER,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1419,ALAN MARAVELIAS,1194.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1420,DYNAMIC WASTE SYSTEMS INC,1181.76,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1421,GREENWOOD PUBLISHING GROUP,1178.97,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1422,POWER 3 COMMUNICATION LLC,1172.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1423,SAMUEL FRONTERO,1150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1424,PICKET FENCES INC,1150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1425,MARK TENTINDO,1150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1426,JOSHUA NORMAN,1150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1427,JOSEPH D GRAY,1150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1428,JEFFREY K GREENBERG,1150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1429,DOUGLAS KNOWLES,1150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1430,CHARLES SPRAGUE,1150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1431,CHARLES P CERRUTTI,1150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1432,BRENT TARASUIK,1150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1433,ARTHUR BOARDWAY,1150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1434,W B HUNT CO,1145.82,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1435,THOMAS MASSARO,1135.20,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1436,TCA SOLUTIONS INC,1115.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1437,MIH SYSTEMS GROUP LLC,1115.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1438,SAYBROOKE ENVIRONMENTAL &,1104.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1439,MAESTRANZI BROS,1104.34,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1440,QUILL INC,1100.95,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1441,"PROJECTDOG, INC",1095.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1442,JULIE SURETTE,1095.16,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1443,CAROL NEUMANN,1095.16,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1444,READING WITH TLC,1091.01,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1445,KEVIN D DILLON,1086.05,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1446,HESTIA,1076.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1447,J P COOKE COMPANY,1074.19,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1448,SHIRA DRAGUN,1070.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1449,"URGENT CARE OPERATIONS, PC",1068.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1450,SCHEDULES PLUS LLC,1060.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1451,SOTER TECHNOLOGIES LLC,1050.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1452,EBSCO INFORMATION SERVICES,1049.66,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1453,MASSACHUSETTS COMPUTER USING EDUCATORS INC,1045.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1454,ENCORE IMAGES INC,1026.77,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1455,BLUETRITON BRANDS INC,1017.97,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1456,NE VOICES INC,1015.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1457,MASS AUDUBON SOCIETY INC,1010.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1458,EAST COAST COMPACTOR CORP,1007.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1459,WILLIAM BOARDWAY,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1460,TODD BURT,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1461,TIMOTHY CRONIN,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1462,SCOTT MARTIN,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1463,RICHARD EHLERT,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1464,PATRICK ATTRIDGE,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1465,MICAH ALDEN-DANFORTH,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1466,MATTHEW TINA,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1467,MATTHEW LUNT,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1468,MATTHEW G CHRISTENSEN,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1469,MARK BARCAMONTE,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1470,LOUISE MOORE-EVERY LITTLE BREEZE CATER,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1471,LIAM GILLILAND,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1472,KRAIG M HILL,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1473,JOSEPH THIBODEAU,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1474,JOHN MORRIS,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1475,JEREMY GILLIS,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1476,JASON GILLILAND,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1477,JAMES HORGAN,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1478,GREGORY T LYDON,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1479,GRANT GLAVIN,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1480,ERIC VERHAULT,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1481,ERIC M RIDGE,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1482,ERIC GLEDHILL,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1483,DAWN LIVIGNE,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1484,BROOKLINE COMMUNITY MENTAL HEALTH CENTER,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1485,AIDAN GILLIS,1000.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1486,TOWN OF SWAMPSCOTT,1000.48,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1487,SWAY MEDICAL INC,997.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1488,THRIFTCO,996.20,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1489,JIM RICHARDS,995.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1490,ROY BRINDAMOUR,995.60,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1491,DIANE DEWING,995.60,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1492,CAROLE BRINDAMOUR,995.60,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1493,THOMAS S KLISE COMPANY,992.35,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1494,EILEEN D'AMOUR,990.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1495,UNITED RENTALS OF N AMERICA,983.15,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1496,ALLIED EQUIPMENT LLC,981.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1497,JONI THAYER,966.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1498,BRAND CO INC,944.12,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1499,TRANE US INC,930.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1500,NASSP,925.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1501,AGGANIS ARENA TICKET OFFICE,925.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1502,SCHOOL NUTRITION ASSOCIATION,915.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1503,VANGUARD ID SYSTEMS,915.04,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1504,STONE & BERG COMPANY INC,910.30,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1505,HARCOURT BINDERY LLC,906.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1506,UNIVERSAL ENVIRONMENTAL CONSULTANTS,900.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1507,ST.JOHNSBURY ACADEMY,900.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1508,MA ASSOCIATION OF PUPIL TRANSPORTATION INC,900.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1509,THE TRUSTEES OF THE RESERVATION,897.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1510,"SRSD ONLINE, INC",897.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1511,G & L LAB INC,897.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1512,FLORENCE GARRITY,896.04,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1513,NETS,895.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1514,NEW ENGLAND WATER ENVIRONMENT ASSOC,888.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1515,TODD LARAMIE,888.67,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1516,NICHOLAS FAGONE,884.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1517,BRAKE & TRUCK SUPPLY INC,884.98,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1518,PENNYWORTH'S INC,879.92,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1519,PLOTBOX INC,864.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1520,KIMBERLY GRAD,859.51,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1521,BOSTON FIRE EXTINGUISHER CO,857.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1522,MASS ASSOCIATION OF CONSERVATION COMMISSIONS,850.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1523,JM MASS MOBILE STICKERS CORP,850.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1524,TW TECH SYSTEMS,844.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1525,ATLANTIC GRAPHICS,840.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1526,THATCHER W KEZER III,840.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1527,CONVERGEONE INC,839.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1528,NORTH SHORE MEDICAL CENTER,835.46,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1529,RELIANT MEDICAL GROUP INC,819.39,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1530,MARK SOUZA,819.45,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1531,STEPHEN CUMMINGS,812.69,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1532,METCO DIRECTORS ASSN,800.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1533,FOX PAINTING CO INC,800.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1534,PSYCHOLOG ASSESSMENT RESOURCES,797.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1535,EDUCERE LLC,797.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1536,JAMES M SHAY,796.48,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1537,CINDY SNOW,796.48,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1538,ANNE MARIE SHAY,796.48,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1539,SUMMA HUMMA ENTERPRISES LLC,793.96,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1540,BOOKPAGE,792.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1541,AUNT FLOW CORP,788.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1542,DASH DRAINS LLC,765.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1543,CONTINUED.COM LLC,763.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1544,BENJAMIN CRAVEN,761.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1545,DAVID M WOLF,758.05,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1546,CATALDO AMBULANCE SVC INC,758.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1547,LARISA FORMAN,757.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1548,NATIONAL EMERGENCY NUMBER ASSOCIATION,750.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1549,BRENDON F. GRAFFUM,750.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1550,SALEM PRESS,747.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1551,CO EYEWEAR,745.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1552,PLAYAWAY PRODUCTS LLC,743.88,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1553,MURPHY'S WASTE OIL SERVICE INC,742.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1554,MINUTEMAN PRESS,736.11,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1555,ACADEMIC THERAPY PUB/HIGH NOON BKS,728.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1556,INTERNATIONAL ASSOCIATION OF CHIEFS OF POLICE,720.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1557,CHRIS HOLAK,719.66,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1558,WALL STREET JOURNAL,719.88,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1559,JASCO ELECTRIC INC,713.04,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1560,"SPRINGSHARE, LLC",709.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1561,ADA TENNIS,708.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1562,COLIN COLEMAN,703.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1563,KEVIN FIGUERA,700.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1564,ESSEX COUNTY ASSESSORS ASSOC,700.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1565,WORLD BOOK INC,696.15,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1566,SUSAN W THORNTON,696.92,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1567,ROBERT LEMIEUX,696.92,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1568,PAUL CAMARDA,696.92,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1569,MICHAEL A PORTER,696.92,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1570,JOHN RAVAGNO,696.92,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1571,GAIL DAVIDSON,696.92,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1572,DAWN NOONAN-RAVAGNO,696.92,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1573,DELVENA THEATRE COMPANY,695.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1574,ROCHESTER 100 INC,693.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1575,GREAT AMERICAN BUSINESS PRODUC,693.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1576,"REXEL USA, INC",689.64,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1577,"U MASS MEMORIAL HEALTH CARE, INC",688.13,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1578,KRISTIN XIARHOS,684.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1579,ANDERSON STREET AUTO BODY INC,684.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1580,"NOODLE TOOLS, INC",675.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1581,"WHENTOWORK, LLC",666.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1582,DANVERSPORT YACHT CLUB MARINA LLC,666.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1583,ROSEN PUBLISHING GROUP,662.54,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1584,"ORIGO EDUCATION, INC",660.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1585,PEABODY POLICE DEPT / CITY OF PEABODY,657.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1586,DENNIS KING,654.07,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1587,"GIMKIT, INC",650.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1588,NORTH SHORE MAGNETIC IMAGING,646.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1589,DISCOVERY EDUCATION INC,643.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1590,SWANK MOTION PICTURES INC,640.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1591,POWER PRODUCTS,635.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1592,TAKKT AMERICA HOLDINGS,634.15,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1593,TIME LLC,632.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1594,AXON ENTERPRISE INC,628.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1595,JOHN'S SEWER & PIPE CLEANING INC,625.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1596,GILMAN GEAR,625.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1597,RYAN P BOISVERT,600.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1598,RC CLEANING SPECIALISTS INC,600.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1599,MARGARET P HOUGHTON,600.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1600,"KEEPER SECURITY, INC",600.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1601,CAROL KUSINITZ,600.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1602,"ARRAYSCAPE GAMING, INC",600.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1603,ADAM SABLICH,600.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1604,VOSS SIGNS LLC,597.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1605,SERVICE PUMPING & DRAIN COMPANY,590.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1606,FOLLETT CONTENT SOLUTIONS LLC,587.76,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1607,DESIGN SCIENCE INC,582.24,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1608,CENTRAL PRINTING CORPORATION,581.21,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1609,KRAFT POWER CORPORATION,581.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1610,"CNHI, LLC",580.45,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1611,FUN EXPRESS LLC,579.32,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1612,FEDERATION FOR CHILDREN,575.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1613,BOSTON FIRE SYSTEMS INC,575.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1614,SHEFFIELD POTTERY INC,572.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1615,CAPSTONE GLOBAL LIBRARY LLC,568.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1616,MASS GENERAL PHYSICIANS ORG,563.08,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1617,BOSTON GLOBE ADVERTISING,561.02,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1618,MATTHEW MANFREDI,556.72,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1619,ADVANTAGE ARCHIVES LLC,555.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1620,JOHN RAGUSA,554.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1621,AMERICAN ASSOCIATION OF TEACHERS OF FRENCH,553.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1622,WEX BANK,551.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1623,VRS DISABILITY MANAGEMENT INC,551.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1624,STEPHANIE K. GREEN,550.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1625,MATTHEW PATTERSON,547.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1626,PEABODY ESSEX MUSEUM,539.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1627,NICHOLAS MICHAUD,531.83,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1628,KEITH TORGAN,525.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1629,BENJAMIN LEBOWITZ,524.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1630,JONATHAN MORLEY,524.94,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1631,ADAM BERNARD,517.37,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1632,DXE MEDICAL INC,509.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1633,INFORMATION TODAY INC,502.53,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1634,THE MA EDUCATIONAL THEATER GUILD INC,500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1635,SUSAN E KORNFIELD,500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1636,STEVEN WHITEHURST,500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1637,OLGA VOYTAZH,500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1638,MATTHEW HEATON,500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1639,MATHEW ARNOLD,500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1640,MASS WATER WORKS ASSOC INC,500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1641,MASS BAY SKI LEAGUE EAST,500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1642,MARBLEHEAD TRADING CO,500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1643,JOSEPH DIPOLI,500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1644,FIRE CHIEFS ASSOC OF MA INC,500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1645,BRENDAN FINNEGAN,500.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1646,ROGER ENNIS JR,499.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1647,JOHN S MARTIN CO INC,497.06,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1648,HOLLY FADER,497.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1649,SCOTT WILLIAMS,489.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1650,JOSE ACOSTA,484.20,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1651,NEXT-GEN SUPPLY GROUP INC,481.21,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1652,ATLANTIC VETERINARY HOSPITAL,480.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1653,FSP BOOKS INC,478.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1654,KELLY FORD,475.16,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1655,"TEACHER INNOVATIONS, INC",468.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1656,PATRICIA M PETERSON,467.70,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1657,WI SCTF,459.08,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1658,AIREX FILTER CORPORATION,454.64,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1659,NATIONAL ASSOCIATION OF SCHOOL RESOURCE OFFICERS,450.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1660,LINDSEY KRAVITZ,450.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1661,CHRIS MIHALI,450.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1662,ASCAP,450.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1663,ABDO PUBLISHING COMPANY,449.05,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1664,NATIONAL ASSOCIATION FOR MUSIC EDUCATION,447.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1665,"BROWN INDUSTRIES, INC",447.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1666,ASI ASSOCIATES INC,447.29,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1667,SARAH VUONA,445.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1668,VERIZON CENTREX,443.97,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1669,ASSOCIATION OF TOWN FINANCE COMMITTEES,442.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1670,SCHOOL OUTFITTERS,438.56,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1671,JONATHAN FOBERT,437.89,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1672,PAST PERFECT SOFTWARE,432.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1673,FLAT ROCK CREATIVE,432.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1674,AMY KOSTECKI,432.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1675,PJF CAPITAL CORP,425.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1676,MARBLEHEAD GARDENS INC,425.97,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1677,JANE WOLFF,424.56,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1678,PORTLAND POTTERY SUPPLY,418.38,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1679,JAGUAR GRAPHICS INC,414.03,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1680,HIGHLAND HARDWARE INC,413.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1681,DOYLE SAILMAKERS INC,412.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1682,JANET BARNET,408.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1683,GINA HART,405.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1684,"WORK 'N GEAR, LLC",403.84,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1685,KENNETH KILMAIN,402.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1686,SHERWIN - WILLIAMS,401.89,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1687,DEBBIE LAFLAMME,400.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1688,SUSAN SHATFORD,400.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1689,GINA SEMPLE,400.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1690,MUNISSION LLC,399.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1691,MARY ORNE,398.24,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1692,MARTHA MANEY,398.24,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1693,LINDA MILLS,398.24,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1694,KEVIN NEUMANN,398.24,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1695,EDMUND DAWES,398.24,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1696,DANA ANDREWS,398.24,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1697,UPCODE INC,396.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1698,KARA GALLAGHER - PETTY CASHIER,393.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1699,APCO INTERNATIONAL INC,391.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1700,US DEPARTMENT OF THE TREASURY,382.68,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1701,MICHAEL LAVENDER,378.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1702,SWEET CONTRACTING CORP,375.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1703,POP UP ART SCHOOL INC,375.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1704,MASS COLLECTORS & TREAS ASSOC,375.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1705,MICHAEL LAROCHELLE,370.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1706,PROJECT ADVENTURE INC,370.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1707,DAVID KILPATRICK INC,360.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1708,COMMONWEALTH POLICE LEGACY INC,358.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1709,LOWELL PUBLISHING COMPANY,354.84,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1710,PETER F MUISE,350.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1711,PELHAM HIGH SCHOOL,350.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1712,MT HOPE HIGH SCHOOL BOOSTERS CLUB,350.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1713,MICHAEL A SARASIN,350.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1714,MASS GENERAL BRIGHAM COMMUNITY PHYSICIANS INC,350.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1715,GLTS  GREATER LAWRENCE REG VOC TECH. HS DISTRICT,350.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1716,FIRST LIGHT LIMO LLC,350.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1717,DENNIS PULEO,350.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1718,CARRIE ANNE TOOHEY,350.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1719,ANDY COUSENS INC,350.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1720,360 DETAILING INC,350.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1721,DIVAL SAFETY EQUIPMENT,350.65,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1722,MEAGHAN KALPIN,348.56,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1723,KRIS W BEHSMAN,347.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1724,LITERACY RESOURCES LLC,347.12,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1725,DOUGHBOY UNIFORMS,345.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1726,MCI COMMUNICATION SERVICES,343.05,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1727,WALMART COMMUNITY CREDIT CARD,343.83,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1728,LAW ENFORCEMENT DIMENSIONS LLC,340.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1729,BEN'S UNIFORMS,340.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1730,JUSTIN BOUTWELL,339.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1731,HARMELING PHYSICAL THERAPY,339.05,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1732,TYLER SLEPOY,338.19,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1733,IKON OFFICE SOLUTIONS,336.89,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1734,JUSTIN DOUCETTE,330.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1735,AMERICAN INS SVC GROUP,330.30,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1736,SEASIDE PLUMBING & HEATING INC,327.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1737,CITY OF NEWBURYPORT,325.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1738,ARCADIA PUBLISHING,324.87,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1739,BEATRICE STAHL,318.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1740,STEVE WEISS MUSIC INC,318.95,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1741,MBTA TRANSIT POLICE ACADEMY,315.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1742,LEAH BORDIERI,315.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1743,RACHEL LEES,314.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1744,JASON MCDONALD,313.48,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1745,HUNTER NOLDIN,312.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1746,JENNIFER MANGINI,311.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1747,THERESA DULONG,309.27,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1748,SOLAR THINGS INC,304.04,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1749,CHICAGO DISTRIBUTION CENTER,304.69,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1750,JODI HOPPER,303.94,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1751,WAKEFIELD MUNICIPAL GAS & LIGHT DEPT,300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1752,MATTHEW A ABRAHAMS,300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1753,MARBLEHEAD IMAGES,300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1754,JON WATERMAN,300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1755,GLOCK PROFESSIONAL INC,300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1756,EASTERN MA MUNICIPAL AUDITOR'S AND ACCOUNTANT,300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1757,CLAIRE KEYES,300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1758,CHARLES BECKER,300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1759,CARYL BEISON,300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1760,BOB GREEN,300.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1761,NAPA AUTO PARTS,300.26,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1762,MICHAEL KEATING,298.68,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1763,MARYANN PERRY,298.68,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1764,KATHLEEN BISHOP,298.68,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1765,DALE BISHOP,298.68,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1766,MAP OF THE MONTH,288.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1767,HENRY CHRISTENSEN,287.97,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1768,VILLAGE MOTORS NORTH INC,284.66,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1769,GREENNET,278.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1770,RR DONNELLEY & SONS COMPANY,276.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1771,"MASSACHUSETTS MUNICIPAL HUMAN RESOURCES, INC",275.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1772,AMERICAN ASSOC OF SCHOOL PERSONNEL ADMINISTRATORS,275.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1773,NEW ENGLAND HISTORIC GENEALOGICAL SOCIETY,270.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1774,MARBLEHEAD SPORT SHOP,270.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1775,INTERNATIONAL ASSOCIATION OF FIRE CHIEFS,268.33,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1776,MAGGIE WHEELER,265.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1777,MLS PROPERTY INFORMATION NETWORK INC,261.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1778,UPS STORE #0630,261.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1779,AMERICAN EAGLE CO,260.91,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1780,LINCOLN LIBRARY PRESS INC,259.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1781,MAG RETAIL HOLDINGS - FBV LLC,259.18,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1782,CROWN TROPHY,259.35,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1783,DIAHANNE RUBANO,257.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1784,SCHOOL TRANSPORTATION ASSOCIATION OF MASSACHUSETTS,250.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1785,SALTWATER BOOKSTORE LLC,250.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1786,RANDY STILES,250.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1787,POLICE EXECUTIVE RESEARCH FORUM,250.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1788,NICK A ZIANO III,250.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1789,MASS VETERANS SERVICE AGENTS ASS INC,250.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1790,GLENN DAVISON,250.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1791,BRAD TIMM,250.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1792,"JOSTENS, INC",250.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1793,PT UNITED LLC,249.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1794,LORD MATH EDUCATION LLC,247.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1795,ARROWHEAD SCIENTIFIC INC,242.83,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1796,UNIVERSITY OF MAINE SYSTEM INC,240.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1797,MARSHALL MEMO LLC,240.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1798,MA MUNICIPAL AUDITORS & ACCOUNTANTS ASSOCIATION IN,240.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1799,KUYPERS CONSULTING INC,240.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1800,COUNTY OF PLYMOUTH,239.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1801,SEAN SWEENEY JR,235.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1802,"GATEHOUSE MEDIA MA, INC",234.69,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1803,JAMES KENT WHEELER,232.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1804,ANDREA BUNDE,231.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1805,MORNINGSTAR,230.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1806,BROOKLINE MACHINE CO INC,230.26,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1807,GANDER PUBLISHING,230.67,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1808,ROBERT G REDFERN,229.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1809,CLIFTON LUTHERAN CHURCH,228.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1810,NFPA,225.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1811,MAPPO,225.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1812,DANIEL F HARRINGTON,225.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1813,AMY GILLILAND,224.70,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1814,WATER ENVIRONMENT FEDERATION,223.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1815,REBECCA PICKER,220.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1816,DOUGLAS K LECOLST,220.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1817,WS DARLEY & CO,220.42,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1818,REGINALD KERNIZAN,219.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1819,ASHA,218.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1820,KING GAGE ENG CORP,218.44,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1821,SHARON DOLIBER,218.94,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1822,ARCO WELDING SUPPLY CO INC,217.91,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1823,DEBORAH LEAHY,216.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1824,MIDWEST VETERINARY SUPPLY INC,215.75,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1825,AMAZON,214.25,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1826,GRIZZLY INDUSTRIAL INC,210.17,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1827,COX SUBSCRIPTIONS INC,210.68,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1828,MATTHEW STOKES,209.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1829,NILSSON-SIDAN ASSOCIATES,207.82,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1830,SOCIAL STUDIES SCHOOL SERVICE,206.98,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1831,JOSEPH SNOW,205.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1832,WENDY RIVAS,200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1833,TATIANA GALANHI,200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1834,NAYELI-NIKOLE MIRANDA PENA,200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1835,MICHELLE BERGERON,200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1836,MASS HOCKEY COACHES ASSOCIATION INC,200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1837,MASSACHUSETTS BAR INSTITUTE,200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1838,LEXINGTON YOUTH LACROSSE INC,200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1839,KAREN MURPHY,200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1840,JAMES DOUGLASS,200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1841,GRAFTON LEE HAMILTON,200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1842,FRED FORSGARD,200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1843,DAVID SPINALE,200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1844,CHERYL FITZGERALD,200.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1845,TOBII DYNAVOX LLC,199.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1846,WILLIAM M DOW,199.12,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1847,CHRISTOPHER PHILLIPS,199.12,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1848,VLADIMIR LIKHTERMAN,199.92,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1849,MESERET TEFERA,199.98,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1850,LAKESHORE EQUIPMENT COMPANY,197.92,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1851,THE F.A. BARTLETT TREE EXPERT COMPANY,195.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1852,FRANCISCO URENA,195.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1853,NANCY WHIPPLE,189.96,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1854,ABBEY DION,188.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1855,CHRISTOPHER MURRAY,187.49,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1856,STEVEN MOODY,186.36,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1857,STAPLES,185.32,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1858,AMERICAN SCHOOL COUNSELOR ASSOCIATION,184.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1859,STORE SUPPLY WAREHOUSE,183.73,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1860,JEFFREY MASKELL,180.30,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1861,EMILY DEGRANDE,180.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1862,FRENSIS PANO,178.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1863,AMERICAN WATER WORKS,172.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1864,SUSAN FISCHER,160.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1865,ACTFL,158.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1866,NORFOLK POWER EQUIPMENT INC,157.44,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1867,SQUARE INC,157.46,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1868,THE DURKIN COMPANY INC,151.84,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1869,WHISPERING MEADOWS CORP,150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1870,NESPIN,150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1871,MASS ASSOC OF HEALTH BOARDS,150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1872,"MARBLEHEAD MOVERS, LLC",150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1873,AVCOM INC,150.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1874,STATE UNIVERSITY OF IOWA,149.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1875,ANDREW PETTY,148.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1876,ADAM MASTRANGELO,147.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1877,SALVATORE CURIALE,144.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1878,MICHAEL T LOUIZOS,144.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1879,MICHAEL ATKINS,144.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1880,WARD'S NATURAL SCIENCE,144.08,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1881,JAMES JOHNSON,139.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1882,ZIP'S TRUCK EQUIPMENT INC,136.89,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1883,VALLEY REGIONAL HOSPITAL,134.08,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1884,MERCO MARINE INC,134.27,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1885,VIKTORIJA BABRAUSKAITE,133.59,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1886,MICHELE CARLSON,133.89,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1887,JAN DEPAOLO,131.30,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1888,SHANNON N ABEL,130.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1889,CHARLES WOOD DBA DEPRECIATIONWORKS,129.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1890,EQUIPMENT EAST LLC,128.57,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1891,COREY SMITH,126.68,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1892,CHRIS M COMEAU,125.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1893,HARVARD VANGUARD MEDICAL ASSOC,124.53,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1894,THE LIBRARY STORE,123.49,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1895,JANET PANDOLFO,120.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1896,FISHER SCIENTIFIC EDUC MAT DIV,119.60,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1897,"MEDICAL PRIORITY CONSULTANTS, INC",118.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1898,ZEP MANUFACTURING CO,114.41,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1899,LUZ ACOSTA BAEZ,111.45,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1900,LEANDRO DIFILIPPO,111.62,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1901,MICHAEL LINATOPI,109.95,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1902,STACEY SHANE LLOYD,108.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1903,THOMAS HONAN,100.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1904,ROSEANN TRIONFI-MAZZUCHELLI,100.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1905,RICHARD AUGULEWICZ,100.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1906,NORTHEAST ARC,100.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1907,LOGAN CASEY,100.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1908,JOHN SQUIRES,100.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1909,CONNOR RYAN,100.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1910,DONNA COTTERELL,100.26,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1911,MARY KATE FINN,99.56,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1912,USABLUEBOOK,99.98,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1913,AMERICAN ASSOCIATION FOR STATE AND LOCAL HISTORY,98.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1914,VEX ROBOTICS INC,97.78,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1915,MEDICALESHOP INC,96.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1916,"NORTH SHORE EAR, NOSE & THROAT",95.74,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1917,"BAILEY'S TEST STRIPS & THERMOMETERS,LLC",93.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1918,AFFIRMED MEDICAL CORPORATION,90.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1919,MASS GENERAL HOSPITAL,87.36,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1920,ANDREW DIMARE,85.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1921,TERRY TAURO,83.08,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1922,EDWARD MEDEIROS,81.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1923,CREATIVE SHAPES ETC LLC,79.34,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1924,AMY MCHUGH,79.34,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1925,LANGUAGE LINE SERVICES INC,79.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1926,MEGAN MILAN,78.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1927,ZIPGRADE LLC,76.89,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1928,MASSACHUSETTS GOVERNMENT FINANCE OFFICERS ASSOC,75.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1929,CRYSTAL SPRINGS,72.32,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1930,HARVARD MEDICAL FACULTY PHYSICIANS AT BETH ISRAEL,67.82,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1931,KRISTIN MORELLO,66.93,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1932,KB INDUSTRIES INC,64.33,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1933,POLLY BENSON,64.80,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1934,BRIAN WARE,59.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1935,KRISTEN RUSSETT,59.88,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1936,NATIONAL ACADEMIES OF EMERGENCY DISPATCH,55.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1937,ISABEL DENHAM,54.93,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1938,STEPHEN ALMQUIST,50.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1939,RACHELLE BRUZZESE,50.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1940,FRIENDS OF THE WAYLAND PUBLIC LIBRARY,50.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1941,DAVID RIVERA,50.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1942,SHELLEY BURNS,46.40,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1943,CENTRAL FLORIDA YAMAHA INC,46.50,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1944,GRACENOTES LLC,45.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1945,MATTHEW CRONIN,43.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1946,MICHAEL MARSTERS,42.88,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1947,JAMESON HARE,42.88,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1948,MERJ INC,40.55,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1949,BOTTOM LINE PERSONAL,39.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1950,BRADFORD SMITH,39.90,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1951,COLLABORATIVE SUMMER LIBRARY PROGRAM,39.95,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1952,COLLEEN KING,36.56,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1953,NORTH SHORE GUIDANCE DIRECTOR'S ASSOCIATION,35.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1954,FITNESS MASTERS INC,35.41,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1955,MARBLEHEAD VILLAGE MARKET,35.89,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1956,COOK'S ILLUSTRATED,35.95,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1957,JAE GUTTADAURO,35.99,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1958,KENNETH ROMERO,26.95,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1959,CROSBY'S MARKET,23.98,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1960,WILLIAM ROSS,15.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1961,EXPRESS SCRIPTS INC,10.87,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1962,TRACY GIARLA,7.30,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1963,"TEACHERS AS SCHOLARS, INC",0.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1964,STEVE BURDEAU,0.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026
+1965,COUNCIL OF ADMINISTRATORS OF SPECIAL EDUCATION,0.00,FY2026,2025-07-01,2026-04-17,2026-04-17,https://townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json?child_entity=vendor&year=2026


### PR DESCRIPTION
## Summary

- Adds `data/open_finance_vendor_payments_FY26_snapshot_2026-04-17.csv`: all 1,965 vendors paid by the Town in FY26 through 2026-04-17, with cumulative dollars each. Total $84,709,576.43 matches the Open Finance portal headline.
- Adds a matching entry in `data/DATA_CATALOG.md` with the source URL, caveats, and confidence note.

## Why this vs. what we already have

The Town-operated [Open Finance portal](https://townofmarblehead-ma-of.finance.socrata.com) (Tyler/Socrata, fed from MUNIS, updated daily) exposes three explorers: Revenue Budget, Adopted Budget, and vendor-level Checkbook. The first two are redundant with `FY26_General_Fund_Budget.xlsx` and the FY27 Proposed Budget PDF. **Vendor-level checkbook data is the one piece we didn't already have** — this PR captures it.

## Key caveats (all reflected in the catalog entry)

- Unaudited running data, not ACFR. Do not use for historical trends.
- Tax-funded and enterprise-fund spending mixed together: Berkshire Wind ($11.80M, rank 2) is Municipal Light Department power purchasing, ratepayer-funded, not tax-supported.
- "Commonwealth of MA" ($15.94M, rank 1) aggregates unrelated state assessments (MBTA, charter tuition, state retirement, etc.) — use the Cherry Sheet for the breakdown.
- Spending portal covers FY26 only; earlier years return $0. For multi-year trends this file is insufficient.

## Editorial language

The caveat paragraph in `DATA_CATALOG.md` is worth a read — I tried to state facts without framing. Happy to soften/tighten any wording that reads as leading.

## Test plan

- [ ] `head data/open_finance_vendor_payments_FY26_snapshot_2026-04-17.csv` shows the provenance columns (`fiscal_year`, `coverage_start`, `coverage_end`, `snapshot_date`, `source_url`) on every row.
- [ ] Sum of `amount_ytd_usd` column equals $84,709,576.43 (matches portal headline).
- [ ] `DATA_CATALOG.md` renders on the live site preview with the new entry properly formatted.