### PR TITLE
Fix label: Recent board meetings

### DIFF
--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -82,7 +82,7 @@
     </div>
 
     <div class="explore-meetings" id="exploreMeetings">
-      <p class="explore-meetings-label">Recent town meetings</p>
+      <p class="explore-meetings-label">Recent board meetings</p>
       <div class="explore-meetings-list" id="meetingsList">
         <p class="explore-meetings-empty">Loading meetings...</p>
       </div>


### PR DESCRIPTION
## Summary
- Rename "Recent town meetings" to "Recent board meetings"
- "Town Meeting" in MA refers to the annual governance event where residents vote on warrant articles. These are board meetings (Select Board, FinCom, Board of Health, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)