### PR TITLE
what-you-can-do: rebalance the "override fails" path

### DIFF
--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -237,7 +237,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
   <ul>
     <li><strong>Two votes decide the override.</strong> Annual Town Meeting on May 4 decides whether it goes to the ballot. The June 9 ballot picks the tier. Either vote can end the override. See <a href="#your-two-votes">the two votes</a> below.</li>
     <li><strong>Town Meeting is the lever</strong> for the overall size of the town budget. The Select Board handles operations and policy. The Finance Committee reviews and recommends. The School Committee sets priorities within the school budget.</li>
-    <li><strong>Two reform ideas with precedent elsewhere:</strong> a state <abbr class="g" title="Division of Local Services">DLS</abbr> Financial Management Review (free, independent, requested by the Select Board) and more detailed department-level budget reporting (a format choice, no warrant article needed).</li>
+    <li><strong>Two transparency reforms with precedent elsewhere:</strong> a state <abbr class="g" title="Division of Local Services">DLS</abbr> Financial Management Review (free, independent, requested by the Select Board) and more detailed department-level budget reporting (a format choice, no warrant article needed). Cost-level levers (the health premium split, staffing composition, contract-renewal timing) are a separate category and sit with the Select Board, Town Administrator, and School Committee; see the <a href="#structural-reform">structural reform card</a>.</li>
     <li><strong>Every body listed below is public.</strong> Meetings are hybrid. Agendas are posted on the <a href="https://marbleheadma.gov/">town calendar</a> at least 48 hours ahead.</li>
   </ul>
 </div>
@@ -307,6 +307,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
   <div class="goal-card">
     <div class="goal-card-eyebrow">If you want the override to fail</div>
     <p>Vote no on all three tiers. Attend the May 4 Town Meeting to oppose specific line items. Read <a href="no-override-budget.html">what is in the no-override budget</a> to understand what takes effect if no override passes: this is a real outcome, not a hypothetical.</p>
+    <p>If your "no" is motivated by the view that the underlying cost drivers should be restructured rather than funded, the levers that actually move those drivers (the health premium split, staffing composition, contract-renewal timing) are not on this year's ballot. See the <a href="#structural-reform">structural reform card</a> below for where those decisions sit and how residents can push on them.</p>
   </div>
 
   <div class="goal-card">
@@ -314,7 +315,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
     <p>Depends on the cut. School positions: the School Committee sets priorities within the school budget. Town positions: the Town Administrator and Select Board make operational hiring decisions. The override vote sets the overall size; reallocation within it is a different decision, made by different people.</p>
   </div>
 
-  <div class="goal-card">
+  <div class="goal-card" id="structural-reform">
     <div class="goal-card-eyebrow">If you want structural reform regardless of the vote</div>
     <p>Both sides of the override debate, and the <a href="charts/sustainability.html">underlying math</a>, agree that cost drivers need structural attention. The levers with the most long-term impact: the <a href="why-not-elsewhere.html#premium-splits">83/17 health insurance premium split</a> (negotiated between the town and unions under <a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIV/Chapter32B/Section19"><abbr class="g" title="Massachusetts General Laws">MGL</abbr> c.32B &sect;19</a>; the Select Board represents the town side) and <a href="charts/enrollment_vs_staffing.html">staffing composition</a> (Town Administrator for town departments, School Committee for schools). Concrete steps: ask the Select Board to request a <a href="#better-oversight"><abbr class="g" title="Division of Local Services">DLS</abbr> Financial Management Review</a> (free, independent, no warrant article needed). Show up at <a href="https://marbleheadma.gov/finance-committee/">Super Saturday budget hearings</a> and ask about premium split and staffing benchmarks relative to peer towns. Track when the next collective bargaining agreement comes up for renewal: that is when the premium split is actually on the table. Attend School Committee meetings and ask how staffing composition has changed relative to enrollment.</p>
   </div>
@@ -345,7 +346,7 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
   <p><a href="https://www.westboroughma.gov/DocumentCenter/View/4558/FY2026-Budget-Overview">Westborough's FY26 budget</a> presents each department's detailed budget along with performance goals and organizational charts. Marblehead's current budget format is more compact. A resident pushing for this would ask the Town Administrator or Finance Committee to adopt a similar structure for the FY28 budget. This does not require a warrant article; it is a choice about how the annual budget is presented.</p>
 </div>
 
-<p>Both of these are slow. Neither changes this year's vote. Both have concrete precedent in Massachusetts towns of similar or smaller size.</p>
+<p>Both of these are slow. Neither changes this year's vote. Both have concrete precedent in Massachusetts towns of similar or smaller size. Neither, on its own, reduces cost growth: each improves the information the town and residents have about the existing budget. The cost-level levers (the health premium split, staffing composition, contract-renewal timing) are separate, and live in the <a href="#structural-reform">structural reform card</a> above.</p>
 
 <h2 id="who-decides-what">Who decides what</h2>
 <p>Most civic decisions in Marblehead are distributed across several bodies, each with different authority. Knowing which body handles which decision is the difference between writing the right email and writing to no one.</p>


### PR DESCRIPTION
## Summary

Second architectural neutrality fix from the site-wide design review. The previous asymmetry: the "If you want the override to pass" goal card had a complete playbook (vote yes, tier breakdown, May 4 Town Meeting), while the "If you want the override to fail" card stopped at "vote no, read the no-override budget." The "Better oversight, regardless of the vote" section then presented two transparency reforms (DLS Financial Management Review, Westborough-style budget reporting) as if they were the reform path for skeptics, even though the cost-level levers the page already covers elsewhere (health premium split, staffing composition, contract-renewal timing) are the ones that actually reduce cost growth.

This PR surfaces existing page content more symmetrically; no new editorial claims or new reform proposals are introduced.

### Changes

- Add `id="structural-reform"` to the structural reform goal card (card 4) so it can be anchor-linked.
- **Fail card:** add a second paragraph that explicitly points reform-motivated "no" voters to the structural reform card, naming the three cost-level levers.
- **"Better oversight" closing paragraph:** clarify that the two reform ideas there improve information but do not, on their own, reduce cost growth; cross-link to the structural reform card for the cost-level levers.
- **TL;DR bullet 3:** relabel "Two reform ideas" as "Two transparency reforms" and note cost-level levers are a separate category.

## What this PR does *not* cover

- Item 3 of the review: a reform-path scaffold equivalent in detail to `no-override-budget.html` (e.g., a timeline of what "vote no and begin structural reform" would look like in years 1-3). That's a larger editorial undertaking and deserves its own scope conversation.
- Item 4: backward-navigation links on secondary pages.

## Test plan

- [ ] On the preview, click the "structural reform card" link from the fail card and confirm it anchor-jumps to card 4.
- [ ] Click the "structural reform card" link from the Better-oversight closing paragraph and confirm the same.
- [ ] TL;DR bullet 3 link resolves.
- [ ] Content guardrails CI passes.

https://claude.ai/code/session_013QuFTPeH8HqPchKmLe4fSd