### PR TITLE
Story-filter: strip references to off-page charts, sliders, and pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,10 +29,9 @@ og_url: https://marbleheaddata.org/
         and commit to what has to happen during it.
       </p>
       <p class="story-filter">
-        The deficit model defaults the ratchet slider (how fast override
-        revenue gets absorbed into new spending) to five years and treats
-        FY18 as the baked-in gap-start year. Both are editorial choices
-        the chart lets you change.
+        Override revenue is assumed absorbed into new spending over
+        five years, and FY18 is treated as the baked-in gap-start year.
+        Both are editorial choices.
       </p>
     </div>
 
@@ -365,11 +364,6 @@ og_url: https://marbleheaddata.org/
         prevent cuts. The question underneath is a preference one: what do
         I actually want the town to deliver? Residents legitimately disagree,
         and the same override dollar can fund preservation or improvement.
-      </p>
-      <p class="story-filter">
-        The linked charts show what tax effort buys (rate vs. value, peer
-        compensation) and what the published no-override baseline looks
-        like.
       </p>
     </div>
 
@@ -834,11 +828,11 @@ og_url: https://marbleheaddata.org/
         of four lines you read.
       </p>
       <p class="story-filter">
-        The chart lets you toggle four <abbr class="g" title="Full-Time Equivalent">FTE</abbr> series: total, instructional,
-        non-instructional, and special-education. Enrollment is <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr>
-        October 1 headcount; <abbr class="g" title="Full-Time Equivalent">FTE</abbr> is the <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> End-of-Year Report. FY23
-        has a known <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> reporting-method change that looks like a single-year
-        hire but isn't.
+        Enrollment is <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr>
+        October 1 headcount; <abbr class="g" title="Full-Time Equivalent">FTE</abbr> is the <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> End-of-Year Report,
+        broken into total, instructional, non-instructional, and
+        special-education series. FY23 has a known <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> reporting-method
+        change that looks like a single-year hire but isn't.
       </p>
     </div>
 
@@ -1484,8 +1478,7 @@ og_url: https://marbleheaddata.org/
       <p class="story-filter">
         Peers are Melrose, Swampscott, and Stoneham, picked for comparable
         population (~20K-30K), North Shore geography, and service mix; all
-        four share the MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr> reporting. The Town Explorer page lets
-        you build a different cohort from all 351 MA communities.
+        four share the MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr> reporting.
       </p>
     </div>
 
@@ -1752,8 +1745,7 @@ og_url: https://marbleheaddata.org/
       </p>
       <p class="story-filter">
         Monthly figures use FY26 average assessed value ($1,291,507) at
-        full phase-in (Year 3). Re-enter your own assessment on the
-        override calculator to reprice any framing.
+        full phase-in (Year 3).
       </p>
     </div>
 
@@ -3157,10 +3149,6 @@ og_url: https://marbleheaddata.org/
         The question is what oversight exists, where its limits are, and
         whether that's enough for me to accept a budget I didn't build.
       </p>
-      <p class="story-filter">
-        Linked pages show the audit trail (verify) and this site's own
-        framing choices (bias audit).
-      </p>
     </div>
 
     <div class="answers">
@@ -3665,9 +3653,8 @@ og_url: https://marbleheaddata.org/
         tiers, and the alternatives.
       </p>
       <p class="story-filter">
-        Growth is measured FY15 to FY26 in nominal dollars. Inflation
-        context is available on the levy-vs-bill chart but is not the
-        primary lens here; the primary lens is line-item attribution.
+        Growth is measured FY15 to FY26 in nominal dollars. Line-item
+        attribution, not inflation, is the primary lens.
       </p>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -2227,8 +2227,8 @@ og_url: https://marbleheaddata.org/
         tier size and on what changes inside the bridging period.
       </p>
       <p class="story-filter">
-        The deficit model's ratchet slider controls how quickly override
-        revenue gets absorbed into new spending. At the default five years
+        How quickly override revenue gets absorbed into new spending
+        decides how long the bridge lasts. At a five-year absorption
         the bridge looks durable; at one year the gap reopens almost
         immediately. Both are plausible.
       </p>


### PR DESCRIPTION
## Summary

Recovery PR. Follow-up to #621, which auto-merged faster than expected. The two commits here were pushed to the #621 branch *after* the squash-merge fired, so they ended up orphaned on the pre-merge commit. Cherry-picked onto a fresh branch off main.

Both commits apply the same rule to `.story-filter` blocks on index.html: **don't reference controls, charts, pages, or calculators that aren't actually on the page.** The story-filter sits above the answer cards, before the evidence-link section, so references like "the ratchet slider", "the chart lets you toggle", "the override calculator", "the Town Explorer page" read as if the control was visible when it's actually on a linked chart/page.

### Commit 1: again / ratchet (index.html:2229)

Rewrote to stop naming "the deficit model's ratchet slider" as if it were visible. Names the framing choice (absorption rate) directly:

Before: *"The deficit model's ratchet slider controls how quickly override revenue gets absorbed into new spending. At the default five years the bridge looks durable..."*

After: *"How quickly override revenue gets absorbed into new spending decides how long the bridge lasts. At a five-year absorption the bridge looks durable..."*

### Commit 2: sweep of 7 remaining off-page references

- **override (31):** drop "the deficit model" / "the chart lets you change"; keep the two editorial defaults (5-year absorption, FY18 gap-start).
- **servicelevel (369):** delete the story-filter entirely &mdash; the paragraph's whole substance was *"the linked charts show X"*. The question-context above already frames the question as a preference.
- **schools (837):** drop "The chart lets you toggle"; fold the four FTE series into the data-source sentence.
- **taxrank (1486):** drop "The Town Explorer page lets you build..."; keep the peer-selection rationale.
- **mycost (1755):** drop "Re-enter your own assessment on the override calculator"; keep the methodology line.
- **trust (3158):** delete the story-filter entirely &mdash; it was entirely "Linked pages show X". The question-context already frames trust as a judgment question.
- **moneygone (3678):** drop "the levy-vs-bill chart" reference; tighten to "Line-item attribution, not inflation, is the primary lens."

Leaves the methodology-only blocks untouched: voteno (peer cohort), levy, size, again, alternatives, trash, library, seniors &mdash; none of those reference off-page UI.

## Test plan

- [ ] Visit the preview URL and scroll each affected question screen: override, servicelevel, schools, taxrank, mycost, again, trust, moneygone.
- [ ] Confirm no story-filter block references a chart, slider, calculator, or page that only exists off-page.
- [ ] Confirm servicelevel and trust render cleanly with only the `.question-context` paragraph before the answer cards (no empty italic block).
- [ ] Spot-check an untouched story-filter (e.g. seniors at 3411) to confirm styling is unchanged.

https://claude.ai/code/session_01XWChJR2zbyzeC1N7zvWq3G