### PR TITLE
Update override calculator to April 15 phase-in schedule

### DIFF
--- a/charts/override_calculator.html
+++ b/charts/override_calculator.html
@@ -150,15 +150,15 @@ title: "What the Override Costs You"
   </div>
 
 <script>
-// Anchor: Town Administrator's override presentation, April 8, 2026.
-// Each number is the annual tax increase (dollars) on a home assessed at
-// the town average single-family value, with that year's draws fully phased in.
+// Anchor: Select Board override presentation (FINAL), April 15, 2026, slide 8.
+// Each number is the cumulative annual tax increase (dollars) on a home
+// assessed at the town average single-family value, at end of each phase-in year.
 const AVG_ASSESSED = 1291507;
 const STORAGE_KEY = 'mh_override_calc_assessed_value';
 const RATES = {
-  1: { y1:  167.90, y2:  804.93, y3: 1186.68 }, // Tier 1, $9M, Partial Restore
-  2: { y1:  361.62, y2: 1132.65, y3: 1587.17 }, // Tier 2, $12M, Build
-  3: { y1:  555.35, y2: 1369.97, y3: 1985.39 }, // Tier 3, $15M, Invest
+  1: { y1: 168, y2:  857, y3: 1188 }, // Tier 1, $9M, Partial Restore
+  2: { y1: 362, y2: 1237, y3: 1590 }, // Tier 2, $12M, Build
+  3: { y1: 556, y2: 1487, y3: 1989 }, // Tier 3, $15M, Invest
 };
 const TIER_META = {
   1: { label: 'Tier 1 ($9M), Partial Restore', swatch: 'var(--series-tier-1)' },


### PR DESCRIPTION
## Summary
`charts/override_calculator.html` had hardcoded cumulative tax-increase values from the April 8 deck. The April 15 FINAL deck reshaped the phase-in so Year 2 is materially higher (+$52 on Tier 1, +$104 on Tier 2, +$117 on Tier 3 for the avg home). Year 3 totals essentially unchanged.

## Before / After (avg home $1,291,507 cumulative)
|  | April 8 (before) | April 15 (after) |
|---|---|---|
| Tier 1 Y1 / Y2 / Y3 | $167.90 / $804.93 / $1,186.68 | $168 / $857 / $1,188 |
| Tier 2 Y1 / Y2 / Y3 | $361.62 / $1,132.65 / $1,587.17 | $362 / $1,237 / $1,590 |
| Tier 3 Y1 / Y2 / Y3 | $555.35 / $1,369.97 / $1,985.39 | $556 / $1,487 / $1,989 |

The calculator scales these proportionally by assessed home value, so the Y2 correction shows up on every home.

## Scope
Only the calculator. Other consumers of the April 8 numbers use Y3-only values which are within $4 (rounding) and not worth touching:
- `charts/your_tax_bill.html`
- `senior-tax-relief.html`
- `data/override_tax_impact_asf.csv` (source CSV, only referenced by SOURCE_LOOKUP.md which already flags it as "April 8 draws")
- `charts/deficit_model.html` (uses draw amounts; April 15 deck doesn't show revised draws)

## Test plan
- [ ] Open the calculator and confirm Tier 3, Year 2 on avg home reads ~$1,487/yr not ~$1,370/yr