### PR TITLE
Deficit model: readability pass on scenario readout

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -211,6 +211,13 @@ title: "Deficit Dynamics Model"
     color: var(--c-navy);
     font-weight: 700;
   }
+  #dm-stance-explainer strong,
+  #dm-stance-realism strong {
+    font-size: 16px;
+  }
+  .dm-readout-clause + .dm-readout-clause {
+    margin-top: 6px;
+  }
   .dm-svg {
     display: block;
     width: 100%;
@@ -1444,13 +1451,13 @@ An override on its own buys time. It does not change the slope of either line.
     'healthcare': 'Saves $2.2M/yr net after wage offsets and pension flow-through. Requires union concessions on a long-standing benefit. Hingham runs at 50% but reached that position through years of bargaining.',
     'hold-line': 'The closest scenario to what Marblehead already ran FY18 to FY24 (expenses 3.43%, revenue 3.64%). Stops the gap from widening but does not close the existing deficit, which still draws from free cash or reserves each year. Requires contracts to settle at COLA, healthcare enrollment to stay flat, and pensions to grow no faster than their recent CAGR. A GASB pension revaluation or a heavy SPED year breaks the assumption.',
     'hc-cliff': 'Tests the "cliff not chronic" read of FY27. Group insurance grew slower than CPI from FY12 to FY26 (about 29% vs. 37%, see healthcare_costs.html); if that pattern resumes after the FY27 step, the long-run rate returns to near the historical average. Depends on GIC premium behavior outside the town\u2019s control.',
-    'commercial-only': 'Commercial redevelopment at the top of Marblehead\u2019s realistic range adds roughly $500K to $1M per year in recurring capacity. This scenario uses the middle of that range (+0.5pp on revenue growth). The existing gap from FY24 onward does not close because new growth compounds forward but does not retroactively close old deficits. Residential growth is excluded because new housing adds service demand too.',
+    'commercial-only': 'Commercial redevelopment at the top of Marblehead\u2019s realistic range adds roughly $500K to $1M per year in recurring capacity. This scenario uses the middle of that range (+0.5 percentage points on revenue growth). The existing gap from FY24 onward does not close because new growth compounds forward but does not retroactively close old deficits. Residential growth is excluded because new housing adds service demand too.',
     'override-plus-hc':'Stacks two politically hard lifts: an operating override vote plus union concessions on health insurance. Both are plausible individually; combining them depends on winning a vote and a bargaining round.',
     'no-override-reform':'No new revenue; 30 position cuts plus healthcare concessions carry the full load. 30 positions is more than double the site\u2019s 7 to 13 discretionary estimate (see inside-school-staffing.html#options), so the cuts reach mandate-adjacent roles or non-school departments. The hardest path politically: the largest non-override concessions with nothing offered in return.',
-    'permanent-close': 'The 0.8pp drop in expense growth (4.0% to 3.2%) is doing roughly 38% of the work; the override, cuts, and healthcare reform contribute the rest. Requires healthcare premium moderation outside the town\u2019s control plus sustained wage restraint not achieved in the last 20 years.',
+    'permanent-close': 'Lowering expense growth by 0.8 percentage points (from 4.0% to 3.2%) is doing roughly 38% of the work; the override, cuts, and healthcare reform contribute the rest. Requires healthcare premium moderation outside the town\u2019s control plus sustained wage restraint not achieved in the last 20 years.',
     'bend-curve': 'Matches the site\u2019s framing of these reforms as cost-curve benders, not immediate substitutes for override revenue (see inside-school-staffing.html#options). Realistic impact from collaborative expansion, bringing out-of-district SPED placements back in, and shared back-office sums to roughly 0.3 to 0.5 percentage points off expense growth, but not until FY30 at the earliest. The compound-rate projection in this model applies the reduction uniformly, so the near-term years look more optimistic than reality.',
     'composite-cuts': 'Reflects the no-3A, no-override, yes-cuts composite position. Closing the $8.47M FY27 gap at roughly $100K per position implies on the order of 85 positions. Only 7 to 13 can come from the site\u2019s discretionary slice of school staffing (see inside-school-staffing.html#options); the remainder requires mandate relief, non-school department reductions, or both. Shows the magnitude, not which commitments to unwind.',
-    'forced-equilibrium': 'Requires ongoing annual cuts to keep expenses growing at revenue\u2019s rate. At the default rate gap (0.5pp), the scale is roughly half a percent of the budget per year, compounding forward. Only 7 to 13 school positions are documented as discretionary per the site\u2019s staffing analysis (inside-school-staffing.html#options); town-wide discretionary capacity has not yet been quantified. See github.com/agbaber/marblehead/issues/595 for the pending town-wide analysis.'
+    'forced-equilibrium': 'Requires ongoing annual cuts to keep expenses growing at revenue\u2019s rate. At the default rate gap (0.5 percentage points), the scale is roughly half a percent of the budget per year, compounding forward. Only 7 to 13 school positions are documented as discretionary per the site\u2019s staffing analysis (inside-school-staffing.html#options); town-wide discretionary capacity has not yet been quantified. See github.com/agbaber/marblehead/issues/595 for the pending town-wide analysis.'
   };
 
   function updateScenarioReadout() {
@@ -1474,7 +1481,7 @@ An override on its own buys time. It does not change the slope of either line.
       parts.push('<strong>' + positionCuts + ' positions</strong> cut at roughly $100K/yr each (wages plus benefits) = <strong>' + fmtOverride(savings) + '/yr</strong>, about ' + pct + '% of the budget.');
     }
     if (newShare < 83) {
-      parts.push('Healthcare shift to <strong>' + newShare + '%</strong> employer saves <strong>' + fmtOverride(hc.gross) + '/yr</strong> in premiums. Contracts typically return part of that to employees as wage increases (<strong>' + fmtOverride(hc.wageIncrease) + '</strong>), which then raises pension costs (<strong>' + fmtOverride(hc.pensionIncrease) + '</strong>). Net savings: <strong>' + fmtOverride(hc.net) + '/yr</strong>.');
+      parts.push('Healthcare shift to <strong>' + newShare + '%</strong> employer saves <strong>' + fmtOverride(hc.gross) + '/yr</strong> gross. Wage offsets give back <strong>' + fmtOverride(hc.wageIncrease) + '</strong>, pension flow-through adds <strong>' + fmtOverride(hc.pensionIncrease) + '</strong>. Net: <strong>' + fmtOverride(hc.net) + '/yr</strong>.');
     }
     var fy27Step = parseFloat(fy27StepEl.value) || 0;
     if (Math.abs(fy27Step) > 0.01) {
@@ -1505,7 +1512,9 @@ An override on its own buys time. It does not change the slope of either line.
     }
 
     if (parts.length > 0 || note) {
-      stanceEl.innerHTML = parts.join(' ');
+      stanceEl.innerHTML = parts.map(function(p) {
+        return '<div class="dm-readout-clause">' + p + '</div>';
+      }).join('');
       stanceReadout.style.display = '';
     } else {
       stanceReadout.style.display = 'none';


### PR DESCRIPTION
## Summary
- Inline bold numbers in the dynamic scenario readout were rendering at 22px against 14px body, so a multi-lever scenario produced a jumbled run-on paragraph.
- Each clause now stacks on its own line via a new `.dm-readout-clause` wrapper, and the inline `<strong>` is scoped to 16px in `#dm-stance-explainer` / `#dm-stance-realism`. The headline gap number keeps 22px.
- Healthcare line stays a single multi-sentence block because the gross / wage offset / pension / net derivation has to be read together.
- Three `pp` shorthands spelled out as "percentage points" to match the plain-language rule and the existing spelled-out form already in the `bend-curve` note.

## Test plan
- [ ] Open `/charts/deficit_model.html` on the preview, click the "Override + 10 cuts + 65% healthcare" preset, confirm the scenario block reads as four stacked lines instead of one paragraph.
- [ ] Confirm headline `Projected FY40 gap: $12.X M` is still rendered large.
- [ ] Pick the "permanent close" stance and confirm the realism note reads "Lowering expense growth by 0.8 percentage points (from 4.0% to 3.2%)..." with no `0.8pp`.
- [ ] Check mobile width (less than 600px): the explainer block stays at 16px, the headline still uses the 19px mobile override.

Generated with [Claude Code](https://claude.com/claude-code)