### PR TITLE
Fix lighthouse SVG 404 in explore.css

### DIFF
--- a/assets/explore.css
+++ b/assets/explore.css
@@ -15,7 +15,7 @@
     position: fixed;
     bottom: -150px; right: 0;
     width: 840px; height: 1260px;
-    background: url(assets/lighthouse/lighthouse.svg) center / contain no-repeat;
+    background: url(lighthouse/lighthouse.svg) center / contain no-repeat;
     opacity: 0.05;
     pointer-events: none;
     z-index: 0;


### PR DESCRIPTION
## Summary

`assets/explore.css:18` had `url(assets/lighthouse/lighthouse.svg)`. Since the stylesheet itself lives at `/assets/explore.css`, the browser resolves that relative URL against the stylesheet's directory, producing `/assets/assets/lighthouse/lighthouse.svg` — a 404 (visible in the user's curl reproducing the missing asset).

Fixed by dropping the redundant `assets/` prefix so the path resolves to `/assets/lighthouse/lighthouse.svg`, matching the working pattern in `site.css:888`.

## Test plan

- [ ] Visit an explore page on the preview deploy and confirm the lighthouse background renders (and no 404 in DevTools Network).
- [ ] Spot-check that no other `url(assets/...)` exists in `assets/*.css` (already grepped — none).

https://claude.ai/code/session_01VjEwHNNgE49DooTTmnsqu1