### PR TITLE
Tour: theme-aware buttons, fit "if override fails" end label

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -165,14 +165,14 @@ title: "Deficit Dynamics Model"
     font-size: 13px;
     padding: 8px 14px;
     border: 1px solid var(--c-navy);
-    background: #fff;
+    background: transparent;
     color: var(--c-navy);
     border-radius: 4px;
     cursor: pointer;
   }
   .dm-tour-nav-btn:hover, .dm-tour-exit:hover,
   .dm-tour-nav-btn:focus-visible, .dm-tour-exit:focus-visible {
-    background: var(--c-fog);
+    background: color-mix(in srgb, var(--c-navy) 12%, transparent);
   }
   .dm-tour-nav-btn:disabled {
     opacity: 0.4;
@@ -180,11 +180,11 @@ title: "Deficit Dynamics Model"
   }
   .dm-tour-nav-next {
     background: var(--c-navy);
-    color: #fff;
+    color: var(--bg);
   }
   .dm-tour-nav-next:hover,
   .dm-tour-nav-next:focus-visible {
-    background: #1a2d4a;
+    background: color-mix(in srgb, var(--c-navy) 85%, var(--text));
   }
   .dm-tour-exit {
     font-size: 11px;
@@ -1032,7 +1032,7 @@ An override on its own buys time. It does not change the slope of either line.
 
   // === Main chart layout ===
   var svgW = 880, svgH = 460;
-  var mL = 70, mR = 100, mT = 28, mB = 60;
+  var mL = 70, mR = 170, mT = 28, mB = 60;
   var plotW = svgW - mL - mR;
   var plotH = svgH - mT - mB;
 


### PR DESCRIPTION
## Summary

Two minor tweaks to the deficit model tour panel (screenshot feedback):

- **Buttons don't fit dark mode.** `Back`, `Exit tour`, and the `Next` label color were hardcoded white. In dark mode, `--c-fog` flips to dark navy and `--c-navy` flips to light blue, so the panel appeared with bright-white button faces. Switched the ghost buttons to a transparent background and the Next button text to `var(--bg)` so contrast is preserved in both themes. Hover states now use `color-mix` so they work in both directions.
- **"\$171M (if override fails)" end label was clipped.** The main-chart right margin (`mR`) was 100 SVG units, which leaves ~94px for end-of-line labels — fine for "\$205M" but not for the longer constrained-expense label. Widened `mR` to 170 so the full phrase renders inside the viewBox.

## Test plan

- [ ] Open the preview, scroll to the deficit model, start the guided tour. Verify Back / Exit tour / Next buttons look correct in the current theme.
- [ ] Toggle OS dark mode and confirm buttons still read naturally against the panel.
- [ ] Step into the override-active step of the tour and confirm "\$171M (if override fails)" renders fully (no clipping on the right edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)