### PR TITLE
Lint: add Tier 2 content guardrails (acronyms, citations, links, anchors)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -104,4 +104,88 @@ jobs:
             fail=1
           fi
 
+          # ---------- Unwrapped municipal-finance acronyms ----------
+          # STYLE_GUIDE: first use of a governance or municipal-finance
+          # acronym on a page must be wrapped in <abbr class="g" title="...">.
+          # The blocklist is the acronyms actively wrapped elsewhere on the
+          # site (from grep of existing <abbr> usage), so this isn't a
+          # generic all-caps hunter that trips on USA, LLC, YES/NO, etc.
+          # Lines that already contain an <abbr> or a citation marker are
+          # treated as good-faith wraps and pass.
+          ACRONYM_LIST='ACFR|FTE|DOR|DESE|GIC|DLS|MGL|OPEB|PERAC|IEP|IDEA|ACS|MBTA|DPW|SPED|HVAC|EPIMS|ELL|ESSER|CPI|TIR|GASB|SRO|HEO|GIS|COA|GFOA|SJC|FinCom'
+          unwrapped_acronyms=$(printf '%s\n' "$added" \
+            | grep -nE "\\b(${ACRONYM_LIST})s?\\b" \
+            | grep -vE '<abbr|<sup class="cite"|data-source=|data-href=' \
+            || true)
+          if [ -n "$unwrapped_acronyms" ]; then
+            echo "::error title=Unwrapped acronym::STYLE_GUIDE requires first use of governance / municipal-finance acronyms to be wrapped in <abbr class=\"g\" title=\"...\">. Same-line <abbr> passes."
+            printf '%s\n' "$unwrapped_acronyms"
+            fail=1
+          fi
+
+          # ---------- Citation data-source non-empty ----------
+          # Every <sup class="cite"> must carry a non-empty data-source
+          # attribute. assets/citations.js reads it at runtime to build the
+          # auto-injected <h2>Sources</h2> list; a missing or empty
+          # data-source silently drops the source from the rendered page.
+          missing_source=$(printf '%s\n' "$added" \
+            | grep -nE '<sup class="cite"' \
+            | grep -vE 'data-source="[^"]+"' \
+            || true)
+          if [ -n "$missing_source" ]; then
+            echo "::error title=Citation missing data-source::<sup class=\"cite\"> must include a non-empty data-source attribute (assets/citations.js reads it to render the Sources list)."
+            printf '%s\n' "$missing_source"
+            fail=1
+          fi
+
+          # ---------- Internal link resolution ----------
+          # href="page.html" (or /page.html, charts/page.html) must resolve
+          # to an existing file at repo root. External URLs, mailto/tel/js,
+          # and relative-up links (../) are skipped - the first two aren't
+          # ours to validate, the third depends on the referring page's
+          # directory which isn't known to a repo-root check.
+          internal_links=$(printf '%s\n' "$added" \
+            | grep -oE 'href="[^"#?]+\.html[^"]*"' \
+            | sed 's/href="//; s/"$//' \
+            | sort -u \
+            || true)
+          for link in $internal_links; do
+            path=$(printf '%s' "$link" | sed 's/[#?].*$//')
+            case "$path" in
+              http://*|https://*|//*|mailto:*|tel:*|javascript:*) continue ;;
+              *../*|..*) continue ;;
+            esac
+            relative=$(printf '%s' "$path" | sed 's|^/||')
+            [ -z "$relative" ] && continue
+            if [ ! -f "$relative" ]; then
+              echo "::error title=Broken internal link::file not found: $link (checked $relative)"
+              fail=1
+            fi
+          done
+
+          # ---------- Anchor fragment resolution ----------
+          # href="page.html#frag" must find id="frag" or name="frag" in the
+          # target page. Same-page anchors (href="#frag") are skipped - the
+          # host page isn't necessarily in the diff, so we can't verify.
+          anchor_refs=$(printf '%s\n' "$added" \
+            | grep -oE 'href="[^"]+#[^"]+"' \
+            | sed 's/href="//; s/"$//' \
+            | sort -u \
+            || true)
+          for ref in $anchor_refs; do
+            file=$(printf '%s' "$ref" | sed 's/#.*$//')
+            frag=$(printf '%s' "$ref" | sed 's/^[^#]*#//')
+            [ -z "$file" ] && continue
+            case "$file" in
+              http://*|https://*|//*) continue ;;
+              *../*|..*) continue ;;
+            esac
+            relative=$(printf '%s' "$file" | sed 's|^/||')
+            [ -f "$relative" ] || continue
+            if ! grep -qE "(id|name)=\"${frag}\"" "$relative"; then
+              echo "::error title=Broken anchor::#${frag} not found in ${file}"
+              fail=1
+            fi
+          done
+
           exit $fail


### PR DESCRIPTION
## Summary
Four new diff-based checks in \`.github/workflows/lint.yml\`, all scoped to added lines in site-facing HTML/markdown (same pathspec as Tier 1). Builds on #600.

### Tier 2 checks

| # | Check | Rule source |
|---|---|---|
| 5 | **Unwrapped acronyms** in governance / municipal-finance blocklist (30 terms: ACFR, FTE, DOR, DESE, GIC, DLS, MGL, OPEB, PERAC, IEP, IDEA, ACS, MBTA, DPW, SPED, HVAC, EPIMS, ELL, ESSER, CPI, TIR, GASB, SRO, HEO, GIS, COA, GFOA, SJC, FinCom) | STYLE_GUIDE acronym rule |
| 6 | **Citation missing data-source** — every \`<sup class="cite">\` must have a non-empty \`data-source\` attribute | \`assets/citations.js\` reads it; empty silently drops the source |
| 7 | **Broken internal link** — \`href="page.html"\` must resolve to an existing repo file | Stops link rot |
| 8 | **Broken anchor fragment** — \`href="page.html#frag"\` must find \`id="frag"\` or \`name="frag"\` in the target | Stops anchor rot |

### Design notes
- **Blocklist for acronyms, not allowlist.** A generic \`[A-Z]{2,}\` hunter would trip on USA, LLC, YES, MA, etc. The blocklist is sourced from \`grep\` of existing \`<abbr>\` usage — these are the acronyms the site actively wraps elsewhere.
- **Permissive "same-line <abbr> passes"** for the acronym check. A line with \`<abbr class="g" title="ACFR">ACFR</abbr>\` matches both the acronym regex AND the <abbr> filter, so it passes. Lines with multiple acronyms where only one is wrapped will pass — acceptable trade-off for not re-inventing an HTML parser in bash.
- **Citation markers and data-href/data-source lines are excluded** from the acronym check, because those are attribute content not prose.
- **Relative-up links (\`../\`) are skipped** in link resolution — they depend on the referring page's directory, which a repo-root check doesn't know.

### Why this is Tier 2, not Tier 1
The \`layman-language-rule\` STYLE_GUIDE extension (#598) had to land first to define the jargon taxonomy these checks enforce. It did, so here we are.

### Test plan
- [ ] Add an unwrapped \`FTE\` in a new \`<p>\` — acronym check fails
- [ ] Add a \`<sup class="cite" data-href="x">\` without data-source — citation check fails
- [ ] Add \`href="does-not-exist.html"\` — link check fails
- [ ] Add \`href="about.html#no-such-frag"\` — anchor check fails