### PR TITLE
no-override-budget: add Easton and Newton as counter-case towns

### DIFF
--- a/no-override-budget.html
+++ b/no-override-budget.html
@@ -224,9 +224,15 @@ og_url: https://marbleheaddata.org/no-override-budget.html
 
   <h2 data-stance-section="what-other-towns-did" id="what-other-towns-did">What other MA towns did after similar votes</h2>
 
+  <p>Outcomes varied. Some towns that rejected an override returned to the ballot within two years with a larger ask; others managed within the levy limit for years and did not return, absorbing the service reductions. Both patterns are documented in recent Massachusetts cases.</p>
+
   <p>Melrose (population ~28,000) rejected a $7.7M override in June 2024 and reduced 61.4 <abbr class="g" title="Full-Time Equivalents">FTEs</abbr> over two years across teachers, library hours, senior van drivers, and other departments. Elementary class sizes were proposed up to 32 students. The middle and high school shared one principal. Melrose returned to the ballot in November 2025 and passed a $13.5M override, 75% larger than the original ask.<sup class="cite" data-href="data/case_studies.md" data-source="case_studies.md: Melrose $7.7M failed June 2024, staffing and service cuts, $13.5M passed November 2025 (+75%)"></sup></p>
 
   <p>Stoneham rejected a $14.6M override in April 2025. Staff departed for higher-paying districts, leaving 28 vacant positions at the start of the school year. Teachers earned 30% below market rate. The library lost weekend and evening hours. Stoneham passed a $9.3M override in December 2025; the larger $12.5M option failed by 43 votes.<sup class="cite" data-href="data/case_studies.md" data-source="case_studies.md: Stoneham $14.6M failed April 2025, staffing departures and service cuts, $9.3M passed December 2025"></sup></p>
+
+  <p>Easton (population ~25,000) rejected a $4.4M override in 2016 and did not return to the ballot with another operating override for nine years, managing within the levy limit through that span. A $7.3M override in June 2025 also failed; the town then implemented what officials described as the most severe service reductions since 2008, including the equivalent of 47 school <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>.<sup class="cite" data-href="data/case_studies.md" data-source="case_studies.md: Easton $4.4M failed 2016 (no return for 9 years), $7.3M failed June 2025"></sup></p>
+
+  <p>Newton (population ~88,000) rejected a $9.2M override in March 2023. Newton Public Schools faced an $8M shortfall in the FY2024 budget and implemented staff and program cuts; a two-week teachers' strike followed in winter 2024. As of April 2026, Newton has not returned with another operating override. The School Committee approved an FY2026 budget with a $2-3M funding gap rather than going back to the ballot.<sup class="cite" data-href="data/case_studies.md" data-source="case_studies.md: Newton $9.2M failed March 2023, teachers' strike 2024, no return as of April 2026"></sup></p>
 
   <p>Full details and sources for each town:</p>
   <a class="btn-link" href="data/case_studies">Override case studies</a>


### PR DESCRIPTION
## Summary

Fixes the first of three architectural neutrality issues surfaced during the site-wide design review: the "What other MA towns did after similar votes" section on `no-override-budget.html` previously featured two towns (Melrose, Stoneham) that both rejected-and-returned-larger, and linked readers to `data/case_studies.md` for any counter-examples. The in-page sample therefore pointed one way even though `data/case_studies.md` already documents towns that rejected and did not return.

This PR adds:

- A brief framing sentence before the existing examples ("Outcomes varied. Some towns that rejected an override returned to the ballot within two years with a larger ask; others managed within the levy limit for years and did not return, absorbing the service reductions.").
- An **Easton** paragraph: rejected a $4.4M override in 2016, did not return for nine years, $7.3M rejected again in June 2025, followed by cuts equivalent to 47 school FTEs.
- A **Newton** paragraph: rejected $9.2M in March 2023, $8M FY2024 school shortfall, two-week teachers' strike winter 2024, no return as of April 2026.

All facts are sourced from `data/case_studies.md` via the same `<sup class="cite">` pattern the existing paragraphs use. Structure is parallel so neither pattern dominates visually.

## What this PR does *not* cover

- Rebalancing `what-you-can-do.html` (item 3 of the review).
- Adding a reform-path scaffold equivalent to `no-override-budget.html` (item 2 of the review).
- Backward-navigation links on secondary pages.

Each is planned as its own PR after review of this one.

## Test plan

- [ ] Preview page renders with five paragraphs in the "What other MA towns did" section, in the order: framing → Melrose → Stoneham → Easton → Newton.
- [ ] `<sup class="cite">` markers on Easton and Newton resolve in the auto-injected Sources list at the bottom of the page.
- [ ] `<abbr class="g">` tooltip on "FTEs" in the Easton paragraph behaves identically to the existing Melrose one.
- [ ] Content guardrails CI passes.

https://claude.ai/code/session_013QuFTPeH8HqPchKmLe4fSd