### PR TITLE
Lint: exempt minutes catalog drafts from content guardrails

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,7 +50,11 @@ jobs:
 
           # Restrict to site-facing HTML/markdown. Exclusions match the
           # Jekyll exclude list in _config.yml, plus .github so this
-          # workflow file never trips its own checks.
+          # workflow file never trips its own checks. Minutes catalog
+          # narrative drafts are dense topic-to-meeting cross-references
+          # where inline <abbr> on every OPEB/GIC/DPW would make the doc
+          # unreadable; they're `sitemap: false` opt-in review pages, not
+          # site-facing prose.
           PATHSPEC=(
             '*.html'
             '*.md'
@@ -60,6 +64,9 @@ jobs:
             ':!docs'
             ':!community-pulse'
             ':!.github'
+            ':!data/is-the-board-trying.md'
+            ':!data/what-have-we-tried.md'
+            ':!data/minutes_catalog*.md'
           )
 
           added=$(git diff "origin/$BASE_REF"...HEAD -- "${PATHSPEC[@]}" \


### PR DESCRIPTION
## Summary

Narrow exemption for the minutes catalog narrative drafts (merged in #615) from the Tier 2 content guardrails. These pages are dense topic-to-meeting cross-references citing `OPEB`, `GIC`, `DPW`, and similar acronyms many times per line; inline `<abbr>` on every occurrence would render the catalog unreadable with no reader benefit, since the pages are `sitemap: false` opt-in review surfaces — not site-facing prose.

Also pre-exempts `data/minutes_catalog*.md` via glob so the taxonomy-normalization notes and future catalog iterations don't trip the same rule.

## Changes

```diff
 PATHSPEC=(
   '*.html'
   '*.md'
   ':!README.md'
   ':!STYLE_GUIDE.md'
   ':!CLAUDE.md'
   ':!docs'
   ':!community-pulse'
   ':!.github'
+  ':!data/is-the-board-trying.md'
+  ':!data/what-have-we-tried.md'
+  ':!data/minutes_catalog*.md'
 )
```

8 lines added, 1 changed (comment expansion).

## Scope

Narrow, not broad. Does not carve out `sitemap: false` globally — that would create a too-easy escape hatch from the guardrails. Every exemption remains explicit and reviewable.

## Test plan

- [ ] Lint run on this PR passes (no site-facing content touched).
- [ ] Follow-up edit to `data/is-the-board-trying.md` adding a new OPEB citation does not trip lint.
- [ ] Follow-up edit to `data/case_studies.md` adding an unwrapped OPEB still trips lint (proves the exemption is narrow).