### PR TITLE
Feature tools prominently and add Next button in stats strip

### DIFF
--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -29,22 +29,6 @@
       <p class="votes-strip-note">Either vote can end the override. <a class="votes-strip-link" href="what-you-can-do.html#your-two-votes">How the two votes work together &rarr;</a></p>
     </div>
 
-    <div class="explore-tools">
-      <p class="explore-tools-label">Run the numbers yourself</p>
-      <div class="explore-tools-row">
-        <a class="explore-tool-card" href="charts/deficit_model.html">
-          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
-          <span class="explore-tool-title">Deficit Model</span>
-          <span class="explore-tool-desc">Revenue crossed expenses in FY18. Drag the sliders to see when each override tier runs out.</span>
-        </a>
-        <a class="explore-tool-card" href="charts/town_explorer.html">
-          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-          <span class="explore-tool-title">Town Explorer</span>
-          <span class="explore-tool-desc">Where does Marblehead rank among all 351 MA towns? Filter by population, income, tax rate, and more.</span>
-        </a>
-      </div>
-    </div>
-
     <!-- Stats strip: progress + engagement + reset -->
     <div class="explore-stats" id="exploreStats" style="display:none">
       <div class="explore-stats-progress-row">
@@ -68,6 +52,22 @@
           </span>
           <button type="button" class="explore-stats-reset" id="statsReset">Delete my data</button>
         </div>
+      </div>
+    </div>
+
+    <div class="explore-tools">
+      <p class="explore-tools-label">Run the numbers yourself</p>
+      <div class="explore-tools-row">
+        <a class="explore-tool-card" href="charts/deficit_model.html">
+          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+          <span class="explore-tool-title">Deficit Model</span>
+          <span class="explore-tool-desc">Revenue crossed expenses in FY18. Drag the sliders to see when each override tier runs out.</span>
+        </a>
+        <a class="explore-tool-card" href="charts/town_explorer.html">
+          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <span class="explore-tool-title">Town Explorer</span>
+          <span class="explore-tool-desc">Where does Marblehead rank among all 351 MA towns? Filter by population, income, tax rate, and more.</span>
+        </a>
       </div>
     </div>
 

--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -34,17 +34,13 @@
       <div class="explore-tools-row">
         <a class="explore-tool-card" href="charts/deficit_model.html">
           <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
-          <span class="explore-tool-text">
-            <span class="explore-tool-title">Deficit Model</span>
-            <span class="explore-tool-desc">Revenue crossed expenses in FY18. See when each tier runs out.</span>
-          </span>
+          <span class="explore-tool-title">Deficit Model</span>
+          <span class="explore-tool-desc">Revenue crossed expenses in FY18. Drag the sliders to see when each override tier runs out.</span>
         </a>
         <a class="explore-tool-card" href="charts/town_explorer.html">
           <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-          <span class="explore-tool-text">
-            <span class="explore-tool-title">Town Explorer</span>
-            <span class="explore-tool-desc">Where does Marblehead rank among all 351 MA towns?</span>
-          </span>
+          <span class="explore-tool-title">Town Explorer</span>
+          <span class="explore-tool-desc">Where does Marblehead rank among all 351 MA towns? Filter by population, income, tax rate, and more.</span>
         </a>
       </div>
     </div>

--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -34,13 +34,17 @@
       <div class="explore-tools-row">
         <a class="explore-tool-card" href="charts/deficit_model.html">
           <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
-          <span class="explore-tool-title">Deficit Model</span>
-          <span class="explore-tool-desc">Revenue crossed expenses in FY18. Drag the sliders to see when each override tier runs out.</span>
+          <span class="explore-tool-text">
+            <span class="explore-tool-title">Deficit Model</span>
+            <span class="explore-tool-desc">Revenue crossed expenses in FY18. See when each tier runs out.</span>
+          </span>
         </a>
         <a class="explore-tool-card" href="charts/town_explorer.html">
           <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-          <span class="explore-tool-title">Town Explorer</span>
-          <span class="explore-tool-desc">Where does Marblehead rank among all 351 MA towns? Filter by population, income, tax rate, and more.</span>
+          <span class="explore-tool-text">
+            <span class="explore-tool-title">Town Explorer</span>
+            <span class="explore-tool-desc">Where does Marblehead rank among all 351 MA towns?</span>
+          </span>
         </a>
       </div>
     </div>

--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -71,7 +71,7 @@
       </div>
     </div>
 
-    <p class="explore-tools-label">Or explore the questions</p>
+    <p class="explore-section-label">Or explore the questions</p>
 
     <div class="explore-shared-banner" id="sharedBanner">
       Tap any question to see the evidence behind their pick.

--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -71,6 +71,8 @@
       </div>
     </div>
 
+    <p class="explore-tools-label">Or explore the questions</p>
+
     <div class="explore-shared-banner" id="sharedBanner">
       Tap any question to see the evidence behind their pick.
       <br><button type="button" class="explore-shared-fresh" id="sharedFresh">Start fresh with your own answers</button>

--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -29,6 +29,22 @@
       <p class="votes-strip-note">Either vote can end the override. <a class="votes-strip-link" href="what-you-can-do.html#your-two-votes">How the two votes work together &rarr;</a></p>
     </div>
 
+    <div class="explore-tools">
+      <p class="explore-tools-label">Run the numbers yourself</p>
+      <div class="explore-tools-row">
+        <a class="explore-tool-card" href="charts/deficit_model.html">
+          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+          <span class="explore-tool-title">Deficit Model</span>
+          <span class="explore-tool-desc">Revenue crossed expenses in FY18. Drag the sliders to see when each override tier runs out.</span>
+        </a>
+        <a class="explore-tool-card" href="charts/town_explorer.html">
+          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <span class="explore-tool-title">Town Explorer</span>
+          <span class="explore-tool-desc">Where does Marblehead rank among all 351 MA towns? Filter by population, income, tax rate, and more.</span>
+        </a>
+      </div>
+    </div>
+
     <!-- Stats strip: progress + engagement + reset -->
     <div class="explore-stats" id="exploreStats" style="display:none">
       <div class="explore-stats-progress-row">
@@ -64,22 +80,6 @@
     </div>
 
     {% include explore-synthesis.html %}
-
-    <div class="explore-tools">
-      <p class="explore-tools-label">Run the numbers yourself</p>
-      <div class="explore-tools-row">
-        <a class="explore-tool-card" href="charts/deficit_model.html">
-          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
-          <span class="explore-tool-title">Deficit Model</span>
-          <span class="explore-tool-desc">Set growth rates, toggle tiers, see when the gap reopens</span>
-        </a>
-        <a class="explore-tool-card" href="charts/town_explorer.html">
-          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-          <span class="explore-tool-title">Town Explorer</span>
-          <span class="explore-tool-desc">Filter, sort, and compare all 351 MA communities</span>
-        </a>
-      </div>
-    </div>
 
     <div class="explore-share-strip" id="shareStrip">
       <button type="button" class="explore-copy-link" data-copy-positions>

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -271,18 +271,21 @@
     text-transform: uppercase;
     letter-spacing: 1px;
     color: var(--text-subtle);
-    margin: 0 0 8px;
+    margin: 0 0 10px;
+    text-align: center;
   }
   .explore-tools-row {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     gap: 8px;
   }
   .explore-tool-card {
     display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: 8px;
-    padding: 8px 14px;
+    text-align: center;
+    gap: 6px;
+    padding: 16px 14px;
     background: var(--surface);
     border: 1.5px solid var(--border);
     border-radius: var(--radius-md);
@@ -290,36 +293,29 @@
     transition: all 0.15s ease;
     text-decoration: none;
     color: var(--text);
-    flex: 1 1 auto;
-    min-width: 0;
   }
   .explore-tool-card:hover {
     border-color: var(--c-teal);
     box-shadow: var(--shadow-sm);
   }
   .explore-tool-icon {
-    width: 18px;
-    height: 18px;
+    width: 22px;
+    height: 22px;
     color: var(--c-teal);
     flex-shrink: 0;
   }
-  .explore-tool-text {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-  }
   .explore-tool-title {
-    font-size: 13px;
+    font-size: 14px;
     font-weight: 700;
     color: var(--text);
   }
   .explore-tool-desc {
-    font-size: 11px;
+    font-size: 12px;
     color: var(--text-muted);
-    line-height: 1.3;
+    line-height: 1.4;
   }
   @media (max-width: 400px) {
-    .explore-tools-row { flex-direction: column; }
+    .explore-tools-row { grid-template-columns: 1fr; }
   }
 
   /* Share strip on landing */

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -1530,6 +1530,24 @@
   .explore-stats-msg--complete {
     color: var(--c-teal);
   }
+  .explore-stats-next {
+    font: inherit;
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--c-teal);
+    background: none;
+    border: 1px solid var(--c-teal);
+    border-radius: 12px;
+    padding: 2px 10px;
+    cursor: pointer;
+    white-space: nowrap;
+    margin-left: 4px;
+    vertical-align: middle;
+  }
+  .explore-stats-next:hover {
+    background: var(--c-teal);
+    color: #fff;
+  }
   /* Row 2: engagement + reset */
   .explore-stats-detail {
     display: flex;

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -1547,7 +1547,6 @@
   .explore-stats-next:hover {
     background: var(--c-teal);
     color: #fff;
-    border-color: var(--c-teal);
   }
   /* Row 2: engagement + reset */
   .explore-stats-detail {

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -2043,3 +2043,4 @@
     .wyl-topic-label { font-size: 14.5px; }
     .wyl-topic-detail { font-size: 13.5px; }
   }
+/* triggered */

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -1547,6 +1547,7 @@
   .explore-stats-next:hover {
     background: var(--c-teal);
     color: #fff;
+    border-color: var(--c-teal);
   }
   /* Row 2: engagement + reset */
   .explore-stats-detail {

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -317,6 +317,17 @@
   @media (max-width: 400px) {
     .explore-tools-row { grid-template-columns: 1fr; }
   }
+  .explore-section-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-subtle);
+    text-align: center;
+    margin: 20px 0 10px;
+    padding-top: 16px;
+    border-top: 1px solid var(--divider);
+  }
 
   /* Share strip on landing */
   .explore-share-strip {

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -271,21 +271,18 @@
     text-transform: uppercase;
     letter-spacing: 1px;
     color: var(--text-subtle);
-    margin: 0 0 10px;
-    text-align: center;
+    margin: 0 0 8px;
   }
   .explore-tools-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+    display: flex;
+    flex-wrap: wrap;
     gap: 8px;
   }
   .explore-tool-card {
     display: flex;
-    flex-direction: column;
     align-items: center;
-    text-align: center;
-    gap: 6px;
-    padding: 16px 14px;
+    gap: 8px;
+    padding: 8px 14px;
     background: var(--surface);
     border: 1.5px solid var(--border);
     border-radius: var(--radius-md);
@@ -293,29 +290,36 @@
     transition: all 0.15s ease;
     text-decoration: none;
     color: var(--text);
+    flex: 1 1 auto;
+    min-width: 0;
   }
   .explore-tool-card:hover {
     border-color: var(--c-teal);
     box-shadow: var(--shadow-sm);
   }
   .explore-tool-icon {
-    width: 22px;
-    height: 22px;
+    width: 18px;
+    height: 18px;
     color: var(--c-teal);
     flex-shrink: 0;
   }
+  .explore-tool-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
   .explore-tool-title {
-    font-size: 14px;
+    font-size: 13px;
     font-weight: 700;
     color: var(--text);
   }
   .explore-tool-desc {
-    font-size: 12px;
+    font-size: 11px;
     color: var(--text-muted);
-    line-height: 1.4;
+    line-height: 1.3;
   }
   @media (max-width: 400px) {
-    .explore-tools-row { grid-template-columns: 1fr; }
+    .explore-tools-row { flex-direction: column; }
   }
 
   /* Share strip on landing */

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -261,7 +261,7 @@
 
   /* ── Tools row on landing ── */
   .explore-tools {
-    margin-top: 20px;
+    margin: 20px 0;
     padding-top: 16px;
     border-top: 1px solid var(--divider);
   }

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -545,6 +545,7 @@
       nextBtn.type = 'button';
       nextBtn.className = 'explore-stats-next';
       nextBtn.textContent = 'Next \u2192';
+      nextBtn.title = 'Jump to next unanswered question';
       nextBtn.addEventListener('click', function () {
         var next = topicOrder.filter(function (t) { return !selections[t]; })[0];
         if (next) switchTopic(next);

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -531,14 +531,26 @@
     var pct = totalCount > 0 ? Math.round((decidedCount / totalCount) * 100) : 0;
     document.getElementById('statBar').style.width = pct + '%';
 
-    // Progress message
+    // Progress message + next button
     var msgEl = document.getElementById('statMsg');
     if (decidedCount === 0) {
       msgEl.textContent = 'Pick your first answer';
       msgEl.className = 'explore-stats-msg';
     } else if (decidedCount < totalCount) {
-      msgEl.textContent = (totalCount - decidedCount) + ' to go';
+      msgEl.textContent = '';
       msgEl.className = 'explore-stats-msg';
+      var remaining = totalCount - decidedCount;
+      var label = document.createTextNode(remaining + ' to go ');
+      var nextBtn = document.createElement('button');
+      nextBtn.type = 'button';
+      nextBtn.className = 'explore-stats-next';
+      nextBtn.textContent = 'Next \u2192';
+      nextBtn.addEventListener('click', function () {
+        var next = topicOrder.filter(function (t) { return !selections[t]; })[0];
+        if (next) switchTopic(next);
+      });
+      msgEl.appendChild(label);
+      msgEl.appendChild(nextBtn);
     } else {
       msgEl.textContent = '';
       msgEl.className = 'explore-stats-msg explore-stats-msg--complete';

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -544,6 +544,15 @@
       msgEl.className = 'explore-stats-msg explore-stats-msg--complete';
     }
 
+    // Hide the detail row (views/shares) when everything is zero -- avoids a
+    // wall of zeros for first-time visitors.
+    var detailEl = statsEl.querySelector('.explore-stats-detail');
+    if (detailEl) {
+      var yourViews = getYourViews(), yourShares = getYourShares();
+      var hasActivity = yourViews > 0 || yourShares > 0 || allViews > 0 || allShares > 0;
+      detailEl.style.display = hasActivity ? '' : 'none';
+    }
+
     statsEl.style.display = '';
   }
 

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -544,15 +544,6 @@
       msgEl.className = 'explore-stats-msg explore-stats-msg--complete';
     }
 
-    // Hide the detail row (views/shares) when everything is zero -- avoids a
-    // wall of zeros for first-time visitors.
-    var detailEl = statsEl.querySelector('.explore-stats-detail');
-    if (detailEl) {
-      var yourViews = getYourViews(), yourShares = getYourShares();
-      var hasActivity = yourViews > 0 || yourShares > 0 || allViews > 0 || allShares > 0;
-      detailEl.style.display = hasActivity ? '' : 'none';
-    }
-
     statsEl.style.display = '';
   }
 


### PR DESCRIPTION
## Summary
- Moves Deficit Model and Town Explorer cards from below the question list to right after the stats strip
- Updates card descriptions to lead with findings instead of UI descriptions
- Adds "Or explore the questions" divider label between tools and question list
- Adds "Next →" button in the stats strip when 1+ questions are answered but not all, jumping to the first undecided question

## Test plan
- [ ] Load homepage, verify tool cards appear after stats strip
- [ ] Click both tool cards, confirm links work
- [ ] Answer one question, verify "Next →" appears in stats strip
- [ ] Click Next, confirm it jumps to an unanswered question
- [ ] Check mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)