### PR TITLE
Delete the .story-filter slot; migrate two captions

### DIFF
--- a/assets/explore.css
+++ b/assets/explore.css
@@ -1764,22 +1764,6 @@
     .explore-tutorial { font-size: 12px; padding: 12px 14px; }
   }
 
-  /* ─── Story-filter caption on question-block ──────────────────────
-     Neutral italic note that names the framing choice the strongest
-     evidence chart is making (time range, peers, metric). Written as
-     context, not disclaimer. */
-  .question-block .story-filter {
-    margin: 10px 0 0;
-    padding: 10px 14px;
-    font-size: 13.5px;
-    line-height: 1.5;
-    color: var(--c-text-mid);
-    background: var(--c-fog);
-    border-left: 3px solid var(--c-border);
-    border-radius: 0 6px 6px 0;
-    font-style: italic;
-  }
-
   /* ─── Evidence-block cross-link to a related question ──────────── */
   .evidence-cross-link {
     margin-top: 14px;

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -1182,12 +1182,7 @@
     label.textContent = 'Start here';
     featuredEl.appendChild(label);
 
-    /* Clone the question block (h1 + context). Drop .story-filter --
-       it's methodology copy that belongs next to the chart, not in the
-       onboarding preview. */
     var qClone = qBlock.cloneNode(true);
-    var storyFilter = qClone.querySelector('.story-filter');
-    if (storyFilter) storyFilter.remove();
     featuredEl.appendChild(qClone);
 
     /* Clone the three answer cards. The clones keep data-question /

--- a/index.html
+++ b/index.html
@@ -28,11 +28,6 @@ og_url: https://marbleheaddata.org/
         reopens the gap. The voter decision is a package: fund the bridge,
         and commit to what has to happen during it.
       </p>
-      <p class="story-filter">
-        Override revenue is assumed absorbed into new spending over
-        five years, and FY18 is treated as the baked-in gap-start year.
-        Both are editorial choices.
-      </p>
     </div>
 
     <div class="answers">
@@ -543,13 +538,6 @@ og_url: https://marbleheaddata.org/
         positions cut, 18.25 school <abbr class="g" title="Full-Time Equivalents">FTEs</abbr> cut, the library at 43% of its
         prior funding. That is the published baseline for a no vote.
       </p>
-      <p class="story-filter">
-        Where those cuts land is a Select Board allocation choice, not
-        a mathematical necessity. A different board could have spread
-        the same dollar reduction differently. Peer-town outcomes after a
-        no vote come from four MA towns whose no votes are at least five
-        years old so post-vote effects are observable.
-      </p>
     </div>
 
     <div class="answers">
@@ -827,13 +815,6 @@ og_url: https://marbleheaddata.org/
         over the same period tells more than one story, depending on which
         of four lines you read.
       </p>
-      <p class="story-filter">
-        Enrollment is <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr>
-        October 1 headcount; <abbr class="g" title="Full-Time Equivalent">FTE</abbr> is the <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> End-of-Year Report,
-        broken into total, instructional, non-instructional, and
-        special-education series. FY23 has a known <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> reporting-method
-        change that looks like a single-year hire but isn't.
-      </p>
     </div>
 
     <div class="answers">
@@ -1050,11 +1031,13 @@ og_url: https://marbleheaddata.org/
         </div>
         <p class="caption">
           High-needs students grew from 27% to 32% of enrollment.
-          <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> data shows special education teacher
-          <abbr class="g" title="Full-Time Equivalent">FTE</abbr> rose 27% (44.6 to 56.7) while general education
-          teachers fell 12% (210.1 to 184.5) over FY15 to FY24. Each
-          student with an <abbr class="g" title="Individualized Education Program">IEP</abbr> requiring a 1:1 aide adds a full
-          position the district must fill.
+          <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> End-of-Year Report shows special
+          education teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> rose 27% (44.6 to 56.7) while
+          general education teachers fell 12% (210.1 to 184.5) over FY15
+          to FY24. FY23 has a known <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> reporting-method change
+          that looks like a single-year hire but isn't. Each student with
+          an <abbr class="g" title="Individualized Education Program">IEP</abbr> requiring a 1:1 aide adds a full position the
+          district must fill.
           <a href="charts/enrollment_vs_staffing.html">See the full breakdown</a>.
         </p>
       </div>
@@ -1169,11 +1152,6 @@ og_url: https://marbleheaddata.org/
         to the tax base). Health insurance, pensions, and contracted
         salaries grow faster than the cap, and new growth in Marblehead
         is small enough that it doesn't close the difference on its own.
-      </p>
-      <p class="story-filter">
-        The same health-insurance data can be read two ways: as a growth
-        rate that outruns the 2.5% cap, or as a share of the budget that
-        reflects the town's 83% premium split. Both framings are legitimate.
       </p>
     </div>
 
@@ -1475,11 +1453,6 @@ og_url: https://marbleheaddata.org/
         a roughly middle position when the bill is expressed as a share
         of median household income. Each lens is a legitimate comparison.
       </p>
-      <p class="story-filter">
-        Peers are Melrose, Swampscott, and Stoneham, picked for comparable
-        population (~20K-30K), North Shore geography, and service mix; all
-        four share the MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr> reporting.
-      </p>
     </div>
 
     <div class="answers">
@@ -1550,7 +1523,9 @@ og_url: https://marbleheaddata.org/
         <p class="caption">
           Marblehead's rate is 28% lower than Swampscott's. Even at full
           Tier 3 ($15M override), Marblehead's projected FY28 rate of
-          $10.06 would still be the lowest of the four.
+          $10.06 would still be the lowest of the four. Peers picked for
+          comparable population (~20K-30K), North Shore geography, and
+          service mix; all four share MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr> reporting.
         </p>
         <a class="evidence-chart-link" href="charts/four_town_rates.html">
           Full four-town rate comparison
@@ -1742,10 +1717,6 @@ og_url: https://marbleheaddata.org/
         at the average home, compounded over ten years, or as a share of
         median household income. None are wrong; they answer slightly
         different questions.
-      </p>
-      <p class="story-filter">
-        Monthly figures use FY26 average assessed value ($1,291,507) at
-        full phase-in (Year 3).
       </p>
     </div>
 
@@ -1998,10 +1969,6 @@ og_url: https://marbleheaddata.org/
         Tier 3 ($15M). Each passes or fails independently. The three
         stances here are Tier 1, Tier 3, and none. Tier 2 is a middle
         position; the comparison matrix is the right view for it.
-      </p>
-      <p class="story-filter">
-        The tier projections hold current cost-growth rates constant (health,
-        pensions, salaries) and assume no structural reform.
       </p>
     </div>
 
@@ -2461,11 +2428,6 @@ og_url: https://marbleheaddata.org/
         differential by roughly half a point per year, compounding.
         Scale is the question.
       </p>
-      <p class="story-filter">
-        These levers are compared against the FY27 $8.47M gap on the
-        short runway before the vote. A longer horizon, or a smaller
-        remaining gap after an override, would change which levers matter.
-      </p>
     </div>
 
     <div class="answers">
@@ -2692,10 +2654,6 @@ og_url: https://marbleheaddata.org/
         property taxes. If it fails, a flat $281/household fee kicks in
         instead. Either way you pay; the choice is how the cost is split.
       </p>
-      <p class="story-filter">
-        Break-even uses the FY27 proposed $281 flat fee against the
-        $2.3M levy spread across the grand list at current rates.
-      </p>
     </div>
 
     <div class="answers">
@@ -2907,10 +2865,6 @@ og_url: https://marbleheaddata.org/
         The no-override budget cuts library operations 43%, the deepest
         reduction of any department. The cut is in a published document,
         not hypothetical.
-      </p>
-      <p class="story-filter">
-        "Heaviest" here is a percentage framing. In absolute dollars the
-        library is not the biggest reduction; in share-of-department it is.
       </p>
     </div>
 
@@ -3379,12 +3333,6 @@ og_url: https://marbleheaddata.org/
         <a href="senior-tax-relief.html">senior-tax-relief page</a>
         covers non-senior fixed-income relief in its own section.
       </p>
-      <p class="story-filter">
-        Share-of-income uses <abbr class="g" title="American Community Survey">ACS</abbr> 65+ median household income as the
-        denominator. Claim figures are MA <abbr class="g" title="Department of Revenue">DOR</abbr> 2022 tax-year data, the
-        most recent available; eligibility estimates use <abbr class="g" title="American Community Survey">ACS</abbr> income
-        distributions and may undercount.
-      </p>
     </div>
 
     <div class="answers">
@@ -3645,10 +3593,6 @@ og_url: https://marbleheaddata.org/
         "unavoidable" and "discretionary" within that growth is the
         priors question: it shapes how readers weigh the override, the
         tiers, and the alternatives.
-      </p>
-      <p class="story-filter">
-        Growth is measured FY15 to FY26 in nominal dollars. Line-item
-        attribution, not inflation, is the primary lens.
       </p>
     </div>
 


### PR DESCRIPTION
## Summary

Delete the `.story-filter` slot on index.html decision-question screens, folding the two genuinely useful methodology notes into the relevant chart captions.

### Why the slot doesn't work

Reading order on each question screen is: h1 &rarr; question-context &rarr; story-filter &rarr; answer cards &rarr; evidence charts. That put the italic "framing note" block *before* the reader had seen any data, which meant every attempt at the slot ended up previewing a distinction the reader hadn't encountered yet. Even after prior PRs stripped TODOs, meta-narration, and off-page control references, the structural problem remained: the slot is forward-referencing by design.

Deletion is cleaner than another rewrite. The question-context above already frames each question; chart captions below carry the real methodology in the context of the chart they describe.

### What migrates

Two pieces of on-page-relevant methodology had no other home, so they fold into the relevant chart caption:

- **schools** question &rarr; SPED-vs-general-ed FTE chart caption (line 1032): the FY23 DESE reporting-method caveat moves to where the discontinuity actually shows up; data source tightens from *"DESE data"* to *"DESE End-of-Year Report"*.
- **taxrank** question &rarr; FY26 four-town rates chart caption (line 1550): peer-selection rationale (comparable population ~20K-30K, North Shore geography, service mix, shared MA DOR DLS reporting) appends to the caption.

The other 10 story-filters had no surviving on-page content to migrate &mdash; their content was either (a) methodology about off-page interactives (the deficit model slider, Town Explorer cohort builder, override calculator) that shouldn't be named from here anyway, or (b) already present in the chart's annotation/caption or the question-context.

### Dead code cleanup

- `assets/explore.css` rule for `.question-block .story-filter` removed (no remaining markup uses it).
- `assets/explore.js` snippet that stripped `.story-filter` from onboarding question-block clones removed (nothing to strip now).

### Net diff

- `index.html`: 12 `<p class="story-filter">` blocks removed, 2 chart captions extended.
- `assets/explore.css`: 16-line rule deleted.
- `assets/explore.js`: 5-line cloneNode snippet simplified.

## Test plan

- [ ] Visit the preview URL and scroll each of the 12 question screens (override, voteno, schools, levy, taxrank, mycost, size, again, alternatives, trash, library, trust, seniors, moneygone). Confirm each renders cleanly as h1 &rarr; question-context &rarr; answer cards &rarr; evidence, with no italic block between context and answers.
- [ ] Scroll to the schools FTE chart (second chart on that screen) and confirm the caption now includes the FY23 DESE reporting-method caveat.
- [ ] Scroll to the taxrank four-town rates chart and confirm the caption now names the peer-selection criteria.
- [ ] Spot-check the onboarding "Start here" featured-question block (triggered by the explore overlay) to confirm it still renders the question-block clone correctly without the removed `.story-filter`-stripping code.

https://claude.ai/code/session_01XWChJR2zbyzeC1N7zvWq3G