### PR TITLE
Promote tools on homepage, add Next button in stats strip

### DIFF
--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -55,6 +55,24 @@
       </div>
     </div>
 
+    <div class="explore-tools">
+      <p class="explore-tools-label">Run the numbers yourself</p>
+      <div class="explore-tools-row">
+        <a class="explore-tool-card" href="charts/deficit_model.html">
+          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+          <span class="explore-tool-title">Deficit Model</span>
+          <span class="explore-tool-desc">Revenue crossed expenses in FY18. Drag the sliders to see when each override tier runs out.</span>
+        </a>
+        <a class="explore-tool-card" href="charts/town_explorer.html">
+          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <span class="explore-tool-title">Town Explorer</span>
+          <span class="explore-tool-desc">Where does Marblehead rank among all 351 MA towns? Filter by population, income, tax rate, and more.</span>
+        </a>
+      </div>
+    </div>
+
+    <p class="explore-section-label">Or explore the questions</p>
+
     <div class="explore-shared-banner" id="sharedBanner">
       Tap any question to see the evidence behind their pick.
       <br><button type="button" class="explore-shared-fresh" id="sharedFresh">Start fresh with your own answers</button>
@@ -64,22 +82,6 @@
     </div>
 
     {% include explore-synthesis.html %}
-
-    <div class="explore-tools">
-      <p class="explore-tools-label">Run the numbers yourself</p>
-      <div class="explore-tools-row">
-        <a class="explore-tool-card" href="charts/deficit_model.html">
-          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
-          <span class="explore-tool-title">Deficit Model</span>
-          <span class="explore-tool-desc">Set growth rates, toggle tiers, see when the gap reopens</span>
-        </a>
-        <a class="explore-tool-card" href="charts/town_explorer.html">
-          <svg class="explore-tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-          <span class="explore-tool-title">Town Explorer</span>
-          <span class="explore-tool-desc">Filter, sort, and compare all 351 MA communities</span>
-        </a>
-      </div>
-    </div>
 
     <div class="explore-meetings" id="exploreMeetings">
       <p class="explore-meetings-label">Recent board meetings</p>

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -261,7 +261,7 @@
 
   /* ── Tools row on landing ── */
   .explore-tools {
-    margin-top: 20px;
+    margin: 20px 0;
     padding-top: 16px;
     border-top: 1px solid var(--divider);
   }
@@ -316,6 +316,17 @@
   }
   @media (max-width: 400px) {
     .explore-tools-row { grid-template-columns: 1fr; }
+  }
+  .explore-section-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-subtle);
+    text-align: center;
+    margin: 0 0 10px;
+    padding-top: 16px;
+    border-top: 1px solid var(--divider);
   }
 
   /* ── Recent meetings ── */
@@ -1618,6 +1629,24 @@
   }
   .explore-stats-msg--complete {
     color: var(--c-teal);
+  }
+  .explore-stats-next {
+    font: inherit;
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--c-teal);
+    background: none;
+    border: 1px solid var(--c-teal);
+    border-radius: 12px;
+    padding: 2px 10px;
+    cursor: pointer;
+    white-space: nowrap;
+    margin-left: 4px;
+    vertical-align: middle;
+  }
+  .explore-stats-next:hover {
+    background: var(--c-teal);
+    color: #fff;
   }
   /* Row 2: engagement + reset */
   .explore-stats-detail {

--- a/assets/explore.js
+++ b/assets/explore.js
@@ -531,14 +531,27 @@
     var pct = totalCount > 0 ? Math.round((decidedCount / totalCount) * 100) : 0;
     document.getElementById('statBar').style.width = pct + '%';
 
-    // Progress message
+    // Progress message + next button
     var msgEl = document.getElementById('statMsg');
     if (decidedCount === 0) {
       msgEl.textContent = 'Pick your first answer';
       msgEl.className = 'explore-stats-msg';
     } else if (decidedCount < totalCount) {
-      msgEl.textContent = (totalCount - decidedCount) + ' to go';
+      msgEl.textContent = '';
       msgEl.className = 'explore-stats-msg';
+      var remaining = totalCount - decidedCount;
+      var label = document.createTextNode(remaining + ' to go ');
+      var nextBtn = document.createElement('button');
+      nextBtn.type = 'button';
+      nextBtn.className = 'explore-stats-next';
+      nextBtn.textContent = 'Next \u2192';
+      nextBtn.title = 'Jump to next unanswered question';
+      nextBtn.addEventListener('click', function () {
+        var next = topicOrder.filter(function (t) { return !selections[t]; })[0];
+        if (next) switchTopic(next);
+      });
+      msgEl.appendChild(label);
+      msgEl.appendChild(nextBtn);
     } else {
       msgEl.textContent = '';
       msgEl.className = 'explore-stats-msg explore-stats-msg--complete';


### PR DESCRIPTION
## Summary
- Moves Deficit Model and Town Explorer cards from below the question list to right after the stats strip
- Updates card descriptions to lead with findings instead of UI descriptions
- Adds "Or explore the questions" divider label between tools and question list
- Adds "Next →" button in the stats strip when 1+ questions are answered but not all, jumping to the first undecided question

## Test plan
- [ ] Load homepage, verify tool cards appear after stats strip
- [ ] Click both tool cards, confirm links work
- [ ] Answer one question, verify "Next →" appears in stats strip
- [ ] Click Next, confirm it jumps to an unanswered question
- [ ] Check mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)