### PR TITLE
Polish question pages: key-stats, chart links, bullets, read-next

### DIFF
--- a/assets/explore.css
+++ b/assets/explore.css
@@ -988,6 +988,50 @@
     mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect x='1' y='10' width='3' height='5' rx='0.5'/%3E%3Crect x='6' y='6' width='3' height='9' rx='0.5'/%3E%3Crect x='11' y='2' width='3' height='13' rx='0.5'/%3E%3C/svg%3E") center/contain no-repeat;
   }
 
+  /* ── Nugget: highlighted number + short context ── */
+  .evidence-nugget {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    background: color-mix(in srgb, var(--c-navy) 6%, var(--surface));
+    border: 1px solid var(--divider);
+    border-radius: 10px;
+    padding: 12px 16px;
+    margin: 10px 0 8px;
+  }
+  .evidence-nugget-value {
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    line-height: 1.1;
+  }
+  .evidence-nugget-label {
+    font-size: 13px;
+    color: var(--text-muted);
+    line-height: 1.45;
+  }
+  @media (max-width: 600px) {
+    .evidence-nugget { flex-direction: column; gap: 4px; padding: 10px 14px; }
+    .evidence-nugget-value { font-size: 19px; }
+  }
+
+  /* ── Evidence lists ── */
+  .evidence-point ul {
+    margin: 8px 0;
+    padding-left: 20px;
+    list-style: disc;
+  }
+  .evidence-point li {
+    font-size: 13px;
+    color: var(--text-muted);
+    line-height: 1.55;
+    margin-bottom: 4px;
+  }
+  .evidence-point li:last-child { margin-bottom: 0; }
+  .evidence-point li strong { color: var(--text); }
+
   .evidence-caveat {
     font-size: 12px;
     color: var(--text-subtle);

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -1032,6 +1032,111 @@
   .evidence-point li:last-child { margin-bottom: 0; }
   .evidence-point li strong { color: var(--text); }
 
+  /* ── Mini override calculator (injected into every question) ── */
+  .mini-calc {
+    background: color-mix(in srgb, var(--c-navy) 5%, var(--surface));
+    border: 1px solid var(--divider);
+    border-radius: 12px;
+    padding: 14px 18px 16px;
+    margin: 24px 0 8px;
+  }
+  .mini-calc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+  }
+  .mini-calc-title {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-subtle);
+  }
+  .mini-calc-input {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .mini-calc-input label {
+    font-size: 11px;
+    color: var(--text-subtle);
+    white-space: nowrap;
+  }
+  .mini-calc-input input {
+    width: 130px;
+    padding: 5px 10px;
+    font-size: 14px;
+    font-weight: 600;
+    text-align: center;
+    color: var(--text);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-variant-numeric: tabular-nums;
+    font-family: var(--font-sans);
+  }
+  .mini-calc-input input:focus {
+    outline: none;
+    border-color: var(--link);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--link) 20%, transparent);
+  }
+  .mini-calc-tiers {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+  }
+  .mini-calc-tier {
+    text-align: center;
+    padding: 8px 6px;
+    border-radius: 8px;
+    background: var(--surface);
+    border: 1px solid var(--divider);
+  }
+  .mini-calc-tier-label {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--text-subtle);
+    margin-bottom: 4px;
+  }
+  .mini-calc-tier-cost {
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+    line-height: 1.1;
+  }
+  .mini-calc-tier-unit {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-subtle);
+  }
+  .mini-calc-tier-annual {
+    font-size: 11px;
+    color: var(--text-subtle);
+    font-variant-numeric: tabular-nums;
+    margin-top: 2px;
+  }
+  .mini-calc-link {
+    display: block;
+    text-align: center;
+    font-size: 12px;
+    color: var(--link);
+    margin-top: 10px;
+  }
+  @media (max-width: 600px) {
+    .mini-calc { padding: 12px 14px 14px; }
+    .mini-calc-header { flex-direction: column; align-items: flex-start; gap: 8px; }
+    .mini-calc-tiers { grid-template-columns: 1fr; gap: 6px; }
+    .mini-calc-tier { display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; text-align: left; }
+    .mini-calc-tier-label { margin-bottom: 0; }
+    .mini-calc-tier-cost { font-size: 16px; }
+  }
+
   .evidence-caveat {
     font-size: 12px;
     color: var(--text-subtle);

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -991,7 +991,7 @@
   /* ── Nugget: highlighted number + short context ── */
   .evidence-nugget {
     display: flex;
-    align-items: baseline;
+    align-items: flex-start;
     gap: 12px;
     background: color-mix(in srgb, var(--c-navy) 6%, var(--surface));
     border: 1px solid var(--divider);
@@ -1005,12 +1005,14 @@
     color: var(--text);
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
-    line-height: 1.1;
+    line-height: 1.3;
+    padding-top: 1px;
   }
   .evidence-nugget-label {
     font-size: 13px;
     color: var(--text-muted);
     line-height: 1.45;
+    padding-top: 5px;
   }
   @media (max-width: 600px) {
     .evidence-nugget { flex-direction: column; gap: 4px; padding: 10px 14px; }

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -2245,13 +2245,20 @@
   fetchAllCounts(topicOrder);
   updateStatsStrip();
 
-  // ── Mini override calculator (injected into every question screen) ──
+  // ── Mini override calculator (only on questions where cost context helps) ──
   (function miniCalc() {
     var AVG = 1291507;
     var KEY = 'mh_override_calc_assessed_value';
-    // Year-1 cost per tier at average assessed value (from April 8 presentation)
     var R = { 1: 168, 2: 362, 3: 556 };
     var LABELS = { 1: '$9M', 2: '$12M', 3: '$15M' };
+
+    // Only inject on questions where override cost is relevant context
+    var OVERRIDE_TOPICS = ['override', 'mycost', 'size', 'levy', 'taxrank', 'again', 'voteno'];
+    // Trash and seniors get a contextual link instead (they have their own calculators)
+    var LINK_ONLY = {
+      trash:   { href: 'question-2-trash.html#cost-by-home-value', text: 'Trash levy vs. fee calculator' },
+      seniors: { href: 'senior-tax-relief.html',                   text: 'Senior relief calculator' }
+    };
 
     function fmt(n) { return '$' + Math.round(n).toLocaleString('en-US'); }
     function parse(raw) {
@@ -2267,6 +2274,22 @@
     var calcs = [];
 
     document.querySelectorAll('.question-screen').forEach(function (screen) {
+      var topic = screen.getAttribute('data-topic');
+
+      // Link-only topics: just add a contextual chart link
+      if (LINK_ONLY[topic]) {
+        var link = document.createElement('a');
+        link.className = 'evidence-chart-link';
+        link.href = LINK_ONLY[topic].href;
+        link.textContent = LINK_ONLY[topic].text;
+        link.style.marginTop = '18px';
+        screen.appendChild(link);
+        return;
+      }
+
+      // Skip topics where a calculator is irrelevant
+      if (OVERRIDE_TOPICS.indexOf(topic) === -1) return;
+
       var el = document.createElement('div');
       el.className = 'mini-calc';
       el.innerHTML =
@@ -2284,7 +2307,6 @@
         '</div>' +
         '<a class="mini-calc-link" href="charts/override_calculator.html">Full calculator with phase-in and income context &rarr;</a>';
 
-      // Insert before the last </section> child (after all evidence blocks)
       screen.appendChild(el);
       calcs.push(el);
     });
@@ -2300,7 +2322,6 @@
       });
     }
 
-    // Sync all inputs
     var inputs = calcs.map(function (el) { return el.querySelector('input'); });
     var stored = load();
     var initial = stored || AVG;
@@ -2310,7 +2331,6 @@
       inp.addEventListener('input', function () {
         var v = parse(inp.value);
         save(v);
-        // Sync other inputs
         inputs.forEach(function (other) {
           if (other !== inp) other.value = '$' + Math.round(v).toLocaleString('en-US');
         });

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -2253,7 +2253,7 @@
     var LABELS = { 1: '$9M', 2: '$12M', 3: '$15M' };
 
     // Only inject on questions where override cost is relevant context
-    var OVERRIDE_TOPICS = ['override', 'mycost', 'size', 'levy', 'taxrank', 'again', 'voteno'];
+    var OVERRIDE_TOPICS = ['override', 'mycost', 'size', 'levy', 'taxrank', 'voteno'];
     // Trash and seniors get a contextual link instead (they have their own calculators)
     var LINK_ONLY = {
       trash:   { href: 'question-2-trash.html#cost-by-home-value', text: 'Trash levy vs. fee calculator' },

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -2245,4 +2245,84 @@
   fetchAllCounts(topicOrder);
   updateStatsStrip();
 
+  // ── Mini override calculator (injected into every question screen) ──
+  (function miniCalc() {
+    var AVG = 1291507;
+    var KEY = 'mh_override_calc_assessed_value';
+    // Year-1 cost per tier at average assessed value (from April 8 presentation)
+    var R = { 1: 168, 2: 362, 3: 556 };
+    var LABELS = { 1: '$9M', 2: '$12M', 3: '$15M' };
+
+    function fmt(n) { return '$' + Math.round(n).toLocaleString('en-US'); }
+    function parse(raw) {
+      var n = parseFloat(String(raw).replace(/[^0-9.]/g, ''));
+      return (n > 0 && isFinite(n)) ? n : AVG;
+    }
+    function load() {
+      try { var n = parseFloat(localStorage.getItem(KEY)); return (n > 0 && isFinite(n)) ? n : null; }
+      catch (e) { return null; }
+    }
+    function save(v) { try { localStorage.setItem(KEY, String(v)); } catch (e) {} }
+
+    var calcs = [];
+
+    document.querySelectorAll('.question-screen').forEach(function (screen) {
+      var el = document.createElement('div');
+      el.className = 'mini-calc';
+      el.innerHTML =
+        '<div class="mini-calc-header">' +
+          '<span class="mini-calc-title">What this costs your household (Year 1)</span>' +
+          '<div class="mini-calc-input">' +
+            '<label>Home value</label>' +
+            '<input type="text" inputmode="numeric" autocomplete="off">' +
+          '</div>' +
+        '</div>' +
+        '<div class="mini-calc-tiers">' +
+          '<div class="mini-calc-tier" data-t="1"><div class="mini-calc-tier-label">Tier 1 ' + LABELS[1] + '</div><div class="mini-calc-tier-cost"><span class="mc-mo"></span><span class="mini-calc-tier-unit">/mo</span></div><div class="mini-calc-tier-annual"><span class="mc-yr"></span>/yr</div></div>' +
+          '<div class="mini-calc-tier" data-t="2"><div class="mini-calc-tier-label">Tier 2 ' + LABELS[2] + '</div><div class="mini-calc-tier-cost"><span class="mc-mo"></span><span class="mini-calc-tier-unit">/mo</span></div><div class="mini-calc-tier-annual"><span class="mc-yr"></span>/yr</div></div>' +
+          '<div class="mini-calc-tier" data-t="3"><div class="mini-calc-tier-label">Tier 3 ' + LABELS[3] + '</div><div class="mini-calc-tier-cost"><span class="mc-mo"></span><span class="mini-calc-tier-unit">/mo</span></div><div class="mini-calc-tier-annual"><span class="mc-yr"></span>/yr</div></div>' +
+        '</div>' +
+        '<a class="mini-calc-link" href="charts/override_calculator.html">Full calculator with phase-in and income context &rarr;</a>';
+
+      // Insert before the last </section> child (after all evidence blocks)
+      screen.appendChild(el);
+      calcs.push(el);
+    });
+
+    function updateAll(assessed) {
+      calcs.forEach(function (el) {
+        [1, 2, 3].forEach(function (t) {
+          var annual = R[t] * (assessed / AVG);
+          var tier = el.querySelector('[data-t="' + t + '"]');
+          tier.querySelector('.mc-mo').textContent = fmt(annual / 12);
+          tier.querySelector('.mc-yr').textContent = fmt(annual);
+        });
+      });
+    }
+
+    // Sync all inputs
+    var inputs = calcs.map(function (el) { return el.querySelector('input'); });
+    var stored = load();
+    var initial = stored || AVG;
+
+    inputs.forEach(function (inp) {
+      inp.value = '$' + Math.round(initial).toLocaleString('en-US');
+      inp.addEventListener('input', function () {
+        var v = parse(inp.value);
+        save(v);
+        // Sync other inputs
+        inputs.forEach(function (other) {
+          if (other !== inp) other.value = '$' + Math.round(v).toLocaleString('en-US');
+        });
+        updateAll(v);
+      });
+      inp.addEventListener('blur', function () {
+        var v = parse(inp.value);
+        inp.value = '$' + Math.round(v).toLocaleString('en-US');
+      });
+    });
+
+    updateAll(initial);
+  })();
+
 })();

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -2249,7 +2249,9 @@
   (function miniCalc() {
     var AVG = 1291507;
     var KEY = 'mh_override_calc_assessed_value';
-    var R = { 1: 168, 2: 362, 3: 556 };
+    // Year-3 (full phase-in) annual cost at average assessed value.
+    // Source: Town Administrator presentation, April 8, 2026.
+    var R = { 1: 1188, 2: 1590, 3: 1989 };
     var LABELS = { 1: '$9M', 2: '$12M', 3: '$15M' };
 
     // Only inject on questions where override cost is relevant context
@@ -2294,7 +2296,7 @@
       el.className = 'mini-calc';
       el.innerHTML =
         '<div class="mini-calc-header">' +
-          '<span class="mini-calc-title">What this costs your household (Year 1)</span>' +
+          '<span class="mini-calc-title">What this costs your household</span>' +
           '<div class="mini-calc-input">' +
             '<label>Home value</label>' +
             '<input type="text" inputmode="numeric" autocomplete="off">' +

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -2255,7 +2255,7 @@
     var LABELS = { 1: '$9M', 2: '$12M', 3: '$15M' };
 
     // Only inject on questions where override cost is relevant context
-    var OVERRIDE_TOPICS = ['override', 'mycost', 'size', 'levy', 'taxrank', 'voteno'];
+    var OVERRIDE_TOPICS = ['override', 'mycost', 'size', 'levy'];
     // Trash and seniors get a contextual link instead (they have their own calculators)
     var LINK_ONLY = {
       trash:   { href: 'question-2-trash.html#cost-by-home-value', text: 'Trash levy vs. fee calculator' },

--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -3,7 +3,15 @@ title: "How did we get here?"
 scripts: [citations]
 ---
 <h1>How did we get here?</h1>
-  <p>The FY27 override vote is not a surprise. It was forecast, warned about, and predicted in writing by Marblehead's <abbr class="g" title="Finance Committee">FinCom</abbr> for years. Their own transmittal letters to Town Meeting trace a clean arc from "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025.</p>
+
+  <div class="key-stats">
+    <div class="key-stat"><div class="key-stat-value">7 years</div><div class="key-stat-label">of written warnings</div></div>
+    <div class="key-stat"><div class="key-stat-value">$8.47M</div><div class="key-stat-label">FY27 budget gap</div></div>
+    <div class="key-stat"><div class="key-stat-value">16 years</div><div class="key-stat-label">without an override</div></div>
+    <div class="key-stat"><div class="key-stat-value">~400 votes</div><div class="key-stat-label">2023 override defeated by</div></div>
+  </div>
+
+  <p>The FY27 override vote did not come out of nowhere. Marblehead's <abbr class="g" title="Finance Committee">FinCom</abbr> warned about it in writing, year after year, starting in 2019. Their annual letters to Town Meeting went from "pleased to report no override needed" to "significant budgetary challenges ahead" over seven years.</p>
 
   <nav class="page-toc" aria-label="On this page">
     <span class="page-toc-label">On this page</span>
@@ -34,7 +42,7 @@ scripts: [citations]
     <footer>2021 Finance Committee Annual Report, transmittal letter to the 2021 Annual Town Meeting (for the FY22 budget). <a href="data/2021_FinCom_Report.pdf">PDF</a>.</footer>
   </blockquote>
 
-  <p>For sixteen consecutive years, <abbr class="g" title="Finance Committee">FinCom</abbr> reported balanced budgets, celebrated the no-override streak, and told residents the town was well-managed. A different reading of the same timeline: the Finance Committee presided over the spending growth that produced the deficit, and their warnings were about a problem partly of their own making. The <a href="the-debate.html#tension-5">debate page</a> explores this tension in full.</p>
+  <p>For sixteen years, <abbr class="g" title="Finance Committee">FinCom</abbr> reported balanced budgets and told residents the town was well-managed. A different reading of the same timeline: the Finance Committee oversaw the spending growth that produced the deficit. Both readings have evidence behind them. The <a href="the-debate.html#tension-5">debate page</a> lays out both sides.</p>
 
   <h3>2019: The first signal</h3>
   <p>The tone began to shift in the 2019 transmittal letter (for the FY20 budget), which introduced a phrase that had not appeared in earlier letters:</p>
@@ -92,10 +100,20 @@ scripts: [citations]
     The $8.47M FY27 gap breaks into two pieces. Roughly three-quarters is specific costs going up &ndash; health insurance, pension contributions, the new curbside trash contract, and regular salary and contract increases. The remaining quarter is one-time reserves &ndash; Free Cash, interest income, motor vehicle excise &ndash; that balanced the FY26 budget but aren't available at the same level again in FY27.
   </div>
 
-  <p>For the full calculation:</p>
+  <p>The biggest cost drivers behind the gap:</p>
+  <ul>
+    <li><strong>Health insurance</strong> -- the town's costs grew 11% in the most recent year, driven by high-cost drugs and hospital rates</li>
+    <li><strong>Pensions</strong> -- required contributions set by the state, up 9% for FY27</li>
+    <li><strong>Trash contract</strong> -- the new Republic Services contract costs $1M more than the prior deal</li>
+    <li><strong>Salary and step increases</strong> -- contractual raises across town and school employees</li>
+    <li><strong>One-time reserves running out</strong> -- Free Cash and other one-time revenues that balanced FY26 are not available at the same level again</li>
+  </ul>
+
+  <a class="btn-link" href="charts/sustainability.html">See the revenue-vs-spending trend over time</a>
+  <a class="btn-link" href="charts/healthcare_costs.html">Why health insurance keeps rising</a>
   <a class="btn-link" href="no-override-budget.html#fy27-gap-calculated">How the $8.47M FY27 gap is calculated</a>
 
-  <p>What the town actually spent during those same years, and which lines grew fastest, is a separate question.</p>
+  <p>What the town actually spent during those same years, and which lines grew fastest:</p>
   <a class="btn-link" href="where-has-the-money-gone.html">Where has Marblehead's money gone</a>
 
   <div class="read-next">
@@ -108,9 +126,9 @@ scripts: [citations]
       <div class="read-next-title">What's in the no-override budget? &rarr;</div>
       <div class="read-next-desc">The specific staffing and service cuts in the FY27 balanced budget without an override, line by line.</div>
     </a>
-    <a class="read-next-link" href="marblehead-voting-record.html">
-      <div class="read-next-title">Has Marblehead voted yes before? &rarr;</div>
-      <div class="read-next-desc">Every Prop 2&frac12; ballot question since 1988, charted. What passed, what failed, and how much.</div>
+    <a class="read-next-link" href="charts/sustainability.html">
+      <div class="read-next-title">Revenue vs. spending over time &rarr;</div>
+      <div class="read-next-desc">Interactive chart: general fund revenue, expenses, and free cash usage since FY01.</div>
     </a>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -722,13 +722,13 @@ og_url: https://marbleheaddata.org/
             <!-- Revenue line: 3% annual growth from ~$106M -->
             <polyline class="data-line data-line--bold s-revenue" points="94,176 234,152 374,128 444,116"/>
 
-            <!-- Expenses without reform: 5% growth from ~$114M -->
+            <!-- Expenses at recent trend rate -->
             <polyline class="data-line data-line--dashed s-neutral" points="94,144 234,108 374,68 444,48"/>
-            <text class="end-label s-neutral" x="452" y="52">No reform (5%/yr)</text>
+            <text class="end-label s-neutral" x="452" y="52">Expenses at 5%/yr</text>
 
-            <!-- Expenses with reform: 3.5% growth from ~$114M -->
+            <!-- Expenses if growth slows to 3.5% -->
             <polyline class="data-line data-line--bold s-marblehead" points="94,144 234,120 374,96 444,84"/>
-            <text class="end-label s-marblehead" x="452" y="88">With reform (3.5%/yr)</text>
+            <text class="end-label s-marblehead" x="452" y="88">Expenses at 3.5%/yr</text>
 
             <text class="end-label s-revenue" x="452" y="120">Revenue (3%/yr)</text>
           </svg>

--- a/index.html
+++ b/index.html
@@ -1975,12 +1975,11 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>A smaller levy is easier to sustain</h4>
-        <p>
-          At the average home, Tier 1 costs $1,187/year vs. $1,985/year
-          for Tier 3. The smaller permanent levy increase gives the town
-          time to pursue reforms before asking for more.
-        </p>
+        <h4>Tier 1 costs $800/yr less than Tier 3 at the average home</h4>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">$1,187 vs $1,985</span>
+          <span class="evidence-nugget-label">Annual cost at the average home: Tier 1 vs Tier 3. The smaller permanent levy increase gives the town time to pursue reforms before asking for more.</span>
+        </div>
         <a class="evidence-chart-link" href="charts/override_calculator.html">
           Calculate your cost at each tier
         </a>
@@ -2130,9 +2129,10 @@ og_url: https://marbleheaddata.org/
     <div class="question-block">
       <h1>How soon would we come back for another override?</h1>
       <p class="question-context">
-        An override bridges the gap; it does not end the cycle. Whether
-        the next vote is soon, later, or not needed depends on both
-        tier size and on what changes inside the bridging period.
+        An override fills the gap but doesn't stop costs from growing
+        faster than revenue. Whether the next vote comes in three years
+        or ten depends on which tier passes and whether the town slows
+        cost growth in between.
       </p>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -1241,12 +1241,10 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>New growth doesn't close the difference either</h4>
-        <ul>
-          <li>Marblehead's five-year average new growth rate: <strong>0.54%</strong> (lowest in peer set)</li>
-          <li>Peninsula geography, historic districts, and zoning limit new construction</li>
-          <li>Revenue ceiling: 2.5% levy cap + 0.54% new growth = ~3%</li>
-          <li>Health insurance alone grows faster than that</li>
-        </ul>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">0.54%</span>
+          <span class="evidence-nugget-label">Marblehead's five-year average new growth rate -- lowest in the peer set. Peninsula geography, historic districts, and zoning limit new construction. Revenue ceiling: ~3% (2.5% levy cap + 0.54% new growth). Health insurance alone grows faster.</span>
+        </div>
       </div>
 
       <details class="counter-argument">
@@ -2543,13 +2541,10 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>The insurance split is a choice, not a law of nature</h4>
-        <ul>
-          <li>Marblehead pays <strong>83%</strong> of health premiums</li>
-          <li>State law allows 50% to 99%</li>
-          <li>Hingham pays 50%, offsets with higher salaries</li>
-          <li>Moving to 75% would save ~<strong>$1M/year</strong></li>
-          <li>Requires collective bargaining, not a ballot question</li>
-        </ul>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">83%</span>
+          <span class="evidence-nugget-label">Marblehead's employer share of health premiums. State law allows 50-99%. Hingham pays 50%. Moving to 75% would save ~$1M/year. Requires collective bargaining, not a ballot question.</span>
+        </div>
         <a class="evidence-chart-link" href="charts/peer_compensation.html">
           Peer compensation and premium splits
         </a>
@@ -2969,30 +2964,32 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>What the town legally cannot cut</h4>
-        <ul>
-          <li><strong>Pensions:</strong> <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>-mandated schedule (+$463K in FY27)</li>
-          <li><strong>Debt service:</strong> contractual bond payments</li>
-          <li><strong>Essex Tech:</strong> assessment set by the regional district</li>
-        </ul>
+        <p>
+          Pensions (<abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>-mandated, +$463K in FY27), debt service
+          (contractual bond payments), and Essex Tech assessment (set by
+          the regional district). These lines go up regardless of the
+          override outcome.
+        </p>
       </div>
 
       <div class="evidence-point">
         <h4>What contracts prevent cutting</h4>
-        <ul>
-          <li>Police, fire, and teacher salaries locked by collective bargaining</li>
-          <li>Step increases and COLAs locked for the contract term</li>
-          <li>Layoffs trigger seniority rules, bumping, potential arbitration</li>
-          <li><abbr class="g" title="Group Insurance Commission">GIC</abbr> insurance rates: +$1.65M in FY27 (+11%), town cannot negotiate lower</li>
-        </ul>
+        <p>
+          Police, fire, and teacher salaries are locked by collective
+          bargaining. Step increases and COLAs are locked for the
+          contract term. <abbr class="g" title="Group Insurance Commission">GIC</abbr> insurance rates rose $1.65M in FY27
+          (+11%); the town cannot negotiate a lower rate.
+        </p>
       </div>
 
       <div class="evidence-point">
         <h4>The library has none of these protections</h4>
-        <ul>
-          <li>Staff are non-union and at-will</li>
-          <li>No state law requiring minimum library funding</li>
-          <li>Accreditation is voluntary (~$57K in state aid at risk)</li>
-        </ul>
+        <p>
+          Staff are non-union and at-will. No state law requires minimum
+          library funding. Accreditation is voluntary (~$57K in state
+          aid at risk). That makes the library one of the few
+          departments where deep cuts are even legally possible.
+        </p>
       </div>
 
       <div class="evidence-point">
@@ -3150,13 +3147,13 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Who decides what</h4>
-        <ul>
-          <li><strong>Select Board</strong> sets the town budget and handles operations</li>
-          <li><strong>Finance Committee</strong> reviews and recommends</li>
-          <li><strong>School Committee</strong> sets priorities within the school budget</li>
-          <li><strong>Town Meeting</strong> (open to all registered voters) approves appropriations</li>
-          <li>All meetings are hybrid; agendas posted 48 hours ahead</li>
-        </ul>
+        <p>
+          Select Board sets the budget. Finance Committee reviews and
+          recommends. School Committee sets school priorities. Town
+          Meeting (open to all registered voters) approves
+          appropriations. All meetings are hybrid with agendas posted
+          48 hours ahead.
+        </p>
         <a class="evidence-chart-link" href="what-you-can-do.html#who-decides-what">
           Who decides what
         </a>
@@ -3164,12 +3161,12 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Independent audits and state oversight</h4>
-        <ul>
-          <li><abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> audited by an independent firm (clean opinion every year)</li>
-          <li><abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr> reviews tax rates and certifies free cash</li>
-          <li><abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr> audits the pension fund</li>
-        </ul>
-        <p>These are not self-reported numbers.</p>
+        <p>
+          The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> is audited by an independent firm (clean opinion
+          every year). <abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr> reviews tax rates and certifies free
+          cash. <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr> audits the pension fund. These are not
+          self-reported numbers.
+        </p>
       </div>
 
       <div class="evidence-point">
@@ -3387,14 +3384,10 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>The Senior Circuit Breaker is worth up to $2,820/year</h4>
-        <ul>
-          <li>State tax credit for homeowners 65+</li>
-          <li>Income limits: $75K (single), $94K (head of household), $112K (joint)</li>
-          <li>Home assessed at or below $1,298,000</li>
-          <li>Credit = property tax above 10% of income, capped at $2,820</li>
-          <li>Refundable: you get a check even if you owe no state income tax</li>
-          <li>Social Security does not disqualify you</li>
-        </ul>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">$2,820</span>
+          <span class="evidence-nugget-label">Maximum annual state tax credit for homeowners 65+ with income below $75K (single) / $112K (joint) and a home assessed under $1.3M. Refundable: you get a check even if you owe no state income tax.</span>
+        </div>
         <a class="evidence-chart-link" href="senior-tax-relief.html#circuit-breaker">
           Circuit Breaker walkthrough
         </a>
@@ -3402,18 +3395,13 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Worked example: $900K home, $60K income</h4>
-        <ul>
-          <li>Property tax at FY26 rate: <strong>$7,740</strong></li>
-          <li>Plus half water/sewer: <strong>$750</strong></li>
-          <li>Total eligible costs: <strong>$8,490</strong></li>
-          <li>10% of income threshold: <strong>$6,000</strong></li>
-          <li>Circuit Breaker credit: <strong>$2,490</strong> (excess above threshold)</li>
-        </ul>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">$2,490</span>
+          <span class="evidence-nugget-label">Circuit Breaker credit for this household. Property tax ($7,740) + half water/sewer ($750) = $8,490 eligible. Minus 10% of income ($6,000). The state writes you a check for the $2,490 excess.</span>
+        </div>
         <p>
           A Tier 3 override adds ~$1,380 to this bill. The credit grows
           by $330 (to the $2,820 cap), leaving ~$1,050 out of pocket.
-          Seniors farther below the cap absorb more; those already at the
-          cap absorb none.
         </p>
         <a class="evidence-chart-link" href="senior-tax-relief.html">
           Senior relief calculator
@@ -3422,16 +3410,12 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Additional exemptions stack on top</h4>
-        <ul>
-          <li><strong>Veteran exemptions</strong> ($400 to full)</li>
-          <li><strong>Senior tax deferral</strong> (Clause 41A)</li>
-          <li><strong>Low-income senior exemption</strong> (Clause 41C)</li>
-          <li><strong>Surviving spouse exemption</strong> (Clause 17D)</li>
-          <li><strong>Senior Tax Work-Off Program</strong> (Council on Aging)</li>
-        </ul>
         <p>
-          All stack with the Circuit Breaker. Local exemption deadline:
-          April 1. Circuit Breaker follows the state tax filing deadline.
+          Five other programs stack with the Circuit Breaker: veteran
+          exemptions ($400 to full), senior tax deferral (Clause 41A),
+          low-income senior exemption (Clause 41C), surviving spouse
+          exemption (Clause 17D), and the Council on Aging's Senior Tax
+          Work-Off Program. Local deadline: April 1.
         </p>
       </div>
 
@@ -3463,21 +3447,20 @@ og_url: https://marbleheaddata.org/
       <div class="evidence-point">
         <h4>Only 36% of eligible Marblehead seniors claimed it in 2022</h4>
 
-        <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 400 80" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar showing 418 of 1,158 eligible seniors claimed the Circuit Breaker in 2022.">
-            <rect class="data-fill s-marblehead" x="10" y="10" width="144" height="28" rx="4"/>
-            <rect x="154" y="10" width="236" height="28" rx="4" fill="var(--divider)"/>
-            <text class="end-label" x="82" y="29" text-anchor="middle" fill="var(--c-fog)" font-weight="700" font-size="13">418 claimed</text>
-            <text class="end-label" x="272" y="29" text-anchor="middle" font-size="13">~740 did not</text>
-            <text class="tick-label" x="10" y="58" font-size="11">36% claim rate among ~1,158 eligible senior households (2022)</text>
-          </svg>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">36%</span>
+          <span class="evidence-nugget-label">Of ~1,158 eligible senior households, only 418 claimed the Circuit Breaker in 2022. Roughly 740 left money on the table.</span>
         </div>
 
-        <ul>
-          <li>418 seniors filed Schedule CB in 2022</li>
-          <li>~1,158 estimated eligible households</li>
-          <li>~740 left money on the table: unaware, not filing, or blocked by application friction</li>
-        </ul>
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 400 55" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar showing 418 of 1,158 eligible seniors claimed the Circuit Breaker in 2022.">
+            <rect class="data-fill s-marblehead" x="10" y="8" width="144" height="24" rx="4"/>
+            <rect x="154" y="8" width="236" height="24" rx="4" fill="var(--divider)"/>
+            <text class="end-label" x="82" y="25" text-anchor="middle" fill="var(--c-fog)" font-weight="700" font-size="12">418 claimed</text>
+            <text class="end-label" x="272" y="25" text-anchor="middle" font-size="12">~740 did not</text>
+            <text class="tick-label" x="10" y="48" font-size="11">Claim rate among eligible senior households, 2022</text>
+          </svg>
+        </div>
         <a class="evidence-chart-link" href="senior-tax-relief.html#how-to-actually-get-this">
           Claim rates and application steps
         </a>
@@ -3485,22 +3468,22 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>The average claim is $1,054, not $2,820</h4>
-        <ul>
-          <li>Average claim: <strong>$1,054</strong> (37% of the $2,820 cap)</li>
-          <li>For seniors who file: partial offset</li>
-          <li>For seniors who don't file: zero offset</li>
-        </ul>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">$1,054</span>
+          <span class="evidence-nugget-label">Average claim in 2022 -- just 37% of the $2,820 cap. For seniors who don't file at all, the offset is zero.</span>
+        </div>
       </div>
 
       <div class="evidence-point">
         <h4>The local means-tested exemption hasn't taken effect yet</h4>
-        <ul>
-          <li>Town Meeting passed Article 28 in May 2025 (~93% support)</li>
-          <li>Would add a local exemption on top of the Circuit Breaker for longtime seniors</li>
-          <li>Funded from tax overlay, not the operating budget</li>
-          <li>Enabling legislation (H.4225) passed the MA House on March 30, 2026</li>
-          <li>Still awaiting Senate action; does not exist for FY27 until signed into law</li>
-        </ul>
+        <p>
+          Town Meeting passed Article 28 in May 2025 (~93% support),
+          adding a local exemption funded from the tax overlay, not the
+          operating budget. But the enabling state legislation (H.4225)
+          passed the House on March 30, 2026 and is still awaiting
+          Senate action. Until signed into law, this exemption does not
+          exist for FY27.
+        </p>
       </div>
 
       <details class="counter-argument">
@@ -3541,16 +3524,12 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>The relief levers are separate from the override vote</h4>
-        <p>Voting yes or no on the override does not:</p>
-        <ul>
-          <li>Change the Circuit Breaker claim rate</li>
-          <li>Accelerate H.4225 in the Senate</li>
-          <li>Enroll seniors in programs they're not using</li>
-        </ul>
         <p>
-          Better outreach, automatic enrollment, and state-level caps
-          that scale with home values are the direct path to
-          fixed-income relief, override or no override.
+          Voting yes or no on the override doesn't change the Circuit
+          Breaker claim rate, accelerate H.4225 in the Senate, or
+          enroll seniors in programs they're not using. Better outreach
+          and automatic enrollment are the direct path to fixed-income
+          relief, override or no override.
         </p>
         <a class="evidence-chart-link" href="what-you-can-do.html#better-oversight">
           Better oversight and reform options
@@ -3559,11 +3538,12 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>The local exemption doesn't compete with services</h4>
-        <ul>
-          <li>Article 28's exemption is paid from the <strong>tax overlay</strong>, not the operating budget</li>
-          <li>Does not compete with schools, public safety, or library funding</li>
-          <li>Pushing for faster Senate action on H.4225 has no tradeoff against service levels</li>
-        </ul>
+        <p>
+          Article 28's exemption is paid from the tax overlay, not the
+          operating budget. It doesn't compete with schools, public
+          safety, or library funding. Pushing for faster Senate action
+          on H.4225 has no tradeoff against service levels.
+        </p>
       </div>
 
       <details class="counter-argument">
@@ -3660,11 +3640,13 @@ og_url: https://marbleheaddata.org/
           </svg>
         </div>
 
-        <ul>
-          <li>Schools: $32.1M (FY15) to $46.2M (FY24)</li>
-          <li>~$4.6M of the school budget (9%) is mandated out-of-district special education (<abbr class="g" title="Individuals with Disabilities Education Act">IDEA</abbr>)</li>
-          <li>The town cannot decline placements once an IEP requires them</li>
-        </ul>
+        <p>
+          Schools grew from $32.1M to $46.2M over that period. About
+          $4.6M (9%) of the school budget pays for mandated
+          out-of-district special education placements under federal
+          <abbr class="g" title="Individuals with Disabilities Education Act">IDEA</abbr>
+          law. The town cannot decline placements once an IEP requires them.
+        </p>
         <a class="evidence-chart-link" href="where-has-the-money-gone.html">
           Where the money went
         </a>
@@ -3672,12 +3654,10 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Health insurance is set by the state pool, not the town</h4>
-        <ul>
-          <li>Town pays <strong>83%</strong> of employee premiums through the <abbr class="g" title="Group Insurance Commission">GIC</abbr></li>
-          <li><abbr class="g" title="Group Insurance Commission">GIC</abbr> rates are set by the pool, not the town</li>
-          <li>FY27 rate increase alone: <strong>+$1.65M</strong> on a single line item</li>
-          <li>Growth has far outpaced Prop 2.5's 2.5% annual levy cap</li>
-        </ul>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">+$1.65M</span>
+          <span class="evidence-nugget-label">FY27 health insurance increase alone -- one line item. The town pays 83% of premiums through the <abbr class="g" title="Group Insurance Commission">GIC</abbr>; rates are set by the pool, not the town, and have far outpaced the 2.5% levy cap.</span>
+        </div>
         <a class="evidence-chart-link" href="charts/healthcare_costs.html">
           Health insurance vs. tax levy
         </a>
@@ -3685,11 +3665,12 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Pensions and debt service are fixed schedules</h4>
-        <ul>
-          <li>Pensions: <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>-certified schedule, rising <strong>8.6%/yr</strong> through FY35</li>
-          <li>Debt service: contractual (Abbot Library, Mary Alley <abbr class="g" title="Heating, Ventilation, and Air Conditioning">HVAC</abbr>, other capital projects)</li>
-          <li>Neither line has meaningful near-term local discretion</li>
-        </ul>
+        <p>
+          Pension contributions are on a <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>-certified schedule
+          rising 8.6%/yr through FY35. Debt service (Abbot Library,
+          Mary Alley <abbr class="g" title="Heating, Ventilation, and Air Conditioning">HVAC</abbr>) is contractual. Neither line has
+          meaningful near-term local discretion.
+        </p>
         <a class="evidence-chart-link" href="charts/budget_flow.html">
           Full budget flow, by category
         </a>
@@ -3723,13 +3704,15 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Enrollment fell 19%, total education headcount grew 9.6%</h4>
-        <ul>
-          <li>Enrollment: 3,245 (2015) to 2,617 (2024), down <strong>19%</strong></li>
-          <li>Classroom teachers: down ~4%</li>
-          <li>Total education staff (including paras, specialists, admin): up to <strong>537 <abbr class="g" title="Full-Time Equivalents">FTEs</abbr></strong>, a 9.6% increase</li>
-          <li>Student-to-teacher ratio: 12.6 to <strong>10.7</strong> (lowest of four peer towns)</li>
-          <li>Most of the <abbr class="g" title="Full-Time Equivalent">FTE</abbr> jump lands in FY22-to-FY23 (483 to 537), not publicly explained</li>
-        </ul>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">-19% / +9.6%</span>
+          <span class="evidence-nugget-label">Students down 628 (3,245 to 2,617). Total education staff up to 537 <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>. Student-to-teacher ratio fell to 10.7, lowest of four peer towns.</span>
+        </div>
+        <p>
+          Most of the <abbr class="g" title="Full-Time Equivalent">FTE</abbr> jump
+          lands in a single FY22-to-FY23 leap (483 to 537) that hasn't
+          been publicly explained.
+        </p>
         <a class="evidence-chart-link" href="inside-school-staffing.html">
           Inside school staffing
         </a>
@@ -3740,13 +3723,10 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Operating budget balanced on free cash for years</h4>
-        <ul>
-          <li>FY23: <strong>$10.2M</strong> of free cash into the operating budget</li>
-          <li>FY25: <strong>$5.5M</strong></li>
-          <li>FY26: <strong>$7.0M</strong></li>
-          <li>Reserves at <strong>2.5%</strong> of operating budget (state recommends 5-10%)</li>
-          <li><abbr class="g" title="Finance Committee">FinCom</abbr> 2022: "recurring costs structurally outpacing recurring revenues"</li>
-        </ul>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">$10.2M</span>
+          <span class="evidence-nugget-label">Free cash plugged into the FY23 operating budget. FY25: $5.5M. FY26: $7.0M. Reserves sit at 2.5% of the operating budget (state recommends 5-10%).</span>
+        </div>
         <a class="evidence-chart-link" href="how-we-got-here.html">
           Seven years of FinCom warnings
         </a>
@@ -3754,12 +3734,10 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Town Counsel rose 142% in one year, unexplained</h4>
-        <ul>
-          <li>FY27 Proposed Budget: $115K to <strong>$278K</strong> (+$163K, or 142%)</li>
-          <li>Two FY26 documents disagree on the starting figure ($115K vs $228K)</li>
-          <li>Reason for the increase is not publicly documented</li>
-          <li>Same budget zeros out the $250K <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr> trust contribution</li>
-        </ul>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">+142%</span>
+          <span class="evidence-nugget-label">Town Counsel: $115K to $278K in one year. Two FY26 documents disagree on the starting figure. The reason is not publicly documented. The same budget zeros out the $250K <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr> trust contribution.</span>
+        </div>
         <a class="evidence-chart-link" href="where-has-the-money-gone.html#what-grew-faster">
           What grew faster
         </a>
@@ -3793,14 +3771,12 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Six independent reviewers check the books every year</h4>
-        <ul>
-          <li>Independent audit firm (clean opinion every year)</li>
-          <li><abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr> certifies the tax rate</li>
-          <li><abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr> audits the pension fund biennially</li>
-          <li>Finance Committee publishes an annual report</li>
-          <li>Outside auditor issues a management letter most years</li>
-        </ul>
-        <p>These are not self-reported numbers.</p>
+        <p>
+          Independent audit firm (clean opinion every year), <abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr>
+          (certifies tax rate), <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr> (pension fund), Finance Committee
+          (annual report), and the outside auditor (management letter).
+          These are not self-reported numbers.
+        </p>
         <a class="evidence-chart-link" href="where-has-the-money-gone.html#who-checks-books">
           Who has been checking the books
         </a>

--- a/index.html
+++ b/index.html
@@ -724,13 +724,13 @@ og_url: https://marbleheaddata.org/
 
             <!-- Expenses without reform: 5% growth from ~$114M -->
             <polyline class="data-line data-line--dashed s-neutral" points="94,144 234,108 374,68 444,48"/>
-            <text class="annotation" x="452" y="44" font-size="11">No reform (5%/yr)</text>
+            <text class="end-label s-neutral" x="452" y="52">No reform (5%/yr)</text>
 
             <!-- Expenses with reform: 3.5% growth from ~$114M -->
             <polyline class="data-line data-line--bold s-marblehead" points="94,144 234,120 374,96 444,84"/>
-            <text class="annotation" x="452" y="88" font-size="11">With reform (3.5%/yr)</text>
+            <text class="end-label s-marblehead" x="452" y="88">With reform (3.5%/yr)</text>
 
-            <text class="end-label s-revenue" x="452" y="120" font-size="11">Revenue (3%/yr)</text>
+            <text class="end-label s-revenue" x="452" y="120">Revenue (3%/yr)</text>
           </svg>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -3394,10 +3394,10 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Worked example: $900K home, $60K income</h4>
+        <h4>A $900K home with $60K income gets a $2,490 check from the state</h4>
         <div class="evidence-nugget">
           <span class="evidence-nugget-value">$2,490</span>
-          <span class="evidence-nugget-label">Circuit Breaker credit for this household. Property tax ($7,740) + half water/sewer ($750) = $8,490 eligible. Minus 10% of income ($6,000). The state writes you a check for the $2,490 excess.</span>
+          <span class="evidence-nugget-label">Annual Circuit Breaker credit. Tax ($7,740) + half water/sewer ($750) = $8,490 eligible costs. Minus 10% of income ($6,000). The state refunds the $2,490 excess.</span>
         </div>
         <p>
           A Tier 3 override adds ~$1,380 to this bill. The credit grows
@@ -3453,12 +3453,11 @@ og_url: https://marbleheaddata.org/
         </div>
 
         <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 400 55" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar showing 418 of 1,158 eligible seniors claimed the Circuit Breaker in 2022.">
+          <svg class="chart" viewBox="0 0 400 40" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar showing 418 of 1,158 eligible seniors claimed the Circuit Breaker in 2022.">
             <rect class="data-fill s-marblehead" x="10" y="8" width="144" height="24" rx="4"/>
             <rect x="154" y="8" width="236" height="24" rx="4" fill="var(--divider)"/>
             <text class="end-label" x="82" y="25" text-anchor="middle" fill="var(--c-fog)" font-weight="700" font-size="12">418 claimed</text>
             <text class="end-label" x="272" y="25" text-anchor="middle" font-size="12">~740 did not</text>
-            <text class="tick-label" x="10" y="48" font-size="11">Claim rate among eligible senior households, 2022</text>
           </svg>
         </div>
         <a class="evidence-chart-link" href="senior-tax-relief.html#how-to-actually-get-this">

--- a/index.html
+++ b/index.html
@@ -2472,11 +2472,20 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Marblehead's tax base is almost entirely residential</h4>
+
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 400 55" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar showing 95.5% residential vs 4.5% commercial tax base.">
+            <rect class="data-fill s-marblehead" x="10" y="8" width="343" height="22" rx="4"/>
+            <rect x="353" y="8" width="37" height="22" rx="4" fill="var(--divider)"/>
+            <text class="end-label" x="180" y="24" text-anchor="middle" fill="var(--c-fog)" font-weight="700" font-size="12">Residential: 95.5%</text>
+            <text class="end-label" x="371" y="24" text-anchor="middle" font-size="10">4.5%</text>
+            <text class="tick-label" x="10" y="48" font-size="11">Highest residential share in a 21-town peer set</text>
+          </svg>
+        </div>
+
         <p>
-          95.5% of the tax levy comes from residential property, the
-          highest in a 21-town peer set. There's almost no commercial
-          base to shift burden onto. A <abbr class="g" title="Capital Improvement Plan">CIP</abbr> split on 4.5% commercial
-          property produces trivial revenue.
+          Almost no commercial base to shift burden onto. A <abbr class="g" title="Capital Improvement Plan">CIP</abbr> split
+          on 4.5% commercial property produces trivial revenue.
         </p>
         <a class="evidence-chart-link" href="why-not-elsewhere.html">
           Why some towns don't need overrides
@@ -2535,13 +2544,13 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>The insurance split is a choice, not a law of nature</h4>
-        <p>
-          Marblehead pays 83% of health premiums. State law allows
-          anywhere from 50% to 99%. Hingham pays 50% and offsets it
-          with higher salaries. Moving to 75% would save roughly
-          $1M/year. It requires collective bargaining, not a ballot
-          question.
-        </p>
+        <ul>
+          <li>Marblehead pays <strong>83%</strong> of health premiums</li>
+          <li>State law allows 50% to 99%</li>
+          <li>Hingham pays 50%, offsets with higher salaries</li>
+          <li>Moving to 75% would save ~<strong>$1M/year</strong></li>
+          <li>Requires collective bargaining, not a ballot question</li>
+        </ul>
         <a class="evidence-chart-link" href="charts/peer_compensation.html">
           Peer compensation and premium splits
         </a>
@@ -2961,49 +2970,48 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>What the town legally cannot cut</h4>
-        <p>
-          Contributory Retirement: set by <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>
-          on a state-mandated amortization schedule (+$463K in FY27).
-          Debt service: contractual bond payments. Essex Tech
-          assessment: set by the regional district, not the town.
-          These lines go up regardless of the override outcome.
-        </p>
+        <ul>
+          <li><strong>Pensions:</strong> <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>-mandated schedule (+$463K in FY27)</li>
+          <li><strong>Debt service:</strong> contractual bond payments</li>
+          <li><strong>Essex Tech:</strong> assessment set by the regional district</li>
+        </ul>
       </div>
 
       <div class="evidence-point">
         <h4>What contracts prevent cutting</h4>
-        <p>
-          Police, fire, and teacher salaries are set by collective
-          bargaining agreements. Step increases and cost-of-living
-          adjustments are locked for the contract term. Laying off
-          unionized staff triggers seniority rules, bumping, and
-          potential arbitration. Group health insurance rates are set
-          by the <abbr class="g" title="Group Insurance Commission">GIC</abbr>
-          (+$1.65M in FY27, +11%). The town cannot negotiate a lower
-          rate.
-        </p>
+        <ul>
+          <li>Police, fire, and teacher salaries locked by collective bargaining</li>
+          <li>Step increases and COLAs locked for the contract term</li>
+          <li>Layoffs trigger seniority rules, bumping, potential arbitration</li>
+          <li><abbr class="g" title="Group Insurance Commission">GIC</abbr> insurance rates: +$1.65M in FY27 (+11%), town cannot negotiate lower</li>
+        </ul>
       </div>
 
       <div class="evidence-point">
         <h4>The library has none of these protections</h4>
-        <p>
-          Library staff are non-union and at-will. There is no state
-          law requiring a minimum level of library funding. State
-          accreditation (which provides roughly $57,000 in state aid
-          and reciprocal borrowing across the library network) is
-          voluntary, not mandated. That makes the library one of the
-          few departments where deep cuts are even legally possible.
-        </p>
+        <ul>
+          <li>Staff are non-union and at-will</li>
+          <li>No state law requiring minimum library funding</li>
+          <li>Accreditation is voluntary (~$57K in state aid at risk)</li>
+        </ul>
       </div>
 
       <div class="evidence-point">
         <h4>The other unprotected departments got cut too</h4>
-        <p>
-          Community development: -59%. Council on Aging: staffing
-          reductions. Recreation: groundskeeper eliminated. Cemetery:
-          laborer eliminated. The library's 43% is the largest dollar
-          amount because it has the largest unprotected budget.
-        </p>
+
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 400 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Horizontal bars showing no-override cuts by unprotected department: Community Dev -59%, Library -43%, and smaller cuts elsewhere.">
+            <text class="tick-label" x="140" y="22" text-anchor="end" font-size="12">Community Dev</text>
+            <rect class="data-fill s-neutral" x="145" y="10" width="142" height="16" rx="3"/>
+            <text class="end-label" x="293" y="22" font-size="11"> -59%</text>
+            <text class="tick-label" x="140" y="48" text-anchor="end" font-size="12">Library</text>
+            <rect class="data-fill s-neutral" x="145" y="36" width="103" height="16" rx="3"/>
+            <text class="end-label" x="254" y="48" font-size="11"> -43%</text>
+            <text class="tick-label" x="140" y="74" text-anchor="end" font-size="12">Recreation, Cemetery, COA</text>
+            <rect class="data-fill s-neutral" x="145" y="62" width="24" height="16" rx="3"/>
+            <text class="end-label" x="175" y="74" font-size="11"> positions cut</text>
+          </svg>
+        </div>
         <a class="evidence-chart-link" href="no-override-budget.html">
           Department-by-department cuts
         </a>
@@ -3143,14 +3151,13 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Who decides what</h4>
-        <p>
-          The Select Board sets the town budget and handles operations.
-          The Finance Committee reviews and recommends. The School
-          Committee sets priorities within the school budget. Town Meeting
-          (open to all registered voters) approves appropriations. All
-          meetings are hybrid and agendas are posted at least 48 hours
-          ahead on the town calendar.
-        </p>
+        <ul>
+          <li><strong>Select Board</strong> sets the town budget and handles operations</li>
+          <li><strong>Finance Committee</strong> reviews and recommends</li>
+          <li><strong>School Committee</strong> sets priorities within the school budget</li>
+          <li><strong>Town Meeting</strong> (open to all registered voters) approves appropriations</li>
+          <li>All meetings are hybrid; agendas posted 48 hours ahead</li>
+        </ul>
         <a class="evidence-chart-link" href="what-you-can-do.html#who-decides-what">
           Who decides what
         </a>
@@ -3158,12 +3165,12 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Independent audits and state oversight</h4>
-        <p>
-          The town publishes an Annual Comprehensive Financial Report
-          (<abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>) audited by an independent firm. The MA Department of
-          Revenue reviews tax rates and certifies free cash. <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>
-          audits the pension fund. These are not self-reported numbers.
-        </p>
+        <ul>
+          <li><abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> audited by an independent firm (clean opinion every year)</li>
+          <li><abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr> reviews tax rates and certifies free cash</li>
+          <li><abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr> audits the pension fund</li>
+        </ul>
+        <p>These are not self-reported numbers.</p>
       </div>
 
       <div class="evidence-point">
@@ -3381,17 +3388,14 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>The Senior Circuit Breaker is worth up to $2,820/year</h4>
-        <p>
-          The <abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr>
-          Senior Circuit Breaker is a refundable state tax credit for
-          homeowners 65 and older with MA income below $75,000 (single),
-          $94,000 (head of household), or $112,000 (joint), and a home
-          assessed at or below $1,298,000. The credit is the portion of
-          property tax (plus half water and sewer) above 10% of income,
-          capped at $2,820. It's refundable: you get a check even if
-          you owe no state income tax. Social Security income does not
-          disqualify you.
-        </p>
+        <ul>
+          <li>State tax credit for homeowners 65+</li>
+          <li>Income limits: $75K (single), $94K (head of household), $112K (joint)</li>
+          <li>Home assessed at or below $1,298,000</li>
+          <li>Credit = property tax above 10% of income, capped at $2,820</li>
+          <li>Refundable: you get a check even if you owe no state income tax</li>
+          <li>Social Security does not disqualify you</li>
+        </ul>
         <a class="evidence-chart-link" href="senior-tax-relief.html#circuit-breaker">
           Circuit Breaker walkthrough
         </a>
@@ -3399,16 +3403,18 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Worked example: $900K home, $60K income</h4>
+        <ul>
+          <li>Property tax at FY26 rate: <strong>$7,740</strong></li>
+          <li>Plus half water/sewer: <strong>$750</strong></li>
+          <li>Total eligible costs: <strong>$8,490</strong></li>
+          <li>10% of income threshold: <strong>$6,000</strong></li>
+          <li>Circuit Breaker credit: <strong>$2,490</strong> (excess above threshold)</li>
+        </ul>
         <p>
-          At Marblehead's FY26 tax rate of $8.60 per $1,000: property tax
-          $7,740. Half water and sewer: $750. Total eligible: $8,490. 10%
-          of income: $6,000. Excess: $2,490. That's the credit the state
-          writes you a check for. A full Tier 3 override would add about
-          $1,380 to the tax bill on a $900K home; the Circuit Breaker
-          credit grows by $330 (from $2,490 to the $2,820 cap), leaving
-          the senior paying about $1,050 of the override out of pocket.
-          Seniors who start farther below the cap see a larger share
-          absorbed; seniors already at the cap see none.
+          A Tier 3 override adds ~$1,380 to this bill. The credit grows
+          by $330 (to the $2,820 cap), leaving ~$1,050 out of pocket.
+          Seniors farther below the cap absorb more; those already at the
+          cap absorb none.
         </p>
         <a class="evidence-chart-link" href="senior-tax-relief.html">
           Senior relief calculator
@@ -3417,13 +3423,16 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Additional exemptions stack on top</h4>
+        <ul>
+          <li><strong>Veteran exemptions</strong> ($400 to full)</li>
+          <li><strong>Senior tax deferral</strong> (Clause 41A)</li>
+          <li><strong>Low-income senior exemption</strong> (Clause 41C)</li>
+          <li><strong>Surviving spouse exemption</strong> (Clause 17D)</li>
+          <li><strong>Senior Tax Work-Off Program</strong> (Council on Aging)</li>
+        </ul>
         <p>
-          Veteran exemptions ($400 to full), the senior tax deferral
-          (Clause 41A), the low-income senior exemption (Clause 41C),
-          and the surviving spouse exemption (Clause 17D) all stack with
-          the Circuit Breaker. The Council on Aging also runs a Senior
-          Tax Work-Off Program. The deadline for local exemptions is
-          April 1; Circuit Breaker follows the state tax filing deadline.
+          All stack with the Circuit Breaker. Local exemption deadline:
+          April 1. Circuit Breaker follows the state tax filing deadline.
         </p>
       </div>
 
@@ -3454,15 +3463,22 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Only 36% of eligible Marblehead seniors claimed it in 2022</h4>
-        <p>
-          418 Marblehead seniors filed Schedule CB and claimed the
-          Circuit Breaker in 2022. The estimated eligible population is
-          roughly 1,158 senior households at or below the $75,000
-          single-filer income limit. That leaves roughly 740 households
-          either unaware of the program, not filing state returns, or
-          facing application friction that blocks them. The credit is
-          worth nothing to a senior who never files.
-        </p>
+
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 400 80" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar showing 418 of 1,158 eligible seniors claimed the Circuit Breaker in 2022.">
+            <rect class="data-fill s-marblehead" x="10" y="10" width="144" height="28" rx="4"/>
+            <rect x="154" y="10" width="236" height="28" rx="4" fill="var(--divider)"/>
+            <text class="end-label" x="82" y="29" text-anchor="middle" fill="var(--c-fog)" font-weight="700" font-size="13">418 claimed</text>
+            <text class="end-label" x="272" y="29" text-anchor="middle" font-size="13">~740 did not</text>
+            <text class="tick-label" x="10" y="58" font-size="11">36% claim rate among ~1,158 eligible senior households (2022)</text>
+          </svg>
+        </div>
+
+        <ul>
+          <li>418 seniors filed Schedule CB in 2022</li>
+          <li>~1,158 estimated eligible households</li>
+          <li>~740 left money on the table: unaware, not filing, or blocked by application friction</li>
+        </ul>
         <a class="evidence-chart-link" href="senior-tax-relief.html#how-to-actually-get-this">
           Claim rates and application steps
         </a>
@@ -3470,26 +3486,22 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>The average claim is $1,054, not $2,820</h4>
-        <p>
-          The average Marblehead Circuit Breaker claim in 2022 was $1,054,
-          about 37% of the $2,820 cap. For seniors who do file, the
-          credit partially offsets an override; for those who don't file
-          at all, the offset is zero.
-        </p>
+        <ul>
+          <li>Average claim: <strong>$1,054</strong> (37% of the $2,820 cap)</li>
+          <li>For seniors who file: partial offset</li>
+          <li>For seniors who don't file: zero offset</li>
+        </ul>
       </div>
 
       <div class="evidence-point">
         <h4>The local means-tested exemption hasn't taken effect yet</h4>
-        <p>
-          Marblehead Town Meeting passed Article 28 in May 2025 with
-          roughly 93% support. It would add a means-tested local
-          exemption on top of the Circuit Breaker for longtime Marblehead
-          seniors, funded from the tax overlay rather than the operating
-          budget. The enabling state legislation (H.4225) passed the MA
-          House on March 30, 2026, but is still awaiting Senate action.
-          Until it becomes law, the local exemption does not exist for
-          FY27.
-        </p>
+        <ul>
+          <li>Town Meeting passed Article 28 in May 2025 (~93% support)</li>
+          <li>Would add a local exemption on top of the Circuit Breaker for longtime seniors</li>
+          <li>Funded from tax overlay, not the operating budget</li>
+          <li>Enabling legislation (H.4225) passed the MA House on March 30, 2026</li>
+          <li>Still awaiting Senate action; does not exist for FY27 until signed into law</li>
+        </ul>
       </div>
 
       <details class="counter-argument">
@@ -3521,27 +3533,25 @@ og_url: https://marbleheaddata.org/
       <div class="evidence-point">
         <h4>Property taxes tax the home, not the income</h4>
         <p>
-          An override raises property tax on the assessed value of a
-          home, regardless of the household's current income. A retiree
-          who bought their house in 1985 and sees it appraised today at
-          $1.2 million pays the same rate as a working professional who
-          bought the same house last year. Any override, any size, any
-          year carries this property-vs-income mismatch &ndash; it's
-          built into property tax as a mechanism.
+          A retiree who bought in 1985 and sees their home appraised at
+          $1.2M today pays the same rate as a working professional who
+          bought last year. That mismatch is built into property tax as
+          a mechanism, regardless of override size or year.
         </p>
       </div>
 
       <div class="evidence-point">
         <h4>The relief levers are separate from the override vote</h4>
+        <p>Voting yes or no on the override does not:</p>
+        <ul>
+          <li>Change the Circuit Breaker claim rate</li>
+          <li>Accelerate H.4225 in the Senate</li>
+          <li>Enroll seniors in programs they're not using</li>
+        </ul>
         <p>
-          Voting yes or no on the override doesn't change the Circuit
-          Breaker claim rate, doesn't accelerate H.4225 in the Senate,
-          and doesn't enroll seniors in programs they're not currently
-          using. Those are separate policy levers with separate
-          decision-makers. Pushing for better outreach, automatic
-          enrollment where possible, and state-level caps that scale
-          with home values is the direct path to fixed-income relief,
-          override or no override.
+          Better outreach, automatic enrollment, and state-level caps
+          that scale with home values are the direct path to
+          fixed-income relief, override or no override.
         </p>
         <a class="evidence-chart-link" href="what-you-can-do.html#better-oversight">
           Better oversight and reform options
@@ -3550,13 +3560,11 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>The local exemption doesn't compete with services</h4>
-        <p>
-          Article 28's means-tested local exemption is paid from the tax
-          overlay, not the operating budget, which means it does not
-          compete with schools, public safety, or library funding.
-          Whatever happens at the override ballot, pushing for faster
-          Senate action on H.4225 has no tradeoff against service levels.
-        </p>
+        <ul>
+          <li>Article 28's exemption is paid from the <strong>tax overlay</strong>, not the operating budget</li>
+          <li>Does not compete with schools, public safety, or library funding</li>
+          <li>Pushing for faster Senate action on H.4225 has no tradeoff against service levels</li>
+        </ul>
       </div>
 
       <details class="counter-argument">
@@ -3642,17 +3650,22 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Schools absorbed 48% of total growth</h4>
-        <p>
-          Schools grew from $32.1M (FY15) to $46.2M (FY24), absorbing
-          roughly 48% of the $35.7M total General Fund growth. About
-          $4.6M of the FY26 school budget &ndash; roughly 9% &ndash;
-          pays for out-of-district special education placements that
-          are mandated by the federal
-          <abbr class="g" title="Individuals with Disabilities Education Act">IDEA</abbr>
-          and Massachusetts special education law. The town does not
-          have discretion to stop paying for placements once a
-          student's Individualized Education Program requires them.
-        </p>
+
+        <div class="chart-wrapper">
+          <svg class="chart" viewBox="0 0 400 70" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar showing schools absorbed 48% of $35.7M general fund growth, FY15 to FY24.">
+            <rect class="data-fill s-marblehead" x="10" y="10" width="182" height="24" rx="4"/>
+            <rect x="192" y="10" width="198" height="24" rx="4" fill="var(--divider)"/>
+            <text class="end-label" x="100" y="27" text-anchor="middle" fill="var(--c-fog)" font-weight="700" font-size="12">Schools: $17.1M (48%)</text>
+            <text class="end-label" x="291" y="27" text-anchor="middle" font-size="12">All other: $18.6M (52%)</text>
+            <text class="tick-label" x="10" y="55" font-size="11">$35.7M total General Fund growth, FY15 to FY24</text>
+          </svg>
+        </div>
+
+        <ul>
+          <li>Schools: $32.1M (FY15) to $46.2M (FY24)</li>
+          <li>~$4.6M of the school budget (9%) is mandated out-of-district special education (<abbr class="g" title="Individuals with Disabilities Education Act">IDEA</abbr>)</li>
+          <li>The town cannot decline placements once an IEP requires them</li>
+        </ul>
         <a class="evidence-chart-link" href="where-has-the-money-gone.html">
           Where the money went
         </a>
@@ -3660,15 +3673,12 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Health insurance is set by the state pool, not the town</h4>
-        <p>
-          The town pays 83% of employee health insurance premiums
-          through the <abbr class="g" title="Group Insurance Commission">GIC</abbr>,
-          Massachusetts's state insurance pool. <abbr class="g" title="Group Insurance Commission">GIC</abbr> rates are set by
-          the pool and have grown substantially faster than
-          Proposition 2&frac12;'s 2.5% annual levy cap. The FY27 rate
-          increase alone added roughly $1.65M to the operating budget
-          on a single line item.
-        </p>
+        <ul>
+          <li>Town pays <strong>83%</strong> of employee premiums through the <abbr class="g" title="Group Insurance Commission">GIC</abbr></li>
+          <li><abbr class="g" title="Group Insurance Commission">GIC</abbr> rates are set by the pool, not the town</li>
+          <li>FY27 rate increase alone: <strong>+$1.65M</strong> on a single line item</li>
+          <li>Growth has far outpaced Prop 2.5's 2.5% annual levy cap</li>
+        </ul>
         <a class="evidence-chart-link" href="charts/healthcare_costs.html">
           Health insurance vs. tax levy
         </a>
@@ -3676,15 +3686,11 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Pensions and debt service are fixed schedules</h4>
-        <p>
-          Marblehead's pension obligations are on a
-          <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>-certified
-          actuarial schedule rising 8.6% per year through FY35.
-          Voter-approved debt service (Abbot Library, Mary Alley
-          <abbr class="g" title="Heating, Ventilation, and Air Conditioning">HVAC</abbr>,
-          and other capital projects) is contractual. Neither line
-          has meaningful near-term local discretion.
-        </p>
+        <ul>
+          <li>Pensions: <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>-certified schedule, rising <strong>8.6%/yr</strong> through FY35</li>
+          <li>Debt service: contractual (Abbot Library, Mary Alley <abbr class="g" title="Heating, Ventilation, and Air Conditioning">HVAC</abbr>, other capital projects)</li>
+          <li>Neither line has meaningful near-term local discretion</li>
+        </ul>
         <a class="evidence-chart-link" href="charts/budget_flow.html">
           Full budget flow, by category
         </a>
@@ -3718,22 +3724,13 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Enrollment fell 19%, total education headcount grew 9.6%</h4>
-        <p>
-          Between 2015 and 2024, Marblehead school enrollment fell from
-          3,245 to 2,617 students &ndash; a drop of 628 students, or
-          19%. Classroom teacher headcount dropped about 4% over the
-          same window. But total education headcount (including
-          paraprofessionals, specialists, and administrators) rose by
-          roughly 58 positions to 537
-          <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>,
-          a 9.6% increase. The student-to-teacher ratio fell from 12.6
-          to 10.7, the lowest of Marblehead's four peer towns. Most of
-          that <abbr class="g" title="Full-Time Equivalent">FTE</abbr> increase lands in a single FY22-to-FY23 jump (483 to
-          537) that the town has not publicly explained; the source may
-          reflect expired federal <abbr class="g" title="Elementary and Secondary School Emergency Relief">ESSER</abbr> positions or a change in
-          reporting methodology, and the number has held at exactly
-          537.0 for two years since.
-        </p>
+        <ul>
+          <li>Enrollment: 3,245 (2015) to 2,617 (2024), down <strong>19%</strong></li>
+          <li>Classroom teachers: down ~4%</li>
+          <li>Total education staff (including paras, specialists, admin): up to <strong>537 <abbr class="g" title="Full-Time Equivalents">FTEs</abbr></strong>, a 9.6% increase</li>
+          <li>Student-to-teacher ratio: 12.6 to <strong>10.7</strong> (lowest of four peer towns)</li>
+          <li>Most of the <abbr class="g" title="Full-Time Equivalent">FTE</abbr> jump lands in FY22-to-FY23 (483 to 537), not publicly explained</li>
+        </ul>
         <a class="evidence-chart-link" href="inside-school-staffing.html">
           Inside school staffing
         </a>
@@ -3744,17 +3741,13 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Operating budget balanced on free cash for years</h4>
-        <p>
-          Town Meeting appropriated $7.0M of free cash (prior-year
-          surplus) into the FY26 operating budget, $5.5M into FY25,
-          and $10.2M into FY23. The
-          <abbr class="g" title="Finance Committee">FinCom</abbr>'s
-          2022 report described the pattern as a "structural budget
-          challenge" caused by "recurring costs structurally outpacing
-          recurring revenues." The 2025 report noted reserves at only
-          2.5% of the operating budget, below the state-recommended
-          range of 5 to 10%.
-        </p>
+        <ul>
+          <li>FY23: <strong>$10.2M</strong> of free cash into the operating budget</li>
+          <li>FY25: <strong>$5.5M</strong></li>
+          <li>FY26: <strong>$7.0M</strong></li>
+          <li>Reserves at <strong>2.5%</strong> of operating budget (state recommends 5-10%)</li>
+          <li><abbr class="g" title="Finance Committee">FinCom</abbr> 2022: "recurring costs structurally outpacing recurring revenues"</li>
+        </ul>
         <a class="evidence-chart-link" href="how-we-got-here.html">
           Seven years of FinCom warnings
         </a>
@@ -3762,19 +3755,12 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Town Counsel rose 142% in one year, unexplained</h4>
-        <p>
-          The FY27 Proposed Budget moves Town Counsel from $115,000 to
-          $278,000 &ndash; a one-year increase of $163,000 or 142%.
-          Two FY26 town documents disagree on the starting figure (one
-          lists $115,000, the other $228,000), and the reason for the
-          year-over-year increase and the discrepancy between the two
-          FY26 figures is not publicly documented. The same budget
-          zeros out the town's $250,000 annual
-          <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr>
-          retiree-benefits-trust contribution, so one legal line grew
-          by about two-thirds of the retiree-benefits contribution in
-          the same budget cycle.
-        </p>
+        <ul>
+          <li>FY27 Proposed Budget: $115K to <strong>$278K</strong> (+$163K, or 142%)</li>
+          <li>Two FY26 documents disagree on the starting figure ($115K vs $228K)</li>
+          <li>Reason for the increase is not publicly documented</li>
+          <li>Same budget zeros out the $250K <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr> trust contribution</li>
+        </ul>
         <a class="evidence-chart-link" href="where-has-the-money-gone.html#what-grew-faster">
           What grew faster
         </a>
@@ -3808,16 +3794,14 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Six independent reviewers check the books every year</h4>
-        <p>
-          Marblehead's books are audited annually by an independent
-          firm (clean opinion every year). The
-          <abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr>
-          certifies the tax rate. <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr> audits the pension fund on a
-          biennial actuarial schedule. The Finance Committee publishes
-          an annual report. The town's outside auditor issues a
-          management letter in most years. These are not self-reported
-          numbers.
-        </p>
+        <ul>
+          <li>Independent audit firm (clean opinion every year)</li>
+          <li><abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr> certifies the tax rate</li>
+          <li><abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr> audits the pension fund biennially</li>
+          <li>Finance Committee publishes an annual report</li>
+          <li>Outside auditor issues a management letter most years</li>
+        </ul>
+        <p>These are not self-reported numbers.</p>
         <a class="evidence-chart-link" href="where-has-the-money-gone.html#who-checks-books">
           Who has been checking the books
         </a>

--- a/index.html
+++ b/index.html
@@ -590,11 +590,11 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>We've said no before</h4>
-        <p>
-          Marblehead has approved only 6 of 20 operating overrides
-          since 1988. The town kept running after each rejection.
-        </p>
+        <h4>Marblehead has rejected 14 of 20 operating overrides since 1988</h4>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">6 of 20</span>
+          <span class="evidence-nugget-label">Operating overrides approved since 1988. The town kept running after each of the 14 rejections.</span>
+        </div>
         <a class="evidence-chart-link" href="marblehead-voting-record.html">
           Voting record since 1988
         </a>
@@ -641,23 +641,21 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Melrose said no, then paid 75% more</h4>
-        <p>
-          Melrose rejected $7.7M in 2024. After cutting 61 positions,
-          class sizes hit 32 students. They came back 18 months later
-          and passed $13.5M.
-        </p>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">$7.7M &rarr; $13.5M</span>
+          <span class="evidence-nugget-label">Melrose rejected $7.7M in 2024. Cut 61 positions, class sizes hit 32. Came back 18 months later and passed $13.5M.</span>
+        </div>
         <a class="evidence-chart-link" href="data/case_studies">
           Override case studies
         </a>
       </div>
 
       <div class="evidence-point">
-        <h4>Stoneham lost teachers to other towns</h4>
-        <p>
-          Stoneham rejected $14.6M in 2025. Staff left for
-          higher-paying districts, leaving 28 positions unfilled.
-          They passed a smaller $9.3M override seven months later.
-        </p>
+        <h4>Stoneham lost staff, then passed a smaller override 7 months later</h4>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">28 unfilled</span>
+          <span class="evidence-nugget-label">Positions after Stoneham rejected $14.6M in 2025. Staff left for higher-paying districts. They passed $9.3M seven months later.</span>
+        </div>
         <a class="evidence-chart-link" href="data/case_studies">
           Override case studies
         </a>

--- a/index.html
+++ b/index.html
@@ -702,52 +702,53 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>The override does not fix the underlying math</h4>
+        <h4>Reform bends the expense line toward revenue</h4>
 
         <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue bars vs expense line, FY24 to FY30. Gap grows even with override.">
+          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue line rising steadily. Two expense lines: one at 5% growth diverging upward, one at 3.5% growth (with reform) converging toward revenue by FY30.">
             <line class="axis-base" x1="60" y1="200" x2="500" y2="200"/>
             <line class="grid-minor" x1="60" y1="160" x2="500" y2="160"/>
             <line class="grid-minor" x1="60" y1="120" x2="500" y2="120"/>
             <line class="grid-minor" x1="60" y1="80" x2="500" y2="80"/>
-            <text class="tick-label" x="53" y="204" text-anchor="end">$80M</text>
-            <text class="tick-label" x="53" y="164" text-anchor="end">$100M</text>
+            <text class="tick-label" x="53" y="204" text-anchor="end">$100M</text>
+            <text class="tick-label" x="53" y="164" text-anchor="end">$110M</text>
             <text class="tick-label" x="53" y="124" text-anchor="end">$120M</text>
-            <text class="tick-label" x="53" y="84" text-anchor="end">$140M</text>
-            <text class="tick-label tick-label--major" x="94" y="220" text-anchor="middle">FY24</text>
-            <text class="tick-label tick-label--major" x="234" y="220" text-anchor="middle">FY27</text>
+            <text class="tick-label" x="53" y="84" text-anchor="end">$130M</text>
+            <text class="tick-label tick-label--major" x="94" y="220" text-anchor="middle">FY27</text>
+            <text class="tick-label tick-label--major" x="234" y="220" text-anchor="middle">FY28</text>
             <text class="tick-label tick-label--major" x="374" y="220" text-anchor="middle">FY29</text>
             <text class="tick-label tick-label--major" x="444" y="220" text-anchor="middle">FY30</text>
-            <rect class="data-fill s-revenue" x="80" y="123" width="28" height="77"/>
-            <rect class="data-fill s-revenue" x="150" y="112" width="28" height="88" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="220" y="103" width="28" height="97" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="290" y="94" width="28" height="106" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="360" y="86" width="28" height="114" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="430" y="78" width="28" height="122" opacity="0.65"/>
-            <polyline class="data-line data-line--bold s-neutral" points="94,120 164,105 234,72 304,52 374,32 444,12"/>
-            <circle class="data-dot s-neutral" cx="94" cy="120" r="3"/>
-            <circle class="data-dot s-neutral" cx="234" cy="72" r="3"/>
-            <circle class="data-dot s-neutral" cx="444" cy="12" r="4"/>
-            <text class="annotation" x="460" y="18">$140M expenses</text>
-            <text class="annotation" x="460" y="82">$121M revenue</text>
+
+            <!-- Revenue line: 3% annual growth from ~$106M -->
+            <polyline class="data-line data-line--bold s-revenue" points="94,176 234,152 374,128 444,116"/>
+
+            <!-- Expenses without reform: 5% growth from ~$114M -->
+            <polyline class="data-line data-line--dashed s-neutral" points="94,144 234,108 374,68 444,48"/>
+            <text class="annotation" x="452" y="44" font-size="11">No reform (5%/yr)</text>
+
+            <!-- Expenses with reform: 3.5% growth from ~$114M -->
+            <polyline class="data-line data-line--bold s-marblehead" points="94,144 234,120 374,96 444,84"/>
+            <text class="annotation" x="452" y="88" font-size="11">With reform (3.5%/yr)</text>
+
+            <text class="end-label s-revenue" x="452" y="120" font-size="11">Revenue (3%/yr)</text>
           </svg>
         </div>
 
         <p class="caption">
-          Without an override, the gap between what the town spends and
-          what it collects grows to $18M by FY30. Even Tier 3 ($15M)
-          only bridges it briefly before expenses pull ahead again. The
-          override buys time; it doesn't change the trend.
+          At 5% expense growth (recent trend), expenses pull away from
+          revenue every year. Bending expense growth to 3.5% through
+          insurance reform, staffing review, and competitive bidding
+          narrows the gap enough that future overrides shrink or
+          disappear. The no-vote argument is that only pressure
+          produces the bend.
         </p>
-        <a class="evidence-chart-link" href="charts/sustainability.html">
-          Full sustainability projections
-        </a>
         <a class="evidence-chart-link" href="charts/deficit_model.html">
-          Adjust the assumptions and see when the gap reopens
+          Adjust the assumptions and see when the gap closes
         </a>
         <p class="evidence-caveat">
-          FY28-FY30 are projections (3% revenue growth,
-          5% expense growth), not forecasts.
+          Illustrative. 3.5% assumes ~$1M/yr savings from moving the
+          health premium split from 83% to 75% plus modest staffing
+          and procurement efficiencies. Not a forecast.
         </p>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -3586,12 +3586,11 @@ og_url: https://marbleheaddata.org/
         <h4>Schools absorbed 48% of total growth</h4>
 
         <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 400 70" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar showing schools absorbed 48% of $35.7M general fund growth, FY15 to FY24.">
-            <rect class="data-fill s-marblehead" x="10" y="10" width="182" height="24" rx="4"/>
-            <rect x="192" y="10" width="198" height="24" rx="4" fill="var(--divider)"/>
-            <text class="end-label" x="100" y="27" text-anchor="middle" fill="var(--c-fog)" font-weight="700" font-size="12">Schools: $17.1M (48%)</text>
-            <text class="end-label" x="291" y="27" text-anchor="middle" font-size="12">All other: $18.6M (52%)</text>
-            <text class="tick-label" x="10" y="55" font-size="11">$35.7M total General Fund growth, FY15 to FY24</text>
+          <svg class="chart" viewBox="0 0 400 40" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar showing schools absorbed 48% of $35.7M general fund growth, FY15 to FY24.">
+            <rect class="data-fill s-marblehead" x="10" y="8" width="182" height="24" rx="4"/>
+            <rect x="192" y="8" width="198" height="24" rx="4" fill="var(--divider)"/>
+            <text class="end-label" x="100" y="25" text-anchor="middle" fill="var(--c-fog)" font-weight="700" font-size="12">Schools: $17.1M (48%)</text>
+            <text class="end-label" x="291" y="25" text-anchor="middle" font-size="12">All other: $18.6M (52%)</text>
           </svg>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -1710,10 +1710,9 @@ og_url: https://marbleheaddata.org/
     <div class="question-block">
       <h1>What would the override cost my household?</h1>
       <p class="question-context">
-        There are three honest framings of "what does it cost." Per month
-        at the average home, compounded over ten years, or as a share of
-        median household income. None are wrong; they answer slightly
-        different questions.
+        The answer depends on how you frame it: monthly cash flow,
+        compounded over a decade, or as a share of what your household
+        earns. Same numbers, different takeaway.
       </p>
     </div>
 
@@ -1759,7 +1758,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Annual cost at full phase-in (Year 3)</h4>
+        <h4>Tier 1 is $99/mo, Tier 3 is $165/mo at the average home</h4>
 
         <div class="chart-wrapper">
           <svg class="chart" viewBox="0 0 560 150" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Horizontal bar chart: annual override cost at average home value. Tier 1 $1,187, Tier 2 $1,587, Tier 3 $1,985.">
@@ -1833,11 +1832,11 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Over 10 years</h4>
-        <p>
-          Tier 3: ~$8,400 over 5 years, ~$19,850 over 10.<br/>
-          Tier 1: ~$5,000 over 5 years, ~$11,870 over 10.
-        </p>
+        <h4>Tier 3 adds up to ~$20K over ten years at the average home</h4>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">~$19,850</span>
+          <span class="evidence-nugget-label">Tier 3 cumulative cost over 10 years at the average home. Tier 1: ~$11,870. These are permanent levy increases that never expire.</span>
+        </div>
         <a class="evidence-chart-link" href="charts/override_calculator.html">
           Calculator with cumulative totals
         </a>
@@ -1921,12 +1920,11 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>At Tier 3, the share sits where Stoneham sits today</h4>
-        <p>
-          Today: Marblehead 6.1%, Stoneham 7.1%, Melrose 7.3%,
-          Swampscott 8.5%. At full Tier 3 Marblehead lands at about
-          7.1%, roughly where Stoneham is now, and below Swampscott.
-        </p>
+        <h4>At Tier 3, Marblehead lands where Stoneham is today</h4>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">6.1% &rarr; 7.1%</span>
+          <span class="evidence-nugget-label">Marblehead's tax-bill-to-income ratio moves from the lowest of four peers to roughly where Stoneham sits now (7.1%). Melrose is 7.3%, Swampscott 8.5%.</span>
+        </div>
         <a class="evidence-chart-link" href="charts/statewide_tax_burden.html">
           Statewide bill/income ratio, 350 MA communities
         </a>

--- a/index.html
+++ b/index.html
@@ -351,10 +351,10 @@ og_url: https://marbleheaddata.org/
     <div class="question-block">
       <h1>What level of service do I want from Marblehead?</h1>
       <p class="question-context">
-        The override debate tends to anchor on loss aversion: pay more to
-        prevent cuts. The question underneath is a preference one: what do
-        I actually want the town to deliver? Residents legitimately disagree,
-        and the same override dollar can fund preservation or improvement.
+        Most of the override debate is about preventing cuts. But the
+        question underneath is simpler: what do I actually want the
+        town to deliver? Some residents want to hold the line, some
+        want less for lower taxes, some want more than what we have now.
       </p>
     </div>
 
@@ -2708,12 +2708,11 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Most peer towns use fees</h4>
-        <p>
-          Swampscott: $300/year. Melrose: $200/year (pay-as-you-throw
-          bags). Fee-based models are the norm. Marblehead has been
-          the outlier.
-        </p>
+        <h4>Most peer towns already use fees</h4>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">$200-$300</span>
+          <span class="evidence-nugget-label">Annual trash fees in peer towns. Melrose: $200/yr (pay-as-you-throw bags). Swampscott: $300/yr. Marblehead has been the outlier funding it through the general levy.</span>
+        </div>
         <a class="evidence-chart-link" href="question-2-trash.html#peer-towns">
           How other towns fund trash
         </a>

--- a/index.html
+++ b/index.html
@@ -1241,13 +1241,12 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>New growth doesn't close the difference either</h4>
-        <p>
-          Marblehead's five-year average new growth rate is 0.54%, the
-          lowest in the peer set. Peninsula geography, historic districts,
-          and zoning limit new construction; rezoning takes years.
-          2.5% + 0.54% is the ceiling on annual revenue growth, and
-          health insurance alone grows faster than that.
-        </p>
+        <ul>
+          <li>Marblehead's five-year average new growth rate: <strong>0.54%</strong> (lowest in peer set)</li>
+          <li>Peninsula geography, historic districts, and zoning limit new construction</li>
+          <li>Revenue ceiling: 2.5% levy cap + 0.54% new growth = ~3%</li>
+          <li>Health insurance alone grows faster than that</li>
+        </ul>
       </div>
 
       <details class="counter-argument">

--- a/index.html
+++ b/index.html
@@ -2953,7 +2953,7 @@ og_url: https://marbleheaddata.org/
             <text class="tick-label" x="140" y="48" text-anchor="end" font-size="12">Library</text>
             <rect class="data-fill s-neutral" x="145" y="36" width="103" height="16" rx="3"/>
             <text class="end-label" x="254" y="48" font-size="11"> -43%</text>
-            <text class="tick-label" x="140" y="74" text-anchor="end" font-size="12">Recreation, Cemetery, COA</text>
+            <text class="tick-label" x="140" y="74" text-anchor="end" font-size="12">Recreation, Cemetery, Council on Aging</text>
             <rect class="data-fill s-neutral" x="145" y="62" width="24" height="16" rx="3"/>
             <text class="end-label" x="175" y="74" font-size="11"> positions cut</text>
           </svg>
@@ -3593,7 +3593,7 @@ og_url: https://marbleheaddata.org/
           $4.6M (9%) of the school budget pays for mandated
           out-of-district special education placements under federal
           <abbr class="g" title="Individuals with Disabilities Education Act">IDEA</abbr>
-          law. The town cannot decline placements once an IEP requires them.
+          law. The town cannot decline placements once an <abbr class="g" title="Individualized Education Program">IEP</abbr> requires them.
         </p>
         <a class="evidence-chart-link" href="where-has-the-money-gone.html">
           Where the money went

--- a/index.html
+++ b/index.html
@@ -1155,7 +1155,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Health insurance and levy growth, indexed</h4>
+        <h4>Health insurance doubled; the levy pays for everything else too</h4>
 
         <div class="chart-wrapper">
           <svg class="chart" viewBox="0 0 760 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Tax levy growth vs health insurance growth, FY06 to FY27, both indexed to 100.">
@@ -1187,13 +1187,11 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Insurance and pensions eat nearly all of the FY27 levy growth</h4>
-        <p>
-          Health insurance goes up $1.65M (+11%). Pensions go up
-          $463K (+9%). Together that's $2.11M &ndash; roughly 97% of the
-          $2.18M in levy growth FY27 produces from the 2.5% cap plus new
-          growth combined. Everything else competes for the residual.
-        </p>
+        <h4>Insurance and pensions eat 97% of FY27's new levy revenue</h4>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">97%</span>
+          <span class="evidence-nugget-label">Of the $2.18M in new levy revenue FY27 produces, $2.11M goes to health insurance (+$1.65M) and pensions (+$463K). Everything else competes for the remaining $70K.</span>
+        </div>
         <a class="evidence-chart-link" href="charts/deficit_model.html">
           Model the gap: drag revenue and expense growth rates yourself
         </a>

--- a/index.html
+++ b/index.html
@@ -23,10 +23,10 @@ og_url: https://marbleheaddata.org/
     <div class="question-block">
       <h1>Does an override buy time, and for what?</h1>
       <p class="question-context">
-        The proposed $8.47M override is a bridge, not a structural fix.
-        It can carry the budget for a few years before the expense slope
-        reopens the gap. The voter decision is a package: fund the bridge,
-        and commit to what has to happen during it.
+        The town has an $8.47M budget gap. The override fills it for a
+        few years, but costs keep growing faster than revenue. The
+        question is whether you trust that something changes in between,
+        or whether new money just delays the same problem.
       </p>
     </div>
 
@@ -192,13 +192,11 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Teacher pay looks low, but total compensation is high</h4>
-        <p>
-          Marblehead teacher salary ($90,696) is lower than Melrose or
-          Stoneham. But the town pays 83% of health insurance premiums,
-          the highest share among peers. Add that in and total
-          compensation per teacher ($122,702) tops both towns.
-        </p>
+        <h4>Teacher salary looks low, but total compensation tops peers</h4>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">$122,702</span>
+          <span class="evidence-nugget-label">Total compensation per teacher (salary + benefits). Salary alone ($90,696) is lower than Melrose or Stoneham, but Marblehead pays 83% of health premiums -- the highest share among peers -- which pushes total comp above both.</span>
+        </div>
         <a class="evidence-chart-link" href="charts/peer_compensation.html">
           Peer compensation chart
         </a>
@@ -270,7 +268,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>The sustainability question remains either way</h4>
+        <h4>Even Tier 3 only bridges the gap briefly</h4>
 
         <div class="chart-wrapper">
           <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue bars vs expense line, FY24 to FY30. Gap grows from $1M to $18M without an override.">
@@ -302,12 +300,10 @@ og_url: https://marbleheaddata.org/
           </svg>
         </div>
 
-        <p class="caption">
-          Without an override, the gap between expenses and revenue grows
-          from roughly $1M (FY24) to $18M by FY30. Even Tier 3 ($15M)
-          briefly bridges the gap in FY29, then reopens to roughly $4M by
-          FY30 as expenses outpace the fixed override levy.
-        </p>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">$18M</span>
+          <span class="evidence-nugget-label">Projected gap by FY30 without an override. Even Tier 3 ($15M) only bridges it briefly before expenses outpace the fixed override levy again.</span>
+        </div>
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Full sustainability projections
         </a>

--- a/index.html
+++ b/index.html
@@ -772,10 +772,10 @@ og_url: https://marbleheaddata.org/
     <div class="question-block">
       <h1>Did school staffing grow while enrollment fell?</h1>
       <p class="question-context">
-        Marblehead enrollment peaked at 3,327 and fell to 2,617, a 21%
-        decline. The <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> <abbr class="g" title="Full-Time Equivalent">FTE</abbr> series
-        over the same period tells more than one story, depending on which
-        of four lines you read.
+        Enrollment fell 21% (3,327 to 2,617). Staff numbers went the
+        other direction by some measures and down by others. Whether
+        that looks like overstaffing depends on which positions you
+        count and whether they're legally required.
       </p>
     </div>
 
@@ -865,11 +865,10 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Most staff per student of any peer town</h4>
-        <p>
-          Marblehead: 5.6 students per staff member. Stoneham: 5.8.
-          Swampscott: 6.6. Melrose: 7.8. At Melrose's ratio, we'd
-          have 307 staff instead of 430.
-        </p>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">5.6</span>
+          <span class="evidence-nugget-label">Students per staff member. Stoneham: 5.8. Swampscott: 6.6. Melrose: 7.8. At Melrose's ratio, Marblehead would have 307 staff instead of 430.</span>
+        </div>
         <a class="evidence-chart-link" href="inside-school-staffing.html#what-the-positions-are">
           Inside school staffing
         </a>
@@ -1069,11 +1068,10 @@ og_url: https://marbleheaddata.org/
 
       <div class="evidence-point">
         <h4>Office and admin staff are where the real gap is</h4>
-        <p>
-          Marblehead: 1.14 office staff per 100 students. Melrose: 0.43.
-          Administrators: 1.09 vs. 0.67. These aren't mandated. This is
-          the biggest difference between Marblehead and its peers.
-        </p>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">1.14 vs 0.43</span>
+          <span class="evidence-nugget-label">Office staff per 100 students: Marblehead vs. Melrose. Administrators: 1.09 vs 0.67. These aren't mandated. This is the biggest difference between Marblehead and its peers.</span>
+        </div>
         <a class="evidence-chart-link" href="inside-school-staffing.html#peer-comparison">
           Staffing by role comparison
         </a>

--- a/index.html
+++ b/index.html
@@ -702,54 +702,18 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Reform bends the expense line toward revenue</h4>
-
-        <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue line rising steadily. Two expense lines: one at 5% growth diverging upward, one at 3.5% growth (with reform) converging toward revenue by FY30.">
-            <line class="axis-base" x1="60" y1="200" x2="500" y2="200"/>
-            <line class="grid-minor" x1="60" y1="160" x2="500" y2="160"/>
-            <line class="grid-minor" x1="60" y1="120" x2="500" y2="120"/>
-            <line class="grid-minor" x1="60" y1="80" x2="500" y2="80"/>
-            <text class="tick-label" x="53" y="204" text-anchor="end">$100M</text>
-            <text class="tick-label" x="53" y="164" text-anchor="end">$110M</text>
-            <text class="tick-label" x="53" y="124" text-anchor="end">$120M</text>
-            <text class="tick-label" x="53" y="84" text-anchor="end">$130M</text>
-            <text class="tick-label tick-label--major" x="94" y="220" text-anchor="middle">FY27</text>
-            <text class="tick-label tick-label--major" x="234" y="220" text-anchor="middle">FY28</text>
-            <text class="tick-label tick-label--major" x="374" y="220" text-anchor="middle">FY29</text>
-            <text class="tick-label tick-label--major" x="444" y="220" text-anchor="middle">FY30</text>
-
-            <!-- Revenue line: 3% annual growth from ~$106M -->
-            <polyline class="data-line data-line--bold s-revenue" points="94,176 234,152 374,128 444,116"/>
-
-            <!-- Expenses at recent trend rate -->
-            <polyline class="data-line data-line--dashed s-neutral" points="94,144 234,108 374,68 444,48"/>
-            <text class="end-label s-neutral" x="452" y="52">Expenses at 5%/yr</text>
-
-            <!-- Expenses if growth slows to 3.5% -->
-            <polyline class="data-line data-line--bold s-marblehead" points="94,144 234,120 374,96 444,84"/>
-            <text class="end-label s-marblehead" x="452" y="88">Expenses at 3.5%/yr</text>
-
-            <text class="end-label s-revenue" x="452" y="120">Revenue (3%/yr)</text>
-          </svg>
+        <h4>Bending expense growth from 5% to 3.5% closes most of the gap</h4>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">5% &rarr; 3.5%</span>
+          <span class="evidence-nugget-label">Recent expense growth vs. what insurance reform (~$1M/yr from moving 83% to 75%), staffing review, and competitive bidding could produce. At 3.5%, the expense line bends back toward revenue and the gap that drives overrides narrows each year.</span>
         </div>
-
-        <p class="caption">
-          At 5% expense growth (recent trend), expenses pull away from
-          revenue every year. Bending expense growth to 3.5% through
-          insurance reform, staffing review, and competitive bidding
-          narrows the gap enough that future overrides shrink or
-          disappear. The no-vote argument is that only pressure
-          produces the bend.
+        <p>
+          Drag the expense slider on the deficit model to see exactly
+          when the lines converge at different growth rates.
         </p>
         <a class="evidence-chart-link" href="charts/deficit_model.html">
-          Adjust the assumptions and see when the gap closes
+          Build your own deficit projection
         </a>
-        <p class="evidence-caveat">
-          Illustrative. 3.5% assumes ~$1M/yr savings from moving the
-          health premium split from 83% to 75% plus modest staffing
-          and procurement efficiencies. Not a forecast.
-        </p>
       </div>
 
       <div class="evidence-point">

--- a/index.html
+++ b/index.html
@@ -2423,12 +2423,11 @@ og_url: https://marbleheaddata.org/
         <h4>Marblehead's tax base is almost entirely residential</h4>
 
         <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 400 55" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar showing 95.5% residential vs 4.5% commercial tax base.">
+          <svg class="chart" viewBox="0 0 400 38" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bar showing 95.5% residential vs 4.5% commercial tax base.">
             <rect class="data-fill s-marblehead" x="10" y="8" width="343" height="22" rx="4"/>
             <rect x="353" y="8" width="37" height="22" rx="4" fill="var(--divider)"/>
             <text class="end-label" x="180" y="24" text-anchor="middle" fill="var(--c-fog)" font-weight="700" font-size="12">Residential: 95.5%</text>
             <text class="end-label" x="371" y="24" text-anchor="middle" font-size="10">4.5%</text>
-            <text class="tick-label" x="10" y="48" font-size="11">Highest residential share in a 21-town peer set</text>
           </svg>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -1441,10 +1441,10 @@ og_url: https://marbleheaddata.org/
     <div class="question-block">
       <h1>How does Marblehead's tax burden compare to similar towns?</h1>
       <p class="question-context">
-        Marblehead has the lowest residential tax rate among four
-        comparable North Shore towns, a high median bill in dollars, and
-        a roughly middle position when the bill is expressed as a share
-        of median household income. Each lens is a legitimate comparison.
+        Marblehead's tax burden looks low, medium, or high depending on
+        what you measure: rate per $1,000, total dollar bill, or share
+        of household income. The three answers use the same data and
+        reach different conclusions.
       </p>
     </div>
 
@@ -1489,7 +1489,7 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>FY26 residential tax rates, four towns</h4>
+        <h4>Marblehead's rate is 28% lower than the next-closest peer</h4>
 
         <div class="chart-wrapper">
           <svg class="chart" viewBox="0 0 560 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Horizontal bar chart: FY26 tax rates for four towns. Marblehead $8.59, Stoneham $11.10, Melrose $11.41, Swampscott $12.00.">
@@ -1526,12 +1526,11 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Same home, lower tax</h4>
-        <p>
-          A $750,000 home in Marblehead pays $6,443/year in property tax.
-          The same-value home in Swampscott pays $9,000. Marblehead's
-          rate delivers a $2,557 annual savings on the same assessed value.
-        </p>
+        <h4>A $750K home pays $2,557 less here than in Swampscott</h4>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">$6,443 vs $9,000</span>
+          <span class="evidence-nugget-label">Same $750K home. Marblehead vs. Swampscott annual property tax. The lower rate saves $2,557/yr on identical assessed value.</span>
+        </div>
         <a class="evidence-chart-link" href="charts/tax_comparison.html">
           Marblehead vs. Swampscott comparison
         </a>
@@ -1581,11 +1580,11 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Homes are worth more, so the bill is higher</h4>
-        <p>
-          Median home value: Marblehead $1,010,100, Swampscott $643,000.
-          Lower rate, but higher bill: $8,677 vs. $7,549.
-        </p>
+        <h4>Lower rate, but higher bill: $8,677 vs $7,549</h4>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">$8,677</span>
+          <span class="evidence-nugget-label">Marblehead's median tax bill vs. Swampscott's $7,549. Homes here are worth more (median $1.01M vs $643K), so a lower rate still produces a bigger check.</span>
+        </div>
         <a class="evidence-chart-link" href="charts/tax_comparison.html">
           Marblehead vs. Swampscott comparison
         </a>
@@ -1634,14 +1633,11 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Bill as share of <abbr class="g" title="American Community Survey">ACS</abbr> median household income</h4>
-        <p>
-          Marblehead 6.1%. Stoneham 7.1%. Melrose 7.3%. Swampscott 8.5%.
-          Dividing the median single-family bill by median household
-          income normalizes across towns with different home values
-          and different household earnings, which rate and bill alone
-          cannot.
-        </p>
+        <h4>As a share of income, Marblehead is the lightest of four peers</h4>
+        <div class="evidence-nugget">
+          <span class="evidence-nugget-value">6.1%</span>
+          <span class="evidence-nugget-label">Marblehead's median bill as a share of median household income. Stoneham 7.1%, Melrose 7.3%, Swampscott 8.5%. This normalizes for both home values and household earnings.</span>
+        </div>
         <a class="evidence-chart-link" href="charts/four_town_rates.html#share-of-income">
           Bill as share of income, all four towns
         </a>

--- a/index.html
+++ b/index.html
@@ -702,17 +702,20 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Bending expense growth from 5% to 3.5% closes most of the gap</h4>
+        <h4>The override doesn't change the growth rate</h4>
         <div class="evidence-nugget">
           <span class="evidence-nugget-value">5% &rarr; 3.5%</span>
-          <span class="evidence-nugget-label">Recent expense growth vs. what insurance reform (~$1M/yr from moving 83% to 75%), staffing review, and competitive bidding could produce. At 3.5%, the expense line bends back toward revenue and the gap that drives overrides narrows each year.</span>
+          <span class="evidence-nugget-label">Expense growth the town needs to hit to close the gap without repeated overrides.</span>
         </div>
         <p>
-          Drag the expense slider on the deficit model to see exactly
-          when the lines converge at different growth rates.
+          Insurance reform (~$1M/yr from moving the premium split from
+          83% to 75%), staffing review, and competitive bidding could
+          bend expense growth from the recent 5% trend toward 3.5%.
+          At that rate, expenses converge back toward revenue. The
+          override buys time but doesn't produce the bend.
         </p>
         <a class="evidence-chart-link" href="charts/deficit_model.html">
-          Build your own deficit projection
+          Drag the slider and see when the lines converge
         </a>
       </div>
 

--- a/question-2-trash.html
+++ b/question-2-trash.html
@@ -729,6 +729,9 @@ og_url: https://marbleheaddata.org/question-2-trash.html
 
 <p>These are open questions for further research or for town officials to answer directly. The Marblehead Health Department can be reached at (781) 631-0212, and Select Board meetings are open to the public.</p>
 
+<a class="btn-link" href="charts/override_calculator.html">What does the full override (Question 1) cost me?</a>
+<a class="btn-link" href="charts/levy_vs_bill.html">How Marblehead's tax levy and median bill have grown over time</a>
+
 <div class="read-next">
   <div class="read-next-label">Read next</div>
   <a class="read-next-link" href="what-is-the-override.html">
@@ -739,9 +742,9 @@ og_url: https://marbleheaddata.org/question-2-trash.html
     <div class="read-next-title">What can you do? &rarr;</div>
     <div class="read-next-desc">Beyond voting yes or no: who decides what, when residents can weigh in, and how to push for better oversight.</div>
   </a>
-  <a class="read-next-link" href="the-debate.html">
-    <div class="read-next-title">Both sides of the override debate &rarr;</div>
-    <div class="read-next-desc">The strongest version of each case across the six dividing lines in the FY27 debate.</div>
+  <a class="read-next-link" href="charts/your_tax_bill.html">
+    <div class="read-next-title">Where your tax dollars go &rarr;</div>
+    <div class="read-next-desc">Interactive breakdown of how Marblehead's tax levy is split across schools, public safety, debt, insurance, and more.</div>
   </a>
 </div>
 

--- a/what-has-the-town-done.html
+++ b/what-has-the-town-done.html
@@ -7,8 +7,14 @@ og_url: https://marbleheaddata.org/what-has-the-town-done.html
 ---
 <h1>What has the town already done to save?</h1>
 
+  <div class="key-stats">
+    <div class="key-stat"><div class="key-stat-value">199 &rarr; ~190</div><div class="key-stat-label">town positions (since 2018)</div></div>
+    <div class="key-stat"><div class="key-stat-value">2</div><div class="key-stat-label">departments consolidated</div></div>
+    <div class="key-stat"><div class="key-stat-value">$10.2M &rarr; $5M</div><div class="key-stat-label">free cash reliance (proposed FY27)</div></div>
+  </div>
+
   <div class="takeaway takeaway--neutral">
-    Override skeptics ask a fair question: what has the town already done to control costs before asking for more money? The answer is scattered across a decade of budget documents and meeting testimony. No single official presentation has compiled it. This page does.
+    Override skeptics ask a fair question: what has the town already done to control costs before asking for more money? The measures below are compiled from FinCom reports, budget hearings, and news coverage. No single official document lists them all.
   </div>
 
   <nav class="page-toc" aria-label="On this page">
@@ -56,6 +62,8 @@ og_url: https://marbleheaddata.org/what-has-the-town-done.html
     <li>Despite the cuts, the department secured $1.9M in grants within two years</li>
   </ul>
   <p class="source-note">Source: March 2026 Select Board budget hearing<sup class="cite" data-href="https://www.marbleheadindependent.com/cuts-across-departments-shape-select-boards-56-6m-budget/" data-source="Marblehead Independent, Cuts across departments (Community Development testimony)"></sup></p>
+
+  <a class="btn-link" href="charts/enrollment_vs_staffing.html">School enrollment vs. staffing over time</a>
 
   <h2 id="consolidation">Departmental consolidation</h2>
 
@@ -107,7 +115,7 @@ og_url: https://marbleheaddata.org/what-has-the-town-done.html
 
   <h2 id="planning">Planning infrastructure</h2>
 
-  <p>Several structural investments were made to improve fiscal planning and oversight:</p>
+  <p>The town added tools and positions to plan ahead:</p>
 
   <ul>
     <li><strong>General Fund Stabilization Fund</strong> created at 2020 ATM. $250,000 annual contributions; balance at start of FY26: $1,500,000. Accessible only by 2/3 vote of Town Meeting.<sup class="cite" data-href="data/2021_FinCom_Report.pdf" data-source="2021 FinCom Report, transmittal letter (Stabilization Fund creation and $250K annual contribution)"></sup></li>
@@ -144,6 +152,9 @@ og_url: https://marbleheaddata.org/what-has-the-town-done.html
     <li><strong>No regionalized services.</strong> No shared-service agreements with neighboring communities for dispatch, IT, procurement, or other functions.</li>
   </ul>
 
+  <a class="btn-link" href="charts/healthcare_costs.html">Why health insurance keeps rising</a>
+  <a class="btn-link" href="charts/peer_compensation.html">How Marblehead's salary-vs-benefits split compares to peers</a>
+
   <h2 id="budget-scrub">The 2019 budget scrub</h2>
 
   <p>The single most significant documented cost-control initiative was the FY20 budget scrub ordered by Town Administrator Jason Silva. From the 2019 FinCom transmittal letter:</p>
@@ -164,9 +175,9 @@ og_url: https://marbleheaddata.org/what-has-the-town-done.html
       <div class="read-next-title">What's in the no-override budget? &rarr;</div>
       <div class="read-next-desc">The specific staffing and service cuts in the FY27 balanced budget without an override, line by line.</div>
     </a>
-    <a class="read-next-link" href="the-debate.html">
-      <div class="read-next-title">Both sides of the override debate &rarr;</div>
-      <div class="read-next-desc">The strongest version of each case, with the key tensions and tradeoffs.</div>
+    <a class="read-next-link" href="charts/sustainability.html">
+      <div class="read-next-title">Revenue vs. spending over time &rarr;</div>
+      <div class="read-next-desc">Interactive chart: general fund revenue, expenses, and free cash usage since FY01.</div>
     </a>
   </div>
 

--- a/what-has-the-town-done.html
+++ b/what-has-the-town-done.html
@@ -14,7 +14,7 @@ og_url: https://marbleheaddata.org/what-has-the-town-done.html
   </div>
 
   <div class="takeaway takeaway--neutral">
-    Override skeptics ask a fair question: what has the town already done to control costs before asking for more money? The measures below are compiled from FinCom reports, budget hearings, and news coverage. No single official document lists them all.
+    Override skeptics ask a fair question: what has the town already done to control costs before asking for more money? The measures below are compiled from <abbr class="g" title="Finance Committee">FinCom</abbr> reports, budget hearings, and news coverage. No single official document lists them all.
   </div>
 
   <nav class="page-toc" aria-label="On this page">

--- a/what-is-the-override.html
+++ b/what-is-the-override.html
@@ -485,9 +485,11 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
     You do not pay the full override amount in year one. The cost phases in over three fiscal years, reaching its full amount only in FY29.
   </div>
 
-  <p>The normal 2.5% annual levy growth under Proposition 2&frac12; continues on top of the override. An override permanently raises the levy limit; after that, the 2.5% growth compounds from the new, higher base. This is state law (<a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter59/Section21C">M.G.L. c. 59 &sect; 21C</a>), not a local policy choice. The town's April 15 presentation shows the override cost without the 2.5% (e.g. $899/yr at median home for Tier 1). The <a href="charts/override_calculator.html">override cost calculator</a>, which uses the town's own phase-in schedule from the April 8 presentation, produces slightly higher figures ($918/yr for Tier 1) because the 2.5% compounds on portions added in earlier years of the phase-in.</p>
+  <p>The normal 2.5% annual levy growth continues on top of the override. An override permanently raises the levy limit; after that, the 2.5% growth compounds from the new, higher base. The town's April 15 presentation shows the override cost without the 2.5% (e.g. $899/yr at median home for Tier 1). The calculator below, which uses the town's own phase-in schedule, produces slightly higher figures ($918/yr for Tier 1) because the 2.5% compounds on portions added in earlier years of the phase-in.</p>
 
-  <p>See the <a href="charts/override_calculator.html">override cost calculator</a> for year-by-year costs at different home values.</p>
+  <a class="btn-link" href="charts/override_calculator.html">What does the override cost me? (calculator)</a>
+  <a class="btn-link" href="charts/sustainability.html">Revenue vs. spending over time</a>
+  <a class="btn-link" href="charts/healthcare_costs.html">Why health insurance keeps rising</a>
 
   <h2 data-stance-section="mou-commitments" id="mou-commitments">The three-board commitment</h2>
 
@@ -736,9 +738,9 @@ og_url: https://marbleheaddata.org/what-is-the-override.html
       <div class="read-next-title">How did we get here? &rarr;</div>
       <div class="read-next-desc">Seven years of Finance Committee warnings, in their own words. The FY27 override was predicted, in writing, as far back as 2019.</div>
     </a>
-    <a class="read-next-link" href="marblehead-voting-record.html">
-      <div class="read-next-title">Has Marblehead voted yes before? &rarr;</div>
-      <div class="read-next-desc">Every Prop 2&frac12; ballot question since 1988, charted. What passed, what failed, and how much.</div>
+    <a class="read-next-link" href="charts/sustainability.html">
+      <div class="read-next-title">Revenue vs. spending over time &rarr;</div>
+      <div class="read-next-desc">Interactive chart: general fund revenue, expenses, and free cash usage since FY01.</div>
     </a>
   </div>
 

--- a/what-you-can-do.html
+++ b/what-you-can-do.html
@@ -348,6 +348,9 @@ og_url: https://marbleheaddata.org/what-you-can-do.html
 
 <p>Both of these are slow. Neither changes this year's vote. Both have concrete precedent in Massachusetts towns of similar or smaller size. Neither, on its own, reduces cost growth: each improves the information the town and residents have about the existing budget. The cost-level levers (the health premium split, staffing composition, contract-renewal timing) are separate, and live in the <a href="#structural-reform">structural reform card</a> above.</p>
 
+<a class="btn-link" href="charts/sustainability.html">Revenue vs. spending over time</a>
+<a class="btn-link" href="charts/enrollment_vs_staffing.html">School enrollment vs. staffing trends</a>
+
 <h2 id="who-decides-what">Who decides what</h2>
 <p>Most civic decisions in Marblehead are distributed across several bodies, each with different authority. Knowing which body handles which decision is the difference between writing the right email and writing to no one.</p>
 

--- a/whats-on-the-ballot.html
+++ b/whats-on-the-ballot.html
@@ -125,6 +125,9 @@ og_url: https://marbleheaddata.org/whats-on-the-ballot.html
 </div>
 <p>Question 2 is independent of Question 1. Either way, residents pay for trash: the override spreads the cost by home value, while the Board of Health's fallback is a flat fee of roughly $281 per household. See <a href="question-2-trash.html">trash: levy or fee?</a> for the details.</p>
 
+<a class="btn-link" href="charts/override_calculator.html">What does the override cost me?</a>
+<a class="btn-link" href="what-is-the-override.html">What is the override? (tier-by-tier breakdown)</a>
+
 <h2 id="offices">Offices up for election</h2>
 
 <p>The 11 elected bodies on the June 9 ballot:<sup class="cite" data-href="https://www.marbleheadindependent.com/a-big-ballot-for-marblehead-24-seats-open-in-june-town-election/" data-source="Marblehead Independent, &quot;A big ballot for Marblehead: 24 seats open in June town election&quot; (March 2026): list of 11 elected bodies with seats on the June ballot"></sup><sup class="cite" data-href="https://www.marbleheadindependent.com/ferrante-pulls-for-select-board-as-marbleheads-24-seat-june-ballot-opens/" data-source="Marblehead Independent, &quot;Ferrante pulls for Select Board as Marblehead's 24-seat June ballot opens&quot; (late March 2026): early candidate filings and incumbent status across boards"></sup></p>
@@ -211,7 +214,16 @@ og_url: https://marbleheaddata.org/whats-on-the-ballot.html
 
 <h2 id="why-this-matters">Why this also matters</h2>
 
-<p>The override questions are the reason many residents will show up on June 9, but the same trip to the polls sets 24 seats on bodies that will run the town for the next one to five years. The Select Board decides what goes on a future warrant. The School Committee sets priorities inside the school budget. The Planning Board decides zoning and subdivision applications. The Board of Health sets the fallback flat fee if Question 2 fails. If you care about how the override money is spent after the vote, or how the no-override budget would be implemented, these are the offices that make those calls.</p>
+<p>The override questions will draw many voters to the polls, but the same ballot sets 24 seats that shape how the town runs for the next one to five years:</p>
+
+<ul>
+  <li><strong>Select Board</strong> decides what goes on a future warrant and oversees the Town Administrator</li>
+  <li><strong>School Committee</strong> sets priorities inside the school budget</li>
+  <li><strong>Planning Board</strong> decides zoning and subdivision applications</li>
+  <li><strong>Board of Health</strong> sets the fallback trash fee if Question 2 fails</li>
+</ul>
+
+<p>If you care about how override money is spent, or how the no-override budget gets implemented, these are the offices that make those calls.</p>
 
 <p>For a fuller walkthrough of which body handles which decision, see <a href="what-you-can-do.html#who-decides-what">who decides what</a> on the civic engagement page.</p>
 
@@ -220,3 +232,19 @@ og_url: https://marbleheaddata.org/whats-on-the-ballot.html
 <p>The authoritative list of certified candidates is posted on the town's <a href="https://marbleheadma.gov/elections-voting/">Elections &amp; Voting page</a> after the April 21 filing deadline. The town clerk can be reached at (781) 631-0528. Sample ballots are typically posted on the town website a few weeks before election day.</p>
 
 <p class="source">Reporting on seat counts, incumbents, and nomination filings is drawn from the Marblehead Independent's March and April 2026 coverage of the nomination-papers window and the Marblehead Current's April 14 letter from Alexa Singer. Candidate status in this page reflects that reporting and may have changed by the April 21 filing deadline. For the official certified list, see the town's Elections &amp; Voting page after April 21.</p>
+
+<div class="read-next">
+  <div class="read-next-label">Read next</div>
+  <a class="read-next-link" href="charts/override_calculator.html">
+    <div class="read-next-title">What does the override cost me? &rarr;</div>
+    <div class="read-next-desc">Enter your home value and see the year-by-year cost for each tier.</div>
+  </a>
+  <a class="read-next-link" href="what-you-can-do.html">
+    <div class="read-next-title">What can I do about it? &rarr;</div>
+    <div class="read-next-desc">Registration, Town Meeting, who decides what, and how to reach elected officials.</div>
+  </a>
+  <a class="read-next-link" href="what-is-the-override.html">
+    <div class="read-next-title">What is the override? &rarr;</div>
+    <div class="read-next-desc">The three tiers explained, with line-by-line breakdowns and the phase-in schedule.</div>
+  </a>
+</div>


### PR DESCRIPTION
## Summary

- **how-we-got-here**: add key-stats strip, bullet list of cost drivers, btn-links to sustainability and healthcare charts, updated read-next
- **what-has-the-town-done**: add key-stats strip, btn-links to enrollment/staffing, healthcare, and peer compensation charts, updated read-next
- **whats-on-the-ballot**: add btn-links to override calculator and override explainer, convert dense paragraph to bullets, add read-next cards
- **question-2-trash**: add btn-links to override calculator and levy-vs-bill chart, swap debate read-next card for tax-bill breakdown chart
- **what-is-the-override**: add btn-links to override calculator, sustainability, and healthcare charts, swap voting-record read-next for sustainability chart
- **what-you-can-do**: add btn-links to sustainability and enrollment-vs-staffing charts in oversight section

All changes use existing CSS patterns. No new styles. All chart link targets verified.

## Test plan
- [ ] Check each page on the preview deploy for layout and link behavior
- [ ] Verify btn-link arrows animate on hover
- [ ] Confirm read-next cards render properly on mobile
- [ ] Spot-check chart links resolve to correct pages