### PR TITLE
Delete .story-filter on the "again" question

### DIFF
--- a/index.html
+++ b/index.html
@@ -2218,12 +2218,6 @@ og_url: https://marbleheaddata.org/
         the next vote is soon, later, or not needed depends on both
         tier size and on what changes inside the bridging period.
       </p>
-      <p class="story-filter">
-        How quickly override revenue gets absorbed into new spending
-        decides how long the bridge lasts. At a five-year absorption
-        the bridge looks durable; at one year the gap reopens almost
-        immediately. Both are plausible.
-      </p>
     </div>
 
     <div class="answers">


### PR DESCRIPTION
## Summary

Delete the `.story-filter` framing note on the "again / how soon would we come back" question, applying the same logic used to delete servicelevel and trust in #622.

Two issues with the current text:

1. **"The bridge" has no local definition.** It refers to the override (established 14 question screens earlier in question 1's question-context: *"The proposed $8.47M override is a bridge, not a structural fix"*). On this question, the question-context above the story-filter only uses "bridges" as a verb and "bridging period" as an adjective &mdash; never anchors "the bridge" as a noun.

2. **Implicit reference to an off-page knob.** The previous rewrite removed the explicit "deficit model's ratchet slider" reference, but the substance ("at a five-year absorption... at one year...") only makes sense if the reader knows there's a slider to toggle. That slider lives on `charts/deficit_model.html`, not here. So the framing assumes off-page interactivity even after the explicit reference was stripped &mdash; the same problem #621/#622 were trying to solve.

The question-context above already frames this question correctly: *"depends on both tier size and on what changes inside the bridging period."* The story-filter slot doesn't earn its space.

## Test plan

- [ ] Visit the preview URL for the "again" question and confirm the question renders cleanly with only the question-context paragraph before the answer cards (no empty italic block).
- [ ] Spot-check an untouched story-filter (e.g. seniors at line 3411) to confirm styling is unchanged.

https://claude.ai/code/session_01XWChJR2zbyzeC1N7zvWq3G