### PR TITLE
Tour step 3: nudge users to try $15M (Tier 3) for a larger wedge

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -2047,7 +2047,7 @@ An override on its own buys time. It does not change the slope of either line.
         }
       },
       {
-        caption: 'Adding an override. Tier 2 ($12M) raises the levy ceiling permanently. Revenue jumps above expenses starting FY27, giving the town a few years of breathing room (green above red). Click Back and Next to compare: the line angles do not change, so expenses keep growing at the same rate and catch up on the same schedule.',
+        caption: 'Adding an override. Tier 2 ($12M) raises the levy ceiling permanently. Revenue jumps above expenses starting FY27, giving the town a few years of breathing room (green above red). Try the override slider at $15M (Tier 3) for a larger wedge. Click Back and Next to compare: the line angles do not change, so expenses keep growing at the same rate and catch up on the same schedule.',
         setup: function() {
           resetToDefaults();
           overrideEl.value = 12;


### PR DESCRIPTION
## Summary

Tour step 3 sets the override slider to Tier 2 (\$12M) as a plausible midpoint. The resulting wedge of revenue-above-expenses is real, but small against the \$50M–\$210M y-axis — you can easily miss that an override is doing anything. Add one sentence to the step-3 caption nudging users to slide the override up to \$15M (Tier 3) to see a larger version of the same effect.

Deliberate choices:
- Keep Tier 2 as the tour's default so the tour is not picking a tier.
- Use the existing slider rather than a new "Tier 3 preview" button — the interactive control is already there; teaching its existence is the point.

## Test plan

- [ ] Preview the deficit model, start the tour, step to "Adding an override."
- [ ] Read the caption and confirm the nudge sentence lands between "green above red" and "Click Back and Next."
- [ ] Manually drag the override slider to \$15M and confirm the wedge visibly grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)