### PR TITLE
Levy Answer A: name the mechanism as "override revenue"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1180,7 +1180,7 @@ og_url: https://marbleheaddata.org/
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="levy">
         <p class="answer-label">Answer A</p>
-        <h2>I want new revenue because costs outrun 2.5% structurally</h2>
+        <h2>I want override revenue because costs outrun 2.5% structurally</h2>
         <p class="answer-summary">
           Health insurance grows 7-11% per year, pensions ~9%. A 2.5%
           revenue cap plus modest new growth cannot keep up with costs the


### PR DESCRIPTION
## Summary

- Answer A headline on the levy question (`?q=levy`) said "I want new revenue because costs outrun 2.5% structurally." In MA municipal finance, "new revenue" is ambiguous — it can read as "new growth" (new construction added to the tax base) rather than an override.
- The answer summary already names the mechanism ("overrides are the mechanism the law leaves"), so the headline now matches: "I want override revenue because costs outrun 2.5% structurally."
- Keeps the three-answer axis intact (override / spending discipline within cap / both), which is the editorial stance — two of the three positions aren't pro-override.

## Test plan

- [ ] Load `/?q=levy` on the preview and confirm Answer A's headline reads "I want override revenue..."
- [ ] Confirm Answers B and C are unchanged
- [ ] Confirm evidence-A ("new growth doesn't close the difference") still renders
