### PR TITLE
About page: correct healthcare trend framing; remove pro-override conclusion

### DIFF
--- a/about.html
+++ b/about.html
@@ -130,7 +130,7 @@ og_title: "Who made this?"
   Between 2015 and 2024, the town's operating budget grew by $35.7M. I expected schools to account for most of it. They accounted for 48%. Healthcare, public safety, debt service, and pensions made up the other half. <a href="/where-has-the-money-gone.html">See the breakdown</a>.</p>
 
   <p><strong>Healthcare is the fastest-growing cost, and it's mostly outside the town's control.</strong>
-  I didn't appreciate how much of the budget pressure comes from health insurance. Costs are growing at 11% annually, driven by <abbr class="g" title="Glucagon-Like Peptide-1 (weight-loss drug class)">GLP-1</abbr> medications and hospital rate increases. Marblehead's claims exceed its premiums (a 114&ndash;119% loss ratio). <a href="/charts/healthcare_costs.html">See the data</a>.</p>
+  I didn't appreciate how much of the budget pressure comes from health insurance. Group insurance ran roughly in line with inflation from FY12 through FY26 (around 2% annually), then jumped 11% from FY26 to FY27, driven by <abbr class="g" title="Glucagon-Like Peptide-1 (weight-loss drug class)">GLP-1</abbr> medications and hospital rate increases. Marblehead's claims exceed its premiums (a 114&ndash;119% loss ratio). <a href="/charts/healthcare_costs.html">See the data</a>.</p>
 
   <p><strong>The Finance Committee predicted this override seven years ago.</strong>
   I assumed this was a sudden fiscal crisis. It wasn't. <abbr class="g" title="Finance Committee">FinCom</abbr> called the budget "unsustainable" in 2019. In 2022, they explicitly predicted an override would be needed by FY24. In 2023, they formally endorsed one for the first time since 2005. The timeline is documented. <a href="/how-we-got-here.html">Read the history</a>.</p>
@@ -139,7 +139,7 @@ og_title: "Who made this?"
   The 2023 override passed Town Meeting 534&ndash;230 (70%) but lost at the ballot 2,992&ndash;3,399 (47%). That's a 23-point swing between roughly 800 Town Meeting attendees and 6,300+ ballot voters. I hadn't realized how different those two groups are. <a href="/how-we-got-here.html">See the timeline</a>.</p>
 
   <p><strong>When peer towns reject an override, they come back for more.</strong>
-  Melrose rejected a $7.7M override in June 2024, then approved $13.5M seventeen months later, after living through 61 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> cuts. I found the same pattern in Stoneham, Auburn, and Reading. Delay increases the eventual ask. <a href="/why-not-elsewhere.html">See the comparisons</a>.</p>
+  Melrose rejected a $7.7M override in June 2024, then approved $13.5M seventeen months later, after living through 61 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> cuts. I found the same pattern in Stoneham, Auburn, and Reading: in every case the second ask was larger than the first. <a href="/why-not-elsewhere.html">See the comparisons</a>.</p>
 
   <p><strong>Trash funding is a restructuring, not new money.</strong>
   I assumed Question 2 was $2.3M of new spending. It's not. Curbside trash collection is already funded through property taxes. Q2 moves it to a dedicated levy line and frees $1.15M of general fund capacity. <a href="/question-2-trash.html">See how it works</a>.</p>


### PR DESCRIPTION
## Summary
Two targeted edits to the "What surprised me" section on \`about.html\`, surfaced during a content review of the stashed about-page-surprises plan.

### Change 1 — Surprise #3 (healthcare)
**Before:** "Costs are growing at 11% annually..."
**After:** "Group insurance ran roughly in line with inflation from FY12 through FY26 (around 2% annually), then jumped 11% from FY26 to FY27..."

Why: group insurance CAGR FY12-FY26 was ~2% (29% total growth over 14 years), slower than CPI (~2.3%). The 11% is a single-year FY26→FY27 jump, not an annual trend. The "growing at 11% annually" framing was factually wrong and would mislead readers about the structural trajectory.

### Change 2 — Surprise #6 (peer towns)
**Before:** "...Delay increases the eventual ask."
**After:** "...in every case the second ask was larger than the first."

Why: "Delay increases the eventual ask" reads as an editorial conclusion pushing a vote. Per CLAUDE.md ("State facts in captions, not conclusions. No framing that implies a voter should vote yes or no on an override"), replaced with the factual observation underneath it.

## Test plan
- [ ] Load about.html on preview, confirm the two surprise paragraphs read naturally
- [ ] Confirm loss ratio, GLP-1, and peer-town figures are unchanged