### PR TITLE
Sketch: four-path intent-based landing page

### DIFF
--- a/browse.html
+++ b/browse.html
@@ -9,7 +9,7 @@ og_url: https://marbleheaddata.org/browse.html
 ---
 <div class="hero">
     <h1>All pages</h1>
-    <p>Every page on marbleheaddata.org, grouped by topic. For the interactive question flow, start at the <a href="/">home page</a>. Every claim cites a primary source &ndash; <a href="#data-sources">see all sources</a>.</p>
+    <p>Every page on marbleheaddata.org, grouped by topic. For the interactive question flow, start at the <a href="/">home page</a>. Every claim cites a primary source &ndash; <a href="#data-and-tools">see all sources</a>.</p>
   </div>
 
   <a class="featured-card" href="super-summary.html">
@@ -248,9 +248,30 @@ og_url: https://marbleheaddata.org/browse.html
     </a>
   </div>
 
-  <div class="data-section" id="data-sources">
-    <h2>Data &amp; Sources</h2>
+  <div class="data-section" id="data-and-tools">
+    <h2>Data and Tools</h2>
     <div class="data-links">
+      <a class="data-link" href="charts/deficit_model.html">
+        <div>
+          <div class="data-link-title">Deficit Model</div>
+          <div class="data-link-desc">Set growth rates, toggle tiers, see when the gap reopens</div>
+        </div>
+        <span class="data-link-badge">TOOL</span>
+      </a>
+      <a class="data-link" href="charts/town_explorer.html">
+        <div>
+          <div class="data-link-title">Town Explorer</div>
+          <div class="data-link-desc">Filter, sort, and compare all 351 MA communities</div>
+        </div>
+        <span class="data-link-badge">TOOL</span>
+      </a>
+      <a class="data-link" href="charts/override_calculator.html">
+        <div>
+          <div class="data-link-title">Override Calculator</div>
+          <div class="data-link-desc">What the override costs at your home value, by tier</div>
+        </div>
+        <span class="data-link-badge">TOOL</span>
+      </a>
       <a class="data-link" href="data/master-data">
         <div>
           <div class="data-link-title">Annual Rollup (FY01&ndash;FY27)</div>

--- a/landing-sketch.html
+++ b/landing-sketch.html
@@ -1,0 +1,50 @@
+---
+layout: home
+title: "Landing sketch"
+community_pulse: off-sections
+sitemap: false
+og_title: "Marblehead Budget Data"
+og_description: Sketch of a four-path landing page for marbleheaddata.org.
+og_type: website
+---
+
+<div class="hero">
+  <h1>Where do you want to start?</h1>
+  <p>Two override ballot questions, May 4 and June 9. The full financial picture is on this site &ndash; pick the door that fits what you're here to do.</p>
+</div>
+
+<div class="question-list">
+
+  <a class="question" href="{{ '/' | relative_url }}">
+    <h2>I'm undecided and want to learn</h2>
+    <p>Walk the main questions with the strongest case on each side. Your picks build into a set of positions you can review or share.</p>
+  </a>
+
+  <a class="question" href="{{ '/' | relative_url }}the-debate.html">
+    <h2>I want to understand the case for the override</h2>
+    <p>The six dividing lines, each with the strongest version of the yes argument and the no response beside it.</p>
+  </a>
+
+  <a class="question" href="{{ '/' | relative_url }}the-debate.html">
+    <h2>I want to understand the case against the override</h2>
+    <p>The same six dividing lines, read from the other direction: the strongest no argument and the yes response beside it.</p>
+  </a>
+
+  <a class="question" href="{{ '/' | relative_url }}browse.html">
+    <h2>I'm just here for the data and tools</h2>
+    <p>Deficit model, town explorer, override calculator, the chart library, and the source lookup behind every number.</p>
+  </a>
+
+</div>
+
+<p class="section-label">Quick links</p>
+<div class="question-list">
+  <a class="question" href="{{ '/' | relative_url }}super-summary.html">
+    <h2>The whole override in 60 seconds</h2>
+    <p>The deficit, the three ballot tiers, what it costs at your home value, and when you vote. One short page.</p>
+  </a>
+  <a class="question" href="{{ '/' | relative_url }}whats-on-the-ballot.html">
+    <h2>What's on the ballot</h2>
+    <p>Both override questions, tier by tier, with the exact ballot language.</p>
+  </a>
+</div>

--- a/landing-sketch.html
+++ b/landing-sketch.html
@@ -39,19 +39,19 @@ og_type: website
 </div>
 
 <div class="question-list">
-  <a class="question" href="{{ '/' | relative_url }}">
+  <a class="question" href="{{ '/' | relative_url }}?ref=router">
     <h2>I'm undecided and want to learn</h2>
     <p>Walk the main questions with the strongest case on each side. Your picks build into a set of positions you can review or share.</p>
   </a>
 </div>
 
 <div class="question-list">
-  <a class="question question--for" href="{{ '/' | relative_url }}the-debate.html">
+  <a class="question question--for" href="{{ '/' | relative_url }}the-debate.html?lens=for&amp;ref=router">
     <p class="stance-label">For the override</p>
     <h2>I want to understand the case for</h2>
     <p>The six dividing lines, each with the strongest version of the yes argument and the no response beside it.</p>
   </a>
-  <a class="question question--against" href="{{ '/' | relative_url }}the-debate.html">
+  <a class="question question--against" href="{{ '/' | relative_url }}the-debate.html?lens=against&amp;ref=router">
     <p class="stance-label">Against the override</p>
     <h2>I want to understand the case against</h2>
     <p>The same six dividing lines, read from the other direction: the strongest no argument and the yes response beside it.</p>
@@ -59,7 +59,7 @@ og_type: website
 </div>
 
 <div class="question-list">
-  <a class="question" href="{{ '/' | relative_url }}browse.html">
+  <a class="question" href="{{ '/' | relative_url }}browse.html?ref=router#data-and-tools">
     <h2>I'm just here for the data and tools</h2>
     <p>Deficit model, town explorer, override calculator, the chart library, and the source lookup behind every number.</p>
   </a>
@@ -67,11 +67,11 @@ og_type: website
 
 <p class="section-label">Quick links</p>
 <div class="question-list">
-  <a class="question" href="{{ '/' | relative_url }}super-summary.html">
+  <a class="question" href="{{ '/' | relative_url }}super-summary.html?ref=router">
     <h2>The whole override in 60 seconds</h2>
     <p>The deficit, the three ballot tiers, what it costs at your home value, and when you vote. One short page.</p>
   </a>
-  <a class="question" href="{{ '/' | relative_url }}whats-on-the-ballot.html">
+  <a class="question" href="{{ '/' | relative_url }}whats-on-the-ballot.html?ref=router">
     <h2>What's on the ballot</h2>
     <p>Both override questions, tier by tier, with the exact ballot language.</p>
   </a>

--- a/landing-sketch.html
+++ b/landing-sketch.html
@@ -7,6 +7,31 @@ og_title: "Marblehead Budget Data"
 og_description: Sketch of a four-path landing page for marbleheaddata.org.
 og_type: website
 ---
+<style>
+  /* Pair the for/against router cards visually: matching chrome so readers
+     read them as a linked pair, using the same teal (for) / brass (against)
+     encoding the-debate.html already uses. Neutral semantic colors, not
+     green/red. */
+  .question--for {
+    border-left: 4px solid var(--c-teal);
+    background: color-mix(in srgb, var(--c-teal) 4%, var(--surface));
+  }
+  .question--against {
+    border-left: 4px solid var(--c-brass);
+    background: color-mix(in srgb, var(--c-brass) 4%, var(--surface));
+  }
+  .stance-label {
+    font-size: 0.625rem; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 1.4px; color: var(--text-subtle);
+    margin: 0 0 4px;
+  }
+  .question--for .stance-label  { color: var(--c-teal); }
+  .question--against .stance-label { color: var(--c-brass); }
+
+  /* Keep consistent 12px spacing between consecutive router sub-lists,
+     matching the flex gap inside a .question-list. */
+  .question-list + .question-list { margin-top: 12px; }
+</style>
 
 <div class="hero">
   <h1>Where do you want to start?</h1>
@@ -14,27 +39,30 @@ og_type: website
 </div>
 
 <div class="question-list">
-
   <a class="question" href="{{ '/' | relative_url }}">
     <h2>I'm undecided and want to learn</h2>
     <p>Walk the main questions with the strongest case on each side. Your picks build into a set of positions you can review or share.</p>
   </a>
+</div>
 
-  <a class="question" href="{{ '/' | relative_url }}the-debate.html">
-    <h2>I want to understand the case for the override</h2>
+<div class="question-list">
+  <a class="question question--for" href="{{ '/' | relative_url }}the-debate.html">
+    <p class="stance-label">For the override</p>
+    <h2>I want to understand the case for</h2>
     <p>The six dividing lines, each with the strongest version of the yes argument and the no response beside it.</p>
   </a>
-
-  <a class="question" href="{{ '/' | relative_url }}the-debate.html">
-    <h2>I want to understand the case against the override</h2>
+  <a class="question question--against" href="{{ '/' | relative_url }}the-debate.html">
+    <p class="stance-label">Against the override</p>
+    <h2>I want to understand the case against</h2>
     <p>The same six dividing lines, read from the other direction: the strongest no argument and the yes response beside it.</p>
   </a>
+</div>
 
+<div class="question-list">
   <a class="question" href="{{ '/' | relative_url }}browse.html">
     <h2>I'm just here for the data and tools</h2>
     <p>Deficit model, town explorer, override calculator, the chart library, and the source lookup behind every number.</p>
   </a>
-
 </div>
 
 <p class="section-label">Quick links</p>

--- a/landing-sketch.html
+++ b/landing-sketch.html
@@ -34,8 +34,8 @@ og_type: website
 </style>
 
 <div class="hero">
-  <h1>Where do you want to start?</h1>
-  <p>Two override ballot questions, May 4 and June 9. The full financial picture is on this site &ndash; pick the door that fits what you're here to do.</p>
+  <h1>Do we need an override?</h1>
+  <p>Two override ballot questions, May 4 and June 9. Every number on this site is traceable to a primary source.</p>
 </div>
 
 <div class="question-list">


### PR DESCRIPTION
## Summary

Standalone preview of a homepage that routes visitors by intent instead of dropping them straight into the question flow. Lives at `/landing-sketch.html`, not wired into nav, `sitemap: false`.

Four paths, all framed as learning rather than arguing:

1. I'm undecided and want to learn &rarr; `/` (current explore experience)
2. I want to understand the case for the override &rarr; `the-debate.html`
3. I want to understand the case against the override &rarr; `the-debate.html`
4. I'm just here for the data and tools &rarr; `browse.html`

Plus two quick-link cards (super-summary, what's on the ballot) for visitors who want the shortest path.

### Design rationale

- Keeps the non-advocacy stance: both partisan paths land on `the-debate.html`, which presents the strongest version of each side. The framing difference is for the reader's mental mode, not different content.
- Avoids "here's your ammunition" framing. "Understand the case for/against" is learning-oriented; "prove to others" was not.
- The data/tools path is the power-user door. Matches what `browse.html`, `data/DATA_CATALOG.md`, and `SOURCE_LOOKUP.md` already serve.

### Open questions

- If this replaces `index.html`, the current explore experience would need a new URL (e.g. `/decide.html`).
- Card 4 could go to the chart library or the data catalog directly instead of `browse.html`.
- Whether the two-vote countdown strip from the current landing should live on this router page too.

## Test plan

- [ ] Preview the Branch URL, check card grid on desktop and mobile
- [ ] Confirm all four cards click through to existing pages
- [ ] Confirm light and dark mode both read cleanly
- [ ] Decide whether any of this merges into `index.html` or lives on as a separate route

https://claude.ai/code/session_015stfobnHFXR96dszyxnLNt