### PR TITLE
Fix broken catalog entry links on minutes narrative pages

### DIFF
--- a/assets/catalog.js
+++ b/assets/catalog.js
@@ -1,0 +1,170 @@
+/* catalog.js – renders referenced catalog entries as anchor targets
+   so inline (#entry-...) links resolve to a detail card at the bottom
+   of the page.  Loads data/catalog_normalized.csv on demand. */
+(function () {
+  'use strict';
+
+  /* ---- collect entry IDs referenced by links on this page ---- */
+  var links = document.querySelectorAll('a[href^="#entry-"]');
+  if (!links.length) return;
+
+  var needed = {};
+  links.forEach(function (a) {
+    var id = a.getAttribute('href').slice(1); // drop leading #
+    needed[id] = true;
+  });
+
+  /* ---- fetch + parse the CSV ---- */
+  fetch('/data/catalog_normalized.csv')
+    .then(function (r) { return r.text(); })
+    .then(function (text) {
+      var rows = parseCSV(text);
+      if (!rows.length) return;
+      var headers = rows[0];
+      var idIdx       = headers.indexOf('entry_id');
+      var dateIdx     = headers.indexOf('meeting_date');
+      var bodyIdx     = headers.indexOf('body');
+      var whatIdx     = headers.indexOf('what_was_tried');
+      var outcomeIdx  = headers.indexOf('outcome');
+      var quoteIdx    = headers.indexOf('evidence_quote');
+      var impIdx      = headers.indexOf('importance');
+      var topicIdx    = headers.indexOf('topic_pass2');
+      if (idIdx < 0) return;
+
+      var entries = [];
+      for (var i = 1; i < rows.length; i++) {
+        var r = rows[i];
+        var entryId = r[idIdx];
+        var anchor = 'entry-' + entryId;
+        if (!needed[anchor]) continue;
+        entries.push({
+          anchor:   anchor,
+          entryId:  entryId,
+          date:     r[dateIdx] || '',
+          body:     r[bodyIdx] || '',
+          what:     r[whatIdx] || '',
+          outcome:  r[outcomeIdx] || '',
+          quote:    r[quoteIdx] || '',
+          importance: r[impIdx] || '',
+          topic:    r[topicIdx] || ''
+        });
+      }
+
+      if (!entries.length) return;
+      render(entries);
+    });
+
+  /* ---- render catalog section ---- */
+  function render(entries) {
+    var section = document.createElement('section');
+    section.className = 'catalog-entries';
+    section.innerHTML = '<h2>Catalog entries cited</h2>' +
+      '<p class="catalog-lead">Each citation in the text above links to an entry below. ' +
+      'Entries are drawn from Select Board and School Committee meeting minutes.</p>';
+
+    entries.forEach(function (e) {
+      var card = document.createElement('div');
+      card.className = 'catalog-card';
+      card.id = e.anchor;
+
+      var bodyLabel = e.body === 'select_board' ? 'Select Board'
+                    : e.body === 'school_committee' ? 'School Committee'
+                    : e.body;
+      var dateLabel = formatDate(e.date);
+      var topicLabel = e.topic.replace(/_/g, ' ');
+      var minutesUrl = '/data/minutes/' + e.body + '/' + e.date + '.cleaned.txt';
+
+      var html = '<div class="catalog-card-head">' +
+        '<span class="catalog-body">' + bodyLabel + '</span>' +
+        '<span class="catalog-date">' + dateLabel + '</span>' +
+        '<span class="catalog-topic">' + topicLabel + '</span>' +
+        '</div>';
+
+      if (e.what) {
+        html += '<p class="catalog-what">' + escHtml(e.what) + '</p>';
+      }
+      if (e.outcome) {
+        html += '<p class="catalog-outcome"><strong>Outcome:</strong> ' + escHtml(e.outcome) + '</p>';
+      }
+      if (e.quote) {
+        html += '<blockquote class="catalog-quote">' + escHtml(e.quote) + '</blockquote>';
+      }
+      html += '<a class="catalog-minutes-link" href="' + minutesUrl + '">View full minutes</a>';
+
+      card.innerHTML = html;
+      section.appendChild(card);
+    });
+
+    /* Insert before the footer */
+    var page = document.querySelector('.page');
+    var footer = page && page.querySelector('.footer');
+    if (footer) {
+      page.insertBefore(section, footer);
+    } else if (page) {
+      page.appendChild(section);
+    }
+
+    /* If the URL already has a hash, scroll to it now that anchors exist */
+    if (window.location.hash) {
+      var target = document.getElementById(window.location.hash.slice(1));
+      if (target) {
+        setTimeout(function () { target.scrollIntoView({ behavior: 'smooth' }); }, 100);
+      }
+    }
+  }
+
+  /* ---- helpers ---- */
+  function formatDate(iso) {
+    if (!iso) return '';
+    var parts = iso.split('-');
+    var months = ['Jan','Feb','Mar','Apr','May','Jun',
+                  'Jul','Aug','Sep','Oct','Nov','Dec'];
+    return months[parseInt(parts[1], 10) - 1] + ' ' + parseInt(parts[2], 10) + ', ' + parts[0];
+  }
+
+  function escHtml(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  /* Minimal RFC 4180 CSV parser (handles quoted fields with embedded
+     commas, newlines, and escaped double-quotes). */
+  function parseCSV(text) {
+    var rows = [];
+    var row = [];
+    var field = '';
+    var inQuote = false;
+    for (var i = 0; i < text.length; i++) {
+      var c = text[i];
+      if (inQuote) {
+        if (c === '"') {
+          if (i + 1 < text.length && text[i + 1] === '"') {
+            field += '"'; i++;
+          } else {
+            inQuote = false;
+          }
+        } else {
+          field += c;
+        }
+      } else {
+        if (c === '"') {
+          inQuote = true;
+        } else if (c === ',') {
+          row.push(field); field = '';
+        } else if (c === '\n') {
+          row.push(field); field = '';
+          if (row.length > 1 || row[0] !== '') rows.push(row);
+          row = [];
+        } else if (c === '\r') {
+          /* skip */
+        } else {
+          field += c;
+        }
+      }
+    }
+    if (field || row.length) {
+      row.push(field);
+      rows.push(row);
+    }
+    return rows;
+  }
+})();

--- a/assets/site.css
+++ b/assets/site.css
@@ -1420,6 +1420,44 @@ body.doc-page .page table:not(.data) th {
 }
 
 /* ==========================================================================
+   Catalog entries (is-the-board-trying / what-have-we-tried)
+   ========================================================================== */
+.catalog-entries { margin-top: 40px; border-top: 1px solid var(--divider); padding-top: 12px; }
+.catalog-lead { font-size: 0.875rem; color: var(--text-muted); margin-bottom: 20px; }
+
+.catalog-card {
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  padding: 14px 16px;
+  margin-bottom: 14px;
+  scroll-margin-top: 80px;
+}
+.catalog-card:target { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.catalog-card-head {
+  display: flex; flex-wrap: wrap; gap: 8px; align-items: baseline;
+  margin-bottom: 8px; font-size: 0.8125rem;
+}
+.catalog-body  { font-weight: 700; color: var(--text); }
+.catalog-date  { color: var(--text-muted); }
+.catalog-topic { color: var(--text-muted); font-style: italic; }
+
+.catalog-what    { font-size: 0.875rem; line-height: 1.55; margin: 0 0 6px; }
+.catalog-outcome { font-size: 0.8125rem; line-height: 1.5; color: var(--text-muted); margin: 0 0 6px; }
+.catalog-quote {
+  font-size: 0.8125rem; line-height: 1.5;
+  border-left: 3px solid var(--divider);
+  margin: 8px 0; padding: 4px 12px;
+  color: var(--text-muted); font-style: italic;
+}
+.catalog-minutes-link { font-size: 0.8125rem; }
+
+@media (max-width: 600px) {
+  .catalog-card { padding: 10px 12px; }
+  .catalog-what { font-size: 0.8125rem; }
+}
+
+/* ==========================================================================
    Chart SVG — reusable classes
    Colors propagate via `color` + `currentColor` for theme compatibility.
    ========================================================================== */

--- a/is-the-board-trying.md
+++ b/is-the-board-trying.md
@@ -73,3 +73,5 @@ Minutes vary in completeness. Some entries reflect votes without recorded delibe
 ## Closing
 
 Readers seeking the texture of specific attempts, including the proposals that were tabled, the motions that failed, and the warrant articles that were placeholders, should consult the linked entries directly. A companion page, "What have we tried?", organizes these attempts by topic and outcome and is the recommended next step for readers building a timeline or comparing proposals across years. The catalog is a starting point for public inquiry, not a conclusion about it.
+
+<script src="/assets/catalog.js" defer></script>

--- a/what-have-we-tried.md
+++ b/what-have-we-tried.md
@@ -216,3 +216,5 @@ The limited volume in these topics may reflect that attempts in these areas were
 ## Closing
 
 The catalog describes a wide range of attempts across multiple years and policy areas, with substantial concentration in structural deficit planning, capital facilities, staffing, special education, and overrides. For a companion view focused on deliberative posture and follow-through rather than topical inventory, see the companion page "Is the board trying?". Readers may follow any catalog entry's anchor link above to review the underlying meeting record.
+
+<script src="/assets/catalog.js" defer></script>


### PR DESCRIPTION
## Summary

- The ~129 inline citations on `is-the-board-trying.html` and `what-have-we-tried.html` (e.g. `[select_board 2019-05-13](#entry-...)`) pointed to same-page anchors that didn't exist anywhere on the page
- Added `assets/catalog.js` which fetches `data/catalog_normalized.csv`, renders only the referenced entries as cards at the bottom of each page, and creates the anchor targets so the links resolve
- Each card shows: body (Select Board / School Committee), date, topic, action summary, outcome, evidence quote, and a link to the full minutes text file
- Cards highlight with an accent outline when targeted via `#entry-...` hash
- CSS for catalog cards scoped in `site.css`

## Test plan

- [ ] Visit https://marbleheaddata.org/is-the-board-trying.html and verify "Catalog entries cited" section renders at page bottom
- [ ] Click any inline citation link (e.g. `[select_board 2019-05-13]`) and confirm it scrolls to the matching card
- [ ] Visit with a direct hash URL like `#entry-select_board_2019-05-13_seq-001` and confirm it scrolls + highlights
- [ ] Verify `what-have-we-tried.html` also renders its catalog entries
- [ ] Check mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)