### PR TITLE
Link fee-vs-tax case law note from question-2-trash page

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -158,8 +158,15 @@ jobs:
             relative=$(printf '%s' "$path" | sed 's|^/||')
             [ -z "$relative" ] && continue
             if [ ! -f "$relative" ]; then
-              echo "::error title=Broken internal link::file not found: $link (checked $relative)"
-              fail=1
+              # Jekyll renders data/FOO.md to data/FOO.html at build time,
+              # so an href to the .html URL is correct even when only the
+              # .md source exists in the repo. Fall back to the markdown
+              # source before declaring the link broken.
+              md_fallback="${relative%.html}.md"
+              if [ "$md_fallback" = "$relative" ] || [ ! -f "$md_fallback" ]; then
+                echo "::error title=Broken internal link::file not found: $link (checked $relative)"
+                fail=1
+              fi
             fi
           done
 

--- a/question-2-trash.html
+++ b/question-2-trash.html
@@ -678,6 +678,25 @@ og_url: https://marbleheaddata.org/question-2-trash.html
 
 <details class="deep-dive deep-dive--prose">
   <summary>
+    <h2 id="legal-durability">Can the $281 fee survive a court challenge?</h2>
+    <div class="deep-dive-preview">
+      <p>Massachusetts has a specific test, from the 1984 <em>Emerson College v. City of Boston</em> decision, for whether a charge a municipality calls a fee is legally a fee or actually a tax. A flat $281 per-household charge faces structural exposure on that test. The nearest precedent: in November 2006 a Hampden Superior Court judge stopped the City of Springfield from collecting a flat municipal trash fee; Springfield rebuilt it with an enterprise fund and an explicit opt-out, and the revised version survived.</p>
+    </div>
+    <span class="deep-dive-more">Continue reading <span class="arrow">&#x25B8;</span></span>
+  </summary>
+  <div class="deep-dive-body">
+
+<p>Massachusetts has a specific test for whether a charge a municipality calls a fee is legally a fee or actually a tax. It comes from <em>Emerson College v. City of Boston</em>, the 1984 <abbr class="g" title="Supreme Judicial Court">SJC</abbr> decision that set the three-prong fee-vs-tax test. If a charge fails any prong, it is a tax, which matters because taxes beyond the existing levy require a Proposition 2&frac12; override vote.</p>
+
+<p>A flat $281 per-household charge is structurally exposed on the voluntariness prong (a mandatory flat fee survives only if households can genuinely opt out, typically by declining curbside service in favor of the transfer station) and on the cost-recovery prong (revenue must be segregated to the service, not deposited into the general fund). The nearest Massachusetts precedent is Springfield: in November 2006, a Hampden Superior Court judge issued a preliminary injunction stopping the City from collecting a flat municipal trash fee. Springfield rebuilt the fee with an explicit opt-out, a dedicated enterprise fund, and per-container pricing, and the revised version was upheld.</p>
+
+<p>Whether Marblehead's fee would end up in Springfield's FY2007 posture (struck down) or FY2008 posture (upheld) depends on how the Board of Health writes the fee order, and several key structural questions are not yet answered publicly. The full analysis, including the three prongs, the precedent table, the Marblehead plaintiff classes with standing to sue, and the open research questions, is in the <a href="data/case_law_fee_vs_tax.html">case law note on fee vs. tax under Proposition 2&frac12;</a>. <em>Not legal advice.</em></p>
+
+  </div>
+</details>
+
+<details class="deep-dive deep-dive--prose">
+  <summary>
     <h2 id="trickiness-concern">What the trickiness concern is actually about</h2>
     <div class="deep-dive-preview">
       <p>A concern raised in local discussion is that the $2.3 million override is being described as funding curbside trash service, when residents were already paying for that same service through existing property taxes via the Waste Collection department. The concern is that the framing implies residents face a choice about whether to fund trash, when really the choice is about how.</p>


### PR DESCRIPTION
## Summary

The Emerson v. Boston case law note was merged in #590 as `data/case_law_fee_vs_tax.md` and is live at https://marbleheaddata.org/data/case_law_fee_vs_tax.html, but no page links to it. A reader arriving at `question-2-trash.html` has no way to find the legal analysis of the $281 fallback fee.

Adds a collapsible section **"Can the $281 fee survive a court challenge?"** to `question-2-trash.html`, placed between "Long-term alternatives not on the ballot" and "What the trickiness concern is actually about."

## Design choices

- **Deep-dive details pattern**, matching neighboring sections. The H2 and a 3-sentence preview are visible in a page scan; the full text (three prongs, Springfield precedent) is collapsed by default. Prominence without adding length to the default read.
- **No duplication of the full analysis.** Body copy is 3 short paragraphs and links out to the case law note for the precedent table, plaintiff classes, and open research questions.
- **Plain-language gloss** on first use per STYLE_GUIDE: *Emerson College v. City of Boston* is named and dated, SJC is wrapped in `<abbr class="g">`, "voluntariness" and "cost-recovery" prongs are defined inline rather than left as legal-test jargon.
- **Neutral framing.** States the factual doctrine and the Springfield precedent (struck down, then rebuilt, then upheld). Does not prescribe a vote. Carries a `Not legal advice.` disclaimer mirroring the destination doc.

## Test plan

- [ ] Verify the new section appears between "Long-term alternatives" and the "trickiness concern" deep-dive
- [ ] Verify the inline link to `data/case_law_fee_vs_tax.html` resolves on the preview deploy
- [ ] Scan for STYLE_GUIDE violations (no em-dashes, no editorial tilt, `<abbr>` on SJC, case name italicized and glossed on first use)
- [ ] Confirm the deep-dive expand/collapse works on mobile and desktop