### PR TITLE
Label the back link: "← Home" instead of bare arrow

### DIFF
--- a/_layouts/chart.html
+++ b/_layouts/chart.html
@@ -5,7 +5,7 @@ body_class: chart-page
 {% include nav.html %}
 
 <div class="container">
-  <a class="back" href="{{ '/' | relative_url }}">&larr;</a>
+  <a class="back" href="{{ '/' | relative_url }}">&larr; Home</a>
 
   {{ content }}
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,7 +4,7 @@ layout: default
 {% include nav.html %}
 
 <div class="page">
-  <a class="back" href="{{ '/' | relative_url }}">&larr;</a>
+  <a class="back" href="{{ '/' | relative_url }}">&larr; Home</a>
 
   {%- comment -%}
   Reading-time label. Word count uses strip_html first so inline <style>


### PR DESCRIPTION
## Summary

Trivial polish. Every non-home page already has:

- A `.back` pill at the top of the layout, linking to `/`
- The site-nav brand in the top-left corner, also linking to `/`

The pill was icon-only (`←`), which relied on readers to infer both that it was a link and where it went. This PR adds "Home" next to the arrow in both `_layouts/page.html` and `_layouts/chart.html`, making the affordance explicit and improving screen-reader behavior (a bare `&larr;` is announced as "left arrow," not "home").

No visual layout change beyond the added word (the pill already uses `inline-flex` with reasonable padding). `home.html` layout correctly has no `.back` pill and is unchanged.

## Background

My earlier site-review flagged this as "no consistent back-to-overview link on secondary pages." That was wrong — the link exists and has existed. The real issue was that icon-only arrows aren't self-describing. Hence the labeling rather than any new navigation.

## Test plan

- [ ] On preview, confirm the `.back` pill now reads "← Home" on:
  - A text page (`what-you-can-do.html`)
  - A chart page (`charts/budget_flow.html`)
  - A data doc page (`data/case_studies.html`)
- [ ] Confirm `index.html` still has no `.back` pill.
- [ ] Confirm the pill still clickable-links to `/`.

https://claude.ai/code/session_013QuFTPeH8HqPchKmLe4fSd