### PR TITLE
Deficit model: scenario-set refresh (Approach 2)

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -840,6 +840,10 @@ title: "Deficit Dynamics Model"
     <span class="dm-scenario-title">Permanently close the gap</span>
     <span class="dm-scenario-desc">Slower expense growth + healthcare reform + override. Lines stay apart.</span>
   </button>
+  <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="bend-curve">
+    <span class="dm-scenario-title">Bend the cost curve (3 to 5 years)</span>
+    <span class="dm-scenario-desc">Structural reforms (collaboratives, in-district SPED, shared services) phased over 3 to 5 years.</span>
+  </button>
 </div>
 
 <div class="dm-controls">
@@ -1783,7 +1787,8 @@ An override on its own buys time. It does not change the slope of either line.
     'commercial-only': 'Commercial redevelopment at the top of Marblehead\u2019s realistic range adds roughly $500K to $1M per year in recurring capacity. This scenario uses the middle of that range (+0.5pp on revenue growth). The existing gap from FY24 onward does not close because new growth compounds forward but does not retroactively close old deficits. Residential growth is excluded because new housing adds service demand too.',
     'override-plus-hc':'Stacks two politically hard lifts: an operating override vote plus union concessions on health insurance. Both are plausible individually; combining them depends on winning a vote and a bargaining round.',
     'no-override-reform':'No new revenue; 30 position cuts plus healthcare concessions carry the full load. 30 positions is more than double the site\u2019s 7 to 13 discretionary estimate (see inside-school-staffing.html#options), so the cuts reach mandate-adjacent roles or non-school departments. The hardest path politically: the largest non-override concessions with nothing offered in return.',
-    'permanent-close': 'The 0.8pp drop in expense growth (4.0% to 3.2%) is doing roughly 38% of the work; the override, cuts, and healthcare reform contribute the rest. Requires healthcare premium moderation outside the town\u2019s control plus sustained wage restraint not achieved in the last 20 years.'
+    'permanent-close': 'The 0.8pp drop in expense growth (4.0% to 3.2%) is doing roughly 38% of the work; the override, cuts, and healthcare reform contribute the rest. Requires healthcare premium moderation outside the town\u2019s control plus sustained wage restraint not achieved in the last 20 years.',
+    'bend-curve': 'Matches the site\u2019s framing of these reforms as cost-curve benders, not immediate substitutes for override revenue (see inside-school-staffing.html#options). Realistic impact from collaborative expansion, bringing out-of-district SPED placements back in, and shared back-office sums to roughly 0.3 to 0.5 percentage points off expense growth, but not until FY30 at the earliest. The compound-rate projection in this model applies the reduction uniformly, so the near-term years look more optimistic than reality.'
   };
 
   function updateScenarioReadout() {
@@ -1959,6 +1964,8 @@ An override on its own buys time. It does not change the slope of either line.
         hcShareEl.value = 65;
         wageOffsetEl.value = 50;
         positionCuts = 10;
+      } else if (s === 'bend-curve') {
+        expGrowthEl.value = 3.7;
       }
       onChange();
       if (chartScrollTarget) {
@@ -2431,6 +2438,8 @@ An override on its own buys time. It does not change the slope of either line.
       hcShareEl.value = 65;
       wageOffsetEl.value = 50;
       positionCuts = 10;
+    } else if (urlStance === 'bend-curve') {
+      expGrowthEl.value = 3.7;
     }
     if (stanceNotes[urlStance]) {
       currentStance = urlStance;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -2077,7 +2077,7 @@ An override on its own buys time. It does not change the slope of either line.
         }
       },
       {
-        caption: 'Your turn. Pick any scenario below to see how different levers shape the chart. Each one lists its assumptions, how realistic it is, and what is doing the work. There is no single answer; the point is to see how the tradeoffs compare.',
+        caption: 'Your turn. Scenarios below are framed around positions in the override debate. Each one lists its assumptions and how realistic it is. Pick one to see the chart shift. There is no single answer; the point is to see how the tradeoffs compare.',
         setup: function() { resetToDefaults(); }
       }
     ];

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -908,7 +908,7 @@ title: "Deficit Dynamics Model"
   <div class="dm-control" style="grid-column: 1 / -1;">
     <span class="dm-control-label">FY27 one-time step ($M): <span class="dm-value" id="dm-fy27-step-val">$0.0M</span></span>
     <input type="number" id="dm-fy27-step" min="-5" max="5" step="0.1" value="0" class="dm-fy27-step-input">
-    <div class="dm-hint" id="dm-fy27-step-hint">Use this if you believe FY27 has a one-time cost deviation outside the compound-rate trend (for example, the observed healthcare bump). Default is 0, meaning the compound rate captures everything.</div>
+    <div class="dm-hint" id="dm-fy27-step-hint">A one-time shock added to projected FY27 expenses, not propagated into FY28+. Observed FY27 healthcare cliff: about +$1.1M (the &ldquo;One-time healthcare spike&rdquo; scenario below uses this). Default 0 means the compound rate captures everything. Negative values model a one-time underrun.</div>
   </div>
 </div>
 </details>

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -800,8 +800,8 @@ title: "Deficit Dynamics Model"
     <span class="dm-scenario-desc">$15M absorbed in year one. The skeptic&rsquo;s view: gap barely narrows.</span>
   </button>
   <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="cut">
-    <span class="dm-scenario-title">Cut 50 positions</span>
-    <span class="dm-scenario-desc">~$5M/yr saved. Slope unchanged; gap reopens on the same schedule.</span>
+    <span class="dm-scenario-title">Current pace of cuts</span>
+    <span class="dm-scenario-desc">About 50 positions over FY25 to FY27, roughly matching what the town has already done. Slope unchanged; gap keeps widening.</span>
   </button>
   <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="healthcare">
     <span class="dm-scenario-title">Healthcare share to 50%</span>
@@ -809,7 +809,7 @@ title: "Deficit Dynamics Model"
   </button>
   <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="hold-line">
     <span class="dm-scenario-title">Hold the line</span>
-    <span class="dm-scenario-desc">Expense growth matches revenue at 3.5%. Contracts at COLA, enrollment flat, no new programs.</span>
+    <span class="dm-scenario-desc">Expense growth drops to revenue growth (3.5%). Contracts at COLA, no new programs.</span>
   </button>
 </div>
 
@@ -821,7 +821,7 @@ title: "Deficit Dynamics Model"
   </button>
   <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="no-override-reform">
     <span class="dm-scenario-title">No override, just reform</span>
-    <span class="dm-scenario-desc">30 positions cut plus 65% healthcare share. No new revenue.</span>
+    <span class="dm-scenario-desc">65% healthcare share plus 30 positions cut. No new revenue.</span>
   </button>
   <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="permanent-close">
     <span class="dm-scenario-title">Permanently close the gap</span>
@@ -1744,11 +1744,11 @@ An override on its own buys time. It does not change the slope of either line.
   var stanceNotes = {
     'bridge': 'Buys roughly 5 years of headroom, then the gap reopens on the same slope. Politically hard: Marblehead voters have rejected every operating override attempt since 2006 (2011, 2022, 2023, 2025 all failed).',
     'skeptic': 'Same $15M, but spent in year one rather than stretched. Consistent with historical behavior, where new levy authority tends to be absorbed by the next contract cycle.',
-    'cut': 'Direct payroll reduction of roughly 10% of the town workforce. Lowers the level but does not flatten the slope. Service impact would be visible across every department.',
+    'cut': 'Roughly matches the FY25 to FY27 reductions already in place through layoffs, unfilled vacancies, and stipend reductions. Lowers the level but does not flatten the slope. The site\u2019s staffing analysis identifies 7 to 13 positions as the discretionary slice; further reductions reach mandate-adjacent roles or non-school departments (see inside-school-staffing.html#options).',
     'healthcare': 'Saves $2.2M/yr net after wage offsets and pension flow-through. Requires union concessions on a long-standing benefit. Hingham runs at 50% but reached that position through years of bargaining.',
     'hold-line': 'The closest scenario to what Marblehead already ran FY18 to FY24 (expenses 3.43%, revenue 3.64%). Stops the gap from widening but does not close the existing deficit, which still draws from free cash or reserves each year. Requires contracts to settle at COLA, healthcare enrollment to stay flat, and pensions to grow no faster than their recent CAGR. A GASB pension revaluation or a heavy SPED year breaks the assumption.',
     'override-plus-hc':'Stacks two politically hard lifts: an operating override vote plus union concessions on health insurance. Both are plausible individually; combining them depends on winning a vote and a bargaining round.',
-    'no-override-reform':'No new revenue; 30 position cuts plus healthcare concessions carry the full load. The hardest path politically: the largest non-override concessions with nothing offered in return.',
+    'no-override-reform':'No new revenue; 30 position cuts plus healthcare concessions carry the full load. 30 positions is more than double the site\u2019s 7 to 13 discretionary estimate (see inside-school-staffing.html#options), so the cuts reach mandate-adjacent roles or non-school departments. The hardest path politically: the largest non-override concessions with nothing offered in return.',
     'permanent-close': 'The 0.8pp drop in expense growth (4.0% to 3.2%) is doing roughly 38% of the work; the override, cuts, and healthcare reform contribute the rest. Requires healthcare premium moderation outside the town\u2019s control plus sustained wage restraint not achieved in the last 20 years.'
   };
 

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -816,6 +816,10 @@ title: "Deficit Dynamics Model"
     <span class="dm-scenario-title">Hold the line</span>
     <span class="dm-scenario-desc">Expense growth drops to revenue growth (3.5%). Contracts at COLA, no new programs.</span>
   </button>
+  <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="hc-cliff">
+    <span class="dm-scenario-title">One-time healthcare spike</span>
+    <span class="dm-scenario-desc">FY27 jump in healthcare, then expense growth returns to a normal rate.</span>
+  </button>
 </div>
 
 <span class="dm-scenario-group-label">Combine levers</span>
@@ -1771,6 +1775,7 @@ An override on its own buys time. It does not change the slope of either line.
     'cut': 'Roughly matches the FY25 to FY27 reductions already in place through layoffs, unfilled vacancies, and stipend reductions. Lowers the level but does not flatten the slope. The site\u2019s staffing analysis identifies 7 to 13 positions as the discretionary slice; further reductions reach mandate-adjacent roles or non-school departments (see inside-school-staffing.html#options).',
     'healthcare': 'Saves $2.2M/yr net after wage offsets and pension flow-through. Requires union concessions on a long-standing benefit. Hingham runs at 50% but reached that position through years of bargaining.',
     'hold-line': 'The closest scenario to what Marblehead already ran FY18 to FY24 (expenses 3.43%, revenue 3.64%). Stops the gap from widening but does not close the existing deficit, which still draws from free cash or reserves each year. Requires contracts to settle at COLA, healthcare enrollment to stay flat, and pensions to grow no faster than their recent CAGR. A GASB pension revaluation or a heavy SPED year breaks the assumption.',
+    'hc-cliff': 'Tests the "cliff not chronic" read of FY27. Group insurance grew slower than CPI from FY12 to FY26 (about 29% vs. 37%, see healthcare_costs.html); if that pattern resumes after the FY27 step, the long-run rate returns to near the historical average. Depends on GIC premium behavior outside the town\u2019s control.',
     'override-plus-hc':'Stacks two politically hard lifts: an operating override vote plus union concessions on health insurance. Both are plausible individually; combining them depends on winning a vote and a bargaining round.',
     'no-override-reform':'No new revenue; 30 position cuts plus healthcare concessions carry the full load. 30 positions is more than double the site\u2019s 7 to 13 discretionary estimate (see inside-school-staffing.html#options), so the cuts reach mandate-adjacent roles or non-school departments. The hardest path politically: the largest non-override concessions with nothing offered in return.',
     'permanent-close': 'The 0.8pp drop in expense growth (4.0% to 3.2%) is doing roughly 38% of the work; the override, cuts, and healthcare reform contribute the rest. Requires healthcare premium moderation outside the town\u2019s control plus sustained wage restraint not achieved in the last 20 years.'
@@ -1929,6 +1934,10 @@ An override on its own buys time. It does not change the slope of either line.
         hcShareEl.value = 50;
       } else if (s === 'hold-line') {
         expGrowthEl.value = 3.5;
+      } else if (s === 'hc-cliff') {
+        fy27StepEl.value = 1.08;
+        fy27StepValEl.textContent = '$1.1M';
+        expGrowthEl.value = 3.8;
       } else if (s === 'override-plus-hc') {
         overrideEl.value = 15;
         hcShareEl.value = 65;
@@ -2403,6 +2412,10 @@ An override on its own buys time. It does not change the slope of either line.
       wageOffsetEl.value = 50;
     } else if (urlStance === 'hold-line') {
       expGrowthEl.value = 3.5;
+    } else if (urlStance === 'hc-cliff') {
+      fy27StepEl.value = 1.08;
+      fy27StepValEl.textContent = '$1.1M';
+      expGrowthEl.value = 3.8;
     } else if (urlStance === 'permanent-close') {
       overrideEl.value = 12;
       expGrowthEl.value = 3.2;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -820,6 +820,10 @@ title: "Deficit Dynamics Model"
     <span class="dm-scenario-title">One-time healthcare spike</span>
     <span class="dm-scenario-desc">FY27 jump in healthcare, then expense growth returns to a normal rate.</span>
   </button>
+  <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="commercial-only">
+    <span class="dm-scenario-title">Commercial growth only</span>
+    <span class="dm-scenario-desc">Revenue lifted by realistic commercial redevelopment. No new residential from 3A.</span>
+  </button>
 </div>
 
 <span class="dm-scenario-group-label">Combine levers</span>
@@ -1776,6 +1780,7 @@ An override on its own buys time. It does not change the slope of either line.
     'healthcare': 'Saves $2.2M/yr net after wage offsets and pension flow-through. Requires union concessions on a long-standing benefit. Hingham runs at 50% but reached that position through years of bargaining.',
     'hold-line': 'The closest scenario to what Marblehead already ran FY18 to FY24 (expenses 3.43%, revenue 3.64%). Stops the gap from widening but does not close the existing deficit, which still draws from free cash or reserves each year. Requires contracts to settle at COLA, healthcare enrollment to stay flat, and pensions to grow no faster than their recent CAGR. A GASB pension revaluation or a heavy SPED year breaks the assumption.',
     'hc-cliff': 'Tests the "cliff not chronic" read of FY27. Group insurance grew slower than CPI from FY12 to FY26 (about 29% vs. 37%, see healthcare_costs.html); if that pattern resumes after the FY27 step, the long-run rate returns to near the historical average. Depends on GIC premium behavior outside the town\u2019s control.',
+    'commercial-only': 'Commercial redevelopment at the top of Marblehead\u2019s realistic range adds roughly $500K to $1M per year in recurring capacity. This scenario uses the middle of that range (+0.5pp on revenue growth). The existing gap from FY24 onward does not close because new growth compounds forward but does not retroactively close old deficits. Residential growth is excluded because new housing adds service demand too.',
     'override-plus-hc':'Stacks two politically hard lifts: an operating override vote plus union concessions on health insurance. Both are plausible individually; combining them depends on winning a vote and a bargaining round.',
     'no-override-reform':'No new revenue; 30 position cuts plus healthcare concessions carry the full load. 30 positions is more than double the site\u2019s 7 to 13 discretionary estimate (see inside-school-staffing.html#options), so the cuts reach mandate-adjacent roles or non-school departments. The hardest path politically: the largest non-override concessions with nothing offered in return.',
     'permanent-close': 'The 0.8pp drop in expense growth (4.0% to 3.2%) is doing roughly 38% of the work; the override, cuts, and healthcare reform contribute the rest. Requires healthcare premium moderation outside the town\u2019s control plus sustained wage restraint not achieved in the last 20 years.'
@@ -1938,6 +1943,8 @@ An override on its own buys time. It does not change the slope of either line.
         fy27StepEl.value = 1.08;
         fy27StepValEl.textContent = '$1.1M';
         expGrowthEl.value = 3.8;
+      } else if (s === 'commercial-only') {
+        revGrowthEl.value = 4.0;
       } else if (s === 'override-plus-hc') {
         overrideEl.value = 15;
         hcShareEl.value = 65;
@@ -2416,6 +2423,8 @@ An override on its own buys time. It does not change the slope of either line.
       fy27StepEl.value = 1.08;
       fy27StepValEl.textContent = '$1.1M';
       expGrowthEl.value = 3.8;
+    } else if (urlStance === 'commercial-only') {
+      revGrowthEl.value = 4.0;
     } else if (urlStance === 'permanent-close') {
       overrideEl.value = 12;
       expGrowthEl.value = 3.2;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -31,6 +31,11 @@ title: "Deficit Dynamics Model"
     width: 100%;
     accent-color: var(--c-navy);
   }
+  .dm-fy27-step-input {
+    width: 100px;
+    font: inherit;
+    padding: 4px 8px;
+  }
   .dm-value {
     font-variant-numeric: tabular-nums;
     font-weight: 700;
@@ -880,6 +885,11 @@ title: "Deficit Dynamics Model"
     <input type="range" id="dm-wage-offset" min="0" max="100" step="5" value="50">
     <div class="dm-hint" id="dm-wage-hint">How much of the premium savings employees negotiate back as higher wages.</div>
   </div>
+  <div class="dm-control" style="grid-column: 1 / -1;">
+    <span class="dm-control-label">FY27 one-time step ($M): <span class="dm-value" id="dm-fy27-step-val">$0.0M</span></span>
+    <input type="number" id="dm-fy27-step" min="-5" max="5" step="0.1" value="0" class="dm-fy27-step-input">
+    <div class="dm-hint" id="dm-fy27-step-hint">Use this if you believe FY27 has a one-time cost deviation outside the compound-rate trend (for example, the observed healthcare bump). Default is 0, meaning the compound rate captures everything.</div>
+  </div>
 </div>
 </details>
 
@@ -1046,6 +1056,8 @@ An override on its own buys time. It does not change the slope of either line.
   var hcShareVal = document.getElementById('dm-hc-share-val');
   var wageOffsetEl = document.getElementById('dm-wage-offset');
   var wageOffsetVal = document.getElementById('dm-wage-offset-val');
+  var fy27StepEl = document.getElementById('dm-fy27-step');
+  var fy27StepValEl = document.getElementById('dm-fy27-step-val');
 
   // === Formatting ===
   function fmtM(v) {
@@ -1135,6 +1147,7 @@ An override on its own buys time. It does not change the slope of either line.
     var expG = parseFloat(expGrowthEl.value) / 100;
     var ovr = parseFloat(overrideEl.value);
     var ratchetYears = parseInt(ratchetEl.value);
+    var fy27Step = parseFloat(fy27StepEl.value) || 0;
 
     var rev = histRev.slice();
     var exp = histExp.slice();
@@ -1170,8 +1183,14 @@ An override on its own buys time. It does not change the slope of either line.
           e += bump.annualAmount;
         }
       }
+      // FY27 one-time step: add to reported value but do not propagate
+      // into the forward compounding state.
+      var reportedE = e;
+      if (i === phaseYears[0] && fy27Step !== 0) {
+        reportedE = e + fy27Step;
+      }
       rev.push(r);
-      exp.push(e);
+      exp.push(reportedE);
     }
 
     // Constrained expense line: what happens if there's no override
@@ -1201,11 +1220,16 @@ An override on its own buys time. It does not change the slope of either line.
     var hc = computeHcSavings();
     var e0 = histExp[lastHistIdx] - positionCuts * costPerPosition - hc.net;
     var e = e0;
+    var fy27Step = parseFloat(fy27StepEl.value) || 0;
     for (var i = histCount; i < nYears; i++) {
       r = r * (1 + revG);
       e = e * (1 + expG);
       baseRev.push(r);
-      baseExp.push(e);
+      var reportedE = e;
+      if (i === phaseYears[0] && fy27Step !== 0) {
+        reportedE = e + fy27Step;
+      }
+      baseExp.push(reportedE);
     }
 
     var tierRevs = [];
@@ -1775,6 +1799,11 @@ An override on its own buys time. It does not change the slope of either line.
     if (newShare < 83) {
       parts.push('Healthcare shift to <strong>' + newShare + '%</strong> employer saves <strong>' + fmtOverride(hc.gross) + '/yr</strong> in premiums. Contracts typically return part of that to employees as wage increases (<strong>' + fmtOverride(hc.wageIncrease) + '</strong>), which then raises pension costs (<strong>' + fmtOverride(hc.pensionIncrease) + '</strong>). Net savings: <strong>' + fmtOverride(hc.net) + '/yr</strong>.');
     }
+    var fy27Step = parseFloat(fy27StepEl.value) || 0;
+    if (Math.abs(fy27Step) > 0.01) {
+      var stepSign = fy27Step >= 0 ? '+' : '-';
+      parts.push('FY27 one-time step: <strong>' + stepSign + '$' + Math.abs(fy27Step).toFixed(1) + 'M</strong>, not propagated into the forward trend.');
+    }
     if (Math.abs(rv - 3.5) > 0.05 || Math.abs(ev - 4.0) > 0.05) {
       parts.push('Growth set to <strong>revenue ' + rv.toFixed(1) + '%/yr</strong>, <strong>expenses ' + ev.toFixed(1) + '%/yr</strong> (defaults: 3.5% / 4.0%).');
     }
@@ -1815,6 +1844,14 @@ An override on its own buys time. It does not change the slope of either line.
       currentStance = null;
       onChange();
     });
+  });
+
+  fy27StepEl.addEventListener('input', function() {
+    var v = parseFloat(fy27StepEl.value) || 0;
+    var sign = v >= 0 ? '$' : '-$';
+    fy27StepValEl.textContent = sign + Math.abs(v).toFixed(1) + 'M';
+    currentStance = null;
+    onChange();
   });
 
   // Position cuts buttons
@@ -1878,6 +1915,8 @@ An override on its own buys time. It does not change the slope of either line.
       positionCuts = 0;
       hcShareEl.value = 83;
       wageOffsetEl.value = 50;
+      fy27StepEl.value = 0;
+      fy27StepValEl.textContent = '$0.0M';
 
       if (s === 'bridge') {
         overrideEl.value = 15;
@@ -1934,6 +1973,8 @@ An override on its own buys time. It does not change the slope of either line.
       positionCuts = 0;
       hcShareEl.value = 83;
       wageOffsetEl.value = 50;
+      fy27StepEl.value = 0;
+      fy27StepValEl.textContent = '$0.0M';
       currentStance = null;
     }
 

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -811,14 +811,6 @@ title: "Deficit Dynamics Model"
     <span class="dm-scenario-title">Hold the line</span>
     <span class="dm-scenario-desc">Expense growth matches revenue at 3.5%. Contracts at COLA, enrollment flat, no new programs.</span>
   </button>
-  <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="cost-slows">
-    <span class="dm-scenario-title">Cost growth slows to 3%</span>
-    <span class="dm-scenario-desc">If GIC moderates and contracts stay restrained, lines run roughly parallel.</span>
-  </button>
-  <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="new-growth">
-    <span class="dm-scenario-title">More new development</span>
-    <span class="dm-scenario-desc">Revenue growth at 4.5% from sustained construction and new growth.</span>
-  </button>
 </div>
 
 <span class="dm-scenario-group-label">Combine levers</span>
@@ -826,14 +818,6 @@ title: "Deficit Dynamics Model"
   <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="override-plus-hc">
     <span class="dm-scenario-title">Override + healthcare reform</span>
     <span class="dm-scenario-desc">$15M override plus 65% employer share. Layered relief.</span>
-  </button>
-  <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="override-plus-cuts">
-    <span class="dm-scenario-title">Override + modest cuts</span>
-    <span class="dm-scenario-desc">$12M override plus 20 position cuts.</span>
-  </button>
-  <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="kitchen-sink">
-    <span class="dm-scenario-title">Pull every lever</span>
-    <span class="dm-scenario-desc">$15M, healthcare reform, position cuts, fast spending ramp.</span>
   </button>
   <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="no-override-reform">
     <span class="dm-scenario-title">No override, just reform</span>
@@ -1763,12 +1747,8 @@ An override on its own buys time. It does not change the slope of either line.
     'cut': 'Direct payroll reduction of roughly 10% of the town workforce. Lowers the level but does not flatten the slope. Service impact would be visible across every department.',
     'healthcare': 'Saves $2.2M/yr net after wage offsets and pension flow-through. Requires union concessions on a long-standing benefit. Hingham runs at 50% but reached that position through years of bargaining.',
     'hold-line': 'The closest scenario to what Marblehead already ran FY18 to FY24 (expenses 3.43%, revenue 3.64%). Stops the gap from widening but does not close the existing deficit, which still draws from free cash or reserves each year. Requires contracts to settle at COLA, healthcare enrollment to stay flat, and pensions to grow no faster than their recent CAGR. A GASB pension revaluation or a heavy SPED year breaks the assumption.',
-    'cost-slows': 'A stronger version of "Hold the line": 1.0pp off expense growth rather than 0.5pp. Requires GIC premium growth to moderate (state-controlled) and contracts to settle meaningfully below COLA. Not sustained in the last 20 years.',
-    'new-growth': 'Revenue growth at 4.5% depends on sustained construction and new growth. Marblehead averaged about 1.3pp of new growth FY15 to FY24; pushing to 2pp+ is bounded by zoning and build-out.',
-    'override-plus-hc': 'Stacks two politically hard lifts: an operating override vote plus union concessions on health insurance. Both are plausible individually; combining them depends on winning a vote and a bargaining round.',
-    'override-plus-cuts': 'Override paired with visible service reductions. Voters may read the cuts as evidence the override is needed; opponents may read them as proof the town can absorb cuts.',
-    'kitchen-sink': 'Every lever pulled at once: override, healthcare, cuts, fast spending. Depends on voter, union, and state GIC cooperation simultaneously. More a thought experiment than a plan.',
-    'no-override-reform': 'No new revenue; 30 position cuts plus healthcare concessions carry the full load. The hardest path politically: the largest non-override concessions with nothing offered in return.',
+    'override-plus-hc':'Stacks two politically hard lifts: an operating override vote plus union concessions on health insurance. Both are plausible individually; combining them depends on winning a vote and a bargaining round.',
+    'no-override-reform':'No new revenue; 30 position cuts plus healthcare concessions carry the full load. The hardest path politically: the largest non-override concessions with nothing offered in return.',
     'permanent-close': 'The 0.8pp drop in expense growth (4.0% to 3.2%) is doing roughly 38% of the work; the override, cuts, and healthcare reform contribute the rest. Requires healthcare premium moderation outside the town\u2019s control plus sustained wage restraint not achieved in the last 20 years.'
   };
 
@@ -1910,23 +1890,10 @@ An override on its own buys time. It does not change the slope of either line.
         hcShareEl.value = 50;
       } else if (s === 'hold-line') {
         expGrowthEl.value = 3.5;
-      } else if (s === 'cost-slows') {
-        expGrowthEl.value = 3.0;
-      } else if (s === 'new-growth') {
-        revGrowthEl.value = 4.5;
       } else if (s === 'override-plus-hc') {
         overrideEl.value = 15;
         hcShareEl.value = 65;
         wageOffsetEl.value = 50;
-      } else if (s === 'override-plus-cuts') {
-        overrideEl.value = 12;
-        positionCuts = 20;
-      } else if (s === 'kitchen-sink') {
-        overrideEl.value = 15;
-        hcShareEl.value = 65;
-        wageOffsetEl.value = 50;
-        positionCuts = 10;
-        ratchetEl.value = 3;
       } else if (s === 'no-override-reform') {
         positionCuts = 30;
         hcShareEl.value = 65;
@@ -2389,25 +2356,12 @@ An override on its own buys time. It does not change the slope of either line.
       overrideEl.value = 15;
       hcShareEl.value = 65;
       wageOffsetEl.value = 50;
-    } else if (urlStance === 'override-plus-cuts') {
-      overrideEl.value = 12;
-      positionCuts = 20;
-    } else if (urlStance === 'kitchen-sink') {
-      overrideEl.value = 15;
-      hcShareEl.value = 65;
-      wageOffsetEl.value = 50;
-      positionCuts = 10;
-      ratchetEl.value = 3;
     } else if (urlStance === 'no-override-reform') {
       positionCuts = 30;
       hcShareEl.value = 65;
       wageOffsetEl.value = 50;
     } else if (urlStance === 'hold-line') {
       expGrowthEl.value = 3.5;
-    } else if (urlStance === 'cost-slows') {
-      expGrowthEl.value = 3.0;
-    } else if (urlStance === 'new-growth') {
-      revGrowthEl.value = 4.5;
     } else if (urlStance === 'permanent-close') {
       overrideEl.value = 12;
       expGrowthEl.value = 3.2;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -844,6 +844,10 @@ title: "Deficit Dynamics Model"
     <span class="dm-scenario-title">Bend the cost curve (3 to 5 years)</span>
     <span class="dm-scenario-desc">Structural reforms (collaboratives, in-district SPED, shared services) phased over 3 to 5 years.</span>
   </button>
+  <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="composite-cuts">
+    <span class="dm-scenario-title">No override, no growth, just cuts</span>
+    <span class="dm-scenario-desc">Both levers off the table. Cuts absorb the full FY27 gap.</span>
+  </button>
 </div>
 
 <div class="dm-controls">
@@ -1788,7 +1792,8 @@ An override on its own buys time. It does not change the slope of either line.
     'override-plus-hc':'Stacks two politically hard lifts: an operating override vote plus union concessions on health insurance. Both are plausible individually; combining them depends on winning a vote and a bargaining round.',
     'no-override-reform':'No new revenue; 30 position cuts plus healthcare concessions carry the full load. 30 positions is more than double the site\u2019s 7 to 13 discretionary estimate (see inside-school-staffing.html#options), so the cuts reach mandate-adjacent roles or non-school departments. The hardest path politically: the largest non-override concessions with nothing offered in return.',
     'permanent-close': 'The 0.8pp drop in expense growth (4.0% to 3.2%) is doing roughly 38% of the work; the override, cuts, and healthcare reform contribute the rest. Requires healthcare premium moderation outside the town\u2019s control plus sustained wage restraint not achieved in the last 20 years.',
-    'bend-curve': 'Matches the site\u2019s framing of these reforms as cost-curve benders, not immediate substitutes for override revenue (see inside-school-staffing.html#options). Realistic impact from collaborative expansion, bringing out-of-district SPED placements back in, and shared back-office sums to roughly 0.3 to 0.5 percentage points off expense growth, but not until FY30 at the earliest. The compound-rate projection in this model applies the reduction uniformly, so the near-term years look more optimistic than reality.'
+    'bend-curve': 'Matches the site\u2019s framing of these reforms as cost-curve benders, not immediate substitutes for override revenue (see inside-school-staffing.html#options). Realistic impact from collaborative expansion, bringing out-of-district SPED placements back in, and shared back-office sums to roughly 0.3 to 0.5 percentage points off expense growth, but not until FY30 at the earliest. The compound-rate projection in this model applies the reduction uniformly, so the near-term years look more optimistic than reality.',
+    'composite-cuts': 'Reflects the no-3A, no-override, yes-cuts composite position. Closing the $8.47M FY27 gap at roughly $100K per position implies on the order of 85 positions. Only 7 to 13 can come from the site\u2019s discretionary slice of school staffing (see inside-school-staffing.html#options); the remainder requires mandate relief, non-school department reductions, or both. Shows the magnitude, not which commitments to unwind.'
   };
 
   function updateScenarioReadout() {
@@ -1966,6 +1971,8 @@ An override on its own buys time. It does not change the slope of either line.
         positionCuts = 10;
       } else if (s === 'bend-curve') {
         expGrowthEl.value = 3.7;
+      } else if (s === 'composite-cuts') {
+        positionCuts = 85;
       }
       onChange();
       if (chartScrollTarget) {
@@ -2440,6 +2447,8 @@ An override on its own buys time. It does not change the slope of either line.
       positionCuts = 10;
     } else if (urlStance === 'bend-curve') {
       expGrowthEl.value = 3.7;
+    } else if (urlStance === 'composite-cuts') {
+      positionCuts = 85;
     }
     if (stanceNotes[urlStance]) {
       currentStance = urlStance;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -848,6 +848,10 @@ title: "Deficit Dynamics Model"
     <span class="dm-scenario-title">No override, no growth, just cuts</span>
     <span class="dm-scenario-desc">Both levers off the table. Cuts absorb the full FY27 gap.</span>
   </button>
+  <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="forced-equilibrium">
+    <span class="dm-scenario-title">Cuts to match the trend</span>
+    <span class="dm-scenario-desc">Ongoing cuts each year that keep expenses growing at revenue&rsquo;s rate.</span>
+  </button>
 </div>
 
 <div class="dm-controls">
@@ -1019,6 +1023,7 @@ An override on its own buys time. It does not change the slope of either line.
 
   var taxMode = false;
   var positionCuts = 0;
+  var forcedEquilibriumActive = false;
   var costPerPosition = 0.1; // $100K in $M
 
   // Cached chart data for hover tooltips
@@ -1199,6 +1204,13 @@ An override on its own buys time. It does not change the slope of either line.
           e += bump.annualAmount;
         }
       }
+      // Forced-equilibrium cuts: subtract (expG - revG) x current expense
+      // each projected year so the effective expense growth matches
+      // revenue. Modifies e in place so the next iteration compounds from
+      // the reduced value, reflecting ongoing cuts.
+      if (forcedEquilibriumActive && expG > revG) {
+        e -= (expG - revG) * e;
+      }
       // FY27 one-time step: add to reported value but do not propagate
       // into the forward compounding state.
       var reportedE = e;
@@ -1240,6 +1252,9 @@ An override on its own buys time. It does not change the slope of either line.
     for (var i = histCount; i < nYears; i++) {
       r = r * (1 + revG);
       e = e * (1 + expG);
+      if (forcedEquilibriumActive && expG > revG) {
+        e -= (expG - revG) * e;
+      }
       baseRev.push(r);
       var reportedE = e;
       if (i === phaseYears[0] && fy27Step !== 0) {
@@ -1793,7 +1808,8 @@ An override on its own buys time. It does not change the slope of either line.
     'no-override-reform':'No new revenue; 30 position cuts plus healthcare concessions carry the full load. 30 positions is more than double the site\u2019s 7 to 13 discretionary estimate (see inside-school-staffing.html#options), so the cuts reach mandate-adjacent roles or non-school departments. The hardest path politically: the largest non-override concessions with nothing offered in return.',
     'permanent-close': 'The 0.8pp drop in expense growth (4.0% to 3.2%) is doing roughly 38% of the work; the override, cuts, and healthcare reform contribute the rest. Requires healthcare premium moderation outside the town\u2019s control plus sustained wage restraint not achieved in the last 20 years.',
     'bend-curve': 'Matches the site\u2019s framing of these reforms as cost-curve benders, not immediate substitutes for override revenue (see inside-school-staffing.html#options). Realistic impact from collaborative expansion, bringing out-of-district SPED placements back in, and shared back-office sums to roughly 0.3 to 0.5 percentage points off expense growth, but not until FY30 at the earliest. The compound-rate projection in this model applies the reduction uniformly, so the near-term years look more optimistic than reality.',
-    'composite-cuts': 'Reflects the no-3A, no-override, yes-cuts composite position. Closing the $8.47M FY27 gap at roughly $100K per position implies on the order of 85 positions. Only 7 to 13 can come from the site\u2019s discretionary slice of school staffing (see inside-school-staffing.html#options); the remainder requires mandate relief, non-school department reductions, or both. Shows the magnitude, not which commitments to unwind.'
+    'composite-cuts': 'Reflects the no-3A, no-override, yes-cuts composite position. Closing the $8.47M FY27 gap at roughly $100K per position implies on the order of 85 positions. Only 7 to 13 can come from the site\u2019s discretionary slice of school staffing (see inside-school-staffing.html#options); the remainder requires mandate relief, non-school department reductions, or both. Shows the magnitude, not which commitments to unwind.',
+    'forced-equilibrium': 'Requires ongoing annual cuts to keep expenses growing at revenue\u2019s rate. At the default rate gap (0.5pp), the scale is roughly half a percent of the budget per year, compounding forward. Only 7 to 13 school positions are documented as discretionary per the site\u2019s staffing analysis (inside-school-staffing.html#options); town-wide discretionary capacity has not yet been quantified. See github.com/agbaber/marblehead/issues/595 for the pending town-wide analysis.'
   };
 
   function updateScenarioReadout() {
@@ -1823,6 +1839,10 @@ An override on its own buys time. It does not change the slope of either line.
     if (Math.abs(fy27Step) > 0.01) {
       var stepSign = fy27Step >= 0 ? '+' : '-';
       parts.push('FY27 one-time step: <strong>' + stepSign + '$' + Math.abs(fy27Step).toFixed(1) + 'M</strong>, not propagated into the forward trend.');
+    }
+    if (forcedEquilibriumActive && ev > rv) {
+      var gap = (ev - rv).toFixed(1);
+      parts.push('<strong>Compound cuts</strong> applied each year equal to the expense-to-revenue gap (about ' + gap + '% of the budget annually), so the expense line stays parallel to revenue rather than running at the underlying ' + ev.toFixed(1) + '% rate.');
     }
     if (Math.abs(rv - 3.5) > 0.05 || Math.abs(ev - 4.0) > 0.05) {
       parts.push('Growth set to <strong>revenue ' + rv.toFixed(1) + '%/yr</strong>, <strong>expenses ' + ev.toFixed(1) + '%/yr</strong> (defaults: 3.5% / 4.0%).');
@@ -1862,6 +1882,7 @@ An override on its own buys time. It does not change the slope of either line.
   [revGrowthEl, expGrowthEl, overrideEl, ratchetEl, hcShareEl, wageOffsetEl].forEach(function(el) {
     el.addEventListener('input', function() {
       currentStance = null;
+      forcedEquilibriumActive = false;
       onChange();
     });
   });
@@ -1871,6 +1892,7 @@ An override on its own buys time. It does not change the slope of either line.
     var sign = v >= 0 ? '$' : '-$';
     fy27StepValEl.textContent = sign + Math.abs(v).toFixed(1) + 'M';
     currentStance = null;
+    forcedEquilibriumActive = false;
     onChange();
   });
 
@@ -1937,6 +1959,7 @@ An override on its own buys time. It does not change the slope of either line.
       wageOffsetEl.value = 50;
       fy27StepEl.value = 0;
       fy27StepValEl.textContent = '$0.0M';
+      forcedEquilibriumActive = false;
 
       if (s === 'bridge') {
         overrideEl.value = 15;
@@ -1973,6 +1996,8 @@ An override on its own buys time. It does not change the slope of either line.
         expGrowthEl.value = 3.7;
       } else if (s === 'composite-cuts') {
         positionCuts = 85;
+      } else if (s === 'forced-equilibrium') {
+        forcedEquilibriumActive = true;
       }
       onChange();
       if (chartScrollTarget) {
@@ -2005,6 +2030,7 @@ An override on its own buys time. It does not change the slope of either line.
       wageOffsetEl.value = 50;
       fy27StepEl.value = 0;
       fy27StepValEl.textContent = '$0.0M';
+      forcedEquilibriumActive = false;
       currentStance = null;
     }
 
@@ -2449,6 +2475,8 @@ An override on its own buys time. It does not change the slope of either line.
       expGrowthEl.value = 3.7;
     } else if (urlStance === 'composite-cuts') {
       positionCuts = 85;
+    } else if (urlStance === 'forced-equilibrium') {
+      forcedEquilibriumActive = true;
     }
     if (stanceNotes[urlStance]) {
       currentStance = urlStance;

--- a/docs/superpowers/plans/2026-04-17-deficit-model-scenarios.md
+++ b/docs/superpowers/plans/2026-04-17-deficit-model-scenarios.md
@@ -1,0 +1,1118 @@
+# Deficit model scenario-set refresh — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prune 4 existing scenarios in `charts/deficit_model.html`, add 5 new ones (A, C, D, E, G), copy-edit 3 existing (#3, #5, #11), add an `fy27Step` control, and update the tour step 7 caption. Leave the overall UX and tour structure intact.
+
+**Architecture:** All work lives in one file (`charts/deficit_model.html`). Each new scenario is a preset button that resets sliders to defaults then applies specific values in the stance click handler (line 1889). The `fy27Step` input is a number input inside the existing `<details>` "Assumptions" block, wired into the `compute()` and `computeTiers()` functions as a one-time additive shock to the FY27 projected expense value that does not propagate into forward compounding. D's compound-cut logic runs inside its own preset branch and stores an additional per-year cut delta used by `compute()`.
+
+**Tech Stack:** Static HTML, inline JS, SVG, Jekyll (frontmatter only, no liquid). No test framework beyond `tests/smoke-test.mjs` (Playwright against a live URL).
+
+**Spec:** `docs/superpowers/specs/2026-04-17-deficit-model-scenarios-design.md`
+
+**Related issues:** #595 (town-wide cuts-only forecast), #596 (stance-based reorganization).
+
+---
+
+### Task 0: Verify FY27 step value and FY27 gap against primary sources
+
+This is a research task before any code. No commit. The goal is to pin the two load-bearing numbers used in scenarios A and E so the preset values are defensible.
+
+**Files consulted (not modified):**
+- `data/2026-04-15_Override_Presentation_FINAL.txt` (latest override deck)
+- `data/2026-04-08_Override_Presentation.txt` (prior deck for cross-check)
+- FY27 proposed budget file in `data/` (find it)
+- `charts/healthcare_costs.html` (trend context)
+
+- [ ] **Step 1: Locate and read the FY27 proposed budget file**
+
+Run:
+
+```bash
+ls data/ | grep -i "budget\|fy27"
+```
+
+Identify the FY27 budget file, read it, and note the total projected FY27 expenses and the healthcare line item specifically.
+
+- [ ] **Step 2: Extract FY26 healthcare and FY27 healthcare from primary sources**
+
+Goal: confirm or correct the memory note "HC is $15.1M" (FY26) and "+11%" (FY27 increase). Look at the April 15 deck `data/2026-04-15_Override_Presentation_FINAL.txt` for the healthcare line items. Note the exact figures.
+
+- [ ] **Step 3: Compute the FY27 step**
+
+Given normalized expense growth rate `g_norm` (3.8% per spec), the FY27 step is:
+
+```
+step = FY27_healthcare_actual - (FY26_healthcare * (1 + g_norm))
+```
+
+Record the computed step value. This is the preset value for scenario A.
+
+Expected range: roughly +$1.0M to +$1.5M depending on exact FY26 and FY27 healthcare figures. If the computed step falls outside $0.5M to $2.5M, re-check inputs rather than shipping an outlier.
+
+- [ ] **Step 4: Confirm the FY27 gap figure ($8.47M)**
+
+In the April 15 deck, locate the stated FY27 deficit. Confirm it matches $8.47M, or record the correct figure. This is the preset target for scenario E.
+
+- [ ] **Step 5: Record the verified numbers**
+
+Append a short note to the spec file documenting the two verified numbers, with source citations:
+
+```bash
+cd /Users/agbaber/marblehead/.worktrees/deficit-model-scenarios
+# Edit docs/superpowers/specs/2026-04-17-deficit-model-scenarios-design.md
+# Add a "## Verified numbers" section at the bottom with:
+#   - FY27 step = $X.XM (source: April 15 deck, page Y; FY27 budget line Z)
+#   - FY27 gap = $X.XM (source: April 15 deck, page Y)
+#   - Derivation shown
+```
+
+No commit yet. These numbers are inputs to later tasks.
+
+---
+
+### Task 1: Prune 4 scenarios (#6 cost-slows, #7 new-growth, #9 override-plus-cuts, #10 kitchen-sink)
+
+**Files:**
+- Modify: `charts/deficit_model.html`
+
+- [ ] **Step 1: Read current state of the stance button block**
+
+Run:
+
+```bash
+sed -n '792,846p' charts/deficit_model.html
+```
+
+Verify the scenario cards are still at these locations before editing. If line numbers have shifted, re-locate using `grep -n 'data-stance' charts/deficit_model.html`.
+
+- [ ] **Step 2: Remove the four card buttons from the HTML**
+
+Delete these four `<button>` elements (matched exactly — the scenarios they represent):
+
+```html
+<button type="button" class="dm-scenario-card dm-stance-btn" data-stance="cost-slows">
+  <span class="dm-scenario-title">Cost growth slows to 3%</span>
+  <span class="dm-scenario-desc">If GIC moderates and contracts stay restrained, lines run roughly parallel.</span>
+</button>
+```
+
+```html
+<button type="button" class="dm-scenario-card dm-stance-btn" data-stance="new-growth">
+  <span class="dm-scenario-title">More new development</span>
+  <span class="dm-scenario-desc">Revenue growth at 4.5% from sustained construction and new growth.</span>
+</button>
+```
+
+```html
+<button type="button" class="dm-scenario-card dm-stance-btn" data-stance="override-plus-cuts">
+  <span class="dm-scenario-title">Override + modest cuts</span>
+  <span class="dm-scenario-desc">$12M override plus 20 position cuts.</span>
+</button>
+```
+
+```html
+<button type="button" class="dm-scenario-card dm-stance-btn" data-stance="kitchen-sink">
+  <span class="dm-scenario-title">Pull every lever</span>
+  <span class="dm-scenario-desc">$15M, healthcare reform, position cuts, fast spending ramp.</span>
+</button>
+```
+
+- [ ] **Step 3: Remove the corresponding `stanceNotes` entries**
+
+Around line 1760 in the `var stanceNotes = { ... }` block, delete the four entries keyed `cost-slows`, `new-growth`, `override-plus-cuts`, `kitchen-sink`. Their values are the existing realism text for each (preserved here for matching):
+
+```js
+'cost-slows': 'A stronger version of "Hold the line": 1.0pp off expense growth rather than 0.5pp. Requires GIC premium growth to moderate (state-controlled) and contracts to settle meaningfully below COLA. Not sustained in the last 20 years.',
+'new-growth': 'Revenue growth at 4.5% depends on sustained construction and new growth. Marblehead averaged about 1.3pp of new growth FY15 to FY24; pushing to 2pp+ is bounded by zoning and build-out.',
+'override-plus-cuts': 'Override paired with visible service reductions. Voters may read the cuts as evidence the override is needed; opponents may read them as proof the town can absorb cuts.',
+'kitchen-sink': 'Every lever pulled at once: override, healthcare, cuts, fast spending. Depends on voter, union, and state GIC cooperation simultaneously. More a thought experiment than a plan.',
+```
+
+- [ ] **Step 4: Remove the corresponding preset branches in the click handler**
+
+In the stance click handler (starts around line 1889), delete these `else if` branches:
+
+```js
+} else if (s === 'cost-slows') {
+  expGrowthEl.value = 3.0;
+} else if (s === 'new-growth') {
+  revGrowthEl.value = 4.5;
+}
+```
+
+```js
+} else if (s === 'override-plus-cuts') {
+  overrideEl.value = 12;
+  positionCuts = 20;
+}
+```
+
+```js
+} else if (s === 'kitchen-sink') {
+  overrideEl.value = 15;
+  hcShareEl.value = 65;
+  wageOffsetEl.value = 50;
+  positionCuts = 10;
+  ratchetEl.value = 3;
+}
+```
+
+- [ ] **Step 5: Verify nothing else references the pruned slugs**
+
+Run:
+
+```bash
+grep -n "cost-slows\|new-growth\|override-plus-cuts\|kitchen-sink" charts/deficit_model.html
+```
+
+Expected: no matches. If any remain, investigate and remove.
+
+- [ ] **Step 6: Verify the file still parses**
+
+Open the file in a browser:
+
+```bash
+open charts/deficit_model.html
+```
+
+Check the browser dev tools console for JS errors. Check that the 8 remaining scenario cards render and that clicking each of them (pick a sample of 3) still updates the chart without errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/agbaber/marblehead/.worktrees/deficit-model-scenarios
+git diff --stat charts/deficit_model.html
+git add charts/deficit_model.html
+git commit -m "$(cat <<'EOF'
+Deficit model: prune 4 scenarios
+
+Removes cost-slows (superseded by the forthcoming one-time healthcare
+spike scenario), new-growth (superseded by commercial-only), and the
+two kitchen-sink variants (override-plus-cuts, kitchen-sink) that
+duplicate existing combinations.
+
+Part of the scenario-set refresh. Spec:
+docs/superpowers/specs/2026-04-17-deficit-model-scenarios-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: `1 file changed, <few lines> insertions(+), <more lines> deletions(-)`.
+
+---
+
+### Task 2: Copy edits to #3, #5, #11
+
+**Files:**
+- Modify: `charts/deficit_model.html`
+
+- [ ] **Step 1: Update card HTML for scenario #3 (stance `cut`)**
+
+Replace the existing card:
+
+```html
+<button type="button" class="dm-scenario-card dm-stance-btn" data-stance="cut">
+  <span class="dm-scenario-title">Cut 50 positions</span>
+  <span class="dm-scenario-desc">~$5M/yr saved. Slope unchanged; gap reopens on the same schedule.</span>
+</button>
+```
+
+With:
+
+```html
+<button type="button" class="dm-scenario-card dm-stance-btn" data-stance="cut">
+  <span class="dm-scenario-title">Current pace of cuts</span>
+  <span class="dm-scenario-desc">About 50 positions over FY25 to FY27, roughly matching what the town has already done. Slope unchanged; gap keeps widening.</span>
+</button>
+```
+
+- [ ] **Step 2: Update the `stanceNotes.cut` entry**
+
+Replace the existing entry:
+
+```js
+'cut': 'Direct payroll reduction of roughly 10% of the town workforce. Lowers the level but does not flatten the slope. Service impact would be visible across every department.',
+```
+
+With:
+
+```js
+'cut': 'Roughly matches the FY25 to FY27 reductions already in place through layoffs, unfilled vacancies, and stipend reductions. Lowers the level but does not flatten the slope. The site\u2019s staffing analysis identifies 7 to 13 positions as the discretionary slice; further reductions reach mandate-adjacent roles or non-school departments (see inside-school-staffing.html#options).',
+```
+
+Note the `\u2019` for the right single quotation mark (apostrophe in `site's`) since the string is JS-literal.
+
+- [ ] **Step 3: Update card HTML for scenario #5 (stance `hold-line`)**
+
+Replace the existing card desc. Keep title. Replace:
+
+```html
+<span class="dm-scenario-desc">Expense growth matches revenue at 3.5%. Contracts at COLA, enrollment flat, no new programs.</span>
+```
+
+With:
+
+```html
+<span class="dm-scenario-desc">Expense growth drops to revenue growth (3.5%). Contracts at COLA, no new programs.</span>
+```
+
+The `stanceNotes['hold-line']` entry stays as-is (the existing realism note already specifies "healthcare enrollment to stay flat" which is the accurate reading).
+
+- [ ] **Step 4: Update card HTML for scenario #11 (stance `no-override-reform`)**
+
+Replace the existing card desc. Keep title. Replace:
+
+```html
+<span class="dm-scenario-desc">30 positions cut plus 65% healthcare share. No new revenue.</span>
+```
+
+With:
+
+```html
+<span class="dm-scenario-desc">65% healthcare share plus 30 positions cut. No new revenue.</span>
+```
+
+- [ ] **Step 5: Update the `stanceNotes['no-override-reform']` entry**
+
+Replace:
+
+```js
+'no-override-reform': 'No new revenue; 30 position cuts plus healthcare concessions carry the full load. The hardest path politically: the largest non-override concessions with nothing offered in return.',
+```
+
+With:
+
+```js
+'no-override-reform': 'No new revenue; 30 position cuts plus healthcare concessions carry the full load. 30 positions is more than double the site\u2019s 7 to 13 discretionary estimate (see inside-school-staffing.html#options), so the cuts reach mandate-adjacent roles or non-school departments. The hardest path politically: the largest non-override concessions with nothing offered in return.',
+```
+
+- [ ] **Step 6: Verify no em-dashes in the diff**
+
+Run:
+
+```bash
+git diff charts/deficit_model.html | grep -E "—|&mdash;|(\s)--(\s)"
+```
+
+Expected: no matches.
+
+- [ ] **Step 7: Open in browser and click each of #3, #5, #11**
+
+```bash
+open charts/deficit_model.html
+```
+
+For each scenario:
+- Verify the card shows the new title/desc.
+- Click it. Verify the readout panel shows the updated realism note.
+- Verify no console errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add charts/deficit_model.html
+git commit -m "$(cat <<'EOF'
+Deficit model: copy edits to #3, #5, #11
+
+Re-title and re-describe #3 to reflect that ~50 positions matches the
+FY25-FY27 cuts already in place, not a hypothetical reduction. Drop
+ambiguous "enrollment flat" phrasing from #5. Extend #11 realism note
+with the 7-13 discretionary-slice caveat from the site's staffing
+analysis.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Add `fy27Step` control and extend auto-explainer
+
+**Files:**
+- Modify: `charts/deficit_model.html`
+
+- [ ] **Step 1: Add the HTML control**
+
+Locate the `<details class="dm-controls-wrap" open>` block starting at line 876. Inside the inner `<div class="dm-controls">` (line 878), after the existing four controls (the last one ends around line 898), add:
+
+```html
+<div class="dm-control" style="grid-column: 1 / -1;">
+  <span class="dm-control-label">FY27 one-time step ($M): <span class="dm-value" id="dm-fy27-step-val">$0.0M</span></span>
+  <input type="number" id="dm-fy27-step" min="-5" max="5" step="0.1" value="0" style="width: 100px; font: inherit; padding: 4px 8px;">
+  <div class="dm-hint" id="dm-fy27-step-hint">Use this if you believe FY27 has a one-time cost deviation outside the compound-rate trend (for example, the observed healthcare bump). Default is 0, meaning the compound rate captures everything.</div>
+</div>
+```
+
+- [ ] **Step 2: Add the DOM reference and value element in the IIFE**
+
+Around line 1043 (the DOM refs block), after the existing `wageOffsetVal` reference, add:
+
+```js
+var fy27StepEl = document.getElementById('dm-fy27-step');
+var fy27StepValEl = document.getElementById('dm-fy27-step-val');
+```
+
+- [ ] **Step 3: Update the phaseYears index reference**
+
+Confirm `phaseYears[0]` is FY27 (should be index 12 per line 991). No code change, just verify:
+
+```bash
+grep -n "phaseYears" charts/deficit_model.html | head -5
+```
+
+Expected: `var phaseYears = [12, 13, 14];  // FY27, FY28, FY29` or similar.
+
+- [ ] **Step 4: Wire `fy27Step` into `compute()`**
+
+In `compute()` (line 1149), after the line:
+
+```js
+var ratchetYears = parseInt(ratchetEl.value);
+```
+
+Add:
+
+```js
+var fy27Step = parseFloat(fy27StepEl.value) || 0;
+```
+
+Then locate the projection loop (line 1165). Replace:
+
+```js
+for (var i = histCount; i < nYears; i++) {
+  r = r * (1 + revG);
+  e = e * (1 + expG);
+  // Phase in override over FY27-FY29
+  if (ovr > 0) {
+    for (var p = 0; p < phaseYears.length; p++) {
+      if (i === phaseYears[p]) {
+        var draw = ovr * phaseRatios[p];
+        r += draw;
+        // Schedule gradual expense absorption
+        if (ratchetYears > 0) {
+          pendingBumps.push({ startIdx: i, annualAmount: draw / ratchetYears });
+        }
+      }
+    }
+  }
+  // Apply accumulated ratchet bumps
+  for (var b = 0; b < pendingBumps.length; b++) {
+    var bump = pendingBumps[b];
+    var yearsSinceStart = i - bump.startIdx;
+    if (yearsSinceStart >= 0 && yearsSinceStart < ratchetYears) {
+      e += bump.annualAmount;
+    }
+  }
+  rev.push(r);
+  exp.push(e);
+}
+```
+
+With:
+
+```js
+for (var i = histCount; i < nYears; i++) {
+  r = r * (1 + revG);
+  e = e * (1 + expG);
+  // Phase in override over FY27-FY29
+  if (ovr > 0) {
+    for (var p = 0; p < phaseYears.length; p++) {
+      if (i === phaseYears[p]) {
+        var draw = ovr * phaseRatios[p];
+        r += draw;
+        // Schedule gradual expense absorption
+        if (ratchetYears > 0) {
+          pendingBumps.push({ startIdx: i, annualAmount: draw / ratchetYears });
+        }
+      }
+    }
+  }
+  // Apply accumulated ratchet bumps
+  for (var b = 0; b < pendingBumps.length; b++) {
+    var bump = pendingBumps[b];
+    var yearsSinceStart = i - bump.startIdx;
+    if (yearsSinceStart >= 0 && yearsSinceStart < ratchetYears) {
+      e += bump.annualAmount;
+    }
+  }
+  // FY27 one-time step: add to reported value but do not propagate
+  // into the forward compounding state.
+  var reportedE = e;
+  if (i === phaseYears[0] && fy27Step !== 0) {
+    reportedE = e + fy27Step;
+  }
+  rev.push(r);
+  exp.push(reportedE);
+}
+```
+
+- [ ] **Step 5: Wire `fy27Step` into `computeTiers()`**
+
+In `computeTiers()` (line 1209), apply the same pattern. Find:
+
+```js
+for (var i = histCount; i < nYears; i++) {
+  r = r * (1 + revG);
+  e = e * (1 + expG);
+  baseRev.push(r);
+  baseExp.push(e);
+}
+```
+
+Replace with:
+
+```js
+var fy27Step = parseFloat(fy27StepEl.value) || 0;
+for (var i = histCount; i < nYears; i++) {
+  r = r * (1 + revG);
+  e = e * (1 + expG);
+  baseRev.push(r);
+  var reportedE = e;
+  if (i === phaseYears[0] && fy27Step !== 0) {
+    reportedE = e + fy27Step;
+  }
+  baseExp.push(reportedE);
+}
+```
+
+- [ ] **Step 6: Update the value readout on input change**
+
+Locate where other controls wire their value displays (search for `revGrowthVal.textContent` around line 1270 or similar). Add an event listener for `fy27StepEl`:
+
+```bash
+grep -n "revGrowthEl.addEventListener\|onChange" charts/deficit_model.html | head -5
+```
+
+Near where other `addEventListener` calls are, add:
+
+```js
+fy27StepEl.addEventListener('input', function() {
+  var v = parseFloat(fy27StepEl.value) || 0;
+  fy27StepValEl.textContent = (v >= 0 ? '$' : '-$') + Math.abs(v).toFixed(1) + 'M';
+  onChange();
+});
+```
+
+Place this alongside the other controls' event listeners. If listeners are registered in a loop, add `fy27StepEl` to that list if the pattern supports it; otherwise add a standalone listener.
+
+- [ ] **Step 7: Extend `updateScenarioReadout` to mention fy27Step**
+
+In `updateScenarioReadout` (line 1775), find the block that appends growth rate info (around line 1798):
+
+```js
+if (Math.abs(rv - 3.5) > 0.05 || Math.abs(ev - 4.0) > 0.05) {
+  parts.push('Growth set to <strong>revenue ' + rv.toFixed(1) + '%/yr</strong>, <strong>expenses ' + ev.toFixed(1) + '%/yr</strong> (defaults: 3.5% / 4.0%).');
+}
+```
+
+Immediately before that block, read `fy27Step` and append a sentence when non-zero:
+
+```js
+var fy27Step = parseFloat(fy27StepEl.value) || 0;
+if (Math.abs(fy27Step) > 0.01) {
+  var sign = fy27Step >= 0 ? '+' : '-';
+  parts.push('FY27 one-time step: <strong>' + sign + '$' + Math.abs(fy27Step).toFixed(1) + 'M</strong>, not propagated into the forward trend.');
+}
+```
+
+- [ ] **Step 8: Update `resetToDefaults` (tour) and the preset click handler to reset `fy27Step`**
+
+In `resetToDefaults()` (around line 1962) inside the tour IIFE, after `wageOffsetEl.value = 50;` add:
+
+```js
+fy27StepEl.value = 0;
+fy27StepValEl.textContent = '$0.0M';
+```
+
+In the stance click handler (around line 1894) at the defaults-reset block, after `wageOffsetEl.value = 50;` add the same two lines.
+
+- [ ] **Step 9: Verify in browser**
+
+```bash
+open charts/deficit_model.html
+```
+
+- Expand the "Assumptions" `<details>`. Verify the new "FY27 one-time step ($M)" input renders.
+- Enter `1.1`. Verify:
+  - The value readout shows `$1.1M`.
+  - The expense line at FY27 jumps visibly.
+  - The FY28 value snaps back near the compound-only projection.
+  - No JS console errors.
+- Enter `0`. Verify the expense line returns to the no-step baseline.
+- Click an existing scenario (e.g. "Override buys time"). Verify fy27Step resets to 0.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add charts/deficit_model.html
+git commit -m "$(cat <<'EOF'
+Deficit model: add FY27 one-time step control
+
+Introduces fy27Step input in the Assumptions panel. Shock applied at
+FY27 only, not propagated into forward compounding (FY28+ compounds
+from the pre-shock state). Unlocks the one-time-healthcare-spike
+scenario landing next. Extends updateScenarioReadout to mention the
+step when non-zero.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Add scenario A (`hc-cliff` — One-time healthcare spike)
+
+**Files:**
+- Modify: `charts/deficit_model.html`
+
+**Prerequisite:** Task 0 Step 3 must have produced a verified `fy27Step` value. Use that value in Step 2 below. If not yet verified, block this task.
+
+- [ ] **Step 1: Add the card button**
+
+In the first `<div class="dm-scenarios">` block (under "Try a scenario", around line 793), append a new card after the last existing entry in that group:
+
+```html
+<button type="button" class="dm-scenario-card dm-stance-btn" data-stance="hc-cliff">
+  <span class="dm-scenario-title">One-time healthcare spike</span>
+  <span class="dm-scenario-desc">FY27 jump in healthcare, then expense growth returns to a normal rate.</span>
+</button>
+```
+
+- [ ] **Step 2: Add the preset branch**
+
+In the stance click handler, after the last existing `else if` in the "single-lever" group (after the `new-growth` block was removed in Task 1, the last single-lever scenario is `hold-line`), add:
+
+```js
+} else if (s === 'hc-cliff') {
+  fy27StepEl.value = 1.1; // verified value from Task 0; update if pinned differently
+  fy27StepValEl.textContent = '$1.1M';
+  expGrowthEl.value = 3.8;
+}
+```
+
+Use the actual verified number from Task 0 rather than 1.1 if different.
+
+- [ ] **Step 3: Add the `stanceNotes` entry**
+
+Add to `stanceNotes` (order: match the card's position in the UI):
+
+```js
+'hc-cliff': 'Tests the "cliff not chronic" read of FY27. Group insurance grew slower than CPI from FY12 to FY26 (about 29% vs. 37%, see healthcare_costs.html); if that pattern resumes after the FY27 step, the long-run rate returns to near the historical average. Depends on GIC premium behavior outside the town\u2019s control.',
+```
+
+- [ ] **Step 4: Verify in browser**
+
+```bash
+open charts/deficit_model.html
+```
+
+- Click the new "One-time healthcare spike" card.
+- Verify `fy27Step` input shows the verified value, expense growth slider shows 3.8%, revenue growth slider shows 3.5%.
+- Verify the chart shows a visible FY27 expense bump with FY28+ resuming a normal trajectory.
+- Verify the "Scenario modeled" readout includes both "FY27 one-time step" and "expenses 3.8%/yr".
+- Verify the "Realism" note matches the new text.
+- No console errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charts/deficit_model.html
+git commit -m "$(cat <<'EOF'
+Deficit model: add "One-time healthcare spike" scenario
+
+Tests the cliff-vs-chronic read of FY27. Uses the new fy27Step control
+to apply a one-time shock at FY27 while expense growth goes to 3.8%
+going forward. FY27 step value derived from FY27 healthcare deviation
+from the normalized compound projection (see spec for derivation).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Add scenario C (`commercial-only` — Commercial growth only)
+
+**Files:**
+- Modify: `charts/deficit_model.html`
+
+- [ ] **Step 1: Add the card button**
+
+In the "Try a scenario" `<div class="dm-scenarios">` block, append:
+
+```html
+<button type="button" class="dm-scenario-card dm-stance-btn" data-stance="commercial-only">
+  <span class="dm-scenario-title">Commercial growth only</span>
+  <span class="dm-scenario-desc">Revenue lifted by realistic commercial redevelopment. No new residential from 3A.</span>
+</button>
+```
+
+- [ ] **Step 2: Add the preset branch**
+
+In the stance click handler, add after the `hc-cliff` branch:
+
+```js
+} else if (s === 'commercial-only') {
+  revGrowthEl.value = 4.0;
+}
+```
+
+- [ ] **Step 3: Add the `stanceNotes` entry**
+
+```js
+'commercial-only': 'Commercial redevelopment at the top of Marblehead\u2019s realistic range adds roughly $500K to $1M per year in recurring capacity. This scenario uses the middle of that range (~$500K/yr, +0.5pp on revenue growth). The existing gap from FY24 onward does not close because new growth compounds forward but does not retroactively close old deficits. Residential growth is excluded because new housing adds service demand too.',
+```
+
+- [ ] **Step 4: Verify in browser**
+
+- Click the new "Commercial growth only" card.
+- Verify revenue growth shows 4.0%, everything else at defaults.
+- Verify the chart shows the expense and revenue lines running nearly parallel (both at 4.0% growth), with the FY24 gap persisting.
+- Verify the "Realism" note matches.
+- No console errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charts/deficit_model.html
+git commit -m "$(cat <<'EOF'
+Deficit model: add "Commercial growth only" scenario
+
+Isolates the commercial component of new growth from residential 3A
+housing, using the middle of the realistic commercial range
+(~$500K/yr, +0.5pp on revenue growth). Replaces the pruned
+new-growth scenario which conflated residential and commercial.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Add scenario G (`bend-curve` — Bend the cost curve)
+
+**Files:**
+- Modify: `charts/deficit_model.html`
+
+- [ ] **Step 1: Add the card button**
+
+In the "Combine levers" `<div class="dm-scenarios">` block (the second one, around line 825), append:
+
+```html
+<button type="button" class="dm-scenario-card dm-stance-btn" data-stance="bend-curve">
+  <span class="dm-scenario-title">Bend the cost curve (3 to 5 years)</span>
+  <span class="dm-scenario-desc">Structural reforms (collaboratives, in-district SPED, shared services) phased over 3 to 5 years.</span>
+</button>
+```
+
+- [ ] **Step 2: Add the preset branch**
+
+In the stance click handler, after the last combo branch (`permanent-close`), add:
+
+```js
+} else if (s === 'bend-curve') {
+  expGrowthEl.value = 3.7;
+}
+```
+
+- [ ] **Step 3: Add the `stanceNotes` entry**
+
+```js
+'bend-curve': 'Matches the site\u2019s framing of these reforms as cost-curve benders, not immediate substitutes for override revenue (see inside-school-staffing.html#options). Realistic impact from collaborative expansion, bringing out-of-district SPED placements back in, and shared back-office sums to roughly 0.3 to 0.5 percentage points off expense growth, but not until FY30 at the earliest. The compound-rate projection in this model applies the reduction uniformly, so the near-term years look more optimistic than reality.',
+```
+
+- [ ] **Step 4: Verify in browser**
+
+- Click "Bend the cost curve".
+- Verify expense growth shows 3.7%.
+- Verify the realism note surfaces the uniform-application caveat.
+- No console errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charts/deficit_model.html
+git commit -m "$(cat <<'EOF'
+Deficit model: add "Bend the cost curve" scenario
+
+Models structural reforms (collaboratives, in-district SPED, shared
+services) as a uniform 0.3pp reduction in expense growth. Realism
+note surfaces the limitation that the model applies the reduction
+uniformly, while in reality these reforms would not start until FY30
+at the earliest.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Add scenario E (`composite-cuts` — No override, no growth, just cuts)
+
+**Files:**
+- Modify: `charts/deficit_model.html`
+
+**Prerequisite:** Task 0 Step 4 must have confirmed the FY27 gap figure ($8.47M). Use it to compute `positionCuts`:
+
+```
+positionCuts_E = round(FY27_gap / 0.1)   # $100K per position
+```
+
+At $8.47M, that is 85 positions. Confirm before use.
+
+- [ ] **Step 1: Add the card button**
+
+In the "Combine levers" block, append:
+
+```html
+<button type="button" class="dm-scenario-card dm-stance-btn" data-stance="composite-cuts">
+  <span class="dm-scenario-title">No override, no growth, just cuts</span>
+  <span class="dm-scenario-desc">Both levers off the table. Cuts absorb the full FY27 gap.</span>
+</button>
+```
+
+- [ ] **Step 2: Add the preset branch**
+
+In the stance click handler, after `bend-curve`:
+
+```js
+} else if (s === 'composite-cuts') {
+  positionCuts = 85; // derived from FY27 gap / $100K per position; update if Task 0 pinned differently
+}
+```
+
+- [ ] **Step 3: Add the `stanceNotes` entry**
+
+```js
+'composite-cuts': 'Reflects the no-3A, no-override, yes-cuts composite position. Closing the $8.47M FY27 gap at roughly $100K per position implies on the order of 85 positions. Only 7 to 13 can come from the site\u2019s discretionary slice of school staffing (see inside-school-staffing.html#options); the remainder requires mandate relief, non-school department reductions, or both. Shows the magnitude, not which commitments to unwind.',
+```
+
+- [ ] **Step 4: Verify in browser**
+
+- Click "No override, no growth, just cuts".
+- Verify `positionCuts` shows 85.
+- Verify the chart shows expenses stepped down substantially at FY25 then resuming compound growth.
+- Verify the "Scenario modeled" readout reports the position-cut dollar savings (~$8.5M/yr).
+- Verify the realism note matches.
+- No console errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charts/deficit_model.html
+git commit -m "$(cat <<'EOF'
+Deficit model: add "No override, no growth, just cuts" scenario
+
+Composite anti-3A, anti-override, yes-cuts position. Closes the
+$8.47M FY27 gap via ~85 position cuts ($100K/pos). Realism note
+surfaces the 7-13 discretionary-slice ceiling from the site's
+staffing analysis, so readers understand where the remaining cuts
+would have to land.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Add scenario D (`forced-equilibrium` — Cuts to match the trend)
+
+**Files:**
+- Modify: `charts/deficit_model.html`
+
+D is the most load-bearing scenario. Its realism copy is intentionally conservative and links to #595. The compound-cut math lives inside the preset branch as a stored delta applied in `compute()`.
+
+- [ ] **Step 1: Add a shared state variable for compound cuts**
+
+Near the other shared state declarations (around line 1010, where `positionCuts = 0` is declared), add:
+
+```js
+var forcedEquilibriumActive = false;
+```
+
+- [ ] **Step 2: Add the card button**
+
+In the "Combine levers" block, append:
+
+```html
+<button type="button" class="dm-scenario-card dm-stance-btn" data-stance="forced-equilibrium">
+  <span class="dm-scenario-title">Cuts to match the trend</span>
+  <span class="dm-scenario-desc">Ongoing cuts each year that keep expenses growing at revenue\u2019s rate.</span>
+</button>
+```
+
+Use the literal right single-quote character in the HTML (copy-paste from above, not `\u2019`). The HTML accepts unicode directly; only JS strings need the escape.
+
+- [ ] **Step 3: Add the preset branch**
+
+In the stance click handler, after `composite-cuts`:
+
+```js
+} else if (s === 'forced-equilibrium') {
+  forcedEquilibriumActive = true;
+}
+```
+
+Also update the defaults-reset block at the top of the click handler (line 1893-1900) to include:
+
+```js
+forcedEquilibriumActive = false;
+```
+
+This ensures other scenarios don't inherit the flag.
+
+- [ ] **Step 4: Apply compound cuts inside `compute()`**
+
+In `compute()`, inside the main projection loop (after the override/ratchet logic, before the `fy27Step` block added in Task 3), add:
+
+```js
+// Forced-equilibrium cuts: subtract (expG - revG) x current expense
+// each projected year so the effective expense growth matches revenue.
+if (forcedEquilibriumActive && expG > revG) {
+  e -= (expG - revG) * e;
+}
+```
+
+Place this before the `reportedE` assignment. The compounding state `e` is reduced in-place so the next iteration compounds from the cut value - this is intentional and reflects ongoing cuts. The `reportedE` push uses this reduced `e`.
+
+Also apply the same logic in `computeTiers()`. Inside its base-projection loop (added in Task 3 Step 5), before the `reportedE` assignment, add:
+
+```js
+if (forcedEquilibriumActive && expG > revG) {
+  e -= (expG - revG) * e;
+}
+```
+
+- [ ] **Step 5: Add the `stanceNotes` entry (interim copy)**
+
+```js
+'forced-equilibrium': 'Requires ongoing annual cuts to keep expenses growing at revenue\u2019s rate. At the default rate gap (0.5pp), the scale is roughly half a percent of the budget per year, compounding forward. Only 7 to 13 school positions are documented as discretionary per the site\u2019s staffing analysis (inside-school-staffing.html#options); town-wide discretionary capacity has not yet been quantified. See github.com/agbaber/marblehead/issues/595 for the pending town-wide analysis.',
+```
+
+- [ ] **Step 6: Extend `resetToDefaults` (tour IIFE) to reset the flag**
+
+In `resetToDefaults()` inside the tour block, after the other resets, add:
+
+```js
+forcedEquilibriumActive = false;
+```
+
+- [ ] **Step 7: Extend `updateScenarioReadout` to surface forced-equilibrium in the auto-explainer**
+
+In `updateScenarioReadout`, after the fy27Step branch added in Task 3 Step 7 and before the growth-rate block, add:
+
+```js
+if (forcedEquilibriumActive && ev > rv) {
+  var gap = (ev - rv).toFixed(1);
+  parts.push('<strong>Compound cuts</strong> applied each year equal to the expense-to-revenue gap (about ' + gap + '% of the budget annually), so the expense line stays parallel to revenue rather than running at the underlying ' + ev.toFixed(1) + '% rate.');
+}
+```
+
+Without this, the chart shows parallel lines for D but the readout just reports the slider rates (3.5% / 4.0%), which would read as inconsistent. This branch makes the cut mechanism explicit.
+
+- [ ] **Step 8: Verify in browser**
+
+- Click "Cuts to match the trend".
+- Verify the expense line runs parallel to revenue (both at 3.5% effective growth).
+- Verify the "Scenario modeled" readout shows the compound-cuts sentence from Step 7.
+- Verify clicking any other scenario returns the flag to false and the chart to that scenario's behavior.
+- Verify switching between D and Hold the line produces the same chart shape but different realism notes.
+- Confirm the realism note includes the #595 link.
+- No console errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add charts/deficit_model.html
+git commit -m "$(cat <<'EOF'
+Deficit model: add "Cuts to match the trend" scenario (interim copy)
+
+Models compound annual cuts that force expense growth down to revenue
+growth's rate. Realism note is intentionally conservative and links to
+issue #595, where the town-wide forced-equilibrium forecast
+investigation is tracked. Once #595 lands, D's realism note gets
+upgraded in a follow-up PR with the specific derived forecast.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: Update tour step 7 caption
+
+**Files:**
+- Modify: `charts/deficit_model.html`
+
+- [ ] **Step 1: Locate the tour steps array**
+
+Tour steps are defined starting at line 1973 as `var steps = [ ... ]`. Step 7 is the final entry in the array.
+
+- [ ] **Step 2: Replace step 7's caption**
+
+Find:
+
+```js
+{
+  caption: 'Your turn. Pick any scenario below to see how different levers shape the chart. Each one lists its assumptions, how realistic it is, and what is doing the work. There is no single answer; the point is to see how the tradeoffs compare.',
+  setup: function() { resetToDefaults(); }
+}
+```
+
+Replace with:
+
+```js
+{
+  caption: 'Your turn. Scenarios below are framed around positions in the override debate. Each one lists its assumptions and how realistic it is. Pick one to see the chart shift. There is no single answer; the point is to see how the tradeoffs compare.',
+  setup: function() { resetToDefaults(); }
+}
+```
+
+- [ ] **Step 3: Verify in browser**
+
+- Open the page, click "Show me how this works".
+- Step through all 7 tour steps.
+- At step 7, verify the caption shows the new debate-stance framing.
+- Verify the total step count shows "Step 7 of 7" (it should, since `totalEl.textContent = steps.length` runs dynamically).
+- Exit the tour, click a scenario, verify normal behavior resumes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add charts/deficit_model.html
+git commit -m "$(cat <<'EOF'
+Deficit model: update tour step 7 to name debate-stance framing
+
+Updates the final step's caption to tell readers the scenarios below
+map to positions in the override debate. No structural change to the
+tour: still 7 steps, same setup, same flow. Keeps the tour's current
+tuning intact while tying it to the refreshed scenario set.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 10: Push, open PR, and verify preview
+
+**Files:** none (git operations only)
+
+- [ ] **Step 1: Verify branch is clean and all commits are stacked**
+
+```bash
+cd /Users/agbaber/marblehead/.worktrees/deficit-model-scenarios
+git status
+git log origin/main..HEAD --oneline
+```
+
+Expected: 9 commits ahead of main (the spec commit plus 9 implementation commits = 10; count is 10 if the spec commit hasn't been pushed yet). All commits should be on `deficit-model-scenarios`.
+
+- [ ] **Step 2: Push using the PAT from `.env`**
+
+```bash
+set -a && . /Users/agbaber/marblehead/.env && set +a
+git push "https://${GITHUB_TOKEN}@github.com/agbaber/marblehead.git" deficit-model-scenarios:deficit-model-scenarios -u
+```
+
+If the push fails because the branch already exists remotely, investigate whether another session has pushed to the same branch name before proceeding.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+set -a && . /Users/agbaber/marblehead/.env && set +a
+GH_TOKEN="$GITHUB_TOKEN" gh pr create --repo agbaber/marblehead --base main --head deficit-model-scenarios --title "Deficit model: scenario-set refresh (Approach 2)" --body "$(cat <<'EOF'
+## Summary
+
+Prunes 4 scenarios in `charts/deficit_model.html`, adds 5 new ones (A, C, D, E, G), copy-edits 3 existing (#3, #5, #11), adds an `fy27Step` control to the Assumptions panel, and updates the final tour step caption.
+
+New scenarios codify analytical positions active in the override debate so voters can find the case that matches their view and see what it does to the gap.
+
+## Scenarios
+
+Added:
+- **One-time healthcare spike** - tests cliff vs. chronic read of FY27
+- **Commercial growth only** - isolates commercial from 3A residential
+- **Cuts to match the trend** - compound annual cuts (interim copy, links #595)
+- **No override, no growth, just cuts** - composite anti-3A + anti-override position
+- **Bend the cost curve (3 to 5 years)** - structural reforms
+
+Pruned: Cost growth slows to 3%, More new development, Override + modest cuts, Pull every lever.
+
+Copy-edited: #3 (now "Current pace of cuts"), #5 (drop ambiguous enrollment phrasing), #11 (add 7-13 discretionary caveat).
+
+## Architecture
+
+One file touched (`charts/deficit_model.html`). Two deferred follow-ups:
+
+- #595 tracks the town-wide cuts-only forecast investigation. D's realism note links here.
+- #596 tracks Approach 3 (stance-based reorganization) for future work.
+
+## Test plan
+
+- [ ] Open the preview URL and click each of the 13 scenario cards; verify each sets the expected sliders and produces a readable realism note.
+- [ ] Step through the "Show me how this works" tour; verify step 7 shows the new debate-stance framing.
+- [ ] Enter values in the FY27 one-time step input; verify the expense line shows a visible FY27 shock that does not propagate into FY28+.
+- [ ] Run `node tests/smoke-test.mjs` against the preview URL (`SITE=<preview URL>`).
+- [ ] Eyeball the scenario layout on mobile (Safari responsive mode, 375px width).
+
+Spec: `docs/superpowers/specs/2026-04-17-deficit-model-scenarios-design.md`
+EOF
+)" 2>&1 | tail -5
+```
+
+Record the PR URL returned.
+
+- [ ] **Step 4: Wait for the preview deploy and fetch the Branch URL**
+
+Preview deploys take about 2 minutes. Fetch the preview comment:
+
+```bash
+set -a && . /Users/agbaber/marblehead/.env && set +a
+GH_TOKEN="$GITHUB_TOKEN" gh pr view <PR_NUMBER> --repo agbaber/marblehead --json comments --jq '.comments[] | select(.body | startswith("### Preview")) | .body' | head -20
+```
+
+Extract the `**Branch URL:**` value from the sticky comment.
+
+If the comment is not there yet, wait and re-poll. Do not send a bare PR link in the next step.
+
+- [ ] **Step 5: Smoke-test against the preview URL**
+
+```bash
+SITE=<BRANCH_URL> node tests/smoke-test.mjs
+```
+
+Expected: all existing smoke tests pass. If a test fails, diagnose before asking for review.
+
+- [ ] **Step 6: Report PR URL and preview URL**
+
+Tell the user:
+- The PR URL
+- The preview Branch URL (full URL, not abbreviated)
+- Confirmation that smoke tests pass
+
+---
+
+## Self-review checklist (before handing off)
+
+- [ ] Every new scenario has: card HTML, `stanceNotes` entry, preset branch, rendered correctly in browser.
+- [ ] Every edited scenario's copy matches the spec.
+- [ ] No em-dashes in any added copy.
+- [ ] No meta-narration in any added copy.
+- [ ] Every numerical claim links to a primary source or site page that carries one.
+- [ ] `fy27Step` default is 0; non-zero values do not propagate into FY28+ compounding.
+- [ ] `forcedEquilibriumActive` resets to false whenever another scenario is picked or defaults are applied.
+- [ ] Tour still has 7 steps (not 8).
+- [ ] Total scenario count is 13 (was 12).
+- [ ] All 9 commits are on `deficit-model-scenarios`; PR is open; smoke tests pass against preview.

--- a/docs/superpowers/specs/2026-04-17-deficit-model-scenarios-design.md
+++ b/docs/superpowers/specs/2026-04-17-deficit-model-scenarios-design.md
@@ -1,0 +1,355 @@
+---
+title: "Deficit model: scenario-set refresh (Approach 2)"
+date: 2026-04-17
+status: approved
+---
+
+# Deficit model: scenario-set refresh
+
+## Summary
+
+The deficit model at `charts/deficit_model.html` has 12 scenarios. This spec
+prunes 4, adds 5, edits the copy of 3, and adds one new control to the
+"Assumptions" panel so the added scenarios can be modeled honestly. Total
+scenarios after: 13.
+
+The new scenarios codify the analytical positions active in the override
+debate, so voters can find the case that matches their own stance and see
+what it does to the gap. Two deeper analyses (town-wide cuts forecast;
+stance-based reorganization of the scenario area) are deferred to follow-up
+issues (#595, #596).
+
+## Scope
+
+### In scope
+
+- Prune 4 existing scenarios: #6, #7, #9, #10.
+- Edit copy on 3 existing scenarios: #3, #5, #11.
+- Add 5 new scenarios: A, C, D, E, G (detail below).
+- Add one new control, `fy27Step`, inside the existing `<details>`
+  "Assumptions" block. Default 0.
+- Add compound-cut logic for scenarios D and E inside their preset handlers.
+  No new UI control, math applied within preset code.
+- Extend the auto-generated "Scenario modeled" explainer in
+  `updateScenarioReadout` to mention `fy27Step` when non-zero.
+- Update the caption on tour step 7 to name the debate-stance framing
+  explicitly. No change to step count, no new step.
+- Every new or edited scenario has a card title, a one-line card
+  description, and a realism note in `stanceNotes`.
+
+### Out of scope (deferred)
+
+- Issue #595: town-wide forced-equilibrium forecast investigation. The D
+  scenario ships with interim realism copy that points at this issue.
+- Issue #596: stance-based reorganization of the scenario area (Approach 3),
+  including multiple new controls and a restructured tour.
+
+### Hard constraints
+
+- No em-dashes in new copy.
+- No meta-narration ("this scenario shows&hellip;", "this chart
+  demonstrates&hellip;") per the added CLAUDE.md rule.
+- No green/red semantic color cues on new scenarios.
+- Every numerical claim in new copy cites a primary source or links to a
+  site page that does.
+
+## Scenario inventory
+
+### Keep (8)
+
+| ID | Title | Action |
+|----|-------|--------|
+| #1 | Override buys time | unchanged |
+| #2 | Override spent immediately | unchanged |
+| #3 | "Cut 50 positions" | retitle and re-describe (see below) |
+| #4 | Healthcare share to 50% | unchanged |
+| #5 | Hold the line | drop ambiguous "enrollment flat" phrase from card desc |
+| #8 | Override + HC reform | unchanged |
+| #11 | No override, just reform | extend realism note with discretionary-slice caveat |
+| #12 | Permanently close the gap | unchanged |
+
+### Prune (4)
+
+| ID | Title | Why |
+|----|-------|-----|
+| #6 | Cost growth slows to 3% | Superseded by A (one-time healthcare spike). |
+| #7 | More new development | Conflates commercial and residential growth. Superseded by C (commercial only). |
+| #9 | Override + modest cuts | Duplicative of #8 and #11. |
+| #10 | Pull every lever | Kitchen sink. #12 already carries the best-case case with a cleaner frame. |
+
+### Add (5)
+
+| ID | Title | Group |
+|----|-------|-------|
+| A | One-time healthcare spike | Try a scenario |
+| C | Commercial growth only | Try a scenario |
+| D | Cuts to match the trend | Combine levers |
+| E | No override, no growth, just cuts | Combine levers |
+| G | Bend the cost curve (3 to 5 years) | Combine levers |
+
+Grouping placement keeps the existing "Try a scenario" / "Combine levers"
+split. Stance-based regrouping is deferred to #596.
+
+## Scenario copy
+
+### Edit #3
+
+Current:
+
+- Title: "Cut 50 positions"
+- Card desc: "~$5M/yr saved. Slope unchanged; gap reopens on the same schedule."
+
+Proposed:
+
+- Title: "Current pace of cuts"
+- Card desc: "About 50 positions over FY25 to FY27, roughly matching what
+  the town has already done. Slope unchanged; gap keeps widening."
+- Realism: "Roughly matches the FY25 to FY27 reductions already in place
+  through layoffs, unfilled vacancies, and stipend reductions. Lowers the
+  level but does not flatten the slope. The site's staffing analysis
+  identifies 7 to 13 positions as the discretionary slice; further
+  reductions reach mandate-adjacent roles or non-school departments."
+- Links: `inside-school-staffing.html#options`.
+
+### Edit #5
+
+Current:
+
+- Title: "Hold the line"
+- Card desc: "Expense growth matches revenue at 3.5%. Contracts at COLA,
+  enrollment flat, no new programs."
+
+Proposed:
+
+- Title: "Hold the line" (unchanged)
+- Card desc: "Expense growth drops to revenue growth (3.5%). Contracts at
+  COLA, no new programs."
+- Realism: unchanged (existing text is accurate; the "healthcare enrollment"
+  clarification it already contains is sufficient).
+
+Reason for the card desc change: the phrase "enrollment flat" is ambiguous
+between student enrollment (which is already declining 19% per
+`charts/enrollment_vs_staffing.html`, so "flat" would misread the reality)
+and healthcare enrollment (which is what the realism note actually means).
+Dropping the phrase removes the ambiguity without changing the scenario's
+math.
+
+### Edit #11
+
+Current:
+
+- Title: "No override, just reform"
+- Card desc: "30 positions cut plus 65% healthcare share. No new revenue."
+
+Proposed:
+
+- Title: "No override, just reform" (unchanged)
+- Card desc: "65% healthcare share plus 30 positions cut. No new revenue."
+- Realism: "No new revenue; 30 position cuts plus healthcare concessions
+  carry the full load. 30 positions is more than double the site's 7 to 13
+  discretionary estimate, so the cuts reach mandate-adjacent roles or
+  non-school departments. The hardest path politically: the largest
+  non-override concessions with nothing offered in return."
+- Links: `inside-school-staffing.html#options`.
+
+### Add A (stance slug: `hc-cliff`)
+
+- Title: "One-time healthcare spike"
+- Card desc: "FY27 jump in healthcare, then expense growth returns to a
+  normal rate."
+- Realism: "Tests the 'cliff not chronic' read of FY27. Group insurance
+  grew slower than CPI from FY12 to FY26 (about 29% vs. 37%); if that
+  pattern resumes after the FY27 step, the long-run rate returns to near
+  the historical average. Depends on GIC premium behavior outside the
+  town's control."
+- Links: `charts/healthcare_costs.html`.
+- Preset: `fy27Step` = the deviation between actual FY27 healthcare and
+  what the normalized compound projection would give. At `expGrowth` =
+  3.8%, the compound projection of FY26 $15.1M gives FY27 healthcare
+  &asymp; $15.67M. Actual FY27 at +11% gives $16.76M. Step &asymp; +$1.1M.
+  This is smaller than the $1.7M total FY27 healthcare increase; the
+  difference is the portion of growth already captured by the compound
+  rate. Final value confirmed against FY27 proposed budget and April 15
+  override deck before ship. `expGrowth` = 3.8%, `revGrowth` = 3.5%.
+
+### Add C (stance slug: `commercial-only`)
+
+- Title: "Commercial growth only"
+- Card desc: "Revenue lifted by realistic commercial redevelopment. No new
+  residential from 3A."
+- Realism: "Commercial redevelopment at the top of Marblehead's realistic
+  range adds roughly $500K to $1M per year in recurring capacity. This
+  scenario uses the middle of that range. The existing gap from FY24
+  onward does not close because new growth compounds forward but does not
+  retroactively close old deficits. Residential growth is excluded because
+  new housing adds service demand too."
+- Preset: `revGrowth` = 4.0% (+0.5pp from baseline), `expGrowth` = 4.0%
+  default.
+
+### Add D (stance slug: `forced-equilibrium`)
+
+- Title: "Cuts to match the trend"
+- Card desc: "Ongoing cuts each year that keep expenses growing at
+  revenue's rate."
+- Realism (interim, pending #595): "Requires ongoing annual cuts to keep
+  expenses growing at revenue's rate. At the default rate gap (0.5pp),
+  the scale is roughly half a percent of the budget per year, compounding
+  forward. Only 7 to 13 school positions are documented as discretionary
+  per the site's staffing analysis; town-wide discretionary capacity has
+  not yet been quantified. See issue #595 for the pending analysis."
+- Links: `inside-school-staffing.html#options`, issue #595.
+- Preset: compound-cut logic inside the preset handler. Each projected
+  year, subtract `(expGrowth - revGrowth) x currentExpense` from the
+  expense line. Stored separately from the `positionCuts` counter so the
+  existing position-cut slider is not affected.
+- Realism upgrade: once #595 lands with a town-wide page, D's realism note
+  is updated in a follow-up PR to cite the specific forecast and link the
+  new page.
+
+### Add E (stance slug: `composite-cuts`)
+
+- Title: "No override, no growth, just cuts"
+- Card desc: "Both levers off the table. Cuts absorb the full FY27 gap."
+- Realism: "Reflects the no-3A, no-override, yes-cuts composite position.
+  Closing the $8.47M FY27 gap at roughly $100K per position implies on
+  the order of 85 positions. Only 7 to 13 can come from the site's
+  discretionary slice of school staffing; the remainder requires mandate
+  relief, non-school department reductions, or both. Shows the
+  magnitude, not which commitments to unwind."
+- Links: `inside-school-staffing.html#options`.
+- Preset: `positionCuts` &asymp; 85 (front-loaded; exact number derived from
+  confirmed $8.47M FY27 gap divided by $100K per position), `override` = 0,
+  growth rates default.
+
+### Add G (stance slug: `bend-curve`)
+
+- Title: "Bend the cost curve (3 to 5 years)"
+- Card desc: "Structural reforms (collaboratives, in-district SPED, shared
+  services) phased over 3 to 5 years."
+- Realism: "Matches the site's framing of these reforms as cost-curve
+  benders, not immediate substitutes for override revenue. Realistic
+  impact from collaborative expansion, bringing out-of-district SPED
+  placements back in, and shared back-office sums to roughly 0.3 to 0.5
+  percentage points off expense growth, but not until FY30 at the
+  earliest. The compound-rate projection in this model applies the
+  reduction uniformly, so the near-term years look more optimistic than
+  reality."
+- Links: `inside-school-staffing.html#options`.
+- Preset: `expGrowth` = 3.7% (-0.3pp), with the uniform-application
+  limitation flagged in the realism note.
+
+## Model changes
+
+### New control: `fy27Step`
+
+- Location: inside the existing `<details>` "Assumptions" block, below
+  the existing four sliders. Not on the main controls area.
+- Shape: number input (not a range slider). Unit: millions.
+- Default: 0.
+- Label: "FY27 one-time step ($M)"
+- Hint: "Use this if you believe FY27 has a one-time cost deviation
+  outside the compound-rate trend (for example, the observed healthcare
+  bump). Default is 0, meaning the compound rate captures everything."
+- Math: applied as an additive shock to projected expenses in the FY27
+  year only. Not propagated into the compounding trend. FY28+ computes
+  from the pre-shock FY26 value compounded forward, not from (FY27 +
+  step) x (1 + expGrowth).
+- Rationale: lets scenario A (one-time healthcare spike) visualize a
+  genuine cliff + normalization path. The model notes already flag
+  "constant annual compounding, which is a simplification," so this
+  extension is in-spirit.
+
+### Compound-cut logic for D and E
+
+- D: preset setup function applies `(expGrowth - revGrowth) x
+  currentExpense` to each projected year's expense value. Logic lives in
+  the stance preset handler, not in shared model code.
+- E: preset setup function sets `positionCuts` to the value calculated
+  from the confirmed FY27 gap (&asymp;85 positions at $8.47M / $100K per
+  position). Existing model math handles the rest.
+
+### Auto-explainer extension
+
+- The existing `updateScenarioReadout` function (line 1775 of the current
+  file) composes "Scenario modeled" text from slider values: override,
+  positionCuts, hcShare, revGrowth, expGrowth.
+- Add one branch: when `fy27Step` is non-zero, append a sentence like
+  "FY27 one-time step: +$X.XM, not propagated into the forward trend."
+- Ordering: place the new sentence after the override/cuts/healthcare
+  sentences and before the growth-rate sentence, so it reads as a
+  historical-anchor note rather than a forward-projection note.
+
+### Tour integration
+
+- Existing tour has 7 steps (`dm-tour-total` is set dynamically by JS at
+  line 2021 from `steps.length`; the `6` in the HTML literal at line 775
+  is a placeholder).
+- Update **only** step 7's caption. Current text reads "Your turn. Pick
+  any scenario below to see how different levers shape the chart. Each
+  one lists its assumptions, how realistic it is, and what is doing the
+  work. There is no single answer; the point is to see how the tradeoffs
+  compare."
+- Proposed replacement: "Your turn. Scenarios below are framed around
+  positions in the override debate. Each one lists its assumptions and
+  how realistic it is. Pick one to see the chart shift. There is no
+  single answer; the point is to see how the tradeoffs compare."
+- Net step count: still 7. No new step added.
+- Rationale: the existing step 7 already points readers at the scenarios.
+  Updating its caption to name the stance framing is additive rather than
+  structural, which respects the current tour tuning.
+
+## File and commit organization
+
+### Files touched
+
+- `charts/deficit_model.html` - all work lives here:
+  - Scenario card HTML (prune 4, add 5, edit 3 copy).
+  - `stanceNotes` entries for 5 new + 3 edited (updating existing `cut`,
+    `hold-line`, `no-override-reform`).
+  - Preset setup functions for 5 new scenarios.
+  - `fy27Step` control markup inside `<details>` "Assumptions".
+  - `fy27Step` math in the compute function.
+  - Extended `updateScenarioReadout` branch.
+  - Updated tour step 7 caption.
+
+### Commit shape (for the implementation plan)
+
+1. Prune 4 scenarios (card HTML + `stanceNotes` entries).
+2. Copy edits to #3, #5, #11.
+3. Add `fy27Step` control and extend auto-explainer.
+4. Add scenario A (one-time healthcare spike), using `fy27Step`.
+5. Add scenario C (commercial growth only).
+6. Add scenario G (bend the cost curve).
+7. Add scenario E (no override, no growth, just cuts).
+8. Add scenario D (cuts to match the trend) with interim realism copy
+   linking #595.
+9. Update tour step 7 caption.
+
+One PR, 9 commits. D is last because its copy is the most load-bearing
+and may need iteration against the live preview.
+
+### Verification gates before merging
+
+- FY27 step value (&asymp; +$1.1M preliminary estimate) reconciled against
+  FY27 proposed budget, April 15 Select Board override deck (commit
+  `69314c3`), and current expense growth rate assumption. The step
+  represents deviation from the compound projection, not the total FY27
+  healthcare increase.
+- `$8.47M` FY27 gap in E's `positionCuts` calculation confirmed against
+  the April 15 FINAL override presentation.
+- Tour plays through cleanly on desktop and mobile (the tour was
+  explicitly flagged as carefully tuned).
+- All new scenarios produce readable explainer + realism text at their
+  preset values.
+- No em-dashes in new copy.
+- No meta-narration in new copy.
+
+## Related issues
+
+- **#595** Investigate cuts-only path: town-wide forecast for
+  forced-equilibrium. D's realism note links to this issue. Once the
+  issue's output lands, D's realism note is upgraded in a follow-up PR.
+- **#596** Deficit model: stance-based scenario reorganization
+  (Approach 3). Future enhancement covering stance-based grouping,
+  additional new controls (cuts ramp timing, structural reform start
+  year), and tour restructure.

--- a/docs/superpowers/specs/2026-04-17-deficit-model-scenarios-design.md
+++ b/docs/superpowers/specs/2026-04-17-deficit-model-scenarios-design.md
@@ -353,3 +353,75 @@ and may need iteration against the live preview.
   (Approach 3). Future enhancement covering stance-based grouping,
   additional new controls (cuts ramp timing, structural reform start
   year), and tour restructure.
+
+## Verified numbers
+
+Research performed 2026-04-17. Primary sources consulted:
+`data/FY27_Proposed_Budget_No_Override.txt` (Table of Estimate
+Appropriations, Line 221 Group Insurance) and
+`data/state_of_town_financials.json` (sourced to State of the Town
+presentation, Jan 28 2026, Thatcher Kezer).
+
+### Number 1: fy27Step (one-time healthcare step above normalized growth)
+
+**Source:** `data/FY27_Proposed_Budget_No_Override.txt`, Line 221 Group
+Insurance (FY27 Proposed Budget document, also recorded in
+`data/group_insurance_FY06-27.csv` row FY2027, cited to FY27 Proposed
+Budget).
+
+Raw budget figures:
+- FY26 Group Insurance budget: $15,100,893
+- FY27 Group Insurance proposed: $16,754,748
+- Actual YoY increase: $1,653,855 (+10.95%)
+
+Derivation using g_norm = 3.8%:
+
+```
+fy27_normalized = 15,100,893 * 1.038 = 15,674,727
+fy27Step = 16,754,748 - 15,674,727 = 1,080,021
+```
+
+**Verified fy27Step: $1.080M**
+
+Memory notes estimated ~$1.09M using +$1.66M absolute and the formula
+above. The actual absolute increase is $1,653,855 (not $1.66M), which
+gives $1.080M (not $1.09M). The discrepancy is rounding in the memory
+note's "$1.66M" approximation. The correct figure from primary source is
+**$1.080M**; use this in code.
+
+### Number 2: FY27 total general fund deficit
+
+**Source:** `data/state_of_town_financials.json`, field `FY27_deficit`:
+8471823. JSON records its source as "State of the Town Presentation, Jan
+28 2026, Thatcher Kezer."
+
+Cross-checks:
+- April 8 Select Board transcript (`data/select_board_2026-04-08_transcript.txt`)
+  contains the MOU draft language: "facing a $7.7 million budget deficit
+  for fiscal year '27." The same transcript also references the TA
+  explaining that figure came down from a higher number after accounting
+  for school reductions and the new trash carve-out.
+- The April 15 FINAL override presentation
+  (`data/2026-04-15_Override_Presentation_FINAL.txt`) does not state an
+  explicit dollar gap; it frames the override as a three-tier $9M/$12M/$15M
+  choice without restating the underlying structural deficit.
+- The waterfall plan at `docs/superpowers/plans/2026-04-11-fy27-gap-waterfall-implementation.md`
+  uses $8,471,823 and cites the State of the Town presentation (Jan 28
+  2026) as its primary source, consistent with the JSON.
+
+**On the $7.7M vs $8.47M discrepancy:** The April 8 MOU draft language
+references $7.7M, which is an intermediate figure the TA described as the
+pre-adjustment gap. The $8.47M in `state_of_town_financials.json` comes
+from the earlier Jan 28 State of the Town and represents the full
+structural operating gap (revenue down ~$2.3M, expenses up ~$6.2M). These
+are reconcilable: the $8.47M is the structural gap; the $7.7M referenced
+in April 8 appears to be the gap after accounting for school-side
+adjustments already made in the FY27 balanced budget proposal. The
+April 15 FINAL deck does not resolve the discrepancy directly.
+
+**Decision:** Use $8,471,823 ($8.47M) for scenario E's `positionCuts`
+calculation, consistent with `state_of_town_financials.json` and the Jan
+28 2026 primary source. At $100K per position, that is 85 positions. Add
+an inline code comment citing the source.
+
+**Verified FY27 gap: $8.47M ($8,471,823)**


### PR DESCRIPTION
## Summary

Prunes 4 scenarios in `charts/deficit_model.html`, adds 5 new ones (A, C, D, E, G), copy-edits 3 existing (#3, #5, #11), adds an `fy27Step` control to the Assumptions panel, and updates the final tour step caption.

New scenarios codify analytical positions active in the override debate so voters can find the case that matches their view and see what it does to the gap.

## Scenarios

**Added:**
- **One-time healthcare spike** (`hc-cliff`) - tests the cliff vs. chronic read of FY27
- **Commercial growth only** (`commercial-only`) - isolates commercial from 3A residential
- **Cuts to match the trend** (`forced-equilibrium`) - compound annual cuts, interim copy links #595
- **No override, no growth, just cuts** (`composite-cuts`) - composite anti-3A + anti-override position
- **Bend the cost curve (3 to 5 years)** (`bend-curve`) - structural reforms

**Pruned:** `cost-slows`, `new-growth`, `override-plus-cuts`, `kitchen-sink`.

**Copy-edited:**
- #3 now "Current pace of cuts" (anchored to FY25-FY27 reality, not hypothetical)
- #5 drops ambiguous "enrollment flat" phrasing
- #11 realism note surfaces the 7-13 discretionary-slice caveat from the site's staffing analysis

## New control

`fy27Step` number input in the Assumptions panel (default 0). Applies a one-time shock to projected expenses at FY27 without propagating into FY28+ compounding. Required for scenario A to honestly show a cliff + normalization rather than a sustained higher rate.

## Architecture

One file touched (`charts/deficit_model.html`). 12 scenarios to 13, plus one new control. JS parses cleanly. Self-verified with `new Function()` sanity check.

Two deferred follow-ups:
- **#595** town-wide cuts-only forecast investigation. D's realism note links here.
- **#596** Approach 3 stance-based scenario reorganization for future work.

## Verified numbers

- fy27Step value $1.08M derived from FY26 $15,100,893 to FY27 $16,754,748 at +10.95%, minus compound projection at 3.8% (source: FY27 Proposed Budget No Override, confirmed against April 15 override deck)
- FY27 gap value $8,471,823 (source: State of the Town presentation, Jan 28 2026, Thatcher Kezer)

Derivations documented in spec: `docs/superpowers/specs/2026-04-17-deficit-model-scenarios-design.md`

## Test plan

- [ ] Open the preview URL and click each of the 13 scenario cards; verify each sets the expected sliders and produces a readable realism note
- [ ] Step through the "Show me how this works" tour; verify step 7 shows the new debate-stance framing, total steps still 7
- [ ] Enter values in the FY27 one-time step input; verify the expense line shows a visible FY27 shock that does not propagate into FY28+
- [ ] Run `node tests/smoke-test.mjs` against the preview URL
- [ ] Eyeball the scenario layout on mobile (Safari responsive mode, 375px width)

Spec: `docs/superpowers/specs/2026-04-17-deficit-model-scenarios-design.md`
Plan: `docs/superpowers/plans/2026-04-17-deficit-model-scenarios.md`