### PR TITLE
Add locked ballot widget with cascade nudge and cross-tabs

### DIFF
--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -65,6 +65,64 @@
 
     {% include explore-synthesis.html %}
 
+    <!-- Ballot widget: locked until all questions answered -->
+    <div class="ballot-widget" id="ballotWidget">
+      <div class="ballot-widget-lock-overlay" id="ballotLock">
+        <span class="ballot-widget-lock-icon" aria-hidden="true">&#x1F512;</span>
+        <span class="ballot-widget-lock-msg"><strong>Answer all questions</strong> to unlock your practice ballot and see how your picks compare to others who voted the same way.</span>
+      </div>
+      <p class="ballot-widget-label">Your ballot &middot; June 9, 2026</p>
+      <div class="ballot-widget-rows">
+        <div class="ballot-widget-row" data-ballot="q1a">
+          <span class="ballot-widget-q">1A</span>
+          <div class="ballot-widget-desc">
+            <span class="ballot-widget-amount">$15M</span>
+            <span class="ballot-widget-tier">Invest</span>
+          </div>
+          <div class="ballot-widget-choices">
+            <button type="button" class="ballot-widget-btn" data-vote="yes">Yes</button>
+            <button type="button" class="ballot-widget-btn" data-vote="no">No</button>
+          </div>
+        </div>
+        <div class="ballot-widget-row" data-ballot="q1b">
+          <span class="ballot-widget-q">1B</span>
+          <div class="ballot-widget-desc">
+            <span class="ballot-widget-amount">$12M</span>
+            <span class="ballot-widget-tier">Stabilize</span>
+          </div>
+          <div class="ballot-widget-choices">
+            <button type="button" class="ballot-widget-btn" data-vote="yes">Yes</button>
+            <button type="button" class="ballot-widget-btn" data-vote="no">No</button>
+          </div>
+        </div>
+        <div class="ballot-widget-row" data-ballot="q1c">
+          <span class="ballot-widget-q">1C</span>
+          <div class="ballot-widget-desc">
+            <span class="ballot-widget-amount">$9M</span>
+            <span class="ballot-widget-tier">Restore</span>
+          </div>
+          <div class="ballot-widget-choices">
+            <button type="button" class="ballot-widget-btn" data-vote="yes">Yes</button>
+            <button type="button" class="ballot-widget-btn" data-vote="no">No</button>
+          </div>
+        </div>
+        <div class="ballot-widget-row" data-ballot="trash">
+          <span class="ballot-widget-q">2</span>
+          <div class="ballot-widget-desc">
+            <span class="ballot-widget-amount">$2.3M</span>
+            <span class="ballot-widget-tier">Curbside Trash</span>
+          </div>
+          <div class="ballot-widget-choices">
+            <button type="button" class="ballot-widget-btn" data-vote="yes">Yes</button>
+            <button type="button" class="ballot-widget-btn" data-vote="no">No</button>
+          </div>
+        </div>
+      </div>
+      <div class="ballot-widget-nudge" id="ballotNudge"></div>
+      <button type="button" class="ballot-widget-submit" id="ballotSubmit">See how your picks compare</button>
+      <div class="ballot-widget-submitted" id="ballotSubmitted">Comparison unlocked on each question above</div>
+    </div>
+
     <div class="explore-tools">
       <p class="explore-tools-label">Run the numbers yourself</p>
       <div class="explore-tools-row">

--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -70,33 +70,24 @@
             <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
             <button type="button" class="ballot-card-btn" data-vote="no">No</button>
           </div>
-          <div class="ballot-card-row-info">
-            <span class="ballot-card-row-q">1A</span>
-            <span class="ballot-card-row-amt">$15M</span>
-            <span class="ballot-card-row-tier">Invest</span>
-          </div>
+          <span class="ballot-card-row-q">1A</span>
+          <span class="ballot-card-row-amt">$15M <span class="ballot-card-row-tier">Invest</span></span>
         </div>
         <div class="ballot-card-row" data-ballot="q1b">
           <div class="ballot-card-choices">
             <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
             <button type="button" class="ballot-card-btn" data-vote="no">No</button>
           </div>
-          <div class="ballot-card-row-info">
-            <span class="ballot-card-row-q">1B</span>
-            <span class="ballot-card-row-amt">$12M</span>
-            <span class="ballot-card-row-tier">Stabilize</span>
-          </div>
+          <span class="ballot-card-row-q">1B</span>
+          <span class="ballot-card-row-amt">$12M <span class="ballot-card-row-tier">Stabilize</span></span>
         </div>
         <div class="ballot-card-row" data-ballot="q1c">
           <div class="ballot-card-choices">
             <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
             <button type="button" class="ballot-card-btn" data-vote="no">No</button>
           </div>
-          <div class="ballot-card-row-info">
-            <span class="ballot-card-row-q">1C</span>
-            <span class="ballot-card-row-amt">$9M</span>
-            <span class="ballot-card-row-tier">Restore</span>
-          </div>
+          <span class="ballot-card-row-q">1C</span>
+          <span class="ballot-card-row-amt">$9M <span class="ballot-card-row-tier">Restore</span></span>
         </div>
       </div>
       <div class="ballot-card-divider"></div>
@@ -106,11 +97,8 @@
             <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
             <button type="button" class="ballot-card-btn" data-vote="no">No</button>
           </div>
-          <div class="ballot-card-row-info">
-            <span class="ballot-card-row-q">Q2</span>
-            <span class="ballot-card-row-amt">$2.3M</span>
-            <span class="ballot-card-row-tier">Curbside Trash</span>
-          </div>
+          <span class="ballot-card-row-q">Q2</span>
+          <span class="ballot-card-row-amt">$2.3M <span class="ballot-card-row-tier">Curbside Trash</span></span>
         </div>
       </div>
       <div class="ballot-card-nudge" id="ballotNudge"></div>

--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -53,6 +53,45 @@
           <button type="button" class="explore-stats-reset" id="statsReset">Delete my data</button>
         </div>
       </div>
+      <!-- Ballot row: appears after all questions answered -->
+      <div class="ballot-widget" id="ballotWidget">
+        <div class="ballot-widget-header">
+          <span class="ballot-widget-label">Your ballot</span>
+          <span class="ballot-widget-lock" id="ballotLockMsg"></span>
+        </div>
+        <div class="ballot-widget-grid">
+          <div class="ballot-widget-item" data-ballot="q1a">
+            <span class="ballot-widget-q">1A <span class="ballot-widget-amt">$15M</span></span>
+            <div class="ballot-widget-choices">
+              <button type="button" class="ballot-widget-btn" data-vote="yes">Y</button>
+              <button type="button" class="ballot-widget-btn" data-vote="no">N</button>
+            </div>
+          </div>
+          <div class="ballot-widget-item" data-ballot="q1b">
+            <span class="ballot-widget-q">1B <span class="ballot-widget-amt">$12M</span></span>
+            <div class="ballot-widget-choices">
+              <button type="button" class="ballot-widget-btn" data-vote="yes">Y</button>
+              <button type="button" class="ballot-widget-btn" data-vote="no">N</button>
+            </div>
+          </div>
+          <div class="ballot-widget-item" data-ballot="q1c">
+            <span class="ballot-widget-q">1C <span class="ballot-widget-amt">$9M</span></span>
+            <div class="ballot-widget-choices">
+              <button type="button" class="ballot-widget-btn" data-vote="yes">Y</button>
+              <button type="button" class="ballot-widget-btn" data-vote="no">N</button>
+            </div>
+          </div>
+          <div class="ballot-widget-item" data-ballot="trash">
+            <span class="ballot-widget-q">Q2 <span class="ballot-widget-amt">Trash</span></span>
+            <div class="ballot-widget-choices">
+              <button type="button" class="ballot-widget-btn" data-vote="yes">Y</button>
+              <button type="button" class="ballot-widget-btn" data-vote="no">N</button>
+            </div>
+          </div>
+          <button type="button" class="ballot-widget-go" id="ballotSubmit">Compare</button>
+        </div>
+        <div class="ballot-widget-nudge" id="ballotNudge"></div>
+      </div>
     </div>
 
     <div class="explore-shared-banner" id="sharedBanner">
@@ -64,64 +103,6 @@
     </div>
 
     {% include explore-synthesis.html %}
-
-    <!-- Ballot widget: locked until all questions answered -->
-    <div class="ballot-widget" id="ballotWidget">
-      <div class="ballot-widget-lock-overlay" id="ballotLock">
-        <span class="ballot-widget-lock-icon" aria-hidden="true">&#x1F512;</span>
-        <span class="ballot-widget-lock-msg"><strong>Answer all questions</strong> to unlock your practice ballot and see how your picks compare to others who voted the same way.</span>
-      </div>
-      <p class="ballot-widget-label">Your ballot &middot; June 9, 2026</p>
-      <div class="ballot-widget-rows">
-        <div class="ballot-widget-row" data-ballot="q1a">
-          <span class="ballot-widget-q">1A</span>
-          <div class="ballot-widget-desc">
-            <span class="ballot-widget-amount">$15M</span>
-            <span class="ballot-widget-tier">Invest</span>
-          </div>
-          <div class="ballot-widget-choices">
-            <button type="button" class="ballot-widget-btn" data-vote="yes">Yes</button>
-            <button type="button" class="ballot-widget-btn" data-vote="no">No</button>
-          </div>
-        </div>
-        <div class="ballot-widget-row" data-ballot="q1b">
-          <span class="ballot-widget-q">1B</span>
-          <div class="ballot-widget-desc">
-            <span class="ballot-widget-amount">$12M</span>
-            <span class="ballot-widget-tier">Stabilize</span>
-          </div>
-          <div class="ballot-widget-choices">
-            <button type="button" class="ballot-widget-btn" data-vote="yes">Yes</button>
-            <button type="button" class="ballot-widget-btn" data-vote="no">No</button>
-          </div>
-        </div>
-        <div class="ballot-widget-row" data-ballot="q1c">
-          <span class="ballot-widget-q">1C</span>
-          <div class="ballot-widget-desc">
-            <span class="ballot-widget-amount">$9M</span>
-            <span class="ballot-widget-tier">Restore</span>
-          </div>
-          <div class="ballot-widget-choices">
-            <button type="button" class="ballot-widget-btn" data-vote="yes">Yes</button>
-            <button type="button" class="ballot-widget-btn" data-vote="no">No</button>
-          </div>
-        </div>
-        <div class="ballot-widget-row" data-ballot="trash">
-          <span class="ballot-widget-q">2</span>
-          <div class="ballot-widget-desc">
-            <span class="ballot-widget-amount">$2.3M</span>
-            <span class="ballot-widget-tier">Curbside Trash</span>
-          </div>
-          <div class="ballot-widget-choices">
-            <button type="button" class="ballot-widget-btn" data-vote="yes">Yes</button>
-            <button type="button" class="ballot-widget-btn" data-vote="no">No</button>
-          </div>
-        </div>
-      </div>
-      <div class="ballot-widget-nudge" id="ballotNudge"></div>
-      <button type="button" class="ballot-widget-submit" id="ballotSubmit">See how your picks compare</button>
-      <div class="ballot-widget-submitted" id="ballotSubmitted">Comparison unlocked on each question above</div>
-    </div>
 
     <div class="explore-tools">
       <p class="explore-tools-label">Run the numbers yourself</p>

--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -55,55 +55,61 @@
       </div>
     </div>
 
-    <!-- Ballot card: always visible at top, buttons visible but locked until all questions answered -->
+    <!-- Ballot card: always visible at top, locked until all questions answered -->
     <div class="ballot-card locked" id="ballotWidget">
       <div class="ballot-card-header">
         <span class="ballot-card-title">Your ballot &middot; June 9</span>
-        <span class="ballot-card-lock-msg" id="ballotLockMsg">Answer all questions to unlock</span>
+        <span class="ballot-card-lock-msg" id="ballotLockMsg">
+          <svg class="ballot-card-lock-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+          <span id="ballotLockText">Answer all questions to unlock</span>
+        </span>
       </div>
-      <div class="ballot-card-rows">
+      <div class="ballot-card-rows" id="ballotRows">
         <div class="ballot-card-row" data-ballot="q1a">
+          <div class="ballot-card-choices">
+            <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
+            <button type="button" class="ballot-card-btn" data-vote="no">No</button>
+          </div>
           <div class="ballot-card-row-info">
             <span class="ballot-card-row-q">1A</span>
             <span class="ballot-card-row-amt">$15M</span>
             <span class="ballot-card-row-tier">Invest</span>
           </div>
+        </div>
+        <div class="ballot-card-row" data-ballot="q1b">
           <div class="ballot-card-choices">
             <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
             <button type="button" class="ballot-card-btn" data-vote="no">No</button>
           </div>
-        </div>
-        <div class="ballot-card-row" data-ballot="q1b">
           <div class="ballot-card-row-info">
             <span class="ballot-card-row-q">1B</span>
             <span class="ballot-card-row-amt">$12M</span>
             <span class="ballot-card-row-tier">Stabilize</span>
           </div>
+        </div>
+        <div class="ballot-card-row" data-ballot="q1c">
           <div class="ballot-card-choices">
             <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
             <button type="button" class="ballot-card-btn" data-vote="no">No</button>
           </div>
-        </div>
-        <div class="ballot-card-row" data-ballot="q1c">
           <div class="ballot-card-row-info">
             <span class="ballot-card-row-q">1C</span>
             <span class="ballot-card-row-amt">$9M</span>
             <span class="ballot-card-row-tier">Restore</span>
           </div>
+        </div>
+      </div>
+      <div class="ballot-card-divider"></div>
+      <div class="ballot-card-rows">
+        <div class="ballot-card-row" data-ballot="trash">
           <div class="ballot-card-choices">
             <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
             <button type="button" class="ballot-card-btn" data-vote="no">No</button>
           </div>
-        </div>
-        <div class="ballot-card-row" data-ballot="trash">
           <div class="ballot-card-row-info">
             <span class="ballot-card-row-q">Q2</span>
             <span class="ballot-card-row-amt">$2.3M</span>
-            <span class="ballot-card-row-tier">Trash</span>
-          </div>
-          <div class="ballot-card-choices">
-            <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
-            <button type="button" class="ballot-card-btn" data-vote="no">No</button>
+            <span class="ballot-card-row-tier">Curbside Trash</span>
           </div>
         </div>
       </div>

--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -61,9 +61,10 @@
         <span class="ballot-card-title">Your ballot &middot; June 9</span>
         <span class="ballot-card-lock-msg" id="ballotLockMsg">
           <svg class="ballot-card-lock-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-          <span id="ballotLockText">Answer all questions to unlock</span>
+          <a href="#" class="ballot-card-lock-link" id="ballotLockLink">Answer all questions to unlock</a>
         </span>
       </div>
+      <a href="#" class="ballot-card-cta" id="ballotCta">Start answering</a>
       <div class="ballot-card-rows" id="ballotRows">
         <div class="ballot-card-row" data-ballot="q1a">
           <div class="ballot-card-choices">

--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -53,45 +53,6 @@
           <button type="button" class="explore-stats-reset" id="statsReset">Delete my data</button>
         </div>
       </div>
-      <!-- Ballot row: appears after all questions answered -->
-      <div class="ballot-widget" id="ballotWidget">
-        <div class="ballot-widget-header">
-          <span class="ballot-widget-label">Your ballot</span>
-          <span class="ballot-widget-lock" id="ballotLockMsg"></span>
-        </div>
-        <div class="ballot-widget-grid">
-          <div class="ballot-widget-item" data-ballot="q1a">
-            <span class="ballot-widget-q">1A <span class="ballot-widget-amt">$15M</span></span>
-            <div class="ballot-widget-choices">
-              <button type="button" class="ballot-widget-btn" data-vote="yes">Y</button>
-              <button type="button" class="ballot-widget-btn" data-vote="no">N</button>
-            </div>
-          </div>
-          <div class="ballot-widget-item" data-ballot="q1b">
-            <span class="ballot-widget-q">1B <span class="ballot-widget-amt">$12M</span></span>
-            <div class="ballot-widget-choices">
-              <button type="button" class="ballot-widget-btn" data-vote="yes">Y</button>
-              <button type="button" class="ballot-widget-btn" data-vote="no">N</button>
-            </div>
-          </div>
-          <div class="ballot-widget-item" data-ballot="q1c">
-            <span class="ballot-widget-q">1C <span class="ballot-widget-amt">$9M</span></span>
-            <div class="ballot-widget-choices">
-              <button type="button" class="ballot-widget-btn" data-vote="yes">Y</button>
-              <button type="button" class="ballot-widget-btn" data-vote="no">N</button>
-            </div>
-          </div>
-          <div class="ballot-widget-item" data-ballot="trash">
-            <span class="ballot-widget-q">Q2 <span class="ballot-widget-amt">Trash</span></span>
-            <div class="ballot-widget-choices">
-              <button type="button" class="ballot-widget-btn" data-vote="yes">Y</button>
-              <button type="button" class="ballot-widget-btn" data-vote="no">N</button>
-            </div>
-          </div>
-          <button type="button" class="ballot-widget-go" id="ballotSubmit">Compare</button>
-        </div>
-        <div class="ballot-widget-nudge" id="ballotNudge"></div>
-      </div>
     </div>
 
     <div class="explore-shared-banner" id="sharedBanner">
@@ -100,6 +61,72 @@
     </div>
     <div class="explore-question-list" id="questionList">
       <!-- JS builds these from the actual question h1s -->
+    </div>
+
+    <!-- Ballot card: locked teaser that expands when all questions answered -->
+    <div class="ballot-card locked" id="ballotWidget">
+      <div class="ballot-card-locked" id="ballotLocked">
+        <div class="ballot-card-lock-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+        </div>
+        <div class="ballot-card-lock-text">
+          <span class="ballot-card-lock-title">Practice your ballot</span>
+          <span class="ballot-card-lock-sub" id="ballotLockMsg">Answer all 15 questions to unlock</span>
+        </div>
+      </div>
+      <div class="ballot-card-body" id="ballotBody">
+        <p class="ballot-card-title">Your ballot &middot; June 9, 2026</p>
+        <p class="ballot-card-sub">Mark each question, then see how others who voted the same way answered above.</p>
+        <div class="ballot-card-rows">
+          <div class="ballot-card-row" data-ballot="q1a">
+            <div class="ballot-card-row-info">
+              <span class="ballot-card-row-q">1A</span>
+              <span class="ballot-card-row-amt">$15M</span>
+              <span class="ballot-card-row-tier">Invest</span>
+            </div>
+            <div class="ballot-card-choices">
+              <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
+              <button type="button" class="ballot-card-btn" data-vote="no">No</button>
+            </div>
+          </div>
+          <div class="ballot-card-row" data-ballot="q1b">
+            <div class="ballot-card-row-info">
+              <span class="ballot-card-row-q">1B</span>
+              <span class="ballot-card-row-amt">$12M</span>
+              <span class="ballot-card-row-tier">Stabilize</span>
+            </div>
+            <div class="ballot-card-choices">
+              <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
+              <button type="button" class="ballot-card-btn" data-vote="no">No</button>
+            </div>
+          </div>
+          <div class="ballot-card-row" data-ballot="q1c">
+            <div class="ballot-card-row-info">
+              <span class="ballot-card-row-q">1C</span>
+              <span class="ballot-card-row-amt">$9M</span>
+              <span class="ballot-card-row-tier">Restore</span>
+            </div>
+            <div class="ballot-card-choices">
+              <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
+              <button type="button" class="ballot-card-btn" data-vote="no">No</button>
+            </div>
+          </div>
+          <div class="ballot-card-row" data-ballot="trash">
+            <div class="ballot-card-row-info">
+              <span class="ballot-card-row-q">Q2</span>
+              <span class="ballot-card-row-amt">$2.3M</span>
+              <span class="ballot-card-row-tier">Trash</span>
+            </div>
+            <div class="ballot-card-choices">
+              <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
+              <button type="button" class="ballot-card-btn" data-vote="no">No</button>
+            </div>
+          </div>
+        </div>
+        <div class="ballot-card-nudge" id="ballotNudge"></div>
+        <button type="button" class="ballot-card-submit" id="ballotSubmit">See how your picks compare</button>
+        <div class="ballot-card-done" id="ballotDone">Comparisons unlocked on each question</div>
+      </div>
     </div>
 
     {% include explore-synthesis.html %}

--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -55,78 +55,69 @@
       </div>
     </div>
 
+    <!-- Ballot card: always visible at top, buttons visible but locked until all questions answered -->
+    <div class="ballot-card locked" id="ballotWidget">
+      <div class="ballot-card-header">
+        <span class="ballot-card-title">Your ballot &middot; June 9</span>
+        <span class="ballot-card-lock-msg" id="ballotLockMsg">Answer all questions to unlock</span>
+      </div>
+      <div class="ballot-card-rows">
+        <div class="ballot-card-row" data-ballot="q1a">
+          <div class="ballot-card-row-info">
+            <span class="ballot-card-row-q">1A</span>
+            <span class="ballot-card-row-amt">$15M</span>
+            <span class="ballot-card-row-tier">Invest</span>
+          </div>
+          <div class="ballot-card-choices">
+            <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
+            <button type="button" class="ballot-card-btn" data-vote="no">No</button>
+          </div>
+        </div>
+        <div class="ballot-card-row" data-ballot="q1b">
+          <div class="ballot-card-row-info">
+            <span class="ballot-card-row-q">1B</span>
+            <span class="ballot-card-row-amt">$12M</span>
+            <span class="ballot-card-row-tier">Stabilize</span>
+          </div>
+          <div class="ballot-card-choices">
+            <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
+            <button type="button" class="ballot-card-btn" data-vote="no">No</button>
+          </div>
+        </div>
+        <div class="ballot-card-row" data-ballot="q1c">
+          <div class="ballot-card-row-info">
+            <span class="ballot-card-row-q">1C</span>
+            <span class="ballot-card-row-amt">$9M</span>
+            <span class="ballot-card-row-tier">Restore</span>
+          </div>
+          <div class="ballot-card-choices">
+            <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
+            <button type="button" class="ballot-card-btn" data-vote="no">No</button>
+          </div>
+        </div>
+        <div class="ballot-card-row" data-ballot="trash">
+          <div class="ballot-card-row-info">
+            <span class="ballot-card-row-q">Q2</span>
+            <span class="ballot-card-row-amt">$2.3M</span>
+            <span class="ballot-card-row-tier">Trash</span>
+          </div>
+          <div class="ballot-card-choices">
+            <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
+            <button type="button" class="ballot-card-btn" data-vote="no">No</button>
+          </div>
+        </div>
+      </div>
+      <div class="ballot-card-nudge" id="ballotNudge"></div>
+      <button type="button" class="ballot-card-submit" id="ballotSubmit">See how your picks compare</button>
+      <div class="ballot-card-done" id="ballotDone">Comparisons unlocked on each question</div>
+    </div>
+
     <div class="explore-shared-banner" id="sharedBanner">
       Tap any question to see the evidence behind their pick.
       <br><button type="button" class="explore-shared-fresh" id="sharedFresh">Start fresh with your own answers</button>
     </div>
     <div class="explore-question-list" id="questionList">
       <!-- JS builds these from the actual question h1s -->
-    </div>
-
-    <!-- Ballot card: locked teaser that expands when all questions answered -->
-    <div class="ballot-card locked" id="ballotWidget">
-      <div class="ballot-card-locked" id="ballotLocked">
-        <div class="ballot-card-lock-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-        </div>
-        <div class="ballot-card-lock-text">
-          <span class="ballot-card-lock-title">Practice your ballot</span>
-          <span class="ballot-card-lock-sub" id="ballotLockMsg">Answer all 15 questions to unlock</span>
-        </div>
-      </div>
-      <div class="ballot-card-body" id="ballotBody">
-        <p class="ballot-card-title">Your ballot &middot; June 9, 2026</p>
-        <p class="ballot-card-sub">Mark each question, then see how others who voted the same way answered above.</p>
-        <div class="ballot-card-rows">
-          <div class="ballot-card-row" data-ballot="q1a">
-            <div class="ballot-card-row-info">
-              <span class="ballot-card-row-q">1A</span>
-              <span class="ballot-card-row-amt">$15M</span>
-              <span class="ballot-card-row-tier">Invest</span>
-            </div>
-            <div class="ballot-card-choices">
-              <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
-              <button type="button" class="ballot-card-btn" data-vote="no">No</button>
-            </div>
-          </div>
-          <div class="ballot-card-row" data-ballot="q1b">
-            <div class="ballot-card-row-info">
-              <span class="ballot-card-row-q">1B</span>
-              <span class="ballot-card-row-amt">$12M</span>
-              <span class="ballot-card-row-tier">Stabilize</span>
-            </div>
-            <div class="ballot-card-choices">
-              <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
-              <button type="button" class="ballot-card-btn" data-vote="no">No</button>
-            </div>
-          </div>
-          <div class="ballot-card-row" data-ballot="q1c">
-            <div class="ballot-card-row-info">
-              <span class="ballot-card-row-q">1C</span>
-              <span class="ballot-card-row-amt">$9M</span>
-              <span class="ballot-card-row-tier">Restore</span>
-            </div>
-            <div class="ballot-card-choices">
-              <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
-              <button type="button" class="ballot-card-btn" data-vote="no">No</button>
-            </div>
-          </div>
-          <div class="ballot-card-row" data-ballot="trash">
-            <div class="ballot-card-row-info">
-              <span class="ballot-card-row-q">Q2</span>
-              <span class="ballot-card-row-amt">$2.3M</span>
-              <span class="ballot-card-row-tier">Trash</span>
-            </div>
-            <div class="ballot-card-choices">
-              <button type="button" class="ballot-card-btn" data-vote="yes">Yes</button>
-              <button type="button" class="ballot-card-btn" data-vote="no">No</button>
-            </div>
-          </div>
-        </div>
-        <div class="ballot-card-nudge" id="ballotNudge"></div>
-        <button type="button" class="ballot-card-submit" id="ballotSubmit">See how your picks compare</button>
-        <div class="ballot-card-done" id="ballotDone">Comparisons unlocked on each question</div>
-      </div>
     </div>
 
     {% include explore-synthesis.html %}

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -533,89 +533,54 @@
   }
   .explore-shared-fresh:hover { text-decoration: underline; }
 
-  /* ── Ballot card (locked teaser → unlocked ballot) ── */
+  /* ── Ballot card: buttons always visible, locked = dimmed + no pointer ── */
   .ballot-card {
-    margin: 16px 0;
+    margin: 0 0 16px;
     background: var(--surface);
     border: 1.5px solid var(--border);
     border-radius: var(--radius-md);
-    overflow: hidden;
+    padding: 14px 18px 16px;
     transition: border-color 0.3s ease;
   }
-
-  /* Locked teaser state */
-  .ballot-card-locked {
-    display: flex;
-    align-items: center;
-    gap: 14px;
-    padding: 16px 20px;
-    cursor: default;
-  }
-  .ballot-card.locked .ballot-card-locked { display: flex; }
-  .ballot-card:not(.locked) .ballot-card-locked { display: none; }
-  .ballot-card-lock-icon {
-    flex-shrink: 0;
-    width: 36px;
-    height: 36px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
-    background: color-mix(in srgb, var(--c-teal) 12%, var(--surface));
-    color: var(--c-teal);
-  }
-  .ballot-card-lock-icon svg {
-    width: 18px;
-    height: 18px;
-  }
-  .ballot-card-lock-text {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-  .ballot-card-lock-title {
-    font-size: 15px;
-    font-weight: 700;
-    color: var(--text);
-  }
-  .ballot-card-lock-sub {
-    font-size: 12px;
-    color: var(--text-muted);
-  }
-
-  /* Unlocked body */
-  .ballot-card-body {
-    display: none;
-    padding: 18px 20px 20px;
-  }
-  .ballot-card:not(.locked) .ballot-card-body { display: block; }
   .ballot-card:not(.locked) {
     border-color: var(--c-teal);
   }
-  .ballot-card-title {
-    font-size: 11px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    color: var(--text-subtle);
-    margin: 0 0 4px;
+  .ballot-card-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 10px;
   }
-  .ballot-card-sub {
+  .ballot-card-title {
     font-size: 13px;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .ballot-card-lock-msg {
+    font-size: 11px;
     color: var(--text-muted);
-    margin: 0 0 14px;
-    line-height: 1.45;
+    font-weight: 600;
+  }
+  .ballot-card:not(.locked) .ballot-card-lock-msg {
+    color: var(--c-teal);
   }
   .ballot-card-rows {
     display: flex;
     flex-direction: column;
     gap: 6px;
+    position: relative;
+  }
+  /* Locked: buttons visible but dimmed and unclickable */
+  .ballot-card.locked .ballot-card-rows {
+    opacity: 0.4;
+    pointer-events: none;
+    filter: grayscale(0.5);
   }
   .ballot-card-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 8px 12px;
+    padding: 7px 12px;
     border-radius: 8px;
     background: color-mix(in srgb, var(--border) 25%, transparent);
     transition: background 0.15s ease;
@@ -711,9 +676,8 @@
   .ballot-card.submitted .ballot-card-submit { display: none; }
   .ballot-card.submitted .ballot-card-done { display: block; }
   @media (max-width: 480px) {
-    .ballot-card-locked { padding: 14px 16px; gap: 12px; }
-    .ballot-card-body { padding: 14px 16px 16px; }
-    .ballot-card-row { flex-wrap: wrap; gap: 6px; padding: 8px 10px; }
+    .ballot-card { padding: 12px 14px 14px; }
+    .ballot-card-row { flex-wrap: wrap; gap: 6px; padding: 7px 10px; }
     .ballot-card-choices { width: 100%; justify-content: flex-end; }
   }
 

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -2366,3 +2366,4 @@
     .wyl-topic-label { font-size: 14.5px; }
     .wyl-topic-detail { font-size: 13.5px; }
   }
+

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -533,15 +533,17 @@
   }
   .explore-shared-fresh:hover { text-decoration: underline; }
 
-  /* ── Ballot card: buttons visible, locked = lock icon overlay ── */
+  /* ── Ballot card ── */
   .ballot-card {
-    margin: 0 0 16px;
+    max-width: 380px;
+    margin: 0 auto 18px;
     background: var(--surface);
     border: 1.5px solid var(--border);
     border-radius: var(--radius-md);
-    padding: 14px 18px 16px;
+    padding: 0;
     transition: border-color 0.3s ease;
     position: relative;
+    overflow: hidden;
   }
   .ballot-card:not(.locked) {
     border-color: var(--c-teal);
@@ -550,91 +552,95 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 10px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
   }
   .ballot-card-title {
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
     color: var(--text);
   }
   .ballot-card-lock-msg {
     display: flex;
     align-items: center;
-    gap: 5px;
-    font-size: 11px;
+    gap: 4px;
+    font-size: 10px;
     color: var(--text-muted);
     font-weight: 600;
   }
   .ballot-card-lock-icon {
-    width: 14px;
-    height: 14px;
+    width: 12px;
+    height: 12px;
     color: var(--text-muted);
   }
   .ballot-card:not(.locked) .ballot-card-lock-msg { display: none; }
   .ballot-card-rows {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 0;
     position: relative;
   }
-  /* Locked: dim the rows, block clicks, and show a lock overlay */
   .ballot-card.locked .ballot-card-rows {
-    opacity: 0.35;
+    opacity: 0.3;
     pointer-events: none;
   }
   .ballot-card-divider {
     height: 1px;
     background: var(--border);
-    margin: 10px 0;
+    margin: 0;
   }
-  .ballot-card.locked .ballot-card-divider { opacity: 0.35; }
+  .ballot-card.locked .ballot-card-divider { opacity: 0.3; }
   .ballot-card-row {
-    display: flex;
+    display: grid;
+    grid-template-columns: 110px 28px 1fr;
     align-items: center;
-    gap: 10px;
-    padding: 7px 12px;
-    border-radius: 8px;
-    background: color-mix(in srgb, var(--border) 25%, transparent);
+    gap: 0;
+    padding: 8px 16px;
     transition: background 0.15s ease;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 40%, transparent);
   }
+  .ballot-card-row:last-child { border-bottom: none; }
   .ballot-card-row.has-vote {
-    background: color-mix(in srgb, var(--c-teal) 6%, var(--surface));
+    background: color-mix(in srgb, var(--c-teal) 5%, var(--surface));
   }
   .ballot-card-choices {
     display: flex;
-    gap: 4px;
+    gap: 3px;
     flex-shrink: 0;
   }
-  .ballot-card-row-info {
-    display: flex;
-    align-items: baseline;
-    gap: 6px;
-  }
   .ballot-card-row-q {
-    font-size: 12px;
-    font-weight: 800;
+    font-size: 11px;
+    font-weight: 700;
     color: var(--text-subtle);
+    text-align: right;
+    padding-right: 8px;
   }
   .ballot-card-row-amt {
-    font-size: 15px;
+    font-size: 14px;
     font-weight: 700;
     color: var(--text);
+    white-space: nowrap;
   }
   .ballot-card-row-tier {
-    font-size: 11px;
+    font-size: 10px;
     color: var(--text-muted);
+    margin-left: 4px;
   }
   .ballot-card-btn {
     font: inherit;
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 700;
-    padding: 5px 16px;
-    border-radius: 14px;
+    width: 48px;
+    padding: 5px 0;
+    border-radius: 6px;
     border: 1.5px solid var(--border);
     background: var(--surface);
     color: var(--text-muted);
     cursor: pointer;
     transition: all 0.12s ease;
+    text-align: center;
   }
   .ballot-card-btn:hover {
     border-color: var(--text-subtle);
@@ -651,47 +657,46 @@
     color: #fff;
   }
   .ballot-card-nudge {
-    margin: 8px 0 0;
-    padding: 8px 12px;
-    font-size: 12px;
+    margin: 0;
+    padding: 8px 16px;
+    font-size: 11px;
     line-height: 1.5;
     color: var(--c-brass);
-    background: color-mix(in srgb, var(--c-brass) 8%, var(--surface));
-    border-left: 3px solid var(--c-brass);
-    border-radius: 0 6px 6px 0;
+    background: color-mix(in srgb, var(--c-brass) 6%, var(--surface));
+    border-top: 1px solid color-mix(in srgb, var(--c-brass) 20%, transparent);
     display: none;
   }
   .ballot-card-nudge.visible { display: block; }
   .ballot-card-submit {
     display: none;
-    margin: 14px auto 0;
+    width: 100%;
     font: inherit;
-    font-size: 14px;
+    font-size: 13px;
     font-weight: 700;
-    padding: 9px 24px;
-    border-radius: 20px;
+    padding: 10px;
     border: none;
-    background: var(--c-teal);
-    color: #fff;
+    border-top: 1px solid var(--border);
+    background: color-mix(in srgb, var(--c-teal) 8%, var(--surface));
+    color: var(--c-teal);
     cursor: pointer;
     transition: all 0.12s ease;
   }
-  .ballot-card-submit:hover { filter: brightness(1.1); }
+  .ballot-card-submit:hover { background: color-mix(in srgb, var(--c-teal) 14%, var(--surface)); }
   .ballot-card.all-voted .ballot-card-submit { display: block; }
   .ballot-card-done {
     display: none;
     text-align: center;
-    font-size: 13px;
+    font-size: 11px;
     color: var(--c-teal);
     font-weight: 600;
-    margin-top: 12px;
+    padding: 8px 16px;
+    border-top: 1px solid var(--border);
   }
   .ballot-card.submitted .ballot-card-submit { display: none; }
   .ballot-card.submitted .ballot-card-done { display: block; }
-  @media (max-width: 480px) {
-    .ballot-card { padding: 12px 14px 14px; }
-    .ballot-card-row { flex-wrap: wrap; gap: 6px; padding: 7px 10px; }
-    .ballot-card-choices { width: 100%; justify-content: flex-start; }
+  @media (max-width: 400px) {
+    .ballot-card-row { grid-template-columns: 100px 24px 1fr; padding: 7px 12px; }
+    .ballot-card-btn { width: 44px; font-size: 11px; padding: 4px 0; }
   }
 
   /* ── Cross-tab comparison bar (shown per question after ballot submitted) ── */

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -533,7 +533,7 @@
   }
   .explore-shared-fresh:hover { text-decoration: underline; }
 
-  /* ── Ballot card: buttons always visible, locked = dimmed + no pointer ── */
+  /* ── Ballot card: buttons visible, locked = lock icon overlay ── */
   .ballot-card {
     margin: 0 0 16px;
     background: var(--surface);
@@ -541,13 +541,14 @@
     border-radius: var(--radius-md);
     padding: 14px 18px 16px;
     transition: border-color 0.3s ease;
+    position: relative;
   }
   .ballot-card:not(.locked) {
     border-color: var(--c-teal);
   }
   .ballot-card-header {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     justify-content: space-between;
     margin-bottom: 10px;
   }
@@ -557,29 +558,40 @@
     color: var(--text);
   }
   .ballot-card-lock-msg {
+    display: flex;
+    align-items: center;
+    gap: 5px;
     font-size: 11px;
     color: var(--text-muted);
     font-weight: 600;
   }
-  .ballot-card:not(.locked) .ballot-card-lock-msg {
-    color: var(--c-teal);
+  .ballot-card-lock-icon {
+    width: 14px;
+    height: 14px;
+    color: var(--text-muted);
   }
+  .ballot-card:not(.locked) .ballot-card-lock-msg { display: none; }
   .ballot-card-rows {
     display: flex;
     flex-direction: column;
     gap: 6px;
     position: relative;
   }
-  /* Locked: buttons visible but dimmed and unclickable */
+  /* Locked: dim the rows, block clicks, and show a lock overlay */
   .ballot-card.locked .ballot-card-rows {
-    opacity: 0.4;
+    opacity: 0.35;
     pointer-events: none;
-    filter: grayscale(0.5);
   }
+  .ballot-card-divider {
+    height: 1px;
+    background: var(--border);
+    margin: 10px 0;
+  }
+  .ballot-card.locked .ballot-card-divider { opacity: 0.35; }
   .ballot-card-row {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    gap: 10px;
     padding: 7px 12px;
     border-radius: 8px;
     background: color-mix(in srgb, var(--border) 25%, transparent);
@@ -587,6 +599,11 @@
   }
   .ballot-card-row.has-vote {
     background: color-mix(in srgb, var(--c-teal) 6%, var(--surface));
+  }
+  .ballot-card-choices {
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
   }
   .ballot-card-row-info {
     display: flex;
@@ -606,10 +623,6 @@
   .ballot-card-row-tier {
     font-size: 11px;
     color: var(--text-muted);
-  }
-  .ballot-card-choices {
-    display: flex;
-    gap: 4px;
   }
   .ballot-card-btn {
     font: inherit;
@@ -678,7 +691,7 @@
   @media (max-width: 480px) {
     .ballot-card { padding: 12px 14px 14px; }
     .ballot-card-row { flex-wrap: wrap; gap: 6px; padding: 7px 10px; }
-    .ballot-card-choices { width: 100%; justify-content: flex-end; }
+    .ballot-card-choices { width: 100%; justify-content: flex-start; }
   }
 
   /* ── Cross-tab comparison bar (shown per question after ballot submitted) ── */

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -533,6 +533,237 @@
   }
   .explore-shared-fresh:hover { text-decoration: underline; }
 
+  /* ── Ballot widget (locked until all questions answered) ── */
+  .ballot-widget {
+    margin-top: 24px;
+    padding: 20px;
+    background: var(--surface);
+    border: 1.5px solid var(--border);
+    border-radius: var(--radius-md);
+    position: relative;
+    overflow: hidden;
+    transition: border-color 0.3s ease;
+  }
+  .ballot-widget.unlocked {
+    border-color: var(--c-teal);
+  }
+  .ballot-widget-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-subtle);
+    margin: 0 0 12px;
+    text-align: center;
+  }
+  .ballot-widget-lock-overlay {
+    position: absolute;
+    inset: 0;
+    background: color-mix(in srgb, var(--surface) 80%, transparent);
+    backdrop-filter: blur(3px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    z-index: 2;
+    gap: 8px;
+    transition: opacity 0.3s ease;
+  }
+  .ballot-widget.unlocked .ballot-widget-lock-overlay {
+    opacity: 0;
+    pointer-events: none;
+  }
+  .ballot-widget-lock-icon {
+    font-size: 24px;
+    opacity: 0.5;
+  }
+  .ballot-widget-lock-msg {
+    font-size: 13px;
+    color: var(--text-muted);
+    text-align: center;
+    line-height: 1.5;
+    max-width: 260px;
+  }
+  .ballot-widget-lock-msg strong {
+    color: var(--text);
+  }
+  .ballot-widget-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .ballot-widget-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--border) 30%, transparent);
+    transition: background 0.15s ease;
+  }
+  .ballot-widget-row.has-vote {
+    background: color-mix(in srgb, var(--c-teal) 6%, var(--surface));
+  }
+  .ballot-widget-q {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--text-subtle);
+    min-width: 28px;
+    flex-shrink: 0;
+  }
+  .ballot-widget-desc {
+    flex: 1;
+    min-width: 0;
+  }
+  .ballot-widget-amount {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .ballot-widget-tier {
+    font-size: 11px;
+    color: var(--text-muted);
+    display: block;
+  }
+  .ballot-widget-choices {
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .ballot-widget-btn {
+    font: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 6px 14px;
+    border-radius: 16px;
+    border: 1.5px solid var(--border);
+    background: var(--surface);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .ballot-widget-btn:hover {
+    border-color: var(--text-subtle);
+  }
+  .ballot-widget-btn.voted {
+    background: var(--c-teal);
+    border-color: var(--c-teal);
+    color: #fff;
+  }
+  .ballot-widget-btn[data-vote="no"].voted {
+    background: var(--c-brass);
+    border-color: var(--c-brass);
+    color: #fff;
+  }
+  .ballot-widget-nudge {
+    margin: 10px 0 0;
+    padding: 10px 14px;
+    font-size: 12px;
+    line-height: 1.55;
+    color: var(--c-brass);
+    background: color-mix(in srgb, var(--c-brass) 8%, var(--surface));
+    border-left: 3px solid var(--c-brass);
+    border-radius: 0 8px 8px 0;
+    display: none;
+  }
+  .ballot-widget-nudge.visible {
+    display: block;
+  }
+  .ballot-widget-submit {
+    display: none;
+    margin: 14px auto 0;
+    font: inherit;
+    font-size: 14px;
+    font-weight: 700;
+    padding: 10px 28px;
+    border-radius: 20px;
+    border: none;
+    background: var(--c-teal);
+    color: #fff;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .ballot-widget-submit:hover {
+    filter: brightness(1.1);
+  }
+  .ballot-widget.all-voted .ballot-widget-submit {
+    display: block;
+  }
+  .ballot-widget-submitted {
+    display: none;
+    text-align: center;
+    font-size: 13px;
+    color: var(--c-teal);
+    font-weight: 600;
+    margin-top: 12px;
+  }
+  .ballot-widget.submitted .ballot-widget-submit { display: none; }
+  .ballot-widget.submitted .ballot-widget-submitted { display: block; }
+
+  /* ── Cross-tab comparison bar (shown per question after ballot submitted) ── */
+  .crosstab-bar {
+    margin: 10px 0 0;
+    padding: 10px 14px;
+    background: color-mix(in srgb, var(--c-navy) 5%, var(--surface));
+    border-radius: 8px;
+    display: none;
+  }
+  .crosstab-bar.visible { display: block; }
+  .crosstab-bar-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-subtle);
+    margin-bottom: 6px;
+  }
+  .crosstab-bar-track {
+    height: 16px;
+    border-radius: 3px;
+    display: flex;
+    overflow: hidden;
+    background: var(--border);
+  }
+  .crosstab-bar-seg {
+    transition: width 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    font-weight: 700;
+    color: #fff;
+  }
+  .crosstab-bar-seg.ct-a { background: var(--c-teal); }
+  .crosstab-bar-seg.ct-b { background: var(--c-brass); }
+  .crosstab-bar-seg.ct-c { background: var(--c-buoy); }
+  .crosstab-bar-seg.ct-u { background: var(--text-faint); }
+  .crosstab-bar-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 6px;
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+  .crosstab-bar-legend span {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+  }
+  .crosstab-bar-legend .ct-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .ct-dot-a { background: var(--c-teal); }
+  .ct-dot-b { background: var(--c-brass); }
+  .ct-dot-c { background: var(--c-buoy); }
+  .ct-dot-u { background: var(--text-faint); }
+  @media (max-width: 480px) {
+    .ballot-widget { padding: 14px; }
+    .ballot-widget-row { flex-wrap: wrap; gap: 6px; }
+    .ballot-widget-choices { width: 100%; justify-content: flex-end; }
+  }
+
   /* Hide landing once a topic is active */
   .explore-stage.has-topic .explore-landing { display: none; }
   /* Hide question header in landing state */

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -533,114 +533,70 @@
   }
   .explore-shared-fresh:hover { text-decoration: underline; }
 
-  /* ── Ballot widget (locked until all questions answered) ── */
+  /* ── Ballot widget (compact row inside stats strip) ── */
   .ballot-widget {
-    margin-top: 24px;
-    padding: 20px;
-    background: var(--surface);
-    border: 1.5px solid var(--border);
-    border-radius: var(--radius-md);
-    position: relative;
-    overflow: hidden;
-    transition: border-color 0.3s ease;
+    display: none;
+    border-top: 1px solid var(--border);
+    padding: 8px 16px 10px;
   }
-  .ballot-widget.unlocked {
-    border-color: var(--c-teal);
+  .ballot-widget.visible { display: block; }
+  .ballot-widget-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 6px;
   }
   .ballot-widget-label {
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 1px;
     color: var(--text-subtle);
-    margin: 0 0 12px;
-    text-align: center;
   }
-  .ballot-widget-lock-overlay {
-    position: absolute;
-    inset: 0;
-    background: color-mix(in srgb, var(--surface) 80%, transparent);
-    backdrop-filter: blur(3px);
+  .ballot-widget-lock {
+    font-size: 10px;
+    color: var(--text-muted);
+  }
+  .ballot-widget-grid {
     display: flex;
-    flex-direction: column;
     align-items: center;
-    justify-content: center;
-    z-index: 2;
     gap: 8px;
-    transition: opacity 0.3s ease;
   }
-  .ballot-widget.unlocked .ballot-widget-lock-overlay {
-    opacity: 0;
+  .ballot-widget.locked .ballot-widget-grid {
+    opacity: 0.35;
     pointer-events: none;
   }
-  .ballot-widget-lock-icon {
-    font-size: 24px;
-    opacity: 0.5;
-  }
-  .ballot-widget-lock-msg {
-    font-size: 13px;
-    color: var(--text-muted);
-    text-align: center;
-    line-height: 1.5;
-    max-width: 260px;
-  }
-  .ballot-widget-lock-msg strong {
-    color: var(--text);
-  }
-  .ballot-widget-rows {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-  .ballot-widget-row {
+  .ballot-widget-item {
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 10px 12px;
-    border-radius: 8px;
-    background: color-mix(in srgb, var(--border) 30%, transparent);
-    transition: background 0.15s ease;
-  }
-  .ballot-widget-row.has-vote {
-    background: color-mix(in srgb, var(--c-teal) 6%, var(--surface));
+    gap: 4px;
   }
   .ballot-widget-q {
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 700;
     color: var(--text-subtle);
-    min-width: 28px;
-    flex-shrink: 0;
+    white-space: nowrap;
   }
-  .ballot-widget-desc {
-    flex: 1;
-    min-width: 0;
-  }
-  .ballot-widget-amount {
-    font-size: 14px;
-    font-weight: 700;
-    color: var(--text);
-  }
-  .ballot-widget-tier {
-    font-size: 11px;
+  .ballot-widget-amt {
+    font-weight: 600;
     color: var(--text-muted);
-    display: block;
   }
   .ballot-widget-choices {
     display: flex;
-    gap: 4px;
-    flex-shrink: 0;
+    gap: 2px;
   }
   .ballot-widget-btn {
     font: inherit;
-    font-size: 12px;
+    font-size: 10px;
     font-weight: 700;
-    padding: 6px 14px;
-    border-radius: 16px;
+    padding: 3px 8px;
+    border-radius: 10px;
     border: 1.5px solid var(--border);
     background: var(--surface);
     color: var(--text-muted);
     cursor: pointer;
-    transition: all 0.15s ease;
+    transition: all 0.12s ease;
+    line-height: 1;
   }
   .ballot-widget-btn:hover {
     border-color: var(--text-subtle);
@@ -655,50 +611,37 @@
     border-color: var(--c-brass);
     color: #fff;
   }
-  .ballot-widget-nudge {
-    margin: 10px 0 0;
-    padding: 10px 14px;
-    font-size: 12px;
-    line-height: 1.55;
-    color: var(--c-brass);
-    background: color-mix(in srgb, var(--c-brass) 8%, var(--surface));
-    border-left: 3px solid var(--c-brass);
-    border-radius: 0 8px 8px 0;
-    display: none;
-  }
-  .ballot-widget-nudge.visible {
-    display: block;
-  }
-  .ballot-widget-submit {
-    display: none;
-    margin: 14px auto 0;
+  .ballot-widget-go {
     font: inherit;
-    font-size: 14px;
+    font-size: 11px;
     font-weight: 700;
-    padding: 10px 28px;
-    border-radius: 20px;
+    padding: 4px 12px;
+    border-radius: 12px;
     border: none;
     background: var(--c-teal);
     color: #fff;
     cursor: pointer;
-    transition: all 0.15s ease;
-  }
-  .ballot-widget-submit:hover {
-    filter: brightness(1.1);
-  }
-  .ballot-widget.all-voted .ballot-widget-submit {
-    display: block;
-  }
-  .ballot-widget-submitted {
+    margin-left: auto;
+    transition: all 0.12s ease;
     display: none;
-    text-align: center;
-    font-size: 13px;
-    color: var(--c-teal);
-    font-weight: 600;
-    margin-top: 12px;
   }
-  .ballot-widget.submitted .ballot-widget-submit { display: none; }
-  .ballot-widget.submitted .ballot-widget-submitted { display: block; }
+  .ballot-widget-go:hover { filter: brightness(1.1); }
+  .ballot-widget.all-voted .ballot-widget-go { display: block; }
+  .ballot-widget.submitted .ballot-widget-go { display: none; }
+  .ballot-widget-nudge {
+    padding: 4px 0 0;
+    font-size: 10px;
+    line-height: 1.45;
+    color: var(--c-brass);
+    display: none;
+  }
+  .ballot-widget-nudge.visible { display: block; }
+  @media (max-width: 480px) {
+    .ballot-widget { padding: 6px 12px 8px; }
+    .ballot-widget-grid { flex-wrap: wrap; gap: 6px; }
+    .ballot-widget-item { gap: 3px; }
+    .ballot-widget-btn { padding: 3px 6px; font-size: 9px; }
+  }
 
   /* ── Cross-tab comparison bar (shown per question after ballot submitted) ── */
   .crosstab-bar {
@@ -758,11 +701,6 @@
   .ct-dot-b { background: var(--c-brass); }
   .ct-dot-c { background: var(--c-buoy); }
   .ct-dot-u { background: var(--text-faint); }
-  @media (max-width: 480px) {
-    .ballot-widget { padding: 14px; }
-    .ballot-widget-row { flex-wrap: wrap; gap: 6px; }
-    .ballot-widget-choices { width: 100%; justify-content: flex-end; }
-  }
 
   /* Hide landing once a topic is active */
   .explore-stage.has-topic .explore-landing { display: none; }

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -576,6 +576,33 @@
     color: var(--text-muted);
   }
   .ballot-card:not(.locked) .ballot-card-lock-msg { display: none; }
+  .ballot-card-lock-link {
+    color: var(--text-muted);
+    text-decoration: none;
+  }
+  .ballot-card-lock-link:hover {
+    color: var(--c-teal);
+    text-decoration: underline;
+  }
+  .ballot-card-cta {
+    display: none;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 2;
+    font-size: 13px;
+    font-weight: 700;
+    padding: 8px 22px;
+    border-radius: 20px;
+    background: var(--c-teal);
+    color: #fff;
+    text-decoration: none;
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--c-teal) 30%, transparent);
+    transition: all 0.15s ease;
+  }
+  .ballot-card-cta:hover { filter: brightness(1.1); }
+  .ballot-card.locked .ballot-card-cta { display: block; }
   .ballot-card-rows {
     display: flex;
     flex-direction: column;

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -533,114 +533,188 @@
   }
   .explore-shared-fresh:hover { text-decoration: underline; }
 
-  /* ── Ballot widget (compact row inside stats strip) ── */
-  .ballot-widget {
-    display: none;
-    border-top: 1px solid var(--border);
-    padding: 8px 16px 10px;
+  /* ── Ballot card (locked teaser → unlocked ballot) ── */
+  .ballot-card {
+    margin: 16px 0;
+    background: var(--surface);
+    border: 1.5px solid var(--border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    transition: border-color 0.3s ease;
   }
-  .ballot-widget.visible { display: block; }
-  .ballot-widget-header {
+
+  /* Locked teaser state */
+  .ballot-card-locked {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    margin-bottom: 6px;
+    gap: 14px;
+    padding: 16px 20px;
+    cursor: default;
   }
-  .ballot-widget-label {
-    font-size: 10px;
+  .ballot-card.locked .ballot-card-locked { display: flex; }
+  .ballot-card:not(.locked) .ballot-card-locked { display: none; }
+  .ballot-card-lock-icon {
+    flex-shrink: 0;
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--c-teal) 12%, var(--surface));
+    color: var(--c-teal);
+  }
+  .ballot-card-lock-icon svg {
+    width: 18px;
+    height: 18px;
+  }
+  .ballot-card-lock-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .ballot-card-lock-title {
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .ballot-card-lock-sub {
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+
+  /* Unlocked body */
+  .ballot-card-body {
+    display: none;
+    padding: 18px 20px 20px;
+  }
+  .ballot-card:not(.locked) .ballot-card-body { display: block; }
+  .ballot-card:not(.locked) {
+    border-color: var(--c-teal);
+  }
+  .ballot-card-title {
+    font-size: 11px;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 1px;
     color: var(--text-subtle);
+    margin: 0 0 4px;
   }
-  .ballot-widget-lock {
-    font-size: 10px;
+  .ballot-card-sub {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin: 0 0 14px;
+    line-height: 1.45;
+  }
+  .ballot-card-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ballot-card-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--border) 25%, transparent);
+    transition: background 0.15s ease;
+  }
+  .ballot-card-row.has-vote {
+    background: color-mix(in srgb, var(--c-teal) 6%, var(--surface));
+  }
+  .ballot-card-row-info {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+  .ballot-card-row-q {
+    font-size: 12px;
+    font-weight: 800;
+    color: var(--text-subtle);
+  }
+  .ballot-card-row-amt {
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .ballot-card-row-tier {
+    font-size: 11px;
     color: var(--text-muted);
   }
-  .ballot-widget-grid {
+  .ballot-card-choices {
     display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .ballot-widget.locked .ballot-widget-grid {
-    opacity: 0.35;
-    pointer-events: none;
-  }
-  .ballot-widget-item {
-    display: flex;
-    align-items: center;
     gap: 4px;
   }
-  .ballot-widget-q {
-    font-size: 11px;
-    font-weight: 700;
-    color: var(--text-subtle);
-    white-space: nowrap;
-  }
-  .ballot-widget-amt {
-    font-weight: 600;
-    color: var(--text-muted);
-  }
-  .ballot-widget-choices {
-    display: flex;
-    gap: 2px;
-  }
-  .ballot-widget-btn {
+  .ballot-card-btn {
     font: inherit;
-    font-size: 10px;
+    font-size: 13px;
     font-weight: 700;
-    padding: 3px 8px;
-    border-radius: 10px;
+    padding: 5px 16px;
+    border-radius: 14px;
     border: 1.5px solid var(--border);
     background: var(--surface);
     color: var(--text-muted);
     cursor: pointer;
     transition: all 0.12s ease;
-    line-height: 1;
   }
-  .ballot-widget-btn:hover {
+  .ballot-card-btn:hover {
     border-color: var(--text-subtle);
+    color: var(--text);
   }
-  .ballot-widget-btn.voted {
+  .ballot-card-btn.voted {
     background: var(--c-teal);
     border-color: var(--c-teal);
     color: #fff;
   }
-  .ballot-widget-btn[data-vote="no"].voted {
+  .ballot-card-btn[data-vote="no"].voted {
     background: var(--c-brass);
     border-color: var(--c-brass);
     color: #fff;
   }
-  .ballot-widget-go {
+  .ballot-card-nudge {
+    margin: 8px 0 0;
+    padding: 8px 12px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--c-brass);
+    background: color-mix(in srgb, var(--c-brass) 8%, var(--surface));
+    border-left: 3px solid var(--c-brass);
+    border-radius: 0 6px 6px 0;
+    display: none;
+  }
+  .ballot-card-nudge.visible { display: block; }
+  .ballot-card-submit {
+    display: none;
+    margin: 14px auto 0;
     font: inherit;
-    font-size: 11px;
+    font-size: 14px;
     font-weight: 700;
-    padding: 4px 12px;
-    border-radius: 12px;
+    padding: 9px 24px;
+    border-radius: 20px;
     border: none;
     background: var(--c-teal);
     color: #fff;
     cursor: pointer;
-    margin-left: auto;
     transition: all 0.12s ease;
-    display: none;
   }
-  .ballot-widget-go:hover { filter: brightness(1.1); }
-  .ballot-widget.all-voted .ballot-widget-go { display: block; }
-  .ballot-widget.submitted .ballot-widget-go { display: none; }
-  .ballot-widget-nudge {
-    padding: 4px 0 0;
-    font-size: 10px;
-    line-height: 1.45;
-    color: var(--c-brass);
+  .ballot-card-submit:hover { filter: brightness(1.1); }
+  .ballot-card.all-voted .ballot-card-submit { display: block; }
+  .ballot-card-done {
     display: none;
+    text-align: center;
+    font-size: 13px;
+    color: var(--c-teal);
+    font-weight: 600;
+    margin-top: 12px;
   }
-  .ballot-widget-nudge.visible { display: block; }
+  .ballot-card.submitted .ballot-card-submit { display: none; }
+  .ballot-card.submitted .ballot-card-done { display: block; }
   @media (max-width: 480px) {
-    .ballot-widget { padding: 6px 12px 8px; }
-    .ballot-widget-grid { flex-wrap: wrap; gap: 6px; }
-    .ballot-widget-item { gap: 3px; }
-    .ballot-widget-btn { padding: 3px 6px; font-size: 9px; }
+    .ballot-card-locked { padding: 14px 16px; gap: 12px; }
+    .ballot-card-body { padding: 14px 16px 16px; }
+    .ballot-card-row { flex-wrap: wrap; gap: 6px; padding: 8px 10px; }
+    .ballot-card-choices { width: 100%; justify-content: flex-end; }
   }
 
   /* ── Cross-tab comparison bar (shown per question after ballot submitted) ── */

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -2241,17 +2241,16 @@
     suppressURLWrite = false;
   });
 
-  // ── Ballot widget: compact row inside stats strip ──
+  // ── Ballot card: locked teaser → unlocked ballot ──
 
   var ballotWidget = document.getElementById('ballotWidget');
   var ballotNudge = document.getElementById('ballotNudge');
   var ballotLockMsg = document.getElementById('ballotLockMsg');
   var ballotSubmitBtn = document.getElementById('ballotSubmit');
-  var ballotVotes = {}; // { q1a: 'yes'|'no', q1b: ..., q1c: ..., trash: ... }
+  var ballotVotes = {};
   var ballotSubmitted = false;
   var BALLOT_KEYS = ['q1a', 'q1b', 'q1c', 'trash'];
 
-  // Restore persisted ballot state
   try {
     var saved = JSON.parse(localStorage.getItem('explore-ballot') || '{}');
     if (saved && typeof saved === 'object') ballotVotes = saved;
@@ -2271,17 +2270,14 @@
   function updateBallotLock() {
     if (!ballotWidget) return;
     var answered = allQuestionsAnswered();
-    // Show once user has at least 1 pick
-    var hasPicks = topicOrder.some(function (t) { return !!selections[t]; });
-    ballotWidget.classList.toggle('visible', hasPicks);
     ballotWidget.classList.toggle('locked', !answered);
 
     if (ballotLockMsg) {
+      var remaining = topicOrder.filter(function (t) { return !selections[t]; }).length;
       if (answered) {
-        ballotLockMsg.textContent = '';
+        ballotLockMsg.textContent = 'Unlocked';
       } else {
-        var remaining = topicOrder.filter(function (t) { return !selections[t]; }).length;
-        ballotLockMsg.textContent = remaining + ' to go';
+        ballotLockMsg.textContent = remaining + ' question' + (remaining === 1 ? '' : 's') + ' to go';
       }
     }
   }
@@ -2294,20 +2290,17 @@
     if (!ballotWidget) return;
     updateBallotLock();
 
-    // Restore button states from ballotVotes
-    document.querySelectorAll('.ballot-widget-item').forEach(function (item) {
-      var key = item.dataset.ballot;
+    document.querySelectorAll('.ballot-card-row').forEach(function (row) {
+      var key = row.dataset.ballot;
       var vote = ballotVotes[key];
-      item.querySelectorAll('.ballot-widget-btn').forEach(function (btn) {
+      row.classList.toggle('has-vote', !!vote);
+      row.querySelectorAll('.ballot-card-btn').forEach(function (btn) {
         btn.classList.toggle('voted', btn.dataset.vote === vote);
       });
     });
 
-    // Show/hide submit button
     ballotWidget.classList.toggle('all-voted', allBallotVoted() && !ballotSubmitted);
     ballotWidget.classList.toggle('submitted', ballotSubmitted);
-
-    // Cascade nudge
     checkCascadeNudge();
   }
 
@@ -2319,9 +2312,9 @@
 
     var nudgeMsg = '';
     if (yes1a && (no1b || no1c)) {
-      nudgeMsg = 'Tip: Yes on $15M but No below? If $15M fails, lower tiers are your fallback.';
+      nudgeMsg = 'The highest passing tier wins. If $15M falls short, voting Yes on $12M and $9M keeps them as a fallback.';
     } else if (yes1b && no1c) {
-      nudgeMsg = 'Tip: Yes on $12M but No on $9M? $9M is your fallback if $12M fails.';
+      nudgeMsg = 'If $12M doesn\'t pass, voting Yes on $9M keeps it as a fallback.';
     }
 
     if (nudgeMsg) {
@@ -2332,17 +2325,16 @@
     }
   }
 
-  // Click handler for ballot Yes/No buttons
   if (ballotWidget) {
     ballotWidget.addEventListener('click', function (e) {
       if (ballotSubmitted) return;
-      var btn = e.target.closest('.ballot-widget-btn');
+      var btn = e.target.closest('.ballot-card-btn');
       if (!btn) return;
-      var item = btn.closest('.ballot-widget-item');
-      if (!item) return;
+      var row = btn.closest('.ballot-card-row');
+      if (!row) return;
       if (ballotWidget.classList.contains('locked')) return;
 
-      var key = item.dataset.ballot;
+      var key = row.dataset.ballot;
       var vote = btn.dataset.vote;
 
       if (ballotVotes[key] === vote) {
@@ -2359,7 +2351,6 @@
     });
   }
 
-  // Submit handler
   if (ballotSubmitBtn) {
     ballotSubmitBtn.addEventListener('click', function () {
       if (!allBallotVoted()) return;

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -2241,6 +2241,286 @@
     suppressURLWrite = false;
   });
 
+  // ── Ballot widget: lock/unlock, cascade nudge, submit, cross-tabs ──
+
+  var ballotWidget = document.getElementById('ballotWidget');
+  var ballotNudge = document.getElementById('ballotNudge');
+  var ballotSubmitBtn = document.getElementById('ballotSubmit');
+  var ballotVotes = {}; // { q1a: 'yes'|'no', q1b: ..., q1c: ..., trash: ... }
+  var ballotSubmitted = false;
+  var BALLOT_KEYS = ['q1a', 'q1b', 'q1c', 'trash'];
+
+  // Restore persisted ballot state
+  try {
+    var saved = JSON.parse(localStorage.getItem('explore-ballot') || '{}');
+    if (saved && typeof saved === 'object') ballotVotes = saved;
+  } catch (e) {}
+  try {
+    ballotSubmitted = localStorage.getItem('explore-ballot-submitted') === '1';
+  } catch (e) {}
+
+  function persistBallot() {
+    localStorage.setItem('explore-ballot', JSON.stringify(ballotVotes));
+  }
+
+  function allQuestionsAnswered() {
+    return topicOrder.every(function (t) { return !!selections[t]; });
+  }
+
+  function updateBallotLock() {
+    if (!ballotWidget) return;
+    if (allQuestionsAnswered()) {
+      ballotWidget.classList.add('unlocked');
+    } else {
+      ballotWidget.classList.remove('unlocked');
+      var remaining = topicOrder.filter(function (t) { return !selections[t]; }).length;
+      var msg = document.querySelector('#ballotLock .ballot-widget-lock-msg');
+      if (msg) msg.innerHTML = '<strong>' + remaining + ' question' + (remaining === 1 ? '' : 's') + ' left</strong> to unlock your practice ballot.';
+    }
+  }
+
+  function allBallotVoted() {
+    return BALLOT_KEYS.every(function (k) { return ballotVotes[k] === 'yes' || ballotVotes[k] === 'no'; });
+  }
+
+  function updateBallotUI() {
+    if (!ballotWidget) return;
+    updateBallotLock();
+
+    // Restore button states from ballotVotes
+    document.querySelectorAll('.ballot-widget-row').forEach(function (row) {
+      var key = row.dataset.ballot;
+      var vote = ballotVotes[key];
+      row.classList.toggle('has-vote', !!vote);
+      row.querySelectorAll('.ballot-widget-btn').forEach(function (btn) {
+        btn.classList.toggle('voted', btn.dataset.vote === vote);
+      });
+    });
+
+    // Show/hide submit button
+    ballotWidget.classList.toggle('all-voted', allBallotVoted() && !ballotSubmitted);
+    ballotWidget.classList.toggle('submitted', ballotSubmitted);
+
+    // Cascade nudge
+    checkCascadeNudge();
+  }
+
+  function checkCascadeNudge() {
+    // Find gaps: voted Yes on a higher tier but No on a lower one
+    var yes1a = ballotVotes.q1a === 'yes';
+    var yes1b = ballotVotes.q1b === 'yes';
+    var no1b = ballotVotes.q1b === 'no';
+    var no1c = ballotVotes.q1c === 'no';
+
+    var nudgeMsg = '';
+    if (yes1a && (no1b || no1c)) {
+      nudgeMsg = 'You voted Yes on $15M but No on a lower tier. The highest passing tier wins. If $15M falls short, voting Yes on $12M and $9M keeps them as a fallback.';
+    } else if (yes1b && no1c) {
+      nudgeMsg = 'You voted Yes on $12M but No on $9M. If $12M doesn\'t pass, voting Yes on $9M keeps it as a fallback.';
+    }
+
+    if (nudgeMsg) {
+      ballotNudge.textContent = nudgeMsg;
+      ballotNudge.classList.add('visible');
+    } else {
+      ballotNudge.classList.remove('visible');
+    }
+  }
+
+  // Click handler for ballot Yes/No buttons
+  if (ballotWidget) {
+    ballotWidget.addEventListener('click', function (e) {
+      if (ballotSubmitted) return;
+      var btn = e.target.closest('.ballot-widget-btn');
+      if (!btn) return;
+      var row = btn.closest('.ballot-widget-row');
+      if (!row) return;
+      if (!ballotWidget.classList.contains('unlocked')) return;
+
+      var key = row.dataset.ballot;
+      var vote = btn.dataset.vote;
+
+      // Toggle: clicking the same vote again clears it
+      if (ballotVotes[key] === vote) {
+        delete ballotVotes[key];
+      } else {
+        ballotVotes[key] = vote;
+      }
+      persistBallot();
+      updateBallotUI();
+
+      if (typeof posthog !== 'undefined') {
+        posthog.capture('ballot_widget_vote', { question: key, vote: vote });
+      }
+    });
+  }
+
+  // Submit handler
+  if (ballotSubmitBtn) {
+    ballotSubmitBtn.addEventListener('click', function () {
+      if (!allBallotVoted()) return;
+      ballotSubmitted = true;
+      localStorage.setItem('explore-ballot-submitted', '1');
+      updateBallotUI();
+
+      // POST stance to server
+      fetch(API_BASE + '/api/ballot-stance', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          q1a: ballotVotes.q1a,
+          q1b: ballotVotes.q1b,
+          q1c: ballotVotes.q1c,
+          trash: ballotVotes.trash
+        })
+      }).catch(function () {});
+
+      // Fetch and show cross-tabs for all answered topics
+      fetchAllCrosstabs();
+
+      if (typeof posthog !== 'undefined') {
+        posthog.capture('ballot_submitted', {
+          q1a: ballotVotes.q1a, q1b: ballotVotes.q1b,
+          q1c: ballotVotes.q1c, trash: ballotVotes.trash
+        });
+      }
+    });
+  }
+
+  // Classify ballot stance into a group
+  function getBallotGroup() {
+    if (ballotVotes.q1a === 'yes') return 'yes15';
+    if (ballotVotes.q1b === 'yes') return 'yes12';
+    if (ballotVotes.q1c === 'yes') return 'yes9';
+    return 'no';
+  }
+
+  function getTrashGroup() {
+    return ballotVotes.trash === 'yes' ? 'yes' : 'no';
+  }
+
+  var GROUP_LABELS = {
+    no: 'No override',
+    yes9: 'Yes $9M',
+    yes12: 'Yes $12M',
+    yes15: 'Yes $15M'
+  };
+
+  function fetchAllCrosstabs() {
+    topicOrder.forEach(function (topic) {
+      fetchCrosstab(topic);
+    });
+  }
+
+  function fetchCrosstab(topic) {
+    fetch(API_BASE + '/api/ballot-crosstabs?topic=' + encodeURIComponent(topic))
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        if (data) renderCrosstab(topic, data);
+      })
+      .catch(function () {});
+  }
+
+  function renderCrosstab(topic, data) {
+    var screen = document.querySelector('.question-screen[data-topic="' + topic + '"]');
+    if (!screen) return;
+
+    // Determine which group to show based on the topic
+    var isTrashed = (topic === 'trash');
+    var group, groupLabel, picks;
+
+    if (isTrashed) {
+      var tg = getTrashGroup();
+      groupLabel = 'Trash ' + (tg === 'yes' ? 'Yes' : 'No') + ' voters';
+      picks = data.trash[tg];
+    } else {
+      group = getBallotGroup();
+      groupLabel = GROUP_LABELS[group] + ' voters';
+      picks = data.override[group];
+    }
+
+    if (!picks) return;
+    var total = (picks.a || 0) + (picks.b || 0) + (picks.c || 0) + (picks.u || 0);
+    if (total === 0) return;
+
+    // Find or create the crosstab bar
+    var distEl = screen.querySelector('.pick-distribution');
+    var ctBar = screen.querySelector('.crosstab-bar');
+    if (!ctBar) {
+      ctBar = document.createElement('div');
+      ctBar.className = 'crosstab-bar';
+      var insertAfter = distEl || screen.querySelector('.answers');
+      if (insertAfter) insertAfter.after(ctBar);
+      else screen.appendChild(ctBar);
+    }
+
+    function pct(n) { return total > 0 ? Math.round(n / total * 100) : 0; }
+    var pA = pct(picks.a), pB = pct(picks.b), pC = pct(picks.c);
+    var pU = 100 - pA - pB - pC; if (pU < 0) pU = 0;
+
+    // Highlight which answer is the user's pick
+    var userPick = selections[topic];
+    var matchPct = userPick && picks[userPick] ? pct(picks[userPick]) : null;
+
+    var labelText = groupLabel;
+    if (matchPct !== null) {
+      labelText += ' \u00b7 ' + matchPct + '% picked the same as you';
+    }
+
+    // Get answer labels from cards
+    var answerLabels = {};
+    screen.querySelectorAll('.answer-card').forEach(function (c) {
+      var h2 = c.querySelector('h2');
+      if (h2) answerLabels[c.dataset.answer] = h2.textContent;
+    });
+
+    ctBar.innerHTML =
+      '<div class="crosstab-bar-label">' + labelText + '</div>' +
+      '<div class="crosstab-bar-track">' +
+        '<div class="crosstab-bar-seg ct-a" style="width:' + pA + '%">' + (pA >= 12 ? pA + '%' : '') + '</div>' +
+        '<div class="crosstab-bar-seg ct-b" style="width:' + pB + '%">' + (pB >= 12 ? pB + '%' : '') + '</div>' +
+        '<div class="crosstab-bar-seg ct-c" style="width:' + pC + '%">' + (pC >= 12 ? pC + '%' : '') + '</div>' +
+        '<div class="crosstab-bar-seg ct-u" style="width:' + pU + '%">' + (pU >= 12 ? pU + '%' : '') + '</div>' +
+      '</div>' +
+      '<div class="crosstab-bar-legend">' +
+        (picks.a > 0 ? '<span><span class="ct-dot ct-dot-a"></span>' + (answerLabels.a || 'A') + ' ' + pA + '%</span>' : '') +
+        (picks.b > 0 ? '<span><span class="ct-dot ct-dot-b"></span>' + (answerLabels.b || 'B') + ' ' + pB + '%</span>' : '') +
+        (picks.c > 0 ? '<span><span class="ct-dot ct-dot-c"></span>' + (answerLabels.c || 'C') + ' ' + pC + '%</span>' : '') +
+        (picks.u > 0 ? '<span><span class="ct-dot ct-dot-u"></span>Not sure ' + pU + '%</span>' : '') +
+      '</div>';
+    ctBar.classList.add('visible');
+  }
+
+  // Hook into selectAnswer to update ballot lock state
+  var _origSelectAnswer = selectAnswer;
+  selectAnswer = function (question, answer) {
+    _origSelectAnswer(question, answer);
+    updateBallotLock();
+  };
+
+  // Hook into deselect too
+  var _origDeselectAnswer = deselectAnswer;
+  deselectAnswer = function (question) {
+    _origDeselectAnswer(question);
+    updateBallotLock();
+  };
+
+  // On load: restore ballot UI, and if already submitted fetch cross-tabs
+  updateBallotUI();
+  if (ballotSubmitted) {
+    fetchAllCrosstabs();
+  }
+
+  // Clean up ballot on stats reset
+  document.getElementById('statsReset').addEventListener('click', function () {
+    ballotVotes = {};
+    ballotSubmitted = false;
+    localStorage.removeItem('explore-ballot');
+    localStorage.removeItem('explore-ballot-submitted');
+    document.querySelectorAll('.crosstab-bar').forEach(function (el) { el.remove(); });
+    updateBallotUI();
+  });
+
   // ── Init: fetch decided counts and show stats ──
   fetchAllCounts(topicOrder);
   updateStatsStrip();

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -2245,7 +2245,7 @@
 
   var ballotWidget = document.getElementById('ballotWidget');
   var ballotNudge = document.getElementById('ballotNudge');
-  var ballotLockMsg = document.getElementById('ballotLockMsg');
+  var ballotLockMsg = document.getElementById('ballotLockText');
   var ballotSubmitBtn = document.getElementById('ballotSubmit');
   var ballotVotes = {};
   var ballotSubmitted = false;
@@ -2273,12 +2273,7 @@
     ballotWidget.classList.toggle('locked', !answered);
 
     if (ballotLockMsg) {
-      var remaining = topicOrder.filter(function (t) { return !selections[t]; }).length;
-      if (answered) {
-        ballotLockMsg.textContent = 'Unlocked';
-      } else {
-        ballotLockMsg.textContent = remaining + ' question' + (remaining === 1 ? '' : 's') + ' to go';
-      }
+      ballotLockMsg.textContent = answered ? '' : 'Answer all questions to unlock';
     }
   }
 

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -2241,10 +2241,11 @@
     suppressURLWrite = false;
   });
 
-  // ── Ballot widget: lock/unlock, cascade nudge, submit, cross-tabs ──
+  // ── Ballot widget: compact row inside stats strip ──
 
   var ballotWidget = document.getElementById('ballotWidget');
   var ballotNudge = document.getElementById('ballotNudge');
+  var ballotLockMsg = document.getElementById('ballotLockMsg');
   var ballotSubmitBtn = document.getElementById('ballotSubmit');
   var ballotVotes = {}; // { q1a: 'yes'|'no', q1b: ..., q1c: ..., trash: ... }
   var ballotSubmitted = false;
@@ -2269,13 +2270,19 @@
 
   function updateBallotLock() {
     if (!ballotWidget) return;
-    if (allQuestionsAnswered()) {
-      ballotWidget.classList.add('unlocked');
-    } else {
-      ballotWidget.classList.remove('unlocked');
-      var remaining = topicOrder.filter(function (t) { return !selections[t]; }).length;
-      var msg = document.querySelector('#ballotLock .ballot-widget-lock-msg');
-      if (msg) msg.innerHTML = '<strong>' + remaining + ' question' + (remaining === 1 ? '' : 's') + ' left</strong> to unlock your practice ballot.';
+    var answered = allQuestionsAnswered();
+    // Show once user has at least 1 pick
+    var hasPicks = topicOrder.some(function (t) { return !!selections[t]; });
+    ballotWidget.classList.toggle('visible', hasPicks);
+    ballotWidget.classList.toggle('locked', !answered);
+
+    if (ballotLockMsg) {
+      if (answered) {
+        ballotLockMsg.textContent = '';
+      } else {
+        var remaining = topicOrder.filter(function (t) { return !selections[t]; }).length;
+        ballotLockMsg.textContent = remaining + ' to go';
+      }
     }
   }
 
@@ -2288,11 +2295,10 @@
     updateBallotLock();
 
     // Restore button states from ballotVotes
-    document.querySelectorAll('.ballot-widget-row').forEach(function (row) {
-      var key = row.dataset.ballot;
+    document.querySelectorAll('.ballot-widget-item').forEach(function (item) {
+      var key = item.dataset.ballot;
       var vote = ballotVotes[key];
-      row.classList.toggle('has-vote', !!vote);
-      row.querySelectorAll('.ballot-widget-btn').forEach(function (btn) {
+      item.querySelectorAll('.ballot-widget-btn').forEach(function (btn) {
         btn.classList.toggle('voted', btn.dataset.vote === vote);
       });
     });
@@ -2306,7 +2312,6 @@
   }
 
   function checkCascadeNudge() {
-    // Find gaps: voted Yes on a higher tier but No on a lower one
     var yes1a = ballotVotes.q1a === 'yes';
     var yes1b = ballotVotes.q1b === 'yes';
     var no1b = ballotVotes.q1b === 'no';
@@ -2314,9 +2319,9 @@
 
     var nudgeMsg = '';
     if (yes1a && (no1b || no1c)) {
-      nudgeMsg = 'You voted Yes on $15M but No on a lower tier. The highest passing tier wins. If $15M falls short, voting Yes on $12M and $9M keeps them as a fallback.';
+      nudgeMsg = 'Tip: Yes on $15M but No below? If $15M fails, lower tiers are your fallback.';
     } else if (yes1b && no1c) {
-      nudgeMsg = 'You voted Yes on $12M but No on $9M. If $12M doesn\'t pass, voting Yes on $9M keeps it as a fallback.';
+      nudgeMsg = 'Tip: Yes on $12M but No on $9M? $9M is your fallback if $12M fails.';
     }
 
     if (nudgeMsg) {
@@ -2333,14 +2338,13 @@
       if (ballotSubmitted) return;
       var btn = e.target.closest('.ballot-widget-btn');
       if (!btn) return;
-      var row = btn.closest('.ballot-widget-row');
-      if (!row) return;
-      if (!ballotWidget.classList.contains('unlocked')) return;
+      var item = btn.closest('.ballot-widget-item');
+      if (!item) return;
+      if (ballotWidget.classList.contains('locked')) return;
 
-      var key = row.dataset.ballot;
+      var key = item.dataset.ballot;
       var vote = btn.dataset.vote;
 
-      // Toggle: clicking the same vote again clears it
       if (ballotVotes[key] === vote) {
         delete ballotVotes[key];
       } else {
@@ -2363,19 +2367,15 @@
       localStorage.setItem('explore-ballot-submitted', '1');
       updateBallotUI();
 
-      // POST stance to server
       fetch(API_BASE + '/api/ballot-stance', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          q1a: ballotVotes.q1a,
-          q1b: ballotVotes.q1b,
-          q1c: ballotVotes.q1c,
-          trash: ballotVotes.trash
+          q1a: ballotVotes.q1a, q1b: ballotVotes.q1b,
+          q1c: ballotVotes.q1c, trash: ballotVotes.trash
         })
       }).catch(function () {});
 
-      // Fetch and show cross-tabs for all answered topics
       fetchAllCrosstabs();
 
       if (typeof posthog !== 'undefined') {

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -2273,7 +2273,8 @@
     ballotWidget.classList.toggle('locked', !answered);
 
     if (ballotLockMsg) {
-      ballotLockMsg.textContent = answered ? '' : 'Answer all questions to unlock';
+      var linkEl = document.getElementById('ballotLockLink');
+      if (linkEl) linkEl.textContent = answered ? '' : 'Answer all questions to unlock';
     }
   }
 
@@ -2319,6 +2320,18 @@
       ballotNudge.classList.remove('visible');
     }
   }
+
+  // Jump to the first unanswered question (or first question if none answered)
+  function goToNextUnanswered(e) {
+    e.preventDefault();
+    var next = topicOrder.find(function (t) { return !selections[t]; }) || topicOrder[0];
+    switchTopic(next);
+    window.scrollTo(0, 0);
+  }
+  var ballotLockLink = document.getElementById('ballotLockLink');
+  var ballotCta = document.getElementById('ballotCta');
+  if (ballotLockLink) ballotLockLink.addEventListener('click', goToNextUnanswered);
+  if (ballotCta) ballotCta.addEventListener('click', goToNextUnanswered);
 
   if (ballotWidget) {
     ballotWidget.addEventListener('click', function (e) {

--- a/community-pulse/worker/schema/0006_ballot_stances.sql
+++ b/community-pulse/worker/schema/0006_ballot_stances.sql
@@ -1,0 +1,11 @@
+-- Track each user's ballot stance (yes/no on each ballot question).
+-- Used for cross-tab comparisons: "of others who voted like you..."
+
+CREATE TABLE IF NOT EXISTS ballot_stances (
+  ip_hash    TEXT PRIMARY KEY,
+  q1a        TEXT NOT NULL CHECK (q1a IN ('yes', 'no')),
+  q1b        TEXT NOT NULL CHECK (q1b IN ('yes', 'no')),
+  q1c        TEXT NOT NULL CHECK (q1c IN ('yes', 'no')),
+  trash      TEXT NOT NULL CHECK (trash IN ('yes', 'no')),
+  updated_at INTEGER NOT NULL DEFAULT 0
+);

--- a/community-pulse/worker/src/index.js
+++ b/community-pulse/worker/src/index.js
@@ -43,6 +43,14 @@ export async function handleRequest(request, env) {
     if (request.method === 'POST') return handleVotePost(request, env);
   }
 
+  if (url.pathname === '/api/ballot-stance') {
+    if (request.method === 'POST') return handleBallotStance(request, env);
+  }
+
+  if (url.pathname === '/api/ballot-crosstabs') {
+    if (request.method === 'GET') return handleBallotCrosstabs(request, env);
+  }
+
   // Neighbor verification network endpoints.
   if (url.pathname.startsWith('/api/verify/')) {
     const verifyResponse = await handleVerify(request, env, url);
@@ -341,6 +349,97 @@ async function handleVotePost(request, env) {
   const picks = await getPickCounts(env, topic);
   const moves = await getMoveCount(env, topic);
   return new Response(JSON.stringify({ picks, moves, your_vote: answer }), { status: 200, headers: corsHeaders(env) });
+}
+
+const VALID_BALLOT = ['yes', 'no'];
+
+/**
+ * POST /api/ballot-stance -- store user's 4 ballot votes.
+ * Body: { q1a: "yes", q1b: "yes", q1c: "yes", trash: "no" }
+ */
+async function handleBallotStance(request, env) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'invalid body' }), { status: 400, headers: corsHeaders(env) });
+  }
+
+  const { q1a, q1b, q1c, trash } = body || {};
+  if (!VALID_BALLOT.includes(q1a) || !VALID_BALLOT.includes(q1b) ||
+      !VALID_BALLOT.includes(q1c) || !VALID_BALLOT.includes(trash)) {
+    return new Response(JSON.stringify({ error: 'each field must be "yes" or "no"' }), { status: 400, headers: corsHeaders(env) });
+  }
+
+  const clientIp = request.headers.get('CF-Connecting-IP') || request.headers.get('X-Forwarded-For') || 'unknown';
+  const ipHash = await hashIp(clientIp);
+  const now = Date.now();
+
+  await env.DB.prepare(
+    `INSERT INTO ballot_stances (ip_hash, q1a, q1b, q1c, trash, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(ip_hash) DO UPDATE SET q1a=?, q1b=?, q1c=?, trash=?, updated_at=?`
+  ).bind(ipHash, q1a, q1b, q1c, trash, now, q1a, q1b, q1c, trash, now).run();
+
+  return new Response(JSON.stringify({ ok: true, stance: { q1a, q1b, q1c, trash } }), {
+    status: 200, headers: corsHeaders(env)
+  });
+}
+
+/**
+ * Classify a ballot stance row into its override group.
+ * Highest tier voted Yes on determines the group.
+ */
+function classifyStance(row) {
+  if (row.q1a === 'yes') return 'yes15';
+  if (row.q1b === 'yes') return 'yes12';
+  if (row.q1c === 'yes') return 'yes9';
+  return 'no';
+}
+
+/**
+ * GET /api/ballot-crosstabs?topic=override
+ * Returns pick distributions for each stance group + trash group.
+ */
+async function handleBallotCrosstabs(request, env) {
+  const url = new URL(request.url);
+  const topic = url.searchParams.get('topic');
+  if (!topic) {
+    return new Response(JSON.stringify({ error: 'missing topic' }), { status: 400, headers: corsHeaders(env) });
+  }
+
+  // Join ballot_stances with votes to get each voter's stance + pick for this topic.
+  const { results } = await env.DB.prepare(
+    `SELECT b.q1a, b.q1b, b.q1c, b.trash, v.answer
+     FROM ballot_stances b
+     INNER JOIN votes v ON b.ip_hash = v.ip_hash
+     WHERE v.topic = ?`
+  ).bind(topic).all();
+
+  // Build distributions per override group and per trash stance.
+  const groups = { no: {}, yes9: {}, yes12: {}, yes15: {} };
+  const trashGroups = { yes: {}, no: {} };
+  VALID_ANSWERS.forEach(function (a) {
+    groups.no[a] = 0; groups.yes9[a] = 0; groups.yes12[a] = 0; groups.yes15[a] = 0;
+    trashGroups.yes[a] = 0; trashGroups.no[a] = 0;
+  });
+
+  for (const row of results) {
+    const g = classifyStance(row);
+    if (groups[g] && VALID_ANSWERS.includes(row.answer)) {
+      groups[g][row.answer]++;
+    }
+    const tg = row.trash === 'yes' ? 'yes' : 'no';
+    if (VALID_ANSWERS.includes(row.answer)) {
+      trashGroups[tg][row.answer]++;
+    }
+  }
+
+  return new Response(JSON.stringify({
+    override: groups,
+    trash: trashGroups,
+    total_voters: results.length
+  }), { status: 200, headers: corsHeaders(env) });
 }
 
 /** Proxy the production homepage, rewriting API_BASE to point at this worker. */


### PR DESCRIPTION
## Summary

- **Locked ballot widget** on the explorer landing page: 4 yes/no votes (1A $15M, 1B $12M, 1C $9M, Trash) that unlock after answering all explorer questions
- **Cascade nudge**: warns when voting Yes on a higher tier but No on a lower one, explaining the fallback risk
- **Cross-tab comparisons**: after submitting the ballot, each question shows how others in the same ballot-stance group (No / Yes-$9M / Yes-$12M / Yes-$15M) answered
- **Backend**: `POST /api/ballot-stance`, `GET /api/ballot-crosstabs`, new D1 migration `0006_ballot_stances.sql`

## Test plan

- [ ] Verify ballot widget appears locked on landing page
- [ ] Answer all questions (including "not sure"), confirm widget unlocks
- [ ] Mark Yes on 1A, No on 1B/1C -- confirm cascade nudge appears
- [ ] Mark all 4 ballot votes, confirm submit button appears
- [ ] Submit ballot, confirm cross-tab bars appear on each question
- [ ] Reload page, confirm ballot state persists
- [ ] Click "Delete my data", confirm ballot resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)