### PR TITLE
Show per-question and per-election median on statewide overrides chart

### DIFF
--- a/charts/override_landscape.html
+++ b/charts/override_landscape.html
@@ -72,12 +72,12 @@ scripts: [citations]
 <ul class="tldr">
   <li><strong>Operating overrides only.</strong> Debt exclusions (capital projects, school buildings) not included</li>
   <li><strong>65 override elections of $2M+ since FY2020.</strong> 28 passed, 34 failed, 3 split</li>
-  <li><strong>At the $5M-10M range</strong> where Marblehead's ask sits, 8 of 15 passed (53%)</li>
+  <li><strong>Marblehead's three nested tiers</strong> are $9M, $12M, and $15M. Tier 1 falls in the $5M-10M range (53% pass rate); Tiers 2 and 3 fall in $10M+ (58%)</li>
   <li><strong>Marblehead's prior attempts</strong> ($2.5M in FY2024, $3.1M in FY2023) both failed at smaller amounts</li>
 </ul>
 
 <h2>Pass rate by override size (FY2020+)</h2>
-<p style="font-size: 13px; color: var(--text-muted); margin-bottom: 4px;">Per-election amounts (all ballot questions from one town in one year combined). The <span style="color: var(--c-buoy); font-weight: 600;">$5M-10M</span> bucket is where Marblehead's proposed $8.47M falls.</p>
+<p style="font-size: 13px; color: var(--text-muted); margin-bottom: 4px;">Per-election amounts (all ballot questions from one town in one year combined). Marblehead Tier 1 ($9M) falls in the <span style="color: var(--c-buoy); font-weight: 600;">$5M-10M</span> bucket; Tiers 2 and 3 ($12M, $15M) fall in <span style="color: var(--c-buoy); font-weight: 600;">$10M+</span>.</p>
 
 <svg class="ol-svg chart" id="ol-rates" viewBox="0 0 880 260" role="img" aria-label="Bar chart showing override pass rates by dollar amount bucket since FY2020">
   <g id="ol-rate-grid"></g>
@@ -87,22 +87,30 @@ scripts: [citations]
 
 <hr class="ol-divider">
 
-<h2>Closest comparables to Marblehead's $8.47M</h2>
-<p style="font-size: 13px; color: var(--text-muted); margin-bottom: 12px;">Every override between $6M and $11M since FY2020, sorted by amount. Marblehead's proposed FY2027 ask shown for reference.</p>
+<h2>Closest comparables to Marblehead's three tiers</h2>
+<p style="font-size: 13px; color: var(--text-muted); margin-bottom: 12px;">Every override between $6M and $16M since FY2020, sorted by amount descending. Marblehead's three nested ballot tiers shown for reference.</p>
 
 <table class="ol-comps">
   <thead>
     <tr><th>Town</th><th>FY</th><th>Amount</th><th>Result</th></tr>
   </thead>
   <tbody>
+    <tr class="mh-row"><td>Marblehead Tier 3</td><td>2027</td><td class="amt">$15.0M</td><td><span class="outcome-proposed">Proposed</span></td></tr>
+    <tr><td>Arlington</td><td>2027</td><td class="amt">$14.8M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Stoneham</td><td>2026</td><td class="amt">$14.6M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Melrose</td><td>2026</td><td class="amt">$13.5M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Malden</td><td>2027</td><td class="amt">$13.6M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr class="mh-row"><td>Marblehead Tier 2</td><td>2027</td><td class="amt">$12.0M</td><td><span class="outcome-proposed">Proposed</span></td></tr>
+    <tr><td>Brookline</td><td>2024</td><td class="amt">$12.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Nantucket</td><td>2024</td><td class="amt">$10.3M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Winchester</td><td>2020</td><td class="amt">$10.0M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>North Reading</td><td>2025</td><td class="amt">$10.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Dudley</td><td>2024</td><td class="amt">$9.9M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Shrewsbury</td><td>2022</td><td class="amt">$9.5M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Newton</td><td>2023</td><td class="amt">$9.2M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr class="mh-row"><td>Marblehead Tier 1</td><td>2027</td><td class="amt">$9.0M</td><td><span class="outcome-proposed">Proposed</span></td></tr>
     <tr><td>Milton</td><td>2026</td><td class="amt">$8.8M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Belmont</td><td>2025</td><td class="amt">$8.4M</td><td><span class="outcome-win">Passed</span></td></tr>
-    <tr class="mh-row"><td>Marblehead</td><td>2027</td><td class="amt">$8.47M</td><td><span class="outcome-proposed">Proposed</span></td></tr>
     <tr><td>Bridgewater</td><td>2026</td><td class="amt">$8.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Braintree</td><td>2025</td><td class="amt">$8.0M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Hingham</td><td>2024</td><td class="amt">$7.9M</td><td><span class="outcome-win">Passed</span></td></tr>
@@ -124,8 +132,8 @@ scripts: [citations]
   <summary>Notes and sources</summary>
   <p>Override vote data from the Massachusetts Department of Revenue, Division of Local Services Municipal Databank.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride"></sup></p>
   <p>Operating overrides only; debt exclusions not included. Where a town placed multiple override questions on the same ballot, all amounts are combined into a single per-election total. If a majority of questions passed, the election is coded as a win; if a majority failed, a loss.</p>
-  <p>Marblehead's proposed FY2027 override ($8.47M across three ballot tiers) has not yet been voted on.</p>
-  <p>The comparable range ($6M-$11M) includes 22 elections: 10 passed, 10 failed, plus Marblehead's pending vote and one borderline result. A coin flip at this size.</p>
+  <p>Marblehead's proposed FY2027 override uses three nested ballot tiers: Tier 1 ($9M), Tier 2 ($12M), and Tier 3 ($15M). The highest tier that gets a majority sets the override amount. None have been voted on yet.</p>
+  <p>The comparable range ($6M-$16M) includes 27 elections since FY2020. All amounts shown are the ballot question amounts, not the deficit that motivated the override.</p>
   <p>FY2027 data is partial as of April 2026.</p>
 </details>
 

--- a/charts/override_landscape.html
+++ b/charts/override_landscape.html
@@ -268,25 +268,23 @@ scripts: [citations]
     propLabel.textContent = "Marblehead proposed: $8.47M";
     labelsG.appendChild(propLabel);
 
-    // Collision detection for labels
-    var placed = [];
-    function wouldOverlap(x, y, w, h) {
-      for (var i = 0; i < placed.length; i++) {
-        var p = placed[i];
-        if (x < p.x + p.w && x + w > p.x && y < p.y + p.h && y + h > p.y) return true;
-      }
-      return false;
-    }
-
-    // Only label notable dots (near MH range, very large, or Marblehead itself)
-    function shouldLabel(v) {
-      if (v.mh) return true;
-      // Near Marblehead's proposed amount ($7M-10M)
-      if (v.a >= 7000000 && v.a <= 10000000) return true;
-      // Very large
-      if (v.a >= 12000000) return true;
-      return false;
-    }
+    // Whitelist: only label Marblehead + hand-picked comparables
+    // that won't collide. Everything else is tooltip-only.
+    var LABEL_SET = {
+      // Marblehead actuals (always labeled)
+      "Marblehead|2023": {anchor:"start", dx:10, dy:3},
+      "Marblehead|2024": {anchor:"start", dx:10, dy:3},
+      // Key comparables near $8.47M
+      "Braintree|2025": {anchor:"start", dx:8, dy:-6},
+      "Milton|2026": {anchor:"start", dx:8, dy:3},
+      "Belmont|2025": {anchor:"start", dx:8, dy:12},
+      // Bookend wins
+      "Arlington|2027": {anchor:"start", dx:8, dy:3},
+      "Brookline|2024": {anchor:"start", dx:8, dy:3},
+      "Winchester|2020": {anchor:"start", dx:8, dy:3},
+      // Bookend losses
+      "Stoneham|2026": {anchor:"end", dx:-8, dy:3},
+    };
 
     // Jitter: offset dots that share the same FY to avoid overlap
     var byFy = {};
@@ -359,43 +357,17 @@ scripts: [citations]
       dotsG.appendChild(dot);
       dotEls.push({el: dot, v: v, cx: cx, cy: cy});
 
-      // Labels for notable dots
-      if (shouldLabel(v)) {
-        var labelX = cx + r + 4;
-        var labelY = cy + 3;
-        var labelW = 80;
-        var labelH = 12;
-
-        // Try right side first, then left
-        if (wouldOverlap(labelX, labelY - labelH, labelW, labelH)) {
-          labelX = cx - r - 4;
-          var anchor = "end";
-          if (!wouldOverlap(labelX - labelW, labelY - labelH, labelW, labelH)) {
-            placed.push({x: labelX - labelW, y: labelY - labelH, w: labelW, h: labelH});
-          } else {
-            // Try above
-            labelX = cx + r + 4;
-            labelY = cy - r - 2;
-            anchor = "start";
-            placed.push({x: labelX, y: labelY - labelH, w: labelW, h: labelH});
-          }
-          var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
-          label.setAttribute("x", labelX);
-          label.setAttribute("y", labelY);
-          label.setAttribute("text-anchor", anchor || "end");
-          label.setAttribute("class", v.mh ? "ol-label-mh" : "ol-label");
-          label.textContent = v.t;
-          labelsG.appendChild(label);
-        } else {
-          placed.push({x: labelX, y: labelY - labelH, w: labelW, h: labelH});
-          var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
-          label.setAttribute("x", labelX);
-          label.setAttribute("y", labelY);
-          label.setAttribute("text-anchor", "start");
-          label.setAttribute("class", v.mh ? "ol-label-mh" : "ol-label");
-          label.textContent = v.t;
-          labelsG.appendChild(label);
-        }
+      // Label only whitelisted dots
+      var key = v.t + "|" + v.fy;
+      var lp = LABEL_SET[key];
+      if (lp) {
+        var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+        label.setAttribute("x", cx + lp.dx);
+        label.setAttribute("y", cy + lp.dy);
+        label.setAttribute("text-anchor", lp.anchor);
+        label.setAttribute("class", v.mh ? "ol-label-mh" : "ol-label");
+        label.textContent = v.t;
+        labelsG.appendChild(label);
       }
     });
 

--- a/charts/override_landscape.html
+++ b/charts/override_landscape.html
@@ -4,18 +4,17 @@ scripts: [citations]
 ---
 <style>
   .ol-dot-win { fill: var(--c-navy); }
-  .ol-dot-loss { fill: var(--text-subtle); opacity: 0.4; }
+  .ol-dot-loss { fill: none; stroke: var(--text-muted); stroke-width: 2; }
   .ol-dot-mh { fill: var(--c-buoy); }
-  .ol-dot-mh-proposed { fill: none; stroke: var(--c-buoy); stroke-width: 2; stroke-dasharray: 3 2; }
+  .ol-dot-proposed { fill: none; stroke: var(--c-buoy); stroke-width: 2; stroke-dasharray: 3 2; }
   .ol-label { font-size: 9px; fill: var(--text-muted); font-family: inherit; }
-  .ol-label-win { font-size: 9px; fill: var(--c-navy); font-family: inherit; }
-  .ol-label-loss { font-size: 9px; fill: var(--text-muted); font-family: inherit; }
-  .ol-label-mh { font-size: 9px; fill: var(--c-buoy); font-family: inherit; font-weight: 700; }
+  .ol-label-mh { font-size: 10px; fill: var(--c-buoy); font-family: inherit; font-weight: 700; }
   .ol-tick { font-size: 10px; fill: var(--text-muted); font-family: inherit; }
   .ol-callout { font-size: 10px; font-family: inherit; font-weight: 600; }
-  .ol-proposed-line { stroke: var(--c-buoy); stroke-width: 1.5; stroke-dasharray: 4 3; opacity: 0.6; }
-  .ol-proposed-label {
-    font-size: 11px; fill: var(--c-buoy); font-family: inherit; font-weight: 700;
+  .ol-zone { opacity: 0.04; }
+  .ol-zone-label {
+    font-size: 10px; fill: var(--text-muted); font-family: inherit;
+    font-weight: 600; opacity: 0.6;
   }
   .ol-legend {
     display: flex; gap: 16px; justify-content: center; flex-wrap: wrap;
@@ -26,17 +25,23 @@ scripts: [citations]
     border-radius: 50%; vertical-align: middle; margin-right: 4px;
   }
   .ol-legend-swatch--win { background: var(--c-navy); }
-  .ol-legend-swatch--loss { background: var(--text-subtle); opacity: 0.4; }
+  .ol-legend-swatch--loss { background: none; border: 2px solid var(--text-muted); }
   .ol-legend-swatch--mh { background: var(--c-buoy); }
   .ol-legend-swatch--proposed { background: none; border: 2px dashed var(--c-buoy); }
   .ol-svg { display: block; width: 100%; height: auto; max-width: 880px; margin: 0 auto; }
-  .ol-bucket-label {
-    font-size: 11px; fill: var(--text); font-family: inherit; font-weight: 600;
-  }
-  .ol-bucket-stat {
-    font-size: 10px; fill: var(--text-muted); font-family: inherit;
-  }
   .ol-divider { margin: 32px 0 24px; border: none; border-top: 1px solid var(--divider); }
+  .ol-rate-bar-bg { fill: var(--text-subtle); opacity: 0.12; }
+  .ol-rate-bar-fg { fill: var(--c-navy); opacity: 0.7; }
+  .ol-tip {
+    position: absolute; pointer-events: none;
+    background: var(--surface); border: 1px solid var(--border);
+    border-radius: 6px; padding: 8px 12px;
+    font-size: 12px; line-height: 1.5; color: var(--text);
+    box-shadow: var(--shadow-sm); white-space: nowrap;
+    opacity: 0; transition: opacity 0.15s;
+    z-index: 10;
+  }
+  .ol-tip.visible { opacity: 1; }
   details.notes { margin: 20px 0; }
   details.notes summary {
     font-size: 13px; font-weight: 600; color: var(--text-muted);
@@ -47,25 +52,24 @@ scripts: [citations]
     font-size: 12px; line-height: 1.6; color: var(--text-subtle);
     margin: 0 0 10px;
   }
-  .ol-rate-bar-bg { fill: var(--text-subtle); opacity: 0.12; rx: 3; }
-  .ol-rate-bar-fg { fill: var(--c-navy); opacity: 0.7; rx: 3; }
   @media (max-width: 600px) {
-    .ol-label, .ol-label-win, .ol-label-loss, .ol-label-mh { font-size: 8px; }
+    .ol-label, .ol-label-mh { font-size: 8px; }
   }
 </style>
 
 <h1 class="h-center">Where Does Marblehead's Override Land?</h1>
-<p class="subtitle h-center">Every operating override of $2M or more since FY2020, across all Massachusetts municipalities. Marblehead's proposed FY2027 override ($8.47M) marked for context.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes, all municipalities, FY2020-FY2027"></sup></p>
+<p class="subtitle h-center">Every operating override of $2M or more since FY2020, plotted by amount and fiscal year. Marblehead's proposed FY2027 override ($8.47M) marked for context.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes, all municipalities, FY2020-FY2027"></sup></p>
 
 <ul class="tldr">
+  <li><strong>Operating overrides only.</strong> Debt exclusions (capital projects, school buildings) not included</li>
   <li><strong>65 override elections of $2M+ since FY2020.</strong> 28 passed, 34 failed, 3 split</li>
   <li><strong>At the $5M-10M range</strong> where Marblehead's ask sits, 8 of 15 passed (53%)</li>
-  <li><strong>Marblehead's prior attempts</strong> ($2.5M in FY2024, $3.1M in FY2023) both failed, at smaller amounts than the current ask</li>
-  <li><strong>Comparable recent wins:</strong> Braintree $8M, Belmont $8.4M, Milton $8.8M. Comparable recent losses: Bridgewater $8M, Malden $8.2M</li>
+  <li><strong>Marblehead's prior attempts</strong> ($2.5M in FY2024, $3.1M in FY2023) both failed at smaller amounts</li>
+  <li><strong>Comparable recent wins:</strong> Braintree $8M, Belmont $8.4M, Milton $8.8M. Comparable losses: Bridgewater $8M, Malden $8.2M</li>
 </ul>
 
 <h2>Every $2M+ override since FY2020</h2>
-<p class="so-hint" style="font-size: 13px; color: var(--text-muted); margin-bottom: 4px;">Each dot is one town's override election. Horizontal position = total amount requested. Where multiple ballot questions appeared in the same election, amounts are combined.</p>
+<p class="so-hint" style="font-size: 13px; color: var(--text-muted); margin-bottom: 4px;">Each dot is one town's override election. Horizontal position = amount requested; vertical position = fiscal year. Hover or tap for details.</p>
 
 <div class="ol-legend">
   <span><span class="ol-legend-swatch ol-legend-swatch--win"></span> Passed</span>
@@ -74,12 +78,15 @@ scripts: [citations]
   <span><span class="ol-legend-swatch ol-legend-swatch--proposed"></span> Marblehead FY2027 (proposed)</span>
 </div>
 
-<svg class="ol-svg chart" id="ol-strip" viewBox="0 0 880 620" role="img" aria-label="Strip chart of every Massachusetts operating override of 2 million dollars or more since fiscal year 2020, with Marblehead's proposed 8.47 million dollar override marked">
+<div style="position:relative;" id="ol-wrap">
+<div class="ol-tip" id="ol-tip"></div>
+<svg class="ol-svg chart" id="ol-scatter" viewBox="0 0 880 420" role="img" aria-label="Scatter plot of every Massachusetts operating override of 2 million dollars or more since fiscal year 2020, with amount on the horizontal axis and fiscal year on the vertical axis">
   <g id="ol-grid"></g>
+  <g id="ol-zones"></g>
   <g id="ol-dots"></g>
   <g id="ol-labels"></g>
-  <g id="ol-proposed"></g>
 </svg>
+</div>
 
 <hr class="ol-divider">
 
@@ -97,14 +104,14 @@ scripts: [citations]
   <p>Override vote data from the Massachusetts Department of Revenue, Division of Local Services Municipal Databank.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride"></sup></p>
   <p>Operating overrides only; debt exclusions not included. Where a town placed multiple override questions on the same ballot, all amounts are combined into a single per-election total. If a majority of questions passed, the election is coded as a win; if a majority failed, a loss; if evenly split, shown as "split" and excluded from pass rate calculations.</p>
   <p>Marblehead's proposed FY2027 override ($8.47M across three ballot tiers) has not yet been voted on. It is shown as a dashed circle for reference only.</p>
+  <p>Stoneham FY2027 ($21.8M combined across two votes, one passed at $9.3M) is off the chart's x-axis and noted in the tooltip data but not plotted.</p>
   <p>FY2027 data is partial as of April 2026.</p>
 </details>
 
 <script>
 (function() {
   // Elections >= $2M since FY2020, sorted by amount
-  // outcome: 1=win, 0=loss, 0.5=split
-  // mh: 1=marblehead actual, 2=marblehead proposed
+  // o: 1=win, 0=loss, 0.5=split; mh: 1=actual
   var VOTES = [
     {t:"Rutland",fy:2024,a:2000000,o:1},
     {t:"Whitman",fy:2026,a:2000000,o:0},
@@ -169,37 +176,35 @@ scripts: [citations]
     {t:"Melrose",fy:2026,a:13500000,o:1},
     {t:"Malden",fy:2027,a:13600000,o:0},
     {t:"Stoneham",fy:2026,a:14600000,o:0},
-    {t:"Arlington",fy:2027,a:14800000,o:1},
-    {t:"Stoneham",fy:2027,a:21800000,o:0.5}
+    {t:"Arlington",fy:2027,a:14800000,o:1}
+    // Stoneham FY2027 ($21.8M) omitted as outlier
   ];
 
   var MH_PROPOSED = {t:"Marblehead",fy:2027,a:8470000};
 
-  var W = 880, mL = 60, mR = 100;
+  var W = 880;
+  var mL = 60, mR = 30, mT = 30, mB = 40;
   var pW = W - mL - mR;
+  var maxAmt = 15500000;
+  var fyMin = 2019.5, fyMax = 2027.5;
 
   // =============================================
-  // CHART 1: STRIP CHART
+  // CHART 1: SCATTER
   // =============================================
   (function() {
-    var H = 620, mT = 20, mB = 40;
+    var H = 420;
     var pH = H - mT - mB;
-    var n = VOTES.length;
-    var rowH = Math.floor(pH / (n + 2)); // +2 for proposed
-    var dotR = Math.min(rowH * 0.35, 6);
 
-    var maxAmt = 22000000;
     var gridG = document.getElementById("ol-grid");
+    var zonesG = document.getElementById("ol-zones");
     var dotsG = document.getElementById("ol-dots");
     var labelsG = document.getElementById("ol-labels");
-    var proposedG = document.getElementById("ol-proposed");
 
-    function xScale(amt) { return mL + pW * (amt / maxAmt); }
-    function yPos(i) { return mT + (i + 0.5) * rowH; }
+    function xScale(amt) { return mL + pW * Math.min(amt, maxAmt) / maxAmt; }
+    function yScale(fy) { return mT + pH * (1 - (fy - fyMin) / (fyMax - fyMin)); }
 
-    // Grid lines at dollar amounts
-    var gridAmts = [0, 2000000, 4000000, 6000000, 8000000, 10000000, 12000000, 14000000, 16000000, 18000000, 20000000];
-    gridAmts.forEach(function(v) {
+    // X grid (dollar amounts)
+    for (var v = 0; v <= maxAmt; v += 2000000) {
       var x = xScale(v);
       var line = document.createElementNS("http://www.w3.org/2000/svg", "line");
       line.setAttribute("x1", x); line.setAttribute("x2", x);
@@ -214,58 +219,215 @@ scripts: [citations]
       label.setAttribute("class", "ol-tick");
       label.textContent = "$" + (v / 1000000) + "M";
       gridG.appendChild(label);
+    }
+
+    // Y grid (fiscal years)
+    for (var fy = 2020; fy <= 2027; fy++) {
+      var y = yScale(fy);
+      var line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+      line.setAttribute("x1", mL); line.setAttribute("x2", W - mR);
+      line.setAttribute("y1", y); line.setAttribute("y2", y);
+      line.setAttribute("class", "grid-minor");
+      gridG.appendChild(line);
+
+      var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+      label.setAttribute("x", mL - 8);
+      label.setAttribute("y", y + 4);
+      label.setAttribute("text-anchor", "end");
+      label.setAttribute("class", "ol-tick");
+      label.textContent = "FY" + fy;
+      gridG.appendChild(label);
+    }
+
+    // Marblehead's proposed amount: vertical band
+    var mhX = xScale(MH_PROPOSED.a);
+    var bandW = 30;
+    var band = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    band.setAttribute("x", mhX - bandW / 2);
+    band.setAttribute("y", mT);
+    band.setAttribute("width", bandW);
+    band.setAttribute("height", pH);
+    band.setAttribute("fill", "var(--c-buoy)");
+    band.setAttribute("class", "ol-zone");
+    zonesG.appendChild(band);
+
+    // Proposed dot
+    var propDot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+    propDot.setAttribute("cx", mhX);
+    propDot.setAttribute("cy", yScale(MH_PROPOSED.fy));
+    propDot.setAttribute("r", 8);
+    propDot.setAttribute("class", "ol-dot-proposed");
+    dotsG.appendChild(propDot);
+
+    var propLabel = document.createElementNS("http://www.w3.org/2000/svg", "text");
+    propLabel.setAttribute("x", mhX);
+    propLabel.setAttribute("y", mT - 10);
+    propLabel.setAttribute("text-anchor", "middle");
+    propLabel.setAttribute("class", "ol-label-mh");
+    propLabel.setAttribute("font-size", "11px");
+    propLabel.textContent = "Marblehead proposed: $8.47M";
+    labelsG.appendChild(propLabel);
+
+    // Collision detection for labels
+    var placed = [];
+    function wouldOverlap(x, y, w, h) {
+      for (var i = 0; i < placed.length; i++) {
+        var p = placed[i];
+        if (x < p.x + p.w && x + w > p.x && y < p.y + p.h && y + h > p.y) return true;
+      }
+      return false;
+    }
+
+    // Only label notable dots (near MH range, very large, or Marblehead itself)
+    function shouldLabel(v) {
+      if (v.mh) return true;
+      // Near Marblehead's proposed amount ($7M-10M)
+      if (v.a >= 7000000 && v.a <= 10000000) return true;
+      // Very large
+      if (v.a >= 12000000) return true;
+      return false;
+    }
+
+    // Jitter: offset dots that share the same FY to avoid overlap
+    var byFy = {};
+    VOTES.forEach(function(v) {
+      if (!byFy[v.fy]) byFy[v.fy] = [];
+      byFy[v.fy].push(v);
     });
 
-    // Proposed Marblehead line
-    var mhX = xScale(MH_PROPOSED.a);
-    var mhLine = document.createElementNS("http://www.w3.org/2000/svg", "line");
-    mhLine.setAttribute("x1", mhX); mhLine.setAttribute("x2", mhX);
-    mhLine.setAttribute("y1", mT); mhLine.setAttribute("y2", H - mB);
-    mhLine.setAttribute("class", "ol-proposed-line");
-    proposedG.appendChild(mhLine);
+    // Sort within each FY by amount for consistent jitter
+    Object.keys(byFy).forEach(function(fy) {
+      byFy[fy].sort(function(a, b) { return a.a - b.a; });
+    });
 
-    var mhLabel = document.createElementNS("http://www.w3.org/2000/svg", "text");
-    mhLabel.setAttribute("x", mhX);
-    mhLabel.setAttribute("y", mT - 6);
-    mhLabel.setAttribute("text-anchor", "middle");
-    mhLabel.setAttribute("class", "ol-proposed-label");
-    mhLabel.textContent = "Marblehead FY27 proposed: $8.47M";
-    proposedG.appendChild(mhLabel);
+    // Assign jitter offsets
+    var jitterMap = new Map();
+    Object.keys(byFy).forEach(function(fy) {
+      var items = byFy[fy];
+      // Group nearby amounts (within 500K) to detect clusters
+      var clusters = [];
+      var cur = [items[0]];
+      for (var i = 1; i < items.length; i++) {
+        if (items[i].a - cur[cur.length - 1].a < 800000) {
+          cur.push(items[i]);
+        } else {
+          clusters.push(cur);
+          cur = [items[i]];
+        }
+      }
+      clusters.push(cur);
 
-    // Dots and labels
-    VOTES.forEach(function(v, i) {
+      clusters.forEach(function(cluster) {
+        if (cluster.length === 1) {
+          jitterMap.set(cluster[0], 0);
+        } else {
+          var spread = Math.min(cluster.length * 6, pH / 16);
+          cluster.forEach(function(v, j) {
+            var offset = (j - (cluster.length - 1) / 2) * (spread / cluster.length);
+            jitterMap.set(v, offset);
+          });
+        }
+      });
+    });
+
+    // Draw dots
+    var dotEls = [];
+    VOTES.forEach(function(v) {
       var cx = xScale(v.a);
-      var cy = yPos(i);
+      var jitter = jitterMap.get(v) || 0;
+      var cy = yScale(v.fy) + jitter;
+      var r = v.mh ? 7 : (v.a >= 7000000 ? 5.5 : 4.5);
 
       var dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
       dot.setAttribute("cx", cx);
       dot.setAttribute("cy", cy);
-      dot.setAttribute("r", v.mh ? dotR + 1 : dotR);
+      dot.setAttribute("r", r);
 
       if (v.mh) {
         dot.setAttribute("class", "ol-dot-mh");
       } else if (v.o === 1) {
         dot.setAttribute("class", "ol-dot-win");
-      } else if (v.o === 0) {
-        dot.setAttribute("class", "ol-dot-loss");
       } else {
         dot.setAttribute("class", "ol-dot-loss");
-        dot.setAttribute("opacity", "0.6");
       }
+
+      dot.setAttribute("data-town", v.t);
+      dot.setAttribute("data-fy", v.fy);
+      dot.setAttribute("data-amt", v.a);
+      dot.setAttribute("data-outcome", v.o === 1 ? "Passed" : (v.o === 0 ? "Did not pass" : "Split"));
+      dot.style.cursor = "pointer";
       dotsG.appendChild(dot);
+      dotEls.push({el: dot, v: v, cx: cx, cy: cy});
 
-      // Label: "Town FYxx"
-      var labelClass = v.mh ? "ol-label-mh" : (v.o === 1 ? "ol-label-win" : "ol-label-loss");
-      var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
-      label.setAttribute("x", cx + dotR + 4);
-      label.setAttribute("y", cy + 3);
-      label.setAttribute("class", labelClass);
+      // Labels for notable dots
+      if (shouldLabel(v)) {
+        var labelX = cx + r + 4;
+        var labelY = cy + 3;
+        var labelW = 80;
+        var labelH = 12;
 
-      var displayAmt = v.a >= 10000000
-        ? "$" + (v.a / 1000000).toFixed(1) + "M"
-        : "$" + (v.a / 1000000).toFixed(1) + "M";
-      label.textContent = v.t + " FY" + (v.fy % 100).toString().padStart(2, "0");
-      labelsG.appendChild(label);
+        // Try right side first, then left
+        if (wouldOverlap(labelX, labelY - labelH, labelW, labelH)) {
+          labelX = cx - r - 4;
+          var anchor = "end";
+          if (!wouldOverlap(labelX - labelW, labelY - labelH, labelW, labelH)) {
+            placed.push({x: labelX - labelW, y: labelY - labelH, w: labelW, h: labelH});
+          } else {
+            // Try above
+            labelX = cx + r + 4;
+            labelY = cy - r - 2;
+            anchor = "start";
+            placed.push({x: labelX, y: labelY - labelH, w: labelW, h: labelH});
+          }
+          var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+          label.setAttribute("x", labelX);
+          label.setAttribute("y", labelY);
+          label.setAttribute("text-anchor", anchor || "end");
+          label.setAttribute("class", v.mh ? "ol-label-mh" : "ol-label");
+          label.textContent = v.t;
+          labelsG.appendChild(label);
+        } else {
+          placed.push({x: labelX, y: labelY - labelH, w: labelW, h: labelH});
+          var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+          label.setAttribute("x", labelX);
+          label.setAttribute("y", labelY);
+          label.setAttribute("text-anchor", "start");
+          label.setAttribute("class", v.mh ? "ol-label-mh" : "ol-label");
+          label.textContent = v.t;
+          labelsG.appendChild(label);
+        }
+      }
+    });
+
+    // Tooltip
+    var tip = document.getElementById("ol-tip");
+    var wrap = document.getElementById("ol-wrap");
+
+    dotEls.forEach(function(d) {
+      function showTip(e) {
+        var v = d.v;
+        var amt = "$" + (v.a >= 1000000
+          ? (v.a / 1000000).toFixed(1) + "M"
+          : Math.round(v.a / 1000) + "K");
+        tip.innerHTML = "<strong>" + v.t + "</strong> FY" + v.fy +
+          "<br>" + amt + " &mdash; " + d.el.getAttribute("data-outcome");
+        tip.classList.add("visible");
+
+        var rect = wrap.getBoundingClientRect();
+        var svgRect = document.getElementById("ol-scatter").getBoundingClientRect();
+        var dotX = (d.cx / 880) * svgRect.width;
+        var dotY = (d.cy / 420) * svgRect.height;
+
+        tip.style.left = (dotX + svgRect.left - rect.left + 12) + "px";
+        tip.style.top = (dotY + svgRect.top - rect.top - 10) + "px";
+      }
+      function hideTip() { tip.classList.remove("visible"); }
+      d.el.addEventListener("mouseenter", showTip);
+      d.el.addEventListener("mouseleave", hideTip);
+      d.el.addEventListener("touchstart", function(e) {
+        e.preventDefault(); showTip(e);
+        setTimeout(hideTip, 2500);
+      }, {passive: false});
     });
   })();
 
@@ -274,38 +436,38 @@ scripts: [citations]
   // =============================================
   (function() {
     var BUCKETS = [
-      {label:"<$100K",lo:0,hi:100000,win:25,total:34},
-      {label:"$100K-250K",lo:100000,hi:250000,win:30,total:47},
-      {label:"$250K-500K",lo:250000,hi:500000,win:38,total:58},
-      {label:"$500K-1M",lo:500000,hi:1000000,win:38,total:55},
-      {label:"$1M-2M",lo:1000000,hi:2000000,win:22,total:35},
-      {label:"$2M-5M",lo:2000000,hi:5000000,win:12,total:34},
-      {label:"$5M-10M",lo:5000000,hi:10000000,win:15,total:27},
-      {label:"$10M+",lo:10000000,hi:999999999,win:7,total:12}
+      {label:"<$100K",win:25,total:34},
+      {label:"$100-250K",win:30,total:47},
+      {label:"$250-500K",win:38,total:58},
+      {label:"$500K-1M",win:38,total:55},
+      {label:"$1-2M",win:22,total:35},
+      {label:"$2-5M",win:12,total:34},
+      {label:"$5-10M",win:15,total:27},
+      {label:"$10M+",win:7,total:12}
     ];
 
-    var H = 260, mT = 30, mB = 30;
-    var pH = H - mT - mB;
-    var bL = 120, bR = 60;
+    var H = 260, rT = 30, rB = 30;
+    var rH = H - rT - rB;
+    var bL = 100, bR = 80;
     var bW = W - bL - bR;
-    var barH = Math.floor(pH / BUCKETS.length) - 4;
+    var barH = Math.floor(rH / BUCKETS.length) - 4;
 
     var gridG = document.getElementById("ol-rate-grid");
     var barsG = document.getElementById("ol-rate-bars");
     var rLabelsG = document.getElementById("ol-rate-labels");
+    var mhBucketIdx = 6;
 
-    // Grid
     [0, 25, 50, 75, 100].forEach(function(pct) {
       var x = bL + bW * pct / 100;
       var line = document.createElementNS("http://www.w3.org/2000/svg", "line");
       line.setAttribute("x1", x); line.setAttribute("x2", x);
-      line.setAttribute("y1", mT); line.setAttribute("y2", H - mB);
+      line.setAttribute("y1", rT); line.setAttribute("y2", H - rB);
       line.setAttribute("class", pct === 0 ? "axis-base" : "grid-minor");
       gridG.appendChild(line);
 
       var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
       label.setAttribute("x", x);
-      label.setAttribute("y", mT - 8);
+      label.setAttribute("y", rT - 8);
       label.setAttribute("text-anchor", "middle");
       label.setAttribute("class", "ol-label");
       label.textContent = pct + "%";
@@ -315,28 +477,25 @@ scripts: [citations]
     // 50% reference
     var ref = document.createElementNS("http://www.w3.org/2000/svg", "line");
     ref.setAttribute("x1", bL + bW * 0.5); ref.setAttribute("x2", bL + bW * 0.5);
-    ref.setAttribute("y1", mT); ref.setAttribute("y2", H - mB);
+    ref.setAttribute("y1", rT); ref.setAttribute("y2", H - rB);
     ref.setAttribute("class", "grid-major");
     gridG.appendChild(ref);
 
-    // Highlight the bucket Marblehead falls into
-    var mhBucketIdx = 6; // $5M-10M
-
     BUCKETS.forEach(function(b, i) {
-      var y = mT + i * (barH + 4);
+      var y = rT + i * (barH + 4);
       var rate = b.total > 0 ? b.win / b.total * 100 : 0;
 
-      // Background bar
       var bg = document.createElementNS("http://www.w3.org/2000/svg", "rect");
       bg.setAttribute("x", bL); bg.setAttribute("y", y);
       bg.setAttribute("width", bW); bg.setAttribute("height", barH);
+      bg.setAttribute("rx", 3);
       bg.setAttribute("class", "ol-rate-bar-bg");
       barsG.appendChild(bg);
 
-      // Foreground bar
       var fg = document.createElementNS("http://www.w3.org/2000/svg", "rect");
       fg.setAttribute("x", bL); fg.setAttribute("y", y);
       fg.setAttribute("width", bW * rate / 100); fg.setAttribute("height", barH);
+      fg.setAttribute("rx", 3);
       fg.setAttribute("class", "ol-rate-bar-fg");
       if (i === mhBucketIdx) {
         fg.setAttribute("fill", "var(--c-buoy)");
@@ -344,7 +503,6 @@ scripts: [citations]
       }
       barsG.appendChild(fg);
 
-      // Bucket label
       var bl = document.createElementNS("http://www.w3.org/2000/svg", "text");
       bl.setAttribute("x", bL - 6); bl.setAttribute("y", y + barH / 2 + 4);
       bl.setAttribute("text-anchor", "end");
@@ -352,10 +510,9 @@ scripts: [citations]
       bl.textContent = b.label;
       rLabelsG.appendChild(bl);
 
-      // Rate + count label
       var rl = document.createElementNS("http://www.w3.org/2000/svg", "text");
-      var rx = bL + bW * rate / 100 + 6;
-      rl.setAttribute("x", rx); rl.setAttribute("y", y + barH / 2 + 4);
+      rl.setAttribute("x", bL + bW * rate / 100 + 6);
+      rl.setAttribute("y", y + barH / 2 + 4);
       rl.setAttribute("class", "ol-callout");
       rl.setAttribute("fill", i === mhBucketIdx ? "var(--c-buoy)" : "var(--c-navy)");
       rl.textContent = Math.round(rate) + "% (" + b.win + "/" + b.total + ")";

--- a/charts/override_landscape.html
+++ b/charts/override_landscape.html
@@ -88,18 +88,19 @@ scripts: [citations]
 <hr class="ol-divider">
 
 <h2>Closest comparables to Marblehead's three tiers</h2>
-<p style="font-size: 13px; color: var(--text-muted); margin-bottom: 12px;">Every override between $6M and $16M since FY2020, sorted by amount descending. Marblehead's three nested ballot tiers shown for reference.</p>
+<p style="font-size: 13px; color: var(--text-muted); margin-bottom: 12px;">Every override of $6M or more since FY2020, sorted by amount descending. Marblehead's three nested ballot tiers shown for reference.</p>
 
 <table class="ol-comps">
   <thead>
     <tr><th>Town</th><th>FY</th><th>Amount</th><th>Result</th></tr>
   </thead>
   <tbody>
+    <tr><td>Stoneham</td><td>2027</td><td class="amt">$21.8M</td><td><span class="outcome-loss">Split (9.3M passed, 12.5M failed)</span></td></tr>
     <tr class="mh-row"><td>Marblehead Tier 3</td><td>2027</td><td class="amt">$15.0M</td><td><span class="outcome-proposed">Proposed</span></td></tr>
     <tr><td>Arlington</td><td>2027</td><td class="amt">$14.8M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Stoneham</td><td>2026</td><td class="amt">$14.6M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
-    <tr><td>Melrose</td><td>2026</td><td class="amt">$13.5M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Malden</td><td>2027</td><td class="amt">$13.6M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Melrose</td><td>2026</td><td class="amt">$13.5M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr class="mh-row"><td>Marblehead Tier 2</td><td>2027</td><td class="amt">$12.0M</td><td><span class="outcome-proposed">Proposed</span></td></tr>
     <tr><td>Brookline</td><td>2024</td><td class="amt">$12.0M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Nantucket</td><td>2024</td><td class="amt">$10.3M</td><td><span class="outcome-win">Passed</span></td></tr>
@@ -133,7 +134,7 @@ scripts: [citations]
   <p>Override vote data from the Massachusetts Department of Revenue, Division of Local Services Municipal Databank.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride"></sup></p>
   <p>Operating overrides only; debt exclusions not included. Where a town placed multiple override questions on the same ballot, all amounts are combined into a single per-election total. If a majority of questions passed, the election is coded as a win; if a majority failed, a loss.</p>
   <p>Marblehead's proposed FY2027 override uses three nested ballot tiers: Tier 1 ($9M), Tier 2 ($12M), and Tier 3 ($15M). The highest tier that gets a majority sets the override amount. None have been voted on yet.</p>
-  <p>The comparable range ($6M-$16M) includes 27 elections since FY2020. All amounts shown are the ballot question amounts, not the deficit that motivated the override.</p>
+  <p>The table includes every override of $6M or more since FY2020. All amounts shown are the ballot question amounts, not the deficit that motivated the override.</p>
   <p>FY2027 data is partial as of April 2026.</p>
 </details>
 

--- a/charts/override_landscape.html
+++ b/charts/override_landscape.html
@@ -95,28 +95,28 @@ scripts: [citations]
     <tr><th>Town</th><th>FY</th><th>Amount</th><th>Result</th></tr>
   </thead>
   <tbody>
-    <tr><td>Amesbury</td><td>2026</td><td class="amt">$6.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
-    <tr><td>Georgetown</td><td>2026</td><td class="amt">$6.0M</td><td><span class="outcome-win">Passed</span></td></tr>
-    <tr><td>Hanover</td><td>2025</td><td class="amt">$6.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
-    <tr><td>Belmont</td><td>2022</td><td class="amt">$6.4M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
-    <tr><td>Acton</td><td>2025</td><td class="amt">$6.6M</td><td><span class="outcome-win">Passed</span></td></tr>
-    <tr><td>Franklin</td><td>2025</td><td class="amt">$6.8M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
-    <tr><td>Arlington</td><td>2025</td><td class="amt">$7.0M</td><td><span class="outcome-win">Passed</span></td></tr>
-    <tr><td>Natick</td><td>2026</td><td class="amt">$7.0M</td><td><span class="outcome-win">Passed</span></td></tr>
-    <tr><td>Easton</td><td>2026</td><td class="amt">$7.3M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
-    <tr><td>Medford</td><td>2025</td><td class="amt">$7.5M</td><td><span class="outcome-win">Passed</span></td></tr>
-    <tr><td>Melrose</td><td>2025</td><td class="amt">$7.7M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
-    <tr><td>Hingham</td><td>2024</td><td class="amt">$7.9M</td><td><span class="outcome-win">Passed</span></td></tr>
-    <tr><td>Braintree</td><td>2025</td><td class="amt">$8.0M</td><td><span class="outcome-win">Passed</span></td></tr>
-    <tr><td>Bridgewater</td><td>2026</td><td class="amt">$8.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
-    <tr class="mh-row"><td>Marblehead</td><td>2027</td><td class="amt">$8.47M</td><td><span class="outcome-proposed">Proposed</span></td></tr>
-    <tr><td>Belmont</td><td>2025</td><td class="amt">$8.4M</td><td><span class="outcome-win">Passed</span></td></tr>
-    <tr><td>Milton</td><td>2026</td><td class="amt">$8.8M</td><td><span class="outcome-win">Passed</span></td></tr>
-    <tr><td>Newton</td><td>2023</td><td class="amt">$9.2M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
-    <tr><td>Shrewsbury</td><td>2022</td><td class="amt">$9.5M</td><td><span class="outcome-win">Passed</span></td></tr>
-    <tr><td>Dudley</td><td>2024</td><td class="amt">$9.9M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
-    <tr><td>North Reading</td><td>2025</td><td class="amt">$10.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Winchester</td><td>2020</td><td class="amt">$10.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>North Reading</td><td>2025</td><td class="amt">$10.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Dudley</td><td>2024</td><td class="amt">$9.9M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Shrewsbury</td><td>2022</td><td class="amt">$9.5M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Newton</td><td>2023</td><td class="amt">$9.2M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Milton</td><td>2026</td><td class="amt">$8.8M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Belmont</td><td>2025</td><td class="amt">$8.4M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr class="mh-row"><td>Marblehead</td><td>2027</td><td class="amt">$8.47M</td><td><span class="outcome-proposed">Proposed</span></td></tr>
+    <tr><td>Bridgewater</td><td>2026</td><td class="amt">$8.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Braintree</td><td>2025</td><td class="amt">$8.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Hingham</td><td>2024</td><td class="amt">$7.9M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Melrose</td><td>2025</td><td class="amt">$7.7M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Medford</td><td>2025</td><td class="amt">$7.5M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Easton</td><td>2026</td><td class="amt">$7.3M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Natick</td><td>2026</td><td class="amt">$7.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Arlington</td><td>2025</td><td class="amt">$7.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Franklin</td><td>2025</td><td class="amt">$6.8M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Acton</td><td>2025</td><td class="amt">$6.6M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Belmont</td><td>2022</td><td class="amt">$6.4M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Hanover</td><td>2025</td><td class="amt">$6.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Georgetown</td><td>2026</td><td class="amt">$6.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Amesbury</td><td>2026</td><td class="amt">$6.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
   </tbody>
 </table>
 

--- a/charts/override_landscape.html
+++ b/charts/override_landscape.html
@@ -67,12 +67,12 @@ scripts: [citations]
 </style>
 
 <h1 class="h-center">Where Does Marblehead's Override Land?</h1>
-<p class="subtitle h-center">Every operating override of $2M or more since FY2020, across all Massachusetts municipalities.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes, all municipalities, FY2020-FY2027"></sup></p>
+<p class="subtitle h-center">Every operating override of $6M or more across all Massachusetts municipalities, FY1990 to FY2027.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes, all municipalities, all years"></sup></p>
 
 <ul class="tldr">
   <li><strong>Operating overrides only.</strong> Debt exclusions (capital projects, school buildings) not included</li>
-  <li><strong>65 override elections of $2M+ since FY2020.</strong> 28 passed, 34 failed, 3 split</li>
-  <li><strong>Marblehead's three nested tiers</strong> are $9M, $12M, and $15M. Tier 1 falls in the $5M-10M range (53% pass rate); Tiers 2 and 3 fall in $10M+ (58%)</li>
+  <li><strong>55 override elections of $6M+ since 1990.</strong> Marblehead's three nested tiers ($9M, $12M, $15M) are all in this range</li>
+  <li><strong>Tier 3 at $15M</strong> would be the 4th largest override ever attempted and the 2nd largest to pass (behind Arlington's $14.8M in FY2027)</li>
   <li><strong>Marblehead's prior attempts</strong> ($2.5M in FY2024, $3.1M in FY2023) both failed at smaller amounts</li>
 </ul>
 
@@ -87,44 +87,72 @@ scripts: [citations]
 
 <hr class="ol-divider">
 
-<h2>Closest comparables to Marblehead's three tiers</h2>
-<p style="font-size: 13px; color: var(--text-muted); margin-bottom: 12px;">Every override of $6M or more since FY2020, sorted by amount descending. Marblehead's three nested ballot tiers shown for reference.</p>
+<h2>Every $6M+ override ever attempted in Massachusetts</h2>
+<p style="font-size: 13px; color: var(--text-muted); margin-bottom: 12px;">All time, FY1990 to FY2027. Sorted by amount descending. Marblehead's three nested ballot tiers shown for reference.</p>
 
 <table class="ol-comps">
   <thead>
     <tr><th>Town</th><th>FY</th><th>Amount</th><th>Result</th></tr>
   </thead>
   <tbody>
-    <tr><td>Stoneham</td><td>2027</td><td class="amt">$21.8M</td><td><span class="outcome-loss">Split (9.3M passed, 12.5M failed)</span></td></tr>
+    <tr><td>Stoneham</td><td>2027</td><td class="amt">$21.8M</td><td><span class="outcome-loss">Split ($9.3M passed, $12.5M failed)</span></td></tr>
+    <tr><td>Randolph</td><td>2007</td><td class="amt">$21.8M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Needham</td><td>2003</td><td class="amt">$17.3M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr class="mh-row"><td>Marblehead Tier 3</td><td>2027</td><td class="amt">$15.0M</td><td><span class="outcome-proposed">Proposed</span></td></tr>
     <tr><td>Arlington</td><td>2027</td><td class="amt">$14.8M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Stoneham</td><td>2026</td><td class="amt">$14.6M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Holyoke</td><td>1992</td><td class="amt">$14.3M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Malden</td><td>2027</td><td class="amt">$13.6M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Melrose</td><td>2026</td><td class="amt">$13.5M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Springfield</td><td>1991</td><td class="amt">$12.6M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr class="mh-row"><td>Marblehead Tier 2</td><td>2027</td><td class="amt">$12.0M</td><td><span class="outcome-proposed">Proposed</span></td></tr>
     <tr><td>Brookline</td><td>2024</td><td class="amt">$12.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Newton</td><td>2003</td><td class="amt">$11.5M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Winthrop</td><td>2000</td><td class="amt">$10.5M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Nantucket</td><td>2024</td><td class="amt">$10.3M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Winchester</td><td>2020</td><td class="amt">$10.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Springfield</td><td>1990</td><td class="amt">$10.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>North Reading</td><td>2025</td><td class="amt">$10.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Dudley</td><td>2024</td><td class="amt">$9.9M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Shrewsbury</td><td>2022</td><td class="amt">$9.5M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Newton</td><td>2023</td><td class="amt">$9.2M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr class="mh-row"><td>Marblehead Tier 1</td><td>2027</td><td class="amt">$9.0M</td><td><span class="outcome-proposed">Proposed</span></td></tr>
     <tr><td>Milton</td><td>2026</td><td class="amt">$8.8M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Dartmouth</td><td>2008</td><td class="amt">$8.5M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Belmont</td><td>2025</td><td class="amt">$8.4M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Newton</td><td>2014</td><td class="amt">$8.4M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Worcester</td><td>1992</td><td class="amt">$8.2M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Bridgewater</td><td>2026</td><td class="amt">$8.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Braintree</td><td>2025</td><td class="amt">$8.0M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Hingham</td><td>2024</td><td class="amt">$7.9M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Melrose</td><td>2025</td><td class="amt">$7.7M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Brookline</td><td>2016</td><td class="amt">$7.7M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Easton</td><td>2019</td><td class="amt">$7.6M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Reading</td><td>2017</td><td class="amt">$7.5M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Medford</td><td>2025</td><td class="amt">$7.5M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Easton</td><td>2026</td><td class="amt">$7.3M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Lawrence</td><td>1991</td><td class="amt">$7.3M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Barnstable</td><td>2005</td><td class="amt">$7.2M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Framingham</td><td>2003</td><td class="amt">$7.2M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Revere</td><td>1992</td><td class="amt">$7.1M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Natick</td><td>2026</td><td class="amt">$7.0M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Arlington</td><td>2025</td><td class="amt">$7.0M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Franklin</td><td>2025</td><td class="amt">$6.8M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>North Andover</td><td>1992</td><td class="amt">$6.7M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Acton</td><td>2025</td><td class="amt">$6.6M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Brookline</td><td>2019</td><td class="amt">$6.6M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Weymouth</td><td>2016</td><td class="amt">$6.5M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>N. Attleborough</td><td>2019</td><td class="amt">$6.5M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Arlington</td><td>2012</td><td class="amt">$6.5M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Belmont</td><td>2022</td><td class="amt">$6.4M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Brookline</td><td>2009</td><td class="amt">$6.2M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Wellesley</td><td>2006</td><td class="amt">$6.1M</td><td><span class="outcome-loss">Split</span></td></tr>
+    <tr><td>Randolph</td><td>2009</td><td class="amt">$6.1M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Hanover</td><td>2025</td><td class="amt">$6.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Marshfield</td><td>2008</td><td class="amt">$6.0M</td><td><span class="outcome-loss">Split</span></td></tr>
+    <tr><td>Holyoke</td><td>1990</td><td class="amt">$6.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
     <tr><td>Georgetown</td><td>2026</td><td class="amt">$6.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Arlington</td><td>2006</td><td class="amt">$6.0M</td><td><span class="outcome-win">Passed</span></td></tr>
     <tr><td>Amesbury</td><td>2026</td><td class="amt">$6.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
   </tbody>
 </table>
@@ -134,7 +162,7 @@ scripts: [citations]
   <p>Override vote data from the Massachusetts Department of Revenue, Division of Local Services Municipal Databank.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride"></sup></p>
   <p>Operating overrides only; debt exclusions not included. Where a town placed multiple override questions on the same ballot, all amounts are combined into a single per-election total. If a majority of questions passed, the election is coded as a win; if a majority failed, a loss.</p>
   <p>Marblehead's proposed FY2027 override uses three nested ballot tiers: Tier 1 ($9M), Tier 2 ($12M), and Tier 3 ($15M). The highest tier that gets a majority sets the override amount. None have been voted on yet.</p>
-  <p>The table includes every override of $6M or more since FY2020. All amounts shown are the ballot question amounts, not the deficit that motivated the override.</p>
+  <p>The table includes every override of $6M or more, all time (FY1990 to FY2027). All amounts shown are the ballot question amounts (nominal dollars), not the deficit that motivated the override.</p>
   <p>FY2027 data is partial as of April 2026.</p>
 </details>
 

--- a/charts/override_landscape.html
+++ b/charts/override_landscape.html
@@ -1,0 +1,366 @@
+---
+title: "Override Landscape: Large Asks Since FY2020"
+scripts: [citations]
+---
+<style>
+  .ol-dot-win { fill: var(--c-navy); }
+  .ol-dot-loss { fill: var(--text-subtle); opacity: 0.4; }
+  .ol-dot-mh { fill: var(--c-buoy); }
+  .ol-dot-mh-proposed { fill: none; stroke: var(--c-buoy); stroke-width: 2; stroke-dasharray: 3 2; }
+  .ol-label { font-size: 9px; fill: var(--text-muted); font-family: inherit; }
+  .ol-label-win { font-size: 9px; fill: var(--c-navy); font-family: inherit; }
+  .ol-label-loss { font-size: 9px; fill: var(--text-muted); font-family: inherit; }
+  .ol-label-mh { font-size: 9px; fill: var(--c-buoy); font-family: inherit; font-weight: 700; }
+  .ol-tick { font-size: 10px; fill: var(--text-muted); font-family: inherit; }
+  .ol-callout { font-size: 10px; font-family: inherit; font-weight: 600; }
+  .ol-proposed-line { stroke: var(--c-buoy); stroke-width: 1.5; stroke-dasharray: 4 3; opacity: 0.6; }
+  .ol-proposed-label {
+    font-size: 11px; fill: var(--c-buoy); font-family: inherit; font-weight: 700;
+  }
+  .ol-legend {
+    display: flex; gap: 16px; justify-content: center; flex-wrap: wrap;
+    margin: 8px 0 12px; font-size: 12px; color: var(--text-muted);
+  }
+  .ol-legend-swatch {
+    display: inline-block; width: 10px; height: 10px;
+    border-radius: 50%; vertical-align: middle; margin-right: 4px;
+  }
+  .ol-legend-swatch--win { background: var(--c-navy); }
+  .ol-legend-swatch--loss { background: var(--text-subtle); opacity: 0.4; }
+  .ol-legend-swatch--mh { background: var(--c-buoy); }
+  .ol-legend-swatch--proposed { background: none; border: 2px dashed var(--c-buoy); }
+  .ol-svg { display: block; width: 100%; height: auto; max-width: 880px; margin: 0 auto; }
+  .ol-bucket-label {
+    font-size: 11px; fill: var(--text); font-family: inherit; font-weight: 600;
+  }
+  .ol-bucket-stat {
+    font-size: 10px; fill: var(--text-muted); font-family: inherit;
+  }
+  .ol-divider { margin: 32px 0 24px; border: none; border-top: 1px solid var(--divider); }
+  details.notes { margin: 20px 0; }
+  details.notes summary {
+    font-size: 13px; font-weight: 600; color: var(--text-muted);
+    cursor: pointer; padding: 8px 0;
+  }
+  details.notes[open] summary { margin-bottom: 8px; }
+  details.notes p {
+    font-size: 12px; line-height: 1.6; color: var(--text-subtle);
+    margin: 0 0 10px;
+  }
+  .ol-rate-bar-bg { fill: var(--text-subtle); opacity: 0.12; rx: 3; }
+  .ol-rate-bar-fg { fill: var(--c-navy); opacity: 0.7; rx: 3; }
+  @media (max-width: 600px) {
+    .ol-label, .ol-label-win, .ol-label-loss, .ol-label-mh { font-size: 8px; }
+  }
+</style>
+
+<h1 class="h-center">Where Does Marblehead's Override Land?</h1>
+<p class="subtitle h-center">Every operating override of $2M or more since FY2020, across all Massachusetts municipalities. Marblehead's proposed FY2027 override ($8.47M) marked for context.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes, all municipalities, FY2020-FY2027"></sup></p>
+
+<ul class="tldr">
+  <li><strong>65 override elections of $2M+ since FY2020.</strong> 28 passed, 34 failed, 3 split</li>
+  <li><strong>At the $5M-10M range</strong> where Marblehead's ask sits, 8 of 15 passed (53%)</li>
+  <li><strong>Marblehead's prior attempts</strong> ($2.5M in FY2024, $3.1M in FY2023) both failed, at smaller amounts than the current ask</li>
+  <li><strong>Comparable recent wins:</strong> Braintree $8M, Belmont $8.4M, Milton $8.8M. Comparable recent losses: Bridgewater $8M, Malden $8.2M</li>
+</ul>
+
+<h2>Every $2M+ override since FY2020</h2>
+<p class="so-hint" style="font-size: 13px; color: var(--text-muted); margin-bottom: 4px;">Each dot is one town's override election. Horizontal position = total amount requested. Where multiple ballot questions appeared in the same election, amounts are combined.</p>
+
+<div class="ol-legend">
+  <span><span class="ol-legend-swatch ol-legend-swatch--win"></span> Passed</span>
+  <span><span class="ol-legend-swatch ol-legend-swatch--loss"></span> Did not pass</span>
+  <span><span class="ol-legend-swatch ol-legend-swatch--mh"></span> Marblehead (actual)</span>
+  <span><span class="ol-legend-swatch ol-legend-swatch--proposed"></span> Marblehead FY2027 (proposed)</span>
+</div>
+
+<svg class="ol-svg chart" id="ol-strip" viewBox="0 0 880 620" role="img" aria-label="Strip chart of every Massachusetts operating override of 2 million dollars or more since fiscal year 2020, with Marblehead's proposed 8.47 million dollar override marked">
+  <g id="ol-grid"></g>
+  <g id="ol-dots"></g>
+  <g id="ol-labels"></g>
+  <g id="ol-proposed"></g>
+</svg>
+
+<hr class="ol-divider">
+
+<h2>Pass rate by override size (FY2020+)</h2>
+<p class="so-hint" style="font-size: 13px; color: var(--text-muted); margin-bottom: 4px;">Per-election amounts. Marblehead's proposed $8.47M falls in the $5M-10M range.</p>
+
+<svg class="ol-svg chart" id="ol-rates" viewBox="0 0 880 260" role="img" aria-label="Bar chart showing override pass rates by dollar amount bucket since FY2020">
+  <g id="ol-rate-grid"></g>
+  <g id="ol-rate-bars"></g>
+  <g id="ol-rate-labels"></g>
+</svg>
+
+<details class="notes">
+  <summary>Notes and sources</summary>
+  <p>Override vote data from the Massachusetts Department of Revenue, Division of Local Services Municipal Databank.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride"></sup></p>
+  <p>Operating overrides only; debt exclusions not included. Where a town placed multiple override questions on the same ballot, all amounts are combined into a single per-election total. If a majority of questions passed, the election is coded as a win; if a majority failed, a loss; if evenly split, shown as "split" and excluded from pass rate calculations.</p>
+  <p>Marblehead's proposed FY2027 override ($8.47M across three ballot tiers) has not yet been voted on. It is shown as a dashed circle for reference only.</p>
+  <p>FY2027 data is partial as of April 2026.</p>
+</details>
+
+<script>
+(function() {
+  // Elections >= $2M since FY2020, sorted by amount
+  // outcome: 1=win, 0=loss, 0.5=split
+  // mh: 1=marblehead actual, 2=marblehead proposed
+  var VOTES = [
+    {t:"Rutland",fy:2024,a:2000000,o:1},
+    {t:"Whitman",fy:2026,a:2000000,o:0},
+    {t:"Dunstable",fy:2025,a:2074351,o:0},
+    {t:"Paxton",fy:2025,a:2390000,o:0},
+    {t:"Marblehead",fy:2024,a:2472056,o:0,mh:1},
+    {t:"Northampton",fy:2021,a:2500000,o:1},
+    {t:"Hadley",fy:2026,a:2550624,o:0},
+    {t:"Mansfield",fy:2026,a:2703469,o:0},
+    {t:"Belchertown",fy:2026,a:2894400,o:1},
+    {t:"Georgetown",fy:2025,a:3000000,o:0},
+    {t:"Hanson",fy:2026,a:3000000,o:0},
+    {t:"Westport",fy:2024,a:3000000,o:0},
+    {t:"Marblehead",fy:2023,a:3051093,o:0,mh:1},
+    {t:"Grafton",fy:2021,a:3200000,o:1},
+    {t:"Plainville",fy:2021,a:3250000,o:0},
+    {t:"Townsend",fy:2025,a:3356506,o:0},
+    {t:"West Tisbury",fy:2027,a:3491090,o:1},
+    {t:"Winthrop",fy:2026,a:3500000,o:1},
+    {t:"Norwell",fy:2026,a:3700000,o:0},
+    {t:"Hanover",fy:2026,a:3763392,o:1},
+    {t:"Franklin",fy:2026,a:3862672,o:0},
+    {t:"Raynham",fy:2026,a:3938017,o:0},
+    {t:"Hudson",fy:2026,a:3950000,o:1},
+    {t:"West Boylston",fy:2025,a:4000000,o:0},
+    {t:"Westford",fy:2025,a:4200000,o:0},
+    {t:"Pepperell",fy:2025,a:4491136,o:0.5},
+    {t:"Lynnfield",fy:2026,a:4650000,o:1},
+    {t:"Athol",fy:2027,a:4700000,o:0},
+    {t:"Winchendon",fy:2026,a:4800000,o:0.5},
+    {t:"Northbridge",fy:2026,a:4950000,o:0},
+    {t:"Winthrop",fy:2025,a:4950000,o:0},
+    {t:"Nantucket",fy:2022,a:5000000,o:1},
+    {t:"Melrose",fy:2020,a:5180000,o:1},
+    {t:"Arlington",fy:2020,a:5500000,o:1},
+    {t:"Groton",fy:2025,a:5500000,o:0},
+    {t:"Duxbury",fy:2026,a:5800000,o:0},
+    {t:"Norwood",fy:2020,a:5950000,o:1},
+    {t:"Amesbury",fy:2026,a:6000000,o:0},
+    {t:"Georgetown",fy:2026,a:6000000,o:1},
+    {t:"Hanover",fy:2025,a:6002330,o:0},
+    {t:"Belmont",fy:2022,a:6400000,o:0},
+    {t:"Acton",fy:2025,a:6600000,o:1},
+    {t:"Franklin",fy:2025,a:6800000,o:0},
+    {t:"Arlington",fy:2025,a:7000000,o:1},
+    {t:"Natick",fy:2026,a:7000000,o:1},
+    {t:"Easton",fy:2026,a:7300000,o:0},
+    {t:"Medford",fy:2025,a:7500000,o:1},
+    {t:"Melrose",fy:2025,a:7700000,o:0},
+    {t:"Hingham",fy:2024,a:7890467,o:1},
+    {t:"Braintree",fy:2025,a:8000000,o:1},
+    {t:"Bridgewater",fy:2026,a:8008272,o:0},
+    {t:"Belmont",fy:2025,a:8400000,o:1},
+    {t:"Milton",fy:2026,a:8800000,o:1},
+    {t:"Newton",fy:2023,a:9175000,o:0},
+    {t:"Shrewsbury",fy:2022,a:9500000,o:1},
+    {t:"Dudley",fy:2024,a:9938718,o:0},
+    {t:"North Reading",fy:2025,a:10000000,o:0},
+    {t:"Winchester",fy:2020,a:10000000,o:1},
+    {t:"Nantucket",fy:2024,a:10250000,o:1},
+    {t:"Brookline",fy:2024,a:11983367,o:1},
+    {t:"Melrose",fy:2026,a:13500000,o:1},
+    {t:"Malden",fy:2027,a:13600000,o:0},
+    {t:"Stoneham",fy:2026,a:14600000,o:0},
+    {t:"Arlington",fy:2027,a:14800000,o:1},
+    {t:"Stoneham",fy:2027,a:21800000,o:0.5}
+  ];
+
+  var MH_PROPOSED = {t:"Marblehead",fy:2027,a:8470000};
+
+  var W = 880, mL = 60, mR = 100;
+  var pW = W - mL - mR;
+
+  // =============================================
+  // CHART 1: STRIP CHART
+  // =============================================
+  (function() {
+    var H = 620, mT = 20, mB = 40;
+    var pH = H - mT - mB;
+    var n = VOTES.length;
+    var rowH = Math.floor(pH / (n + 2)); // +2 for proposed
+    var dotR = Math.min(rowH * 0.35, 6);
+
+    var maxAmt = 22000000;
+    var gridG = document.getElementById("ol-grid");
+    var dotsG = document.getElementById("ol-dots");
+    var labelsG = document.getElementById("ol-labels");
+    var proposedG = document.getElementById("ol-proposed");
+
+    function xScale(amt) { return mL + pW * (amt / maxAmt); }
+    function yPos(i) { return mT + (i + 0.5) * rowH; }
+
+    // Grid lines at dollar amounts
+    var gridAmts = [0, 2000000, 4000000, 6000000, 8000000, 10000000, 12000000, 14000000, 16000000, 18000000, 20000000];
+    gridAmts.forEach(function(v) {
+      var x = xScale(v);
+      var line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+      line.setAttribute("x1", x); line.setAttribute("x2", x);
+      line.setAttribute("y1", mT); line.setAttribute("y2", H - mB);
+      line.setAttribute("class", v === 0 ? "axis-base" : "grid-minor");
+      gridG.appendChild(line);
+
+      var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+      label.setAttribute("x", x);
+      label.setAttribute("y", H - mB + 16);
+      label.setAttribute("text-anchor", "middle");
+      label.setAttribute("class", "ol-tick");
+      label.textContent = "$" + (v / 1000000) + "M";
+      gridG.appendChild(label);
+    });
+
+    // Proposed Marblehead line
+    var mhX = xScale(MH_PROPOSED.a);
+    var mhLine = document.createElementNS("http://www.w3.org/2000/svg", "line");
+    mhLine.setAttribute("x1", mhX); mhLine.setAttribute("x2", mhX);
+    mhLine.setAttribute("y1", mT); mhLine.setAttribute("y2", H - mB);
+    mhLine.setAttribute("class", "ol-proposed-line");
+    proposedG.appendChild(mhLine);
+
+    var mhLabel = document.createElementNS("http://www.w3.org/2000/svg", "text");
+    mhLabel.setAttribute("x", mhX);
+    mhLabel.setAttribute("y", mT - 6);
+    mhLabel.setAttribute("text-anchor", "middle");
+    mhLabel.setAttribute("class", "ol-proposed-label");
+    mhLabel.textContent = "Marblehead FY27 proposed: $8.47M";
+    proposedG.appendChild(mhLabel);
+
+    // Dots and labels
+    VOTES.forEach(function(v, i) {
+      var cx = xScale(v.a);
+      var cy = yPos(i);
+
+      var dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+      dot.setAttribute("cx", cx);
+      dot.setAttribute("cy", cy);
+      dot.setAttribute("r", v.mh ? dotR + 1 : dotR);
+
+      if (v.mh) {
+        dot.setAttribute("class", "ol-dot-mh");
+      } else if (v.o === 1) {
+        dot.setAttribute("class", "ol-dot-win");
+      } else if (v.o === 0) {
+        dot.setAttribute("class", "ol-dot-loss");
+      } else {
+        dot.setAttribute("class", "ol-dot-loss");
+        dot.setAttribute("opacity", "0.6");
+      }
+      dotsG.appendChild(dot);
+
+      // Label: "Town FYxx"
+      var labelClass = v.mh ? "ol-label-mh" : (v.o === 1 ? "ol-label-win" : "ol-label-loss");
+      var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+      label.setAttribute("x", cx + dotR + 4);
+      label.setAttribute("y", cy + 3);
+      label.setAttribute("class", labelClass);
+
+      var displayAmt = v.a >= 10000000
+        ? "$" + (v.a / 1000000).toFixed(1) + "M"
+        : "$" + (v.a / 1000000).toFixed(1) + "M";
+      label.textContent = v.t + " FY" + (v.fy % 100).toString().padStart(2, "0");
+      labelsG.appendChild(label);
+    });
+  })();
+
+  // =============================================
+  // CHART 2: PASS RATE BY SIZE BUCKET
+  // =============================================
+  (function() {
+    var BUCKETS = [
+      {label:"<$100K",lo:0,hi:100000,win:25,total:34},
+      {label:"$100K-250K",lo:100000,hi:250000,win:30,total:47},
+      {label:"$250K-500K",lo:250000,hi:500000,win:38,total:58},
+      {label:"$500K-1M",lo:500000,hi:1000000,win:38,total:55},
+      {label:"$1M-2M",lo:1000000,hi:2000000,win:22,total:35},
+      {label:"$2M-5M",lo:2000000,hi:5000000,win:12,total:34},
+      {label:"$5M-10M",lo:5000000,hi:10000000,win:15,total:27},
+      {label:"$10M+",lo:10000000,hi:999999999,win:7,total:12}
+    ];
+
+    var H = 260, mT = 30, mB = 30;
+    var pH = H - mT - mB;
+    var bL = 120, bR = 60;
+    var bW = W - bL - bR;
+    var barH = Math.floor(pH / BUCKETS.length) - 4;
+
+    var gridG = document.getElementById("ol-rate-grid");
+    var barsG = document.getElementById("ol-rate-bars");
+    var rLabelsG = document.getElementById("ol-rate-labels");
+
+    // Grid
+    [0, 25, 50, 75, 100].forEach(function(pct) {
+      var x = bL + bW * pct / 100;
+      var line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+      line.setAttribute("x1", x); line.setAttribute("x2", x);
+      line.setAttribute("y1", mT); line.setAttribute("y2", H - mB);
+      line.setAttribute("class", pct === 0 ? "axis-base" : "grid-minor");
+      gridG.appendChild(line);
+
+      var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+      label.setAttribute("x", x);
+      label.setAttribute("y", mT - 8);
+      label.setAttribute("text-anchor", "middle");
+      label.setAttribute("class", "ol-label");
+      label.textContent = pct + "%";
+      rLabelsG.appendChild(label);
+    });
+
+    // 50% reference
+    var ref = document.createElementNS("http://www.w3.org/2000/svg", "line");
+    ref.setAttribute("x1", bL + bW * 0.5); ref.setAttribute("x2", bL + bW * 0.5);
+    ref.setAttribute("y1", mT); ref.setAttribute("y2", H - mB);
+    ref.setAttribute("class", "grid-major");
+    gridG.appendChild(ref);
+
+    // Highlight the bucket Marblehead falls into
+    var mhBucketIdx = 6; // $5M-10M
+
+    BUCKETS.forEach(function(b, i) {
+      var y = mT + i * (barH + 4);
+      var rate = b.total > 0 ? b.win / b.total * 100 : 0;
+
+      // Background bar
+      var bg = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+      bg.setAttribute("x", bL); bg.setAttribute("y", y);
+      bg.setAttribute("width", bW); bg.setAttribute("height", barH);
+      bg.setAttribute("class", "ol-rate-bar-bg");
+      barsG.appendChild(bg);
+
+      // Foreground bar
+      var fg = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+      fg.setAttribute("x", bL); fg.setAttribute("y", y);
+      fg.setAttribute("width", bW * rate / 100); fg.setAttribute("height", barH);
+      fg.setAttribute("class", "ol-rate-bar-fg");
+      if (i === mhBucketIdx) {
+        fg.setAttribute("fill", "var(--c-buoy)");
+        fg.setAttribute("opacity", "0.8");
+      }
+      barsG.appendChild(fg);
+
+      // Bucket label
+      var bl = document.createElementNS("http://www.w3.org/2000/svg", "text");
+      bl.setAttribute("x", bL - 6); bl.setAttribute("y", y + barH / 2 + 4);
+      bl.setAttribute("text-anchor", "end");
+      bl.setAttribute("class", i === mhBucketIdx ? "ol-label-mh" : "ol-label");
+      bl.textContent = b.label;
+      rLabelsG.appendChild(bl);
+
+      // Rate + count label
+      var rl = document.createElementNS("http://www.w3.org/2000/svg", "text");
+      var rx = bL + bW * rate / 100 + 6;
+      rl.setAttribute("x", rx); rl.setAttribute("y", y + barH / 2 + 4);
+      rl.setAttribute("class", "ol-callout");
+      rl.setAttribute("fill", i === mhBucketIdx ? "var(--c-buoy)" : "var(--c-navy)");
+      rl.textContent = Math.round(rate) + "% (" + b.win + "/" + b.total + ")";
+      rLabelsG.appendChild(rl);
+    });
+  })();
+})();
+</script>

--- a/charts/override_landscape.html
+++ b/charts/override_landscape.html
@@ -3,19 +3,9 @@ title: "Override Landscape: Large Asks Since FY2020"
 scripts: [citations]
 ---
 <style>
-  .ol-dot-win { fill: var(--c-navy); }
-  .ol-dot-loss { fill: none; stroke: var(--text-muted); stroke-width: 2; }
-  .ol-dot-mh { fill: var(--c-buoy); }
-  .ol-dot-proposed { fill: none; stroke: var(--c-buoy); stroke-width: 2; stroke-dasharray: 3 2; }
-  .ol-label { font-size: 9px; fill: var(--text-muted); font-family: inherit; }
-  .ol-label-mh { font-size: 10px; fill: var(--c-buoy); font-family: inherit; font-weight: 700; }
+  .ol-label { font-size: 10px; fill: var(--text-muted); font-family: inherit; }
   .ol-tick { font-size: 10px; fill: var(--text-muted); font-family: inherit; }
   .ol-callout { font-size: 10px; font-family: inherit; font-weight: 600; }
-  .ol-zone { opacity: 0.04; }
-  .ol-zone-label {
-    font-size: 10px; fill: var(--text-muted); font-family: inherit;
-    font-weight: 600; opacity: 0.6;
-  }
   .ol-legend {
     display: flex; gap: 16px; justify-content: center; flex-wrap: wrap;
     margin: 8px 0 12px; font-size: 12px; color: var(--text-muted);
@@ -24,24 +14,46 @@ scripts: [citations]
     display: inline-block; width: 10px; height: 10px;
     border-radius: 50%; vertical-align: middle; margin-right: 4px;
   }
-  .ol-legend-swatch--win { background: var(--c-navy); }
-  .ol-legend-swatch--loss { background: none; border: 2px solid var(--text-muted); }
   .ol-legend-swatch--mh { background: var(--c-buoy); }
-  .ol-legend-swatch--proposed { background: none; border: 2px dashed var(--c-buoy); }
   .ol-svg { display: block; width: 100%; height: auto; max-width: 880px; margin: 0 auto; }
   .ol-divider { margin: 32px 0 24px; border: none; border-top: 1px solid var(--divider); }
   .ol-rate-bar-bg { fill: var(--text-subtle); opacity: 0.12; }
   .ol-rate-bar-fg { fill: var(--c-navy); opacity: 0.7; }
-  .ol-tip {
-    position: absolute; pointer-events: none;
-    background: var(--surface); border: 1px solid var(--border);
-    border-radius: 6px; padding: 8px 12px;
-    font-size: 12px; line-height: 1.5; color: var(--text);
-    box-shadow: var(--shadow-sm); white-space: nowrap;
-    opacity: 0; transition: opacity 0.15s;
-    z-index: 10;
+  .ol-comps {
+    max-width: 680px; margin: 0 auto;
+    border-collapse: collapse; width: 100%;
+    font-size: 14px;
   }
-  .ol-tip.visible { opacity: 1; }
+  .ol-comps th {
+    text-align: left; font-weight: 600; font-size: 12px;
+    color: var(--text-muted); border-bottom: 2px solid var(--divider);
+    padding: 6px 12px 6px 0;
+  }
+  .ol-comps td {
+    padding: 8px 12px 8px 0; border-bottom: 1px solid var(--divider);
+    vertical-align: middle;
+  }
+  .ol-comps tr.mh-row td {
+    color: var(--c-buoy); font-weight: 700;
+    border-bottom: 2px solid var(--c-buoy);
+    border-top: 2px solid var(--c-buoy);
+  }
+  .ol-comps .outcome-win {
+    display: inline-block; padding: 2px 8px; border-radius: 3px;
+    background: var(--c-navy); color: var(--c-fog); font-size: 11px;
+    font-weight: 600;
+  }
+  .ol-comps .outcome-loss {
+    display: inline-block; padding: 2px 8px; border-radius: 3px;
+    border: 1.5px solid var(--text-muted); color: var(--text-muted);
+    font-size: 11px; font-weight: 600;
+  }
+  .ol-comps .outcome-proposed {
+    display: inline-block; padding: 2px 8px; border-radius: 3px;
+    border: 1.5px dashed var(--c-buoy); color: var(--c-buoy);
+    font-size: 11px; font-weight: 600;
+  }
+  .ol-comps .amt { font-variant-numeric: tabular-nums; }
   details.notes { margin: 20px 0; }
   details.notes summary {
     font-size: 13px; font-weight: 600; color: var(--text-muted);
@@ -52,46 +64,20 @@ scripts: [citations]
     font-size: 12px; line-height: 1.6; color: var(--text-subtle);
     margin: 0 0 10px;
   }
-  @media (max-width: 600px) {
-    .ol-label, .ol-label-mh { font-size: 8px; }
-  }
 </style>
 
 <h1 class="h-center">Where Does Marblehead's Override Land?</h1>
-<p class="subtitle h-center">Every operating override of $2M or more since FY2020, plotted by amount and fiscal year. Marblehead's proposed FY2027 override ($8.47M) marked for context.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes, all municipalities, FY2020-FY2027"></sup></p>
+<p class="subtitle h-center">Every operating override of $2M or more since FY2020, across all Massachusetts municipalities.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes, all municipalities, FY2020-FY2027"></sup></p>
 
 <ul class="tldr">
   <li><strong>Operating overrides only.</strong> Debt exclusions (capital projects, school buildings) not included</li>
   <li><strong>65 override elections of $2M+ since FY2020.</strong> 28 passed, 34 failed, 3 split</li>
   <li><strong>At the $5M-10M range</strong> where Marblehead's ask sits, 8 of 15 passed (53%)</li>
   <li><strong>Marblehead's prior attempts</strong> ($2.5M in FY2024, $3.1M in FY2023) both failed at smaller amounts</li>
-  <li><strong>Comparable recent wins:</strong> Braintree $8M, Belmont $8.4M, Milton $8.8M. Comparable losses: Bridgewater $8M, Malden $8.2M</li>
 </ul>
 
-<h2>Every $2M+ override since FY2020</h2>
-<p class="so-hint" style="font-size: 13px; color: var(--text-muted); margin-bottom: 4px;">Each dot is one town's override election. Horizontal position = amount requested; vertical position = fiscal year. Hover or tap for details.</p>
-
-<div class="ol-legend">
-  <span><span class="ol-legend-swatch ol-legend-swatch--win"></span> Passed</span>
-  <span><span class="ol-legend-swatch ol-legend-swatch--loss"></span> Did not pass</span>
-  <span><span class="ol-legend-swatch ol-legend-swatch--mh"></span> Marblehead (actual)</span>
-  <span><span class="ol-legend-swatch ol-legend-swatch--proposed"></span> Marblehead FY2027 (proposed)</span>
-</div>
-
-<div style="position:relative;" id="ol-wrap">
-<div class="ol-tip" id="ol-tip"></div>
-<svg class="ol-svg chart" id="ol-scatter" viewBox="0 0 880 420" role="img" aria-label="Scatter plot of every Massachusetts operating override of 2 million dollars or more since fiscal year 2020, with amount on the horizontal axis and fiscal year on the vertical axis">
-  <g id="ol-grid"></g>
-  <g id="ol-zones"></g>
-  <g id="ol-dots"></g>
-  <g id="ol-labels"></g>
-</svg>
-</div>
-
-<hr class="ol-divider">
-
 <h2>Pass rate by override size (FY2020+)</h2>
-<p class="so-hint" style="font-size: 13px; color: var(--text-muted); margin-bottom: 4px;">Per-election amounts. Marblehead's proposed $8.47M falls in the $5M-10M range.</p>
+<p style="font-size: 13px; color: var(--text-muted); margin-bottom: 4px;">Per-election amounts (all ballot questions from one town in one year combined). The <span style="color: var(--c-buoy); font-weight: 600;">$5M-10M</span> bucket is where Marblehead's proposed $8.47M falls.</p>
 
 <svg class="ol-svg chart" id="ol-rates" viewBox="0 0 880 260" role="img" aria-label="Bar chart showing override pass rates by dollar amount bucket since FY2020">
   <g id="ol-rate-grid"></g>
@@ -99,397 +85,137 @@ scripts: [citations]
   <g id="ol-rate-labels"></g>
 </svg>
 
+<hr class="ol-divider">
+
+<h2>Closest comparables to Marblehead's $8.47M</h2>
+<p style="font-size: 13px; color: var(--text-muted); margin-bottom: 12px;">Every override between $6M and $11M since FY2020, sorted by amount. Marblehead's proposed FY2027 ask shown for reference.</p>
+
+<table class="ol-comps">
+  <thead>
+    <tr><th>Town</th><th>FY</th><th>Amount</th><th>Result</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Amesbury</td><td>2026</td><td class="amt">$6.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Georgetown</td><td>2026</td><td class="amt">$6.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Hanover</td><td>2025</td><td class="amt">$6.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Belmont</td><td>2022</td><td class="amt">$6.4M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Acton</td><td>2025</td><td class="amt">$6.6M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Franklin</td><td>2025</td><td class="amt">$6.8M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Arlington</td><td>2025</td><td class="amt">$7.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Natick</td><td>2026</td><td class="amt">$7.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Easton</td><td>2026</td><td class="amt">$7.3M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Medford</td><td>2025</td><td class="amt">$7.5M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Melrose</td><td>2025</td><td class="amt">$7.7M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Hingham</td><td>2024</td><td class="amt">$7.9M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Braintree</td><td>2025</td><td class="amt">$8.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Bridgewater</td><td>2026</td><td class="amt">$8.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr class="mh-row"><td>Marblehead</td><td>2027</td><td class="amt">$8.47M</td><td><span class="outcome-proposed">Proposed</span></td></tr>
+    <tr><td>Belmont</td><td>2025</td><td class="amt">$8.4M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Milton</td><td>2026</td><td class="amt">$8.8M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Newton</td><td>2023</td><td class="amt">$9.2M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Shrewsbury</td><td>2022</td><td class="amt">$9.5M</td><td><span class="outcome-win">Passed</span></td></tr>
+    <tr><td>Dudley</td><td>2024</td><td class="amt">$9.9M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>North Reading</td><td>2025</td><td class="amt">$10.0M</td><td><span class="outcome-loss">Did not pass</span></td></tr>
+    <tr><td>Winchester</td><td>2020</td><td class="amt">$10.0M</td><td><span class="outcome-win">Passed</span></td></tr>
+  </tbody>
+</table>
+
 <details class="notes">
   <summary>Notes and sources</summary>
   <p>Override vote data from the Massachusetts Department of Revenue, Division of Local Services Municipal Databank.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride"></sup></p>
-  <p>Operating overrides only; debt exclusions not included. Where a town placed multiple override questions on the same ballot, all amounts are combined into a single per-election total. If a majority of questions passed, the election is coded as a win; if a majority failed, a loss; if evenly split, shown as "split" and excluded from pass rate calculations.</p>
-  <p>Marblehead's proposed FY2027 override ($8.47M across three ballot tiers) has not yet been voted on. It is shown as a dashed circle for reference only.</p>
-  <p>Stoneham FY2027 ($21.8M combined across two votes, one passed at $9.3M) is off the chart's x-axis and noted in the tooltip data but not plotted.</p>
+  <p>Operating overrides only; debt exclusions not included. Where a town placed multiple override questions on the same ballot, all amounts are combined into a single per-election total. If a majority of questions passed, the election is coded as a win; if a majority failed, a loss.</p>
+  <p>Marblehead's proposed FY2027 override ($8.47M across three ballot tiers) has not yet been voted on.</p>
+  <p>The comparable range ($6M-$11M) includes 22 elections: 10 passed, 10 failed, plus Marblehead's pending vote and one borderline result. A coin flip at this size.</p>
   <p>FY2027 data is partial as of April 2026.</p>
 </details>
 
 <script>
 (function() {
-  // Elections >= $2M since FY2020, sorted by amount
-  // o: 1=win, 0=loss, 0.5=split; mh: 1=actual
-  var VOTES = [
-    {t:"Rutland",fy:2024,a:2000000,o:1},
-    {t:"Whitman",fy:2026,a:2000000,o:0},
-    {t:"Dunstable",fy:2025,a:2074351,o:0},
-    {t:"Paxton",fy:2025,a:2390000,o:0},
-    {t:"Marblehead",fy:2024,a:2472056,o:0,mh:1},
-    {t:"Northampton",fy:2021,a:2500000,o:1},
-    {t:"Hadley",fy:2026,a:2550624,o:0},
-    {t:"Mansfield",fy:2026,a:2703469,o:0},
-    {t:"Belchertown",fy:2026,a:2894400,o:1},
-    {t:"Georgetown",fy:2025,a:3000000,o:0},
-    {t:"Hanson",fy:2026,a:3000000,o:0},
-    {t:"Westport",fy:2024,a:3000000,o:0},
-    {t:"Marblehead",fy:2023,a:3051093,o:0,mh:1},
-    {t:"Grafton",fy:2021,a:3200000,o:1},
-    {t:"Plainville",fy:2021,a:3250000,o:0},
-    {t:"Townsend",fy:2025,a:3356506,o:0},
-    {t:"West Tisbury",fy:2027,a:3491090,o:1},
-    {t:"Winthrop",fy:2026,a:3500000,o:1},
-    {t:"Norwell",fy:2026,a:3700000,o:0},
-    {t:"Hanover",fy:2026,a:3763392,o:1},
-    {t:"Franklin",fy:2026,a:3862672,o:0},
-    {t:"Raynham",fy:2026,a:3938017,o:0},
-    {t:"Hudson",fy:2026,a:3950000,o:1},
-    {t:"West Boylston",fy:2025,a:4000000,o:0},
-    {t:"Westford",fy:2025,a:4200000,o:0},
-    {t:"Pepperell",fy:2025,a:4491136,o:0.5},
-    {t:"Lynnfield",fy:2026,a:4650000,o:1},
-    {t:"Athol",fy:2027,a:4700000,o:0},
-    {t:"Winchendon",fy:2026,a:4800000,o:0.5},
-    {t:"Northbridge",fy:2026,a:4950000,o:0},
-    {t:"Winthrop",fy:2025,a:4950000,o:0},
-    {t:"Nantucket",fy:2022,a:5000000,o:1},
-    {t:"Melrose",fy:2020,a:5180000,o:1},
-    {t:"Arlington",fy:2020,a:5500000,o:1},
-    {t:"Groton",fy:2025,a:5500000,o:0},
-    {t:"Duxbury",fy:2026,a:5800000,o:0},
-    {t:"Norwood",fy:2020,a:5950000,o:1},
-    {t:"Amesbury",fy:2026,a:6000000,o:0},
-    {t:"Georgetown",fy:2026,a:6000000,o:1},
-    {t:"Hanover",fy:2025,a:6002330,o:0},
-    {t:"Belmont",fy:2022,a:6400000,o:0},
-    {t:"Acton",fy:2025,a:6600000,o:1},
-    {t:"Franklin",fy:2025,a:6800000,o:0},
-    {t:"Arlington",fy:2025,a:7000000,o:1},
-    {t:"Natick",fy:2026,a:7000000,o:1},
-    {t:"Easton",fy:2026,a:7300000,o:0},
-    {t:"Medford",fy:2025,a:7500000,o:1},
-    {t:"Melrose",fy:2025,a:7700000,o:0},
-    {t:"Hingham",fy:2024,a:7890467,o:1},
-    {t:"Braintree",fy:2025,a:8000000,o:1},
-    {t:"Bridgewater",fy:2026,a:8008272,o:0},
-    {t:"Belmont",fy:2025,a:8400000,o:1},
-    {t:"Milton",fy:2026,a:8800000,o:1},
-    {t:"Newton",fy:2023,a:9175000,o:0},
-    {t:"Shrewsbury",fy:2022,a:9500000,o:1},
-    {t:"Dudley",fy:2024,a:9938718,o:0},
-    {t:"North Reading",fy:2025,a:10000000,o:0},
-    {t:"Winchester",fy:2020,a:10000000,o:1},
-    {t:"Nantucket",fy:2024,a:10250000,o:1},
-    {t:"Brookline",fy:2024,a:11983367,o:1},
-    {t:"Melrose",fy:2026,a:13500000,o:1},
-    {t:"Malden",fy:2027,a:13600000,o:0},
-    {t:"Stoneham",fy:2026,a:14600000,o:0},
-    {t:"Arlington",fy:2027,a:14800000,o:1}
-    // Stoneham FY2027 ($21.8M) omitted as outlier
+  var W = 880;
+
+  var BUCKETS = [
+    {label:"<$100K",win:25,total:34},
+    {label:"$100-250K",win:30,total:47},
+    {label:"$250-500K",win:38,total:58},
+    {label:"$500K-1M",win:38,total:55},
+    {label:"$1-2M",win:22,total:35},
+    {label:"$2-5M",win:12,total:34},
+    {label:"$5-10M",win:15,total:27},
+    {label:"$10M+",win:7,total:12}
   ];
 
-  var MH_PROPOSED = {t:"Marblehead",fy:2027,a:8470000};
+  var H = 260, mT = 30, mB = 30;
+  var rH = H - mT - mB;
+  var bL = 100, bR = 80;
+  var bW = W - bL - bR;
+  var barH = Math.floor(rH / BUCKETS.length) - 4;
+  var mhBucketIdx = 6;
 
-  var W = 880;
-  var mL = 60, mR = 30, mT = 30, mB = 40;
-  var pW = W - mL - mR;
-  var maxAmt = 15500000;
-  var fyMin = 2019.5, fyMax = 2027.5;
+  var gridG = document.getElementById("ol-rate-grid");
+  var barsG = document.getElementById("ol-rate-bars");
+  var labelsG = document.getElementById("ol-rate-labels");
 
-  // =============================================
-  // CHART 1: SCATTER
-  // =============================================
-  (function() {
-    var H = 420;
-    var pH = H - mT - mB;
+  [0, 25, 50, 75, 100].forEach(function(pct) {
+    var x = bL + bW * pct / 100;
+    var line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+    line.setAttribute("x1", x); line.setAttribute("x2", x);
+    line.setAttribute("y1", mT); line.setAttribute("y2", H - mB);
+    line.setAttribute("class", pct === 0 ? "axis-base" : "grid-minor");
+    gridG.appendChild(line);
 
-    var gridG = document.getElementById("ol-grid");
-    var zonesG = document.getElementById("ol-zones");
-    var dotsG = document.getElementById("ol-dots");
-    var labelsG = document.getElementById("ol-labels");
+    var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+    label.setAttribute("x", x);
+    label.setAttribute("y", mT - 8);
+    label.setAttribute("text-anchor", "middle");
+    label.setAttribute("class", "ol-label");
+    label.textContent = pct + "%";
+    labelsG.appendChild(label);
+  });
 
-    function xScale(amt) { return mL + pW * Math.min(amt, maxAmt) / maxAmt; }
-    function yScale(fy) { return mT + pH * (1 - (fy - fyMin) / (fyMax - fyMin)); }
+  // 50% reference
+  var ref = document.createElementNS("http://www.w3.org/2000/svg", "line");
+  ref.setAttribute("x1", bL + bW * 0.5); ref.setAttribute("x2", bL + bW * 0.5);
+  ref.setAttribute("y1", mT); ref.setAttribute("y2", H - mB);
+  ref.setAttribute("class", "grid-major");
+  gridG.appendChild(ref);
 
-    // X grid (dollar amounts)
-    for (var v = 0; v <= maxAmt; v += 2000000) {
-      var x = xScale(v);
-      var line = document.createElementNS("http://www.w3.org/2000/svg", "line");
-      line.setAttribute("x1", x); line.setAttribute("x2", x);
-      line.setAttribute("y1", mT); line.setAttribute("y2", H - mB);
-      line.setAttribute("class", v === 0 ? "axis-base" : "grid-minor");
-      gridG.appendChild(line);
+  BUCKETS.forEach(function(b, i) {
+    var y = mT + i * (barH + 4);
+    var rate = b.total > 0 ? b.win / b.total * 100 : 0;
 
-      var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
-      label.setAttribute("x", x);
-      label.setAttribute("y", H - mB + 16);
-      label.setAttribute("text-anchor", "middle");
-      label.setAttribute("class", "ol-tick");
-      label.textContent = "$" + (v / 1000000) + "M";
-      gridG.appendChild(label);
+    var bg = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    bg.setAttribute("x", bL); bg.setAttribute("y", y);
+    bg.setAttribute("width", bW); bg.setAttribute("height", barH);
+    bg.setAttribute("rx", 3);
+    bg.setAttribute("class", "ol-rate-bar-bg");
+    barsG.appendChild(bg);
+
+    var fg = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    fg.setAttribute("x", bL); fg.setAttribute("y", y);
+    fg.setAttribute("width", bW * rate / 100); fg.setAttribute("height", barH);
+    fg.setAttribute("rx", 3);
+    fg.setAttribute("class", "ol-rate-bar-fg");
+    if (i === mhBucketIdx) {
+      fg.setAttribute("fill", "var(--c-buoy)");
+      fg.setAttribute("opacity", "0.8");
     }
+    barsG.appendChild(fg);
 
-    // Y grid (fiscal years)
-    for (var fy = 2020; fy <= 2027; fy++) {
-      var y = yScale(fy);
-      var line = document.createElementNS("http://www.w3.org/2000/svg", "line");
-      line.setAttribute("x1", mL); line.setAttribute("x2", W - mR);
-      line.setAttribute("y1", y); line.setAttribute("y2", y);
-      line.setAttribute("class", "grid-minor");
-      gridG.appendChild(line);
+    var bl = document.createElementNS("http://www.w3.org/2000/svg", "text");
+    bl.setAttribute("x", bL - 6); bl.setAttribute("y", y + barH / 2 + 4);
+    bl.setAttribute("text-anchor", "end");
+    bl.setAttribute("class", i === mhBucketIdx ? "ol-callout" : "ol-label");
+    if (i === mhBucketIdx) bl.setAttribute("fill", "var(--c-buoy)");
+    bl.textContent = b.label;
+    labelsG.appendChild(bl);
 
-      var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
-      label.setAttribute("x", mL - 8);
-      label.setAttribute("y", y + 4);
-      label.setAttribute("text-anchor", "end");
-      label.setAttribute("class", "ol-tick");
-      label.textContent = "FY" + fy;
-      gridG.appendChild(label);
-    }
-
-    // Marblehead's proposed amount: vertical band
-    var mhX = xScale(MH_PROPOSED.a);
-    var bandW = 30;
-    var band = document.createElementNS("http://www.w3.org/2000/svg", "rect");
-    band.setAttribute("x", mhX - bandW / 2);
-    band.setAttribute("y", mT);
-    band.setAttribute("width", bandW);
-    band.setAttribute("height", pH);
-    band.setAttribute("fill", "var(--c-buoy)");
-    band.setAttribute("class", "ol-zone");
-    zonesG.appendChild(band);
-
-    // Proposed dot
-    var propDot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
-    propDot.setAttribute("cx", mhX);
-    propDot.setAttribute("cy", yScale(MH_PROPOSED.fy));
-    propDot.setAttribute("r", 8);
-    propDot.setAttribute("class", "ol-dot-proposed");
-    dotsG.appendChild(propDot);
-
-    var propLabel = document.createElementNS("http://www.w3.org/2000/svg", "text");
-    propLabel.setAttribute("x", mhX);
-    propLabel.setAttribute("y", mT - 10);
-    propLabel.setAttribute("text-anchor", "middle");
-    propLabel.setAttribute("class", "ol-label-mh");
-    propLabel.setAttribute("font-size", "11px");
-    propLabel.textContent = "Marblehead proposed: $8.47M";
-    labelsG.appendChild(propLabel);
-
-    // Whitelist: only label Marblehead + hand-picked comparables
-    // that won't collide. Everything else is tooltip-only.
-    var LABEL_SET = {
-      // Marblehead actuals (always labeled)
-      "Marblehead|2023": {anchor:"start", dx:10, dy:3},
-      "Marblehead|2024": {anchor:"start", dx:10, dy:3},
-      // Key comparables near $8.47M
-      "Braintree|2025": {anchor:"start", dx:8, dy:-6},
-      "Milton|2026": {anchor:"start", dx:8, dy:3},
-      "Belmont|2025": {anchor:"start", dx:8, dy:12},
-      // Bookend wins
-      "Arlington|2027": {anchor:"start", dx:8, dy:3},
-      "Brookline|2024": {anchor:"start", dx:8, dy:3},
-      "Winchester|2020": {anchor:"start", dx:8, dy:3},
-      // Bookend losses
-      "Stoneham|2026": {anchor:"end", dx:-8, dy:3},
-    };
-
-    // Jitter: offset dots that share the same FY to avoid overlap
-    var byFy = {};
-    VOTES.forEach(function(v) {
-      if (!byFy[v.fy]) byFy[v.fy] = [];
-      byFy[v.fy].push(v);
-    });
-
-    // Sort within each FY by amount for consistent jitter
-    Object.keys(byFy).forEach(function(fy) {
-      byFy[fy].sort(function(a, b) { return a.a - b.a; });
-    });
-
-    // Assign jitter offsets
-    var jitterMap = new Map();
-    Object.keys(byFy).forEach(function(fy) {
-      var items = byFy[fy];
-      // Group nearby amounts (within 500K) to detect clusters
-      var clusters = [];
-      var cur = [items[0]];
-      for (var i = 1; i < items.length; i++) {
-        if (items[i].a - cur[cur.length - 1].a < 800000) {
-          cur.push(items[i]);
-        } else {
-          clusters.push(cur);
-          cur = [items[i]];
-        }
-      }
-      clusters.push(cur);
-
-      clusters.forEach(function(cluster) {
-        if (cluster.length === 1) {
-          jitterMap.set(cluster[0], 0);
-        } else {
-          var spread = Math.min(cluster.length * 6, pH / 16);
-          cluster.forEach(function(v, j) {
-            var offset = (j - (cluster.length - 1) / 2) * (spread / cluster.length);
-            jitterMap.set(v, offset);
-          });
-        }
-      });
-    });
-
-    // Draw dots
-    var dotEls = [];
-    VOTES.forEach(function(v) {
-      var cx = xScale(v.a);
-      var jitter = jitterMap.get(v) || 0;
-      var cy = yScale(v.fy) + jitter;
-      var r = v.mh ? 7 : (v.a >= 7000000 ? 5.5 : 4.5);
-
-      var dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
-      dot.setAttribute("cx", cx);
-      dot.setAttribute("cy", cy);
-      dot.setAttribute("r", r);
-
-      if (v.mh) {
-        dot.setAttribute("class", "ol-dot-mh");
-      } else if (v.o === 1) {
-        dot.setAttribute("class", "ol-dot-win");
-      } else {
-        dot.setAttribute("class", "ol-dot-loss");
-      }
-
-      dot.setAttribute("data-town", v.t);
-      dot.setAttribute("data-fy", v.fy);
-      dot.setAttribute("data-amt", v.a);
-      dot.setAttribute("data-outcome", v.o === 1 ? "Passed" : (v.o === 0 ? "Did not pass" : "Split"));
-      dot.style.cursor = "pointer";
-      dotsG.appendChild(dot);
-      dotEls.push({el: dot, v: v, cx: cx, cy: cy});
-
-      // Label only whitelisted dots
-      var key = v.t + "|" + v.fy;
-      var lp = LABEL_SET[key];
-      if (lp) {
-        var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
-        label.setAttribute("x", cx + lp.dx);
-        label.setAttribute("y", cy + lp.dy);
-        label.setAttribute("text-anchor", lp.anchor);
-        label.setAttribute("class", v.mh ? "ol-label-mh" : "ol-label");
-        label.textContent = v.t;
-        labelsG.appendChild(label);
-      }
-    });
-
-    // Tooltip
-    var tip = document.getElementById("ol-tip");
-    var wrap = document.getElementById("ol-wrap");
-
-    dotEls.forEach(function(d) {
-      function showTip(e) {
-        var v = d.v;
-        var amt = "$" + (v.a >= 1000000
-          ? (v.a / 1000000).toFixed(1) + "M"
-          : Math.round(v.a / 1000) + "K");
-        tip.innerHTML = "<strong>" + v.t + "</strong> FY" + v.fy +
-          "<br>" + amt + " &mdash; " + d.el.getAttribute("data-outcome");
-        tip.classList.add("visible");
-
-        var rect = wrap.getBoundingClientRect();
-        var svgRect = document.getElementById("ol-scatter").getBoundingClientRect();
-        var dotX = (d.cx / 880) * svgRect.width;
-        var dotY = (d.cy / 420) * svgRect.height;
-
-        tip.style.left = (dotX + svgRect.left - rect.left + 12) + "px";
-        tip.style.top = (dotY + svgRect.top - rect.top - 10) + "px";
-      }
-      function hideTip() { tip.classList.remove("visible"); }
-      d.el.addEventListener("mouseenter", showTip);
-      d.el.addEventListener("mouseleave", hideTip);
-      d.el.addEventListener("touchstart", function(e) {
-        e.preventDefault(); showTip(e);
-        setTimeout(hideTip, 2500);
-      }, {passive: false});
-    });
-  })();
-
-  // =============================================
-  // CHART 2: PASS RATE BY SIZE BUCKET
-  // =============================================
-  (function() {
-    var BUCKETS = [
-      {label:"<$100K",win:25,total:34},
-      {label:"$100-250K",win:30,total:47},
-      {label:"$250-500K",win:38,total:58},
-      {label:"$500K-1M",win:38,total:55},
-      {label:"$1-2M",win:22,total:35},
-      {label:"$2-5M",win:12,total:34},
-      {label:"$5-10M",win:15,total:27},
-      {label:"$10M+",win:7,total:12}
-    ];
-
-    var H = 260, rT = 30, rB = 30;
-    var rH = H - rT - rB;
-    var bL = 100, bR = 80;
-    var bW = W - bL - bR;
-    var barH = Math.floor(rH / BUCKETS.length) - 4;
-
-    var gridG = document.getElementById("ol-rate-grid");
-    var barsG = document.getElementById("ol-rate-bars");
-    var rLabelsG = document.getElementById("ol-rate-labels");
-    var mhBucketIdx = 6;
-
-    [0, 25, 50, 75, 100].forEach(function(pct) {
-      var x = bL + bW * pct / 100;
-      var line = document.createElementNS("http://www.w3.org/2000/svg", "line");
-      line.setAttribute("x1", x); line.setAttribute("x2", x);
-      line.setAttribute("y1", rT); line.setAttribute("y2", H - rB);
-      line.setAttribute("class", pct === 0 ? "axis-base" : "grid-minor");
-      gridG.appendChild(line);
-
-      var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
-      label.setAttribute("x", x);
-      label.setAttribute("y", rT - 8);
-      label.setAttribute("text-anchor", "middle");
-      label.setAttribute("class", "ol-label");
-      label.textContent = pct + "%";
-      rLabelsG.appendChild(label);
-    });
-
-    // 50% reference
-    var ref = document.createElementNS("http://www.w3.org/2000/svg", "line");
-    ref.setAttribute("x1", bL + bW * 0.5); ref.setAttribute("x2", bL + bW * 0.5);
-    ref.setAttribute("y1", rT); ref.setAttribute("y2", H - rB);
-    ref.setAttribute("class", "grid-major");
-    gridG.appendChild(ref);
-
-    BUCKETS.forEach(function(b, i) {
-      var y = rT + i * (barH + 4);
-      var rate = b.total > 0 ? b.win / b.total * 100 : 0;
-
-      var bg = document.createElementNS("http://www.w3.org/2000/svg", "rect");
-      bg.setAttribute("x", bL); bg.setAttribute("y", y);
-      bg.setAttribute("width", bW); bg.setAttribute("height", barH);
-      bg.setAttribute("rx", 3);
-      bg.setAttribute("class", "ol-rate-bar-bg");
-      barsG.appendChild(bg);
-
-      var fg = document.createElementNS("http://www.w3.org/2000/svg", "rect");
-      fg.setAttribute("x", bL); fg.setAttribute("y", y);
-      fg.setAttribute("width", bW * rate / 100); fg.setAttribute("height", barH);
-      fg.setAttribute("rx", 3);
-      fg.setAttribute("class", "ol-rate-bar-fg");
-      if (i === mhBucketIdx) {
-        fg.setAttribute("fill", "var(--c-buoy)");
-        fg.setAttribute("opacity", "0.8");
-      }
-      barsG.appendChild(fg);
-
-      var bl = document.createElementNS("http://www.w3.org/2000/svg", "text");
-      bl.setAttribute("x", bL - 6); bl.setAttribute("y", y + barH / 2 + 4);
-      bl.setAttribute("text-anchor", "end");
-      bl.setAttribute("class", i === mhBucketIdx ? "ol-label-mh" : "ol-label");
-      bl.textContent = b.label;
-      rLabelsG.appendChild(bl);
-
-      var rl = document.createElementNS("http://www.w3.org/2000/svg", "text");
-      rl.setAttribute("x", bL + bW * rate / 100 + 6);
-      rl.setAttribute("y", y + barH / 2 + 4);
-      rl.setAttribute("class", "ol-callout");
-      rl.setAttribute("fill", i === mhBucketIdx ? "var(--c-buoy)" : "var(--c-navy)");
-      rl.textContent = Math.round(rate) + "% (" + b.win + "/" + b.total + ")";
-      rLabelsG.appendChild(rl);
-    });
-  })();
+    var rl = document.createElementNS("http://www.w3.org/2000/svg", "text");
+    rl.setAttribute("x", bL + bW * rate / 100 + 6);
+    rl.setAttribute("y", y + barH / 2 + 4);
+    rl.setAttribute("class", "ol-callout");
+    rl.setAttribute("fill", i === mhBucketIdx ? "var(--c-buoy)" : "var(--c-navy)");
+    rl.textContent = Math.round(rate) + "% (" + b.win + "/" + b.total + ")";
+    labelsG.appendChild(rl);
+  });
 })();
 </script>

--- a/charts/statewide_overrides.html
+++ b/charts/statewide_overrides.html
@@ -9,7 +9,9 @@ scripts: [citations]
   .so-rate-dot { fill: var(--c-teal); }
   .so-rate-area { fill: var(--c-teal); opacity: 0.08; }
   .so-amt-line { fill: none; stroke: var(--c-brass); stroke-width: 2; }
+  .so-amt-line--election { fill: none; stroke: var(--c-navy); stroke-width: 2.5; }
   .so-amt-dot { fill: var(--c-brass); }
+  .so-amt-dot--election { fill: var(--c-navy); }
   .so-label { font-size: 10px; fill: var(--text-muted); font-family: inherit; }
   .so-value { font-size: 9px; fill: var(--text-muted); font-family: inherit; }
   .so-callout { font-size: 10px; font-family: inherit; font-weight: 600; }
@@ -25,6 +27,7 @@ scripts: [citations]
   .so-legend-swatch--fail { background: var(--text-subtle); opacity: 0.35; }
   .so-legend-swatch--rate { background: var(--c-teal); }
   .so-legend-swatch--amt { background: var(--c-brass); }
+  .so-legend-swatch--amt-e { background: var(--c-navy); }
   .so-svg { display: block; width: 100%; height: auto; max-width: 880px; margin: 0 auto; }
   .so-mh { fill: var(--c-buoy); opacity: 0.9; }
   .so-mh-label { font-size: 9px; fill: var(--c-buoy); font-family: inherit; font-weight: 600; }
@@ -53,6 +56,7 @@ scripts: [citations]
   <li><strong>The early '90s were a flood:</strong> 400-600 questions per year, pass rates as low as 25%</li>
   <li><strong>Pass rates climbed through the 2000s-2020s</strong>, peaking above 80% in FY2019 and FY2022-23</li>
   <li><strong>FY2025-26 marks a new surge</strong> in override volume as cost pressures outpace the 2.5% levy cap statewide</li>
+  <li><strong>Median override amount</strong> per election: $443K in FY1990, $1.7M in FY2026. Many early overrides were split into 10-30 ballot questions; the per-question and per-election lines converge as towns shifted to bundled votes</li>
 </ul>
 
 <h2>Override ballot questions per year</h2>
@@ -89,13 +93,14 @@ scripts: [citations]
 <hr class="so-divider">
 
 <h2>Median override amount per year</h2>
-<p class="so-hint" style="font-size: 13px; color: var(--text-muted); margin-bottom: 4px;">Median dollar amount requested on each ballot question (nominal dollars).</p>
+<p class="so-hint" style="font-size: 13px; color: var(--text-muted); margin-bottom: 4px;">Many towns split one override into multiple ballot questions (Chatham FY1990 had 31). The per-election line combines all questions from one town in one year; the per-question line shows each ballot item individually. The two converge in recent years as towns shift toward bundled questions.</p>
 
 <div class="so-legend">
-  <span><span class="so-legend-swatch so-legend-swatch--amt"></span> Median amount</span>
+  <span><span class="so-legend-swatch so-legend-swatch--amt-e"></span> Per election (combined)</span>
+  <span><span class="so-legend-swatch so-legend-swatch--amt"></span> Per ballot question</span>
 </div>
 
-<svg class="so-svg chart" id="so-amt" viewBox="0 0 880 260" role="img" aria-label="Line chart of median override ballot question amount by fiscal year, FY1990 to FY2027">
+<svg class="so-svg chart" id="so-amt" viewBox="0 0 880 280" role="img" aria-label="Line chart of median override amount by fiscal year, FY1990 to FY2027, showing both per-question and per-election medians">
   <g id="so-amt-grid"></g>
   <g id="so-amt-line-g"></g>
   <g id="so-amt-dots"></g>
@@ -108,51 +113,51 @@ scripts: [citations]
   <p>Each ballot question counts as one vote, regardless of dollar size. A single town election can have multiple ballot questions (e.g. Needham FY1997 had ten separate override questions).</p>
   <p>FY2027 data is partial as of April 2026. One Marblehead row (FY2025, "Fix Clerk Error", $0) is excluded as a clerical correction.</p>
   <p>"Pass rate" is the number of questions that passed divided by total questions in that fiscal year. It does not weight by dollar amount or population.</p>
-  <p>Median amount is the median of all ballot question amounts in a given fiscal year, in nominal (not inflation-adjusted) dollars.</p>
+  <p>"Per ballot question" median is the median of all individual ballot question amounts in a given fiscal year. "Per election" median aggregates all questions from the same town in the same fiscal year into a single combined amount before computing the median. The gap between the two lines reflects how many towns split overrides into multiple line-item questions rather than one bundled vote. In nominal (not inflation-adjusted) dollars.</p>
 </details>
 
 <script>
 (function() {
   // === DATA: aggregated from statewide_overrides.csv ===
   var DATA = [
-    {fy:1990,win:176,loss:264,median:58366},
-    {fy:1991,win:169,loss:437,median:70457},
-    {fy:1992,win:141,loss:420,median:49800},
-    {fy:1993,win:109,loss:178,median:30000},
-    {fy:1994,win:102,loss:197,median:20000},
-    {fy:1995,win:72,loss:102,median:35000},
-    {fy:1996,win:54,loss:114,median:32000},
-    {fy:1997,win:29,loss:66,median:66431},
-    {fy:1998,win:39,loss:49,median:30000},
-    {fy:1999,win:34,loss:15,median:83774},
-    {fy:2000,win:27,loss:29,median:118953},
-    {fy:2001,win:50,loss:29,median:92158},
-    {fy:2002,win:54,loss:20,median:262768},
-    {fy:2003,win:55,loss:37,median:243818},
-    {fy:2004,win:79,loss:81,median:182364},
-    {fy:2005,win:81,loss:79,median:95624},
-    {fy:2006,win:91,loss:78,median:154002},
-    {fy:2007,win:52,loss:89,median:203397},
-    {fy:2008,win:48,loss:54,median:165000},
-    {fy:2009,win:60,loss:81,median:158208},
-    {fy:2010,win:33,loss:28,median:115500},
-    {fy:2011,win:26,loss:31,median:175000},
-    {fy:2012,win:21,loss:29,median:272450},
-    {fy:2013,win:19,loss:23,median:235766},
-    {fy:2014,win:14,loss:13,median:230000},
-    {fy:2015,win:21,loss:13,median:410722},
-    {fy:2016,win:21,loss:20,median:300000},
-    {fy:2017,win:14,loss:12,median:300000},
-    {fy:2018,win:12,loss:8,median:475656},
-    {fy:2019,win:36,loss:8,median:325000},
-    {fy:2020,win:22,loss:7,median:420000},
-    {fy:2021,win:12,loss:9,median:361640},
-    {fy:2022,win:19,loss:3,median:168080},
-    {fy:2023,win:18,loss:4,median:231958},
-    {fy:2024,win:46,loss:16,median:450000},
-    {fy:2025,win:23,loss:29,median:1000000},
-    {fy:2026,win:36,loss:38,median:891075},
-    {fy:2027,win:8,loss:7,median:1900000}
+    {fy:1990,win:176,loss:264,medianQ:58366,medianE:443000},
+    {fy:1991,win:169,loss:437,medianQ:70457,medianE:550000},
+    {fy:1992,win:141,loss:420,medianQ:49800,medianE:405347},
+    {fy:1993,win:109,loss:178,medianQ:30000,medianE:200000},
+    {fy:1994,win:102,loss:197,medianQ:20000,medianE:149130},
+    {fy:1995,win:72,loss:102,medianQ:35000,medianE:195163},
+    {fy:1996,win:54,loss:114,medianQ:32000,medianE:200000},
+    {fy:1997,win:29,loss:66,medianQ:66431,medianE:255710},
+    {fy:1998,win:39,loss:49,medianQ:30000,medianE:223537},
+    {fy:1999,win:34,loss:15,medianQ:83774,medianE:224469},
+    {fy:2000,win:27,loss:29,medianQ:118953,medianE:285883},
+    {fy:2001,win:50,loss:29,medianQ:92158,medianE:378464},
+    {fy:2002,win:54,loss:20,medianQ:262768,medianE:489697},
+    {fy:2003,win:55,loss:37,medianQ:243818,medianE:487370},
+    {fy:2004,win:79,loss:81,medianQ:187844,medianE:800000},
+    {fy:2005,win:81,loss:79,medianQ:95624,medianE:508557},
+    {fy:2006,win:91,loss:78,medianQ:154002,medianE:600000},
+    {fy:2007,win:52,loss:89,medianQ:204019,medianE:631167},
+    {fy:2008,win:48,loss:54,medianQ:165000,medianE:550700},
+    {fy:2009,win:60,loss:81,medianQ:158208,medianE:414910},
+    {fy:2010,win:33,loss:28,medianQ:115500,medianE:263331},
+    {fy:2011,win:26,loss:31,medianQ:175000,medianE:656491},
+    {fy:2012,win:21,loss:29,medianQ:272450,medianE:484361},
+    {fy:2013,win:19,loss:23,medianQ:235766,medianE:366800},
+    {fy:2014,win:14,loss:13,medianQ:230000,medianE:455926},
+    {fy:2015,win:21,loss:13,medianQ:410722,medianE:514115},
+    {fy:2016,win:21,loss:20,medianQ:300000,medianE:582800},
+    {fy:2017,win:14,loss:12,medianQ:300000,medianE:344583},
+    {fy:2018,win:12,loss:8,medianQ:475656,medianE:532640},
+    {fy:2019,win:36,loss:8,medianQ:325000,medianE:546767},
+    {fy:2020,win:22,loss:7,medianQ:430000,medianE:450000},
+    {fy:2021,win:12,loss:9,medianQ:361640,medianE:1075158},
+    {fy:2022,win:19,loss:3,medianQ:168080,medianE:777336},
+    {fy:2023,win:18,loss:4,medianQ:231958,medianE:750000},
+    {fy:2024,win:46,loss:16,medianQ:450000,medianE:1058476},
+    {fy:2025,win:23,loss:29,medianQ:1000000,medianE:1320000},
+    {fy:2026,win:36,loss:38,medianQ:891075,medianE:1680100},
+    {fy:2027,win:8,loss:7,medianQ:1900000,medianE:1900000}
   ];
 
   var W = 880, mL = 60, mR = 20;
@@ -333,13 +338,13 @@ scripts: [citations]
   })();
 
   // =============================================
-  // CHART 3: MEDIAN AMOUNT (line)
+  // CHART 3: MEDIAN AMOUNT (two lines)
   // =============================================
   (function() {
-    var H = 260, mT = 20, mB = 40;
+    var H = 280, mT = 20, mB = 40;
     var pH = H - mT - mB;
     var maxAmt = 0;
-    DATA.forEach(function(d) { maxAmt = Math.max(maxAmt, d.median); });
+    DATA.forEach(function(d) { maxAmt = Math.max(maxAmt, d.medianE, d.medianQ); });
     maxAmt = Math.ceil(maxAmt / 500000) * 500000;
 
     var gridG = document.getElementById("so-amt-grid");
@@ -349,6 +354,10 @@ scripts: [citations]
 
     function yScale(v) { return mT + pH * (1 - v / maxAmt); }
     function xScale(i) { return mL + i * (barW + 2) + barW / 2; }
+    function fmtAmt(v) {
+      return v >= 1000000 ? "$" + (v / 1000000).toFixed(1) + "M"
+                          : "$" + Math.round(v / 1000) + "K";
+    }
 
     // Grid
     for (var v = 0; v <= maxAmt; v += 500000) {
@@ -367,38 +376,66 @@ scripts: [citations]
       gridG.appendChild(label);
     }
 
-    // Line
-    var linePoints = DATA.map(function(d, i) {
-      return xScale(i) + "," + yScale(d.median);
+    // Per-election line (navy, bold, drawn first so per-question overlays)
+    var eLinePoints = DATA.map(function(d, i) {
+      return xScale(i) + "," + yScale(d.medianE);
     }).join(" ");
-    var polyline = document.createElementNS("http://www.w3.org/2000/svg", "polyline");
-    polyline.setAttribute("points", linePoints);
-    polyline.setAttribute("class", "so-amt-line");
-    lineG.appendChild(polyline);
+    var ePoly = document.createElementNS("http://www.w3.org/2000/svg", "polyline");
+    ePoly.setAttribute("points", eLinePoints);
+    ePoly.setAttribute("class", "so-amt-line--election");
+    lineG.appendChild(ePoly);
 
-    // Dots + labels
-    var notable = {1991: true, 2002: true, 2015: true, 2024: true, 2027: true};
+    // Per-question line (brass, thinner)
+    var qLinePoints = DATA.map(function(d, i) {
+      return xScale(i) + "," + yScale(d.medianQ);
+    }).join(" ");
+    var qPoly = document.createElementNS("http://www.w3.org/2000/svg", "polyline");
+    qPoly.setAttribute("points", qLinePoints);
+    qPoly.setAttribute("class", "so-amt-line");
+    lineG.appendChild(qPoly);
+
+    // Dots and labels
+    var notableE = {1991: true, 2004: true, 2024: true, 2027: true};
+    var notableQ = {1991: true, 1994: true, 2025: true};
     DATA.forEach(function(d, i) {
-      var cx = xScale(i), cy = yScale(d.median);
+      var cx = xScale(i);
 
-      var dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
-      dot.setAttribute("cx", cx); dot.setAttribute("cy", cy);
-      dot.setAttribute("r", notable[d.fy] ? 4 : 2.5);
-      dot.setAttribute("class", "so-amt-dot");
-      dotsG.appendChild(dot);
+      // Per-election dots
+      var cyE = yScale(d.medianE);
+      var dotE = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+      dotE.setAttribute("cx", cx); dotE.setAttribute("cy", cyE);
+      dotE.setAttribute("r", notableE[d.fy] ? 4 : 2.5);
+      dotE.setAttribute("class", "so-amt-dot--election");
+      dotsG.appendChild(dotE);
 
-      if (notable[d.fy]) {
-        var label = document.createElementNS("http://www.w3.org/2000/svg", "text");
-        label.setAttribute("x", cx);
-        label.setAttribute("y", cy - 8);
-        label.setAttribute("text-anchor", "middle");
-        label.setAttribute("class", "so-callout");
-        label.setAttribute("fill", "var(--c-brass)");
-        var txt = d.median >= 1000000
-          ? "$" + (d.median / 1000000).toFixed(1) + "M"
-          : "$" + Math.round(d.median / 1000) + "K";
-        label.textContent = txt;
-        labelsG.appendChild(label);
+      if (notableE[d.fy]) {
+        var lbl = document.createElementNS("http://www.w3.org/2000/svg", "text");
+        lbl.setAttribute("x", cx);
+        lbl.setAttribute("y", cyE - 8);
+        lbl.setAttribute("text-anchor", "middle");
+        lbl.setAttribute("class", "so-callout");
+        lbl.setAttribute("fill", "var(--c-navy)");
+        lbl.textContent = fmtAmt(d.medianE);
+        labelsG.appendChild(lbl);
+      }
+
+      // Per-question dots
+      var cyQ = yScale(d.medianQ);
+      var dotQ = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+      dotQ.setAttribute("cx", cx); dotQ.setAttribute("cy", cyQ);
+      dotQ.setAttribute("r", notableQ[d.fy] ? 4 : 2);
+      dotQ.setAttribute("class", "so-amt-dot");
+      dotsG.appendChild(dotQ);
+
+      if (notableQ[d.fy]) {
+        var lbl2 = document.createElementNS("http://www.w3.org/2000/svg", "text");
+        lbl2.setAttribute("x", cx);
+        lbl2.setAttribute("y", cyQ + 14);
+        lbl2.setAttribute("text-anchor", "middle");
+        lbl2.setAttribute("class", "so-callout");
+        lbl2.setAttribute("fill", "var(--c-brass)");
+        lbl2.textContent = fmtAmt(d.medianQ);
+        labelsG.appendChild(lbl2);
       }
 
       // Year labels
@@ -412,6 +449,23 @@ scripts: [citations]
         labelsG.appendChild(yl);
       }
     });
+
+    // End labels (direct label at last data point)
+    var last = DATA[DATA.length - 1];
+    var lastX = xScale(DATA.length - 1);
+    var endE = document.createElementNS("http://www.w3.org/2000/svg", "text");
+    endE.setAttribute("x", lastX + 8); endE.setAttribute("y", yScale(last.medianE) + 4);
+    endE.setAttribute("class", "so-label"); endE.setAttribute("fill", "var(--c-navy)");
+    endE.setAttribute("font-weight", "600");
+    endE.textContent = "per election";
+    labelsG.appendChild(endE);
+
+    var endQ = document.createElementNS("http://www.w3.org/2000/svg", "text");
+    endQ.setAttribute("x", lastX + 8); endQ.setAttribute("y", yScale(last.medianQ) + 16);
+    endQ.setAttribute("class", "so-label"); endQ.setAttribute("fill", "var(--c-brass)");
+    endQ.setAttribute("font-weight", "600");
+    endQ.textContent = "per question";
+    labelsG.appendChild(endQ);
   })();
 })();
 </script>

--- a/charts/statewide_overrides.html
+++ b/charts/statewide_overrides.html
@@ -52,6 +52,7 @@ scripts: [citations]
 <p class="subtitle h-center">Every <abbr class="g" title="Proposition 2&frac12;">Prop 2&frac12;</abbr> operating override ballot question across all 305 municipalities, FY1990 to FY2027. Source: MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr> Municipal Databank.<sup class="cite" data-source="MA DOR DLS Municipal Databank, Proposition 2&frac12; Override and Underride Votes, all municipalities, all years"></sup></p>
 
 <ul class="tldr">
+  <li><strong>Operating overrides only.</strong> Debt exclusions (capital projects, school buildings) and underrides are not included. These are the permanent levy increases that fund day-to-day town and school budgets</li>
   <li><strong>4,640 override ballot questions</strong> across 305 towns since 1990; 2,268 passed (48.9%)</li>
   <li><strong>The early '90s were a flood:</strong> 400-600 questions per year, pass rates as low as 25%</li>
   <li><strong>Pass rates climbed through the 2000s-2020s</strong>, peaking above 80% in FY2019 and FY2022-23</li>


### PR DESCRIPTION
## Summary

- The median amount chart now shows two lines instead of one:
  - **Navy (per election)**: combines all ballot questions from one town in one year before computing the median
  - **Brass (per question)**: each individual ballot item
- The gap between them reveals that 41% of town-year elections split overrides into multiple questions (Chatham FY1990 had 31 separate questions)
- The two lines converge in recent years as towns shift to bundled single-question overrides
- Updated TL;DR and notes to explain the distinction

## Why

Per-question median was $58K in FY1990, which looked misleadingly low. Per-election median was $443K, which better represents what towns were actually asking for.

## Test plan

- [ ] Preview: both lines render, navy above brass, converging at right
- [ ] Legend and description are clear
- [ ] End labels ("per election" / "per question") visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)