### PR TITLE
Scroll to first-pick tutorial on desktop

### DIFF
--- a/assets/explore.js
+++ b/assets/explore.js
@@ -1576,15 +1576,19 @@
 
     // Scroll the tapped card to the top of the viewport so the user
     // sees their pick confirmed, with evidence visible below it.
-    // Only scroll if the card isn't already near the top.
-    var tappedCard = document.querySelector(
-      '.answer-card[data-question="' + question + '"][data-answer="' + answer + '"]'
-    );
-    if (tappedCard) {
+    // If the first-pick tutorial just appeared, scroll to that instead
+    // so the user actually sees it rather than it being off-screen above.
+    // Only scroll if the target isn't already near the top.
+    var scrollTarget = (tutorialEl && tutorialEl.classList.contains('visible'))
+      ? tutorialEl
+      : document.querySelector(
+          '.answer-card[data-question="' + question + '"][data-answer="' + answer + '"]'
+        );
+    if (scrollTarget) {
       setTimeout(function () {
-        var rect = tappedCard.getBoundingClientRect();
+        var rect = scrollTarget.getBoundingClientRect();
         if (rect.top < 0 || rect.top > window.innerHeight * 0.4) {
-          tappedCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          scrollTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
       }, 120);
     }


### PR DESCRIPTION
## Summary
- When making your first pick on desktop, the page scrolled to the answer card but the "first pick" tutorial dialog was off-screen above the viewport
- Now scrolls to the tutorial box instead, so users actually see it

## Test plan
- [ ] Clear localStorage, load the explore page on desktop
- [ ] Make a first pick -- tutorial should be visible, not above the fold
- [ ] Subsequent picks (tutorial dismissed) should still scroll to the answer card as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)