### PR TITLE
CI: add merge_group trigger to all workflows (merge-queue prereq)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint
 
 on:
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,6 +22,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
+  # Declared so the merge queue treats this workflow's checks as reported.
+  # The preview job itself is skipped on merge_group (see `if:` below) since
+  # deploying a preview for a queued merge commit is not useful; GitHub
+  # counts the skipped job as success for required-status purposes.
+  merge_group:
 
 # A single deploy per PR; a new push cancels an in-flight run so the
 # comment always reflects the latest commit.
@@ -31,6 +36,7 @@ concurrency:
 
 jobs:
   preview:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Needed so the "post preview URL" step can comment on the PR.

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -3,6 +3,7 @@ name: Site Tests
 on:
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   smoke:


### PR DESCRIPTION
## Summary

Prerequisite for enabling GitHub's native merge queue on `main`. Without the `merge_group` trigger, required status checks never report on the queued merge commit and the queue stalls indefinitely — the canonical gotcha that breaks every first merge-queue rollout.

## Changes

| Workflow | Change |
|---|---|
| `lint.yml` | `on: [pull_request, merge_group]` |
| `smoke-tests.yml` | `on: [pull_request, merge_group]` |
| `preview.yml` | Adds `merge_group` so the check is considered reported, but gates the job itself with `if: github.event_name == 'pull_request'`. A Cloudflare preview deploy for a queued merge commit is not useful; GitHub counts the skipped job as success for required-status purposes. |

8 lines added, nothing removed.

## Why not put preview behind the queue too

Preview is a per-PR review aid, not a correctness check. Running it on every queued merge would double Cloudflare Pages deploys for no reviewer benefit. Gating the job is cheaper than removing the check from required status (which would require a separate branch-protection edit).

## What to do after this merges

1. Settings → Branches → edit `main` protection → check **Require merge queue**.
2. Keep the existing required checks (`Lint / Secret scan`, `Lint / Content guardrails`, `Site Tests / smoke`, `PR Preview / preview`).
3. On the next PR, click **Merge when ready** instead of **Squash and merge**.

## Test plan

- [ ] Open this PR; confirm Lint and Site Tests run on push (pull_request event).
- [ ] Confirm PR Preview still posts the sticky preview comment.
- [ ] After merging and flipping the branch-protection checkbox, queue a follow-up trivial PR and confirm Lint + Site Tests run on the merge_group ref while the preview job reports as skipped/success.

Unblocks the rapid-fire-merge workflow we discussed (no more up-to-date rebase herd).