### PR TITLE
Deficit model: promote "No override, just cuts" scenario to top row

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -804,6 +804,10 @@ title: "Deficit Dynamics Model"
     <span class="dm-scenario-title">Override spent immediately</span>
     <span class="dm-scenario-desc">$15M absorbed in year one. The skeptic&rsquo;s view: gap barely narrows.</span>
   </button>
+  <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="composite-cuts">
+    <span class="dm-scenario-title">No override, just cuts</span>
+    <span class="dm-scenario-desc">About 85 positions, sized to absorb the full FY27 gap. Slope unchanged.</span>
+  </button>
   <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="cut">
     <span class="dm-scenario-title">Current pace of cuts</span>
     <span class="dm-scenario-desc">About 50 positions over FY25 to FY27, roughly matching what the town has already done. Slope unchanged; gap keeps widening.</span>
@@ -843,10 +847,6 @@ title: "Deficit Dynamics Model"
   <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="bend-curve">
     <span class="dm-scenario-title">Bend the cost curve (3 to 5 years)</span>
     <span class="dm-scenario-desc">Structural reforms (collaboratives, in-district SPED, shared services) phased over 3 to 5 years.</span>
-  </button>
-  <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="composite-cuts">
-    <span class="dm-scenario-title">No override, no growth, just cuts</span>
-    <span class="dm-scenario-desc">Both levers off the table. Cuts absorb the full FY27 gap.</span>
   </button>
   <button type="button" class="dm-scenario-card dm-stance-btn" data-stance="forced-equilibrium">
     <span class="dm-scenario-title">Cuts to match the trend</span>


### PR DESCRIPTION
## Summary

The composite-cuts scenario (cuts sized to absorb the full FY27 \$8.47M gap with no override) was living in the "Combine levers" row, which made it hard to find when scanning the scenario picker. It belongs alongside the two override scenarios as one of the three primary reactions to the deficit: override-and-absorb-gradually, override-and-absorb-immediately, or skip-the-override-and-cut.

Changes:
- Move the `composite-cuts` card from "Combine levers" up to "Try a scenario," placed right after "Override spent immediately."
- Rename the card title from "No override, no growth, just cuts" to "No override, just cuts." The stance-note explainer (visible once clicked) still documents the fuller no-3A-growth, no-override framing.
- Reword the card description from "Both levers off the table. Cuts absorb the full FY27 gap." to "About 85 positions, sized to absorb the full FY27 gap. Slope unchanged." Parallels the phrasing of "Current pace of cuts" directly below it.
- `data-stance="composite-cuts"` unchanged, so saved URLs and the URL-stance handler still work.

## Test plan

- [ ] Preview the deficit model and scan the top scenario row. Confirm the order reads: Override buys time / Override spent immediately / No override, just cuts / Current pace of cuts / Healthcare share to 50% / Hold the line / One-time healthcare spike / Commercial growth only.
- [ ] Click "No override, just cuts" and confirm the slider readout shows ~85 position cuts and the chart drops expenses by \~\$8.5M in FY27.
- [ ] Confirm the stance-note explainer still shows the full "no-3A, no-override, yes-cuts composite position" text.
- [ ] Visit `charts/deficit_model.html?stance=composite-cuts` and confirm the URL still selects the promoted card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)