### PR TITLE
What have we tried: strip LLM importance-star ratings

### DIFF
--- a/scripts/minutes/prompts/pass3_synthesize_tried.md
+++ b/scripts/minutes/prompts/pass3_synthesize_tried.md
@@ -14,7 +14,7 @@ Markdown text only. NO preface, NO postface. Target length: 2500 to 4000 words.
 2. **Topic sections.** One per topic with 3 or more catalog entries. Each section:
    - Title (human-readable topic name, e.g. "Structural deficit and reserves").
    - 2 to 4 sentences of context for the topic.
-   - A list of notable attempts, oldest to newest. For each: date + body as `[body YYYY-MM-DD](#entry-{entry_id})`, attempt_type, one-sentence what_was_tried, outcome, importance shown as a star rating of 1-5.
+   - A list of notable attempts, oldest to newest. For each: date + body as `[body YYYY-MM-DD](#entry-{entry_id})`, attempt_type, one-sentence what_was_tried, outcome. Do not emit any importance marker or rating in the output; importance is used upstream for promotion only.
    - At least one verbatim evidence_quote in blockquote form per section.
    - 1 to 2 sentences summarizing the pattern of attempts (scope, frequency, outcomes). Describe; do not evaluate.
 3. **Low-coverage topics.** Single section listing topics with 0 to 2 entries (healthcare_gic, pensions_opeb, solid_waste, etc.). Note that absence may reflect either absence of attempts or the FinCom minutes gap.

--- a/what-have-we-tried.md
+++ b/what-have-we-tried.md
@@ -18,27 +18,27 @@ Recurring entries in this topic describe how Marblehead has named, measured, and
 
 Notable attempts:
 
-- [select_board 2021-02-12](#entry-select_board_2021-02-12_seq-001): proposal, Town Administrator's FY22 State of the Town declared reliance on free cash for the operating budget "no longer sustainable"; presentation received, no vote. ★★★★
-- [select_board 2022-01-25](#entry-select_board_2022-01-25_seq-001): proposal, Finance Director's FY22 State of the Town projected FY23 financial difficulties; discussion only, no vote. ★★★
-- [select_board 2022-10-04](#entry-select_board_2021-10-04_seq-001): proposal, joint Select Board/Finance Committee session reviewing budget process, <abbr class="g" title="Government Finance Officers Association">GFOA</abbr> components, and draft financial policies; no votes taken. ★★★
-- [select_board 2024-01-24](#entry-select_board_2024-01-24_seq-001): study, FY2025 State of the Town framed proactive steps and recently adopted <abbr class="g" title="Department of Revenue">DOR</abbr>-aligned financial policies; no vote. ★★★
-- [select_board 2024-03-29](#entry-select_board_2024-03-29_seq-001): vote, Board voted unanimously to identify creation of a long-term financial plan as a top priority after Town Meeting. ★★★
-- [select_board 2024-03-29](#entry-select_board_2024-03-29_seq-003): vote, Board voted unanimously to produce and publish a <abbr class="g" title="Government Finance Officers Association">GFOA</abbr>-style budget document and pursue <abbr class="g" title="Government Finance Officers Association">GFOA</abbr> award qualification. ★★★
-- [select_board 2024-03-27](#entry-select_board_2024-03-27_seq-001): study, Town Administrator reported 15 of 23 CliftonLarsonAllen Finance Department Assessment recommendations completed, 7 in progress, 1 not implemented. ★★★
-- [select_board 2024-07-24](#entry-select_board_2024-07-24_seq-001): proposal, Finance Committee Chair announced earlier FY25 budget process and a planned 3–5 year long-term financial forecast; no vote. ★★★
-- [select_board 2024-11-13](#entry-select_board_2024-11-13_seq-004): proposal, Finance Committee Chair and CFO presented a preliminary forecast and budget calendar, stressing the need for a 3-year projection on both town and school side. ★★★
-- [select_board 2024-12-11](#entry-select_board_2024-12-11_seq-001): study, Board announced engagement of an independent specialist to perform override analysis, forecasting, and restructuring scenario review. ★★★★
-- [select_board 2025-07-18](#entry-select_board_2025-07-18_seq-003): proposal, Town Administrator confirmed both a level-funded and a Proposition 2½ override budget will be developed for FY27. ★★★★
-- [select_board 2025-10-22](#entry-select_board_2025-10-22_seq-002): study, CFO and Finance Committee Chair presented the FY27 Financial Forecast to the Board. ★★★
-- [select_board 2025-12-10](#entry-select_board_2025-12-10_seq-001): proposal, CFO presented FY27 revenue forecast showing approximately $700,000 revenue decrease and a lower free cash estimate; Board discussed policy of reducing reliance on free cash for operations. ★★★★
-- [select_board 2025-12-10](#entry-select_board_2025-12-10_seq-002): proposal, Board agreed to prepare both a state-required balanced budget and a contingent budget option for voters in light of a projected $7M deficit growing to $15M over three years. ★★★★
-- [select_board 2026-02-11](#entry-select_board_2026-02-11_seq-001): proposal, Board directed Town Administrator and CFO to present a balanced FY27 budget proposal and potential override options, plus 3-year "restored service" and "smart invest" scenarios. ★★★★
-- [school_committee 2019-02-25](#entry-school_committee_2019-02-25_seq-002): proposal, Chair named a "structural problem in the school budget" and directed principals to model level services and 20% cut scenarios. ★★★★
-- [school_committee 2019-09-05](#entry-school_committee_2019-09-05_seq-001): proposal, Superintendent presented a plan closing a $1.1M FY20 gap with unfilled vacancies and curriculum adjustments, described as not sustainable beyond 2019-2020. ★★★★
-- [school_committee 2022-07-19](#entry-school_committee_2022-07-19_seq-001): proposal, Finance Director presented a zero-based budgeting overview and recommended starting FY24 process in October with an intensive staffing review. ★★★
-- [school_committee 2025-09-18](#entry-school_committee_2025-09-18_seq-001): study, FY25 closeout reported ~$454,000 returned to the town, $2.5M in salary under-expended, and $1.24M over budget in <abbr class="g" title="Special Education">SPED</abbr> tuitions. ★★★★
-- [school_committee 2025-10-17](#entry-school_committee_2025-10-17_seq-004): proposal, Committee requested a zero-based budgeting approach against enrollment projections; noted level funding with contractual increases would require $1.7M in cuts or ~30 positions. ★★★★
-- [school_committee 2026-01-15](#entry-school_committee_2026-01-15_seq-006): proposal, Budget Subcommittee reported a $49M level-funded directive with expenses exceeding by ~$1.7M, identifying ~$900,000 in efficiencies leaving an ~$879,000 gap. ★★★★
+- [select_board 2021-02-12](#entry-select_board_2021-02-12_seq-001): proposal, Town Administrator's FY22 State of the Town declared reliance on free cash for the operating budget "no longer sustainable"; presentation received, no vote.
+- [select_board 2022-01-25](#entry-select_board_2022-01-25_seq-001): proposal, Finance Director's FY22 State of the Town projected FY23 financial difficulties; discussion only, no vote.
+- [select_board 2022-10-04](#entry-select_board_2021-10-04_seq-001): proposal, joint Select Board/Finance Committee session reviewing budget process, <abbr class="g" title="Government Finance Officers Association">GFOA</abbr> components, and draft financial policies; no votes taken.
+- [select_board 2024-01-24](#entry-select_board_2024-01-24_seq-001): study, FY2025 State of the Town framed proactive steps and recently adopted <abbr class="g" title="Department of Revenue">DOR</abbr>-aligned financial policies; no vote.
+- [select_board 2024-03-29](#entry-select_board_2024-03-29_seq-001): vote, Board voted unanimously to identify creation of a long-term financial plan as a top priority after Town Meeting.
+- [select_board 2024-03-29](#entry-select_board_2024-03-29_seq-003): vote, Board voted unanimously to produce and publish a <abbr class="g" title="Government Finance Officers Association">GFOA</abbr>-style budget document and pursue <abbr class="g" title="Government Finance Officers Association">GFOA</abbr> award qualification.
+- [select_board 2024-03-27](#entry-select_board_2024-03-27_seq-001): study, Town Administrator reported 15 of 23 CliftonLarsonAllen Finance Department Assessment recommendations completed, 7 in progress, 1 not implemented.
+- [select_board 2024-07-24](#entry-select_board_2024-07-24_seq-001): proposal, Finance Committee Chair announced earlier FY25 budget process and a planned 3–5 year long-term financial forecast; no vote.
+- [select_board 2024-11-13](#entry-select_board_2024-11-13_seq-004): proposal, Finance Committee Chair and CFO presented a preliminary forecast and budget calendar, stressing the need for a 3-year projection on both town and school side.
+- [select_board 2024-12-11](#entry-select_board_2024-12-11_seq-001): study, Board announced engagement of an independent specialist to perform override analysis, forecasting, and restructuring scenario review.
+- [select_board 2025-07-18](#entry-select_board_2025-07-18_seq-003): proposal, Town Administrator confirmed both a level-funded and a Proposition 2½ override budget will be developed for FY27.
+- [select_board 2025-10-22](#entry-select_board_2025-10-22_seq-002): study, CFO and Finance Committee Chair presented the FY27 Financial Forecast to the Board.
+- [select_board 2025-12-10](#entry-select_board_2025-12-10_seq-001): proposal, CFO presented FY27 revenue forecast showing approximately $700,000 revenue decrease and a lower free cash estimate; Board discussed policy of reducing reliance on free cash for operations.
+- [select_board 2025-12-10](#entry-select_board_2025-12-10_seq-002): proposal, Board agreed to prepare both a state-required balanced budget and a contingent budget option for voters in light of a projected $7M deficit growing to $15M over three years.
+- [select_board 2026-02-11](#entry-select_board_2026-02-11_seq-001): proposal, Board directed Town Administrator and CFO to present a balanced FY27 budget proposal and potential override options, plus 3-year "restored service" and "smart invest" scenarios.
+- [school_committee 2019-02-25](#entry-school_committee_2019-02-25_seq-002): proposal, Chair named a "structural problem in the school budget" and directed principals to model level services and 20% cut scenarios.
+- [school_committee 2019-09-05](#entry-school_committee_2019-09-05_seq-001): proposal, Superintendent presented a plan closing a $1.1M FY20 gap with unfilled vacancies and curriculum adjustments, described as not sustainable beyond 2019-2020.
+- [school_committee 2022-07-19](#entry-school_committee_2022-07-19_seq-001): proposal, Finance Director presented a zero-based budgeting overview and recommended starting FY24 process in October with an intensive staffing review.
+- [school_committee 2025-09-18](#entry-school_committee_2025-09-18_seq-001): study, FY25 closeout reported ~$454,000 returned to the town, $2.5M in salary under-expended, and $1.24M over budget in <abbr class="g" title="Special Education">SPED</abbr> tuitions.
+- [school_committee 2025-10-17](#entry-school_committee_2025-10-17_seq-004): proposal, Committee requested a zero-based budgeting approach against enrollment projections; noted level funding with contractual increases would require $1.7M in cuts or ~30 positions.
+- [school_committee 2026-01-15](#entry-school_committee_2026-01-15_seq-006): proposal, Budget Subcommittee reported a $49M level-funded directive with expenses exceeding by ~$1.7M, identifying ~$900,000 in efficiencies leaving an ~$879,000 gap.
 
 > "The Town's historical reliance on free cash to support the operating budget is no longer sustainable. While the Town is currently in good financial health, difficult decisions will need to be made for FY22 and beyond to ensure continued fiscal stability."  ([select_board 2021-02-12](#entry-select_board_2021-02-12_seq-001))
 
@@ -50,19 +50,19 @@ Override and debt exclusion attempts in the catalog include placing capital debt
 
 Notable attempts:
 
-- [select_board 2021-05-07](#entry-select_board_2021-05-07_seq-001): warrant article, Board called a Special Town Meeting and Special Election for June 22, 2021 and placed a Prop 2½ debt exclusion question for a new fire pumper truck. ★★★★
-- [select_board 2021-05-07](#entry-select_board_2021-05-07_seq-002): warrant article, Board placed on the June 22, 2021 ballot a Prop 2½ debt exclusion for Abbot Public Library renovation bonds. ★★★★
-- [select_board 2021-05-17](#entry-select_board_2021-05-17_seq-001): vote, Board rescinded the May 7 special election vote and added the debt exclusion questions to the June 22, 2021 annual ballot. ★★★
-- [school_committee 2021-01-22](#entry-school_committee_2021-01-22_seq-001): discussion, Committee discussed and declined to pursue a general override for FY22, citing pandemic disparities and pending strategic plan. ★★★★
-- [school_committee 2023-01-05](#entry-school_committee_2023-01-05_seq-001): warrant article, Committee voted 4-0 to add placeholder warrant articles for a debt exclusion override and a Proposition 2½ override. ★★★★
-- [school_committee 2023-03-21](#entry-school_committee_2023-03-21_seq-001): proposal, Superintendent presented a Level Services FY24 budget of $45,971,790 (4.52%) contingent on an override, paired with a Reduced Services alternative that would eliminate 33 positions. ★★★★
-- [school_committee 2023-03-27](#entry-school_committee_2023-03-27_seq-002): vote, Committee approved 5-0 the FY24 level services budget contingent on passage of a Proposition 2½ override. ★★★★
-- [school_committee 2023-06-29](#entry-school_committee_2023-06-29_seq-002): vote, Following the failed override, the Committee voted 4-0 to revisit the list of budget cuts pending further analysis. ★★★★
-- [select_board 2025-05-06](#entry-select_board_2025-05-06_seq-001): vote, Board voted to place Question 1 on the June 10, 2025 ballot seeking a debt exclusion for the Mary A. Alley Building. ★★★★
-- [select_board 2025-05-06](#entry-select_board_2025-05-06_seq-002): vote, Board voted to place Question 2 on the June 10, 2025 ballot seeking a debt exclusion for new roof and <abbr class="g" title="Heating, Ventilation, and Air Conditioning">HVAC</abbr> units at the High School. ★★★★
-- [school_committee 2025-11-17](#entry-school_committee_2025-11-17_seq-003): proposal, Committee moved the override warrant article vote from February 5 to January 8 to ensure time before the January 23 warrant closing. ★★★
-- [select_board 2025-12-10](#entry-select_board_2025-12-10_seq-005): discussion, Board discussed significant cuts and non-essential service reductions as override preparation; direction given to Town Administrator and CFO. ★★★★
-- [select_board 2026-02-11](#entry-select_board_2026-02-11_seq-002): proposal, Town Administrator and CFO directed to present potential override options alongside a balanced FY27 budget at the February 25, 2026 meeting. ★★★★
+- [select_board 2021-05-07](#entry-select_board_2021-05-07_seq-001): warrant article, Board called a Special Town Meeting and Special Election for June 22, 2021 and placed a Prop 2½ debt exclusion question for a new fire pumper truck.
+- [select_board 2021-05-07](#entry-select_board_2021-05-07_seq-002): warrant article, Board placed on the June 22, 2021 ballot a Prop 2½ debt exclusion for Abbot Public Library renovation bonds.
+- [select_board 2021-05-17](#entry-select_board_2021-05-17_seq-001): vote, Board rescinded the May 7 special election vote and added the debt exclusion questions to the June 22, 2021 annual ballot.
+- [school_committee 2021-01-22](#entry-school_committee_2021-01-22_seq-001): discussion, Committee discussed and declined to pursue a general override for FY22, citing pandemic disparities and pending strategic plan.
+- [school_committee 2023-01-05](#entry-school_committee_2023-01-05_seq-001): warrant article, Committee voted 4-0 to add placeholder warrant articles for a debt exclusion override and a Proposition 2½ override.
+- [school_committee 2023-03-21](#entry-school_committee_2023-03-21_seq-001): proposal, Superintendent presented a Level Services FY24 budget of $45,971,790 (4.52%) contingent on an override, paired with a Reduced Services alternative that would eliminate 33 positions.
+- [school_committee 2023-03-27](#entry-school_committee_2023-03-27_seq-002): vote, Committee approved 5-0 the FY24 level services budget contingent on passage of a Proposition 2½ override.
+- [school_committee 2023-06-29](#entry-school_committee_2023-06-29_seq-002): vote, Following the failed override, the Committee voted 4-0 to revisit the list of budget cuts pending further analysis.
+- [select_board 2025-05-06](#entry-select_board_2025-05-06_seq-001): vote, Board voted to place Question 1 on the June 10, 2025 ballot seeking a debt exclusion for the Mary A. Alley Building.
+- [select_board 2025-05-06](#entry-select_board_2025-05-06_seq-002): vote, Board voted to place Question 2 on the June 10, 2025 ballot seeking a debt exclusion for new roof and <abbr class="g" title="Heating, Ventilation, and Air Conditioning">HVAC</abbr> units at the High School.
+- [school_committee 2025-11-17](#entry-school_committee_2025-11-17_seq-003): proposal, Committee moved the override warrant article vote from February 5 to January 8 to ensure time before the January 23 warrant closing.
+- [select_board 2025-12-10](#entry-select_board_2025-12-10_seq-005): discussion, Board discussed significant cuts and non-essential service reductions as override preparation; direction given to Town Administrator and CFO.
+- [select_board 2026-02-11](#entry-select_board_2026-02-11_seq-002): proposal, Town Administrator and CFO directed to present potential override options alongside a balanced FY27 budget at the February 25, 2026 meeting.
 
 > "The Select Board and Finance Committee discussed the town's budget challenges, with projections showing a $7 million deficit next year that could grow to $15 million over three years due to factors like double-digit increases in healthcare and pensions, along with inflation. The Board agreed to work on preparing both a state-required balanced budget and a contingent budget option for voters to consider."  ([select_board 2025-12-10](#entry-select_board_2025-12-10_seq-002))
 
@@ -74,21 +74,21 @@ Capital facilities attempts dominate the School Committee record and appear repe
 
 Notable attempts:
 
-- [select_board 2018-07-23](#entry-select_board_2018-07-23_seq-003): vote, Board awarded architectural services contract for Abbot Hall Repair and Restoration to McGinley Kalsow and Associates for up to $700,000. ★★★
-- [select_board 2019-01-29](#entry-select_board_2019-01-29_seq-005): vote, Board awarded OPM services for Abbot Hall to Vertex Companies Inc. for up to $243,790. ★★★
-- [select_board 2019-03-18](#entry-select_board_2019-03-18_seq-001): vote, Board unanimously entered into the MSBA Project Scope and Budget Agreement to replace Gerry, Coffin, and Upper/Lower Bell Schools with a new PK-3 facility on the Bell site. ★★★★★
-- [select_board 2019-03-22](#entry-select_board_2019-03-22_seq-001): vote, Board awarded the Abbot Hall Restoration Project to Kronenberger and Sons for $6,935,000 base bid plus alternates. ★★★★
-- [select_board 2019-05-13](#entry-select_board_2019-05-13_seq-002): vote, Board placed Fort Sewall renovation debt exclusion on the June 18, 2019 ballot. ★★★
-- [school_committee 2019-01-24](#entry-school_committee_2019-01-24_seq-002): warrant article, Committee approved 5-0 a warrant article for design and construction of the new Pre-K–3 elementary school at 40 Baldwin Road, with potential MSBA reimbursement up to 37.08%. ★★★★★
-- [select_board 2021-04-14](#entry-select_board_2021-04-14_seq-002): warrant article, Board supported Article 17 using $8,950,000 in free cash and $330,000 from electric light to reduce the tax rate. ★★★
-- [select_board 2022-03-16](#entry-select_board_2022-03-16_seq-002): vote, Board authorized MSBA Statements of Interest for MHS and Veteran's Middle School roof replacements under Priority Category #5. ★★★
-- [school_committee 2021-12-16](#entry-school_committee_2021-12-16_seq-001): proposal, Facilities Subcommittee presented FY23 Capital Requests from an outside audit (each item critical) and recommended a capital needs debt exclusion override. ★★★★
-- [school_committee 2022-04-07](#entry-school_committee_2022-04-07_seq-002): vote, Committee approved 5-0 a $47,033,366 FY23 operating budget requiring an operating override, including ~$426,407 of facilities and technology capital items moved into operating. ★★★★★
-- [select_board 2024-11-13](#entry-select_board_2024-11-13_seq-006): vote, Board awarded three Tucker's Wharf Resilience Project contracts totaling ~$223,000 (Salem Sound Coastwatch, Collins Engineers, Woods Hole Group). ★★★
-- [select_board 2025-05-05](#entry-select_board_2025-05-05_seq-008): warrant article, Board unanimously supported Article 31 transferring Coffin School from school to general municipal purposes and authorizing its sale. ★★★★
-- [select_board 2025-10-09](#entry-select_board_2025-10-09_seq-001): vote, Board unanimously awarded a $1,590,000 Transfer Station Redesign Construction contract to DeIulis Brothers. ★★★
-- [school_committee 2025-11-20](#entry-school_committee_2025-11-20_seq-001): vote, Committee awarded the MHS roof/<abbr class="g" title="Heating, Ventilation, and Air Conditioning">HVAC</abbr> general contractor contract to Homer Contracting Inc. at $8,970,000, $2,120,000 under budget. ★★★★
-- [school_committee 2026-02-13](#entry-school_committee_2026-02-13_seq-001): proposal, Subcommittee discussed sponsoring a debt exclusion warrant article if the town does not fund the $1.677M FY27 capital request. ★★★★
+- [select_board 2018-07-23](#entry-select_board_2018-07-23_seq-003): vote, Board awarded architectural services contract for Abbot Hall Repair and Restoration to McGinley Kalsow and Associates for up to $700,000.
+- [select_board 2019-01-29](#entry-select_board_2019-01-29_seq-005): vote, Board awarded OPM services for Abbot Hall to Vertex Companies Inc. for up to $243,790.
+- [select_board 2019-03-18](#entry-select_board_2019-03-18_seq-001): vote, Board unanimously entered into the MSBA Project Scope and Budget Agreement to replace Gerry, Coffin, and Upper/Lower Bell Schools with a new PK-3 facility on the Bell site.
+- [select_board 2019-03-22](#entry-select_board_2019-03-22_seq-001): vote, Board awarded the Abbot Hall Restoration Project to Kronenberger and Sons for $6,935,000 base bid plus alternates.
+- [select_board 2019-05-13](#entry-select_board_2019-05-13_seq-002): vote, Board placed Fort Sewall renovation debt exclusion on the June 18, 2019 ballot.
+- [school_committee 2019-01-24](#entry-school_committee_2019-01-24_seq-002): warrant article, Committee approved 5-0 a warrant article for design and construction of the new Pre-K–3 elementary school at 40 Baldwin Road, with potential MSBA reimbursement up to 37.08%.
+- [select_board 2021-04-14](#entry-select_board_2021-04-14_seq-002): warrant article, Board supported Article 17 using $8,950,000 in free cash and $330,000 from electric light to reduce the tax rate.
+- [select_board 2022-03-16](#entry-select_board_2022-03-16_seq-002): vote, Board authorized MSBA Statements of Interest for MHS and Veteran's Middle School roof replacements under Priority Category #5.
+- [school_committee 2021-12-16](#entry-school_committee_2021-12-16_seq-001): proposal, Facilities Subcommittee presented FY23 Capital Requests from an outside audit (each item critical) and recommended a capital needs debt exclusion override.
+- [school_committee 2022-04-07](#entry-school_committee_2022-04-07_seq-002): vote, Committee approved 5-0 a $47,033,366 FY23 operating budget requiring an operating override, including ~$426,407 of facilities and technology capital items moved into operating.
+- [select_board 2024-11-13](#entry-select_board_2024-11-13_seq-006): vote, Board awarded three Tucker's Wharf Resilience Project contracts totaling ~$223,000 (Salem Sound Coastwatch, Collins Engineers, Woods Hole Group).
+- [select_board 2025-05-05](#entry-select_board_2025-05-05_seq-008): warrant article, Board unanimously supported Article 31 transferring Coffin School from school to general municipal purposes and authorizing its sale.
+- [select_board 2025-10-09](#entry-select_board_2025-10-09_seq-001): vote, Board unanimously awarded a $1,590,000 Transfer Station Redesign Construction contract to DeIulis Brothers.
+- [school_committee 2025-11-20](#entry-school_committee_2025-11-20_seq-001): vote, Committee awarded the MHS roof/<abbr class="g" title="Heating, Ventilation, and Air Conditioning">HVAC</abbr> general contractor contract to Homer Contracting Inc. at $8,970,000, $2,120,000 under budget.
+- [school_committee 2026-02-13](#entry-school_committee_2026-02-13_seq-001): proposal, Subcommittee discussed sponsoring a debt exclusion warrant article if the town does not fund the $1.677M FY27 capital request.
 
 > "Motion made and seconded, that the Board of Selectmen, on behalf of the Town, enter into the Massachusetts School Building Authority Project Scope and Budget Agreement for the replacement of the Elbridge Gerry Elementary School, the L.H. Coffin School, and the Upper and Lower Malcolm L. Bell Schools with a new PK-3 elementary school facility on the existing Bell Elementary School site located at 40-42 Baldwin Road, and to authorize the chair, Jackie Belf-Becker, to execute the Agreement on behalf of the Board."  ([select_board 2019-03-18](#entry-select_board_2019-03-18_seq-001))
 
@@ -100,18 +100,18 @@ The catalog contains numerous entries on staffing levels and union agreements, i
 
 Notable attempts:
 
-- [select_board 2019-10-30](#entry-select_board_2019-10-30_seq-001): study, Board awarded a town-wide job classification study to GovHR for up to $49,850. ★★★
-- [school_committee 2020-03-17](#entry-school_committee_2020-03-17_seq-001): vote, Committee voted 5-0 to continue paying all school employees, including hourly and part-time staff, during the COVID-19 closure. ★★★★
-- [school_committee 2021-02-04](#entry-school_committee_2021-02-04_seq-001): vote, Committee approved a three-year Unit A teachers' contract with a 5% pay increase over three years. ★★★
-- [school_committee 2023-02-16](#entry-school_committee_2023-02-16_seq-001): proposal, Superintendent identified ~33 positions across five bargaining units as potential reductions to meet a $1.8M FY24 increase; discussed, no vote. ★★★★
-- [school_committee 2024-09-19](#entry-school_committee_2024-09-19_seq-001): discussion, Bargaining subcommittee publicly framed MEA proposals as "unaffordable and unsustainable," with figures including a 39.5% Unit A increase over 3 years and warnings of required 14% override or 42% layoffs. ★★★★
-- [school_committee 2024-10-17](#entry-school_committee_2024-10-17_seq-001): proposal, Committee members presented a contract negotiations update citing a $11,591,107 MEA wage proposal over 4 years and warning of more than 75 staff layoffs (15% of staff). ★★★★
-- [select_board 2025-05-05](#entry-select_board_2025-05-05_seq-001): vote, Board approved a 2024-2027 MOU with Marblehead IUE/CWA Local 1776 with 2%, 3%, and 3% COLAs, subject to Town Meeting. ★★★
-- [select_board 2025-05-05](#entry-select_board_2025-05-05_seq-004): vote, Board approved a 2025-2028 Police Union MOA with COLA plus POST Compliance increases totaling 3.5%, 3.5%, and 3.5%, subject to Town Meeting. ★★★
-- [select_board 2025-06-25](#entry-select_board_2025-06-25_seq-002): study, Town launched a comprehensive classification and compensation study led by MGT's Katie Yee. ★★★
-- [select_board 2025-07-18](#entry-select_board_2025-07-18_seq-001): proposal, Finance Department restructuring adding an Assistant Town Accountant and splitting the assistant Treasurer/Collector role into two specialized positions. ★★★
-- [school_committee 2025-11-17](#entry-school_committee_2025-11-17_seq-001): study, Assistant Superintendent presented a staffing analysis allocating $38,622,000 by building and role, including an example of reducing first grade from five to four sections. ★★★★
-- [school_committee 2026-01-05](#entry-school_committee_2026-01-05_seq-002): proposal, Administration proposed not filling HR assistant, PT assistant at Glover, 1.75 EL teachers at Village, math intervention at Veterans, and 0.2 art teacher at high school as FY27 efficiencies. ★★★
+- [select_board 2019-10-30](#entry-select_board_2019-10-30_seq-001): study, Board awarded a town-wide job classification study to GovHR for up to $49,850.
+- [school_committee 2020-03-17](#entry-school_committee_2020-03-17_seq-001): vote, Committee voted 5-0 to continue paying all school employees, including hourly and part-time staff, during the COVID-19 closure.
+- [school_committee 2021-02-04](#entry-school_committee_2021-02-04_seq-001): vote, Committee approved a three-year Unit A teachers' contract with a 5% pay increase over three years.
+- [school_committee 2023-02-16](#entry-school_committee_2023-02-16_seq-001): proposal, Superintendent identified ~33 positions across five bargaining units as potential reductions to meet a $1.8M FY24 increase; discussed, no vote.
+- [school_committee 2024-09-19](#entry-school_committee_2024-09-19_seq-001): discussion, Bargaining subcommittee publicly framed MEA proposals as "unaffordable and unsustainable," with figures including a 39.5% Unit A increase over 3 years and warnings of required 14% override or 42% layoffs.
+- [school_committee 2024-10-17](#entry-school_committee_2024-10-17_seq-001): proposal, Committee members presented a contract negotiations update citing a $11,591,107 MEA wage proposal over 4 years and warning of more than 75 staff layoffs (15% of staff).
+- [select_board 2025-05-05](#entry-select_board_2025-05-05_seq-001): vote, Board approved a 2024-2027 MOU with Marblehead IUE/CWA Local 1776 with 2%, 3%, and 3% COLAs, subject to Town Meeting.
+- [select_board 2025-05-05](#entry-select_board_2025-05-05_seq-004): vote, Board approved a 2025-2028 Police Union MOA with COLA plus POST Compliance increases totaling 3.5%, 3.5%, and 3.5%, subject to Town Meeting.
+- [select_board 2025-06-25](#entry-select_board_2025-06-25_seq-002): study, Town launched a comprehensive classification and compensation study led by MGT's Katie Yee.
+- [select_board 2025-07-18](#entry-select_board_2025-07-18_seq-001): proposal, Finance Department restructuring adding an Assistant Town Accountant and splitting the assistant Treasurer/Collector role into two specialized positions.
+- [school_committee 2025-11-17](#entry-school_committee_2025-11-17_seq-001): study, Assistant Superintendent presented a staffing analysis allocating $38,622,000 by building and role, including an example of reducing first grade from five to four sections.
+- [school_committee 2026-01-05](#entry-school_committee_2026-01-05_seq-002): proposal, Administration proposed not filling HR assistant, PT assistant at Glover, 1.75 EL teachers at Village, math intervention at Veterans, and 0.2 art teacher at high school as FY27 efficiencies.
 
 > "The current MEA wage proposals total a $11,591,107 budget increase over 4 years\nThis will result in layoffs of more than 75 staff members (or 15% of the current staff)"  ([school_committee 2024-10-17](#entry-school_committee_2024-10-17_seq-001))
 
@@ -123,17 +123,17 @@ Special education appears repeatedly as a fiscal driver, with attempts focused o
 
 Notable attempts:
 
-- [school_committee 2019-01-10](#entry-school_committee_2019-01-10_seq-001): vote, Committee approved 5-0 a $200,000 transfer from operating lines into Special Education tuition-out to partially address a $731,411 deficit. ★★★★
-- [school_committee 2019-01-16](#entry-school_committee_2019-01-16_seq-002): proposal, Committee discussed a proposed $350,000 Town transfer for <abbr class="g" title="Special Education">SPED</abbr> out-of-district placements, still leaving a $181,411 deficit. ★★★★
-- [school_committee 2019-02-28](#entry-school_committee_2019-02-28_seq-001): proposal, FY20 draft budget included $1,030,258 for <abbr class="g" title="Special Education">SPED</abbr> tuition above level funding and $50,000 for a third-party Special Education Review. ★★★
-- [select_board 2019-06-12](#entry-select_board_2019-06-12_seq-001): vote, Board authorized year-end FY19 transfers totaling $337,585, with $270,000 directed to High School <abbr class="g" title="Special Education">SPED</abbr> tuition to cover a shortfall. ★★★
-- [school_committee 2020-06-08](#entry-school_committee_2020-06-08_seq-002): proposal, FY21 budget included reducing out-of-district placements by $215,105, reducing <abbr class="g" title="Special Education">SPED</abbr> transportation by $45,000 via leasing vans, and prepaying $200,000 of FY21 <abbr class="g" title="Special Education">SPED</abbr> tuition. ★★★
-- [school_committee 2023-07-06](#entry-school_committee_2023-07-06_seq-003): vote, Committee voted 4-1 to allocate funding for a comprehensive special education department audit. ★★★★
-- [school_committee 2024-01-18](#entry-school_committee_2024-01-18_seq-001): study, Committee issued a draft RFP for a comprehensive Special Education program audit covering staffing, inclusion, and administrative structure. ★★★★
-- [school_committee 2025-10-17](#entry-school_committee_2025-10-17_seq-001): proposal, Subcommittee reviewed OOD <abbr class="g" title="Special Education">SPED</abbr> cost structure totaling $6.362M ($5.125M tuition and $1.237M transportation), with reliance on Circuit Breaker and <abbr class="g" title="Individuals with Disabilities Education Act">IDEA</abbr> offsets. ★★★
-- [school_committee 2025-10-30](#entry-school_committee_2025-10-30_seq-001): study, Administration reported a mid-year correction moving $1.7M in OOD <abbr class="g" title="Special Education">SPED</abbr> tuition from the local budget to Circuit Breaker accounts. ★★★
-- [school_committee 2025-11-17](#entry-school_committee_2025-11-17_seq-002): proposal, District consolidated therapeutic special education programs at Brown and Glover and planned to market programs to other districts for tuition revenue. ★★★
-- [school_committee 2025-12-01](#entry-school_committee_2025-12-01_seq-001): proposal, Superintendent identified building internal special education programs as a multi-year goal to reduce out-of-district tuition. ★★★
+- [school_committee 2019-01-10](#entry-school_committee_2019-01-10_seq-001): vote, Committee approved 5-0 a $200,000 transfer from operating lines into Special Education tuition-out to partially address a $731,411 deficit.
+- [school_committee 2019-01-16](#entry-school_committee_2019-01-16_seq-002): proposal, Committee discussed a proposed $350,000 Town transfer for <abbr class="g" title="Special Education">SPED</abbr> out-of-district placements, still leaving a $181,411 deficit.
+- [school_committee 2019-02-28](#entry-school_committee_2019-02-28_seq-001): proposal, FY20 draft budget included $1,030,258 for <abbr class="g" title="Special Education">SPED</abbr> tuition above level funding and $50,000 for a third-party Special Education Review.
+- [select_board 2019-06-12](#entry-select_board_2019-06-12_seq-001): vote, Board authorized year-end FY19 transfers totaling $337,585, with $270,000 directed to High School <abbr class="g" title="Special Education">SPED</abbr> tuition to cover a shortfall.
+- [school_committee 2020-06-08](#entry-school_committee_2020-06-08_seq-002): proposal, FY21 budget included reducing out-of-district placements by $215,105, reducing <abbr class="g" title="Special Education">SPED</abbr> transportation by $45,000 via leasing vans, and prepaying $200,000 of FY21 <abbr class="g" title="Special Education">SPED</abbr> tuition.
+- [school_committee 2023-07-06](#entry-school_committee_2023-07-06_seq-003): vote, Committee voted 4-1 to allocate funding for a comprehensive special education department audit.
+- [school_committee 2024-01-18](#entry-school_committee_2024-01-18_seq-001): study, Committee issued a draft RFP for a comprehensive Special Education program audit covering staffing, inclusion, and administrative structure.
+- [school_committee 2025-10-17](#entry-school_committee_2025-10-17_seq-001): proposal, Subcommittee reviewed OOD <abbr class="g" title="Special Education">SPED</abbr> cost structure totaling $6.362M ($5.125M tuition and $1.237M transportation), with reliance on Circuit Breaker and <abbr class="g" title="Individuals with Disabilities Education Act">IDEA</abbr> offsets.
+- [school_committee 2025-10-30](#entry-school_committee_2025-10-30_seq-001): study, Administration reported a mid-year correction moving $1.7M in OOD <abbr class="g" title="Special Education">SPED</abbr> tuition from the local budget to Circuit Breaker accounts.
+- [school_committee 2025-11-17](#entry-school_committee_2025-11-17_seq-002): proposal, District consolidated therapeutic special education programs at Brown and Glover and planned to market programs to other districts for tuition revenue.
+- [school_committee 2025-12-01](#entry-school_committee_2025-12-01_seq-001): proposal, Superintendent identified building internal special education programs as a multi-year goal to reduce out-of-district tuition.
 
 > "Out-of-district special education costs total $6.362 million: $5.125 million tuition for ~50 students (10% of total budget) plus $1.237 million transportation\n   • Net local impact: $3.562 million tuition and under $1 million transportation after\n   circuit breaker and <abbr class="g" title="Individuals with Disabilities Education Act">IDEA</abbr> fund offsets"  ([school_committee 2025-10-17](#entry-school_committee_2025-10-17_seq-001))
 
@@ -145,19 +145,19 @@ Revenue diversification attempts include new local taxes, home rule petitions fo
 
 Notable attempts:
 
-- [select_board 2019-01-29](#entry-select_board_2019-01-29_seq-001): warrant article, Board sponsored a warrant article on a Marijuana Tax for the 2019 Annual Town Meeting. ★★★
-- [select_board 2021-09-08](#entry-select_board_2021-09-08_seq-001): vote, Board authorized Town Administrator and Town Counsel to negotiate a Community Host Agreement with Seven Leaf Sisters for adult-use marijuana retail; 3-2. ★★★
-- [select_board 2021-12-08](#entry-select_board_2021-12-08_seq-005): vote, Board declared 1 Widger Road Medical Office Building available for lease disposition (minimum 5 years with two 10-year renewals). ★★★
-- [select_board 2024-01-24](#entry-select_board_2024-01-24_seq-002): proposal, Board reported a fall retreat exploring options for increasing town revenue in response to resident concerns. ★★★
-- [select_board 2024-03-27](#entry-select_board_2024-03-27_seq-003): proposal, Town Administrator and CFO held a discussion on a proposed local Meals/Rooms tax with local business owners. ★★★
-- [select_board 2024-12-11](#entry-select_board_2024-12-11_seq-005): vote, Board approved final ARPA Revenue Loss Funding allocation of $584,142 (54% schools / 46% town). ★★★
-- [select_board 2025-04-23](#entry-select_board_2025-04-23_seq-005): warrant article, Board supported Article 28 Home Rule Petition to establish a Means-Tested Senior Citizen Property Tax Exemption. ★★★
-- [select_board 2025-05-14](#entry-select_board_2025-05-14_seq-001): vote, Board adopted 5-0 the Home Rule Petition from Article 28 to establish a Means-Tested Senior Citizen Property Tax Exemption and submit to the General Court. ★★★★
-- [select_board 2025-07-18](#entry-select_board_2025-07-18_seq-005): proposal, Staff committed to tracking and sharing a list of grants and expenditures at risk due to potential <abbr class="g" title="Massachusetts Bay Transportation Authority">MBTA</abbr> 3A non-compliance. ★★★
-- [select_board 2025-10-22](#entry-select_board_2025-10-22_seq-001): study, Town Administrator reported $2,816,493 in FY26 funding losses across seven grants due to <abbr class="g" title="Massachusetts Bay Transportation Authority">MBTA</abbr> 3A non-compliance, and cumulative losses of $3,601,493 across nine grants. ★★★★
-- [select_board 2026-02-11](#entry-select_board_2026-02-11_seq-009): proposal, Chair reported the Home Rule Petition for the Senior Tax Exemption is in its 3rd reading in the Massachusetts House. ★★★
-- [school_committee 2023-07-06](#entry-school_committee_2023-07-06_seq-002): vote, Committee approved 4-0 adjusted athletic user fees generating ~$26,000 for freshman coaching and transportation. ★★★
-- [school_committee 2025-12-01](#entry-school_committee_2025-12-01_seq-003): proposal, Committee agreed fund balances should be used for one-time expenses only; Assistant Superintendent restructured user fee accounting into separate revolving funds. ★★★
+- [select_board 2019-01-29](#entry-select_board_2019-01-29_seq-001): warrant article, Board sponsored a warrant article on a Marijuana Tax for the 2019 Annual Town Meeting.
+- [select_board 2021-09-08](#entry-select_board_2021-09-08_seq-001): vote, Board authorized Town Administrator and Town Counsel to negotiate a Community Host Agreement with Seven Leaf Sisters for adult-use marijuana retail; 3-2.
+- [select_board 2021-12-08](#entry-select_board_2021-12-08_seq-005): vote, Board declared 1 Widger Road Medical Office Building available for lease disposition (minimum 5 years with two 10-year renewals).
+- [select_board 2024-01-24](#entry-select_board_2024-01-24_seq-002): proposal, Board reported a fall retreat exploring options for increasing town revenue in response to resident concerns.
+- [select_board 2024-03-27](#entry-select_board_2024-03-27_seq-003): proposal, Town Administrator and CFO held a discussion on a proposed local Meals/Rooms tax with local business owners.
+- [select_board 2024-12-11](#entry-select_board_2024-12-11_seq-005): vote, Board approved final ARPA Revenue Loss Funding allocation of $584,142 (54% schools / 46% town).
+- [select_board 2025-04-23](#entry-select_board_2025-04-23_seq-005): warrant article, Board supported Article 28 Home Rule Petition to establish a Means-Tested Senior Citizen Property Tax Exemption.
+- [select_board 2025-05-14](#entry-select_board_2025-05-14_seq-001): vote, Board adopted 5-0 the Home Rule Petition from Article 28 to establish a Means-Tested Senior Citizen Property Tax Exemption and submit to the General Court.
+- [select_board 2025-07-18](#entry-select_board_2025-07-18_seq-005): proposal, Staff committed to tracking and sharing a list of grants and expenditures at risk due to potential <abbr class="g" title="Massachusetts Bay Transportation Authority">MBTA</abbr> 3A non-compliance.
+- [select_board 2025-10-22](#entry-select_board_2025-10-22_seq-001): study, Town Administrator reported $2,816,493 in FY26 funding losses across seven grants due to <abbr class="g" title="Massachusetts Bay Transportation Authority">MBTA</abbr> 3A non-compliance, and cumulative losses of $3,601,493 across nine grants.
+- [select_board 2026-02-11](#entry-select_board_2026-02-11_seq-009): proposal, Chair reported the Home Rule Petition for the Senior Tax Exemption is in its 3rd reading in the Massachusetts House.
+- [school_committee 2023-07-06](#entry-school_committee_2023-07-06_seq-002): vote, Committee approved 4-0 adjusted athletic user fees generating ~$26,000 for freshman coaching and transportation.
+- [school_committee 2025-12-01](#entry-school_committee_2025-12-01_seq-003): proposal, Committee agreed fund balances should be used for one-time expenses only; Assistant Superintendent restructured user fee accounting into separate revolving funds.
 
 > "This resulted in a total loss of $2,816,493 in potential funding for FY26, bringing the cumulative impact of <abbr class="g" title="Massachusetts Bay Transportation Authority">MBTA</abbr> 3A-related funding losses to nine grants totaling $3,601,493."  ([select_board 2025-10-22](#entry-select_board_2025-10-22_seq-001))
 
@@ -169,20 +169,20 @@ Governance attempts include the Town Charter Committee process, the merger and r
 
 Notable attempts:
 
-- [select_board 2019-09-25](#entry-select_board_2019-09-25_seq-001): vote, Board and School Committee approved an MOA providing increased collaboration, cooperation, and long-term planning between the two bodies. ★★★
-- [select_board 2020-06-17](#entry-select_board_2020-06-17_seq-006): vote, Board approved transfer of care, custody, and control of storm sewer drains from the Water and Sewer Commission to the Select Board under <abbr class="g" title="Department of Public Works">DPW</abbr>, subject to further approvals. ★★★
-- [select_board 2022-01-12](#entry-select_board_2022-01-12_seq-001): warrant article, Board placed an article on the 2022 ATM warrant to change the name of the Board of Selectmen to Select Board. ★★★
-- [select_board 2022-05-25](#entry-select_board_2022-05-25_seq-004): vote, Board authorized an MOU with the Marblehead Water & Sewer Commission and appointed the Water & Sewer Superintendent as <abbr class="g" title="Department of Public Works">DPW</abbr> Director with a $30,000 stipend. ★★★
-- [select_board 2022-11-16](#entry-select_board_2022-11-16_seq-001): vote, Board voted to revise the Fair Housing Committee's composition to clarify mandates among Fair Housing, Housing Production Plan, and Affordable Housing Trust committees. ★★★
-- [select_board 2024-04-24](#entry-select_board_2024-04-24_seq-002): warrant article, Board unanimously supported Article 35 placing the Assessing Department under the Chief Financial Officer. ★★★
-- [select_board 2024-04-24](#entry-select_board_2024-04-24_seq-003): warrant article, Board unanimously supported Article 38 adopting <abbr class="g" title="Massachusetts General Laws">MGL</abbr> 41b to change Assessors from elected to appointed positions. ★★★
-- [select_board 2024-04-24](#entry-select_board_2024-04-24_seq-009): study, Board authorized a $15,000 Reserve Fund Transfer to hire a consultant to review operations of the Assessor's Office following abatement processing issues. ★★★
-- [select_board 2024-07-11](#entry-select_board_2024-07-11_seq-001): proposal, Select Board met jointly with the Town Charter Committee to discuss a potential Town Charter; no votes taken. ★★★
-- [select_board 2025-05-14](#entry-select_board_2025-05-14_seq-003): working_group, Board received Town Charter Committee update; public forums scheduled and drafting to continue for 10 months with target presentation at May 2026 Town Meeting. ★★★
-- [select_board 2025-06-25](#entry-select_board_2025-06-25_seq-001): vote, Board merged the Fair Housing Committee and Housing Production Plan Implementation Committee into a single Marblehead Housing Committee. ★★★
-- [select_board 2025-09-24](#entry-select_board_2025-09-24_006): study, Town Charter Committee reported target submission to Select Board by January 2026, with potential implementation by 2028. ★★★
-- [school_committee 2024-02-01](#entry-school_committee_2024-02-01_seq-002): vote, Committee reclassified the senior finance role back to Director of Finance and Operations with a $120,000-$150,000 salary range. ★★★
-- [school_committee 2024-04-25](#entry-school_committee_2024-04-25_seq-001): vote, Committee reclassified Director of Student Services to Assistant Superintendent of Student Services and hired Lisa Marie Ippolito pending contract. ★★★
+- [select_board 2019-09-25](#entry-select_board_2019-09-25_seq-001): vote, Board and School Committee approved an MOA providing increased collaboration, cooperation, and long-term planning between the two bodies.
+- [select_board 2020-06-17](#entry-select_board_2020-06-17_seq-006): vote, Board approved transfer of care, custody, and control of storm sewer drains from the Water and Sewer Commission to the Select Board under <abbr class="g" title="Department of Public Works">DPW</abbr>, subject to further approvals.
+- [select_board 2022-01-12](#entry-select_board_2022-01-12_seq-001): warrant article, Board placed an article on the 2022 ATM warrant to change the name of the Board of Selectmen to Select Board.
+- [select_board 2022-05-25](#entry-select_board_2022-05-25_seq-004): vote, Board authorized an MOU with the Marblehead Water & Sewer Commission and appointed the Water & Sewer Superintendent as <abbr class="g" title="Department of Public Works">DPW</abbr> Director with a $30,000 stipend.
+- [select_board 2022-11-16](#entry-select_board_2022-11-16_seq-001): vote, Board voted to revise the Fair Housing Committee's composition to clarify mandates among Fair Housing, Housing Production Plan, and Affordable Housing Trust committees.
+- [select_board 2024-04-24](#entry-select_board_2024-04-24_seq-002): warrant article, Board unanimously supported Article 35 placing the Assessing Department under the Chief Financial Officer.
+- [select_board 2024-04-24](#entry-select_board_2024-04-24_seq-003): warrant article, Board unanimously supported Article 38 adopting <abbr class="g" title="Massachusetts General Laws">MGL</abbr> 41b to change Assessors from elected to appointed positions.
+- [select_board 2024-04-24](#entry-select_board_2024-04-24_seq-009): study, Board authorized a $15,000 Reserve Fund Transfer to hire a consultant to review operations of the Assessor's Office following abatement processing issues.
+- [select_board 2024-07-11](#entry-select_board_2024-07-11_seq-001): proposal, Select Board met jointly with the Town Charter Committee to discuss a potential Town Charter; no votes taken.
+- [select_board 2025-05-14](#entry-select_board_2025-05-14_seq-003): working_group, Board received Town Charter Committee update; public forums scheduled and drafting to continue for 10 months with target presentation at May 2026 Town Meeting.
+- [select_board 2025-06-25](#entry-select_board_2025-06-25_seq-001): vote, Board merged the Fair Housing Committee and Housing Production Plan Implementation Committee into a single Marblehead Housing Committee.
+- [select_board 2025-09-24](#entry-select_board_2025-09-24_006): study, Town Charter Committee reported target submission to Select Board by January 2026, with potential implementation by 2028.
+- [school_committee 2024-02-01](#entry-school_committee_2024-02-01_seq-002): vote, Committee reclassified the senior finance role back to Director of Finance and Operations with a $120,000-$150,000 salary range.
+- [school_committee 2024-04-25](#entry-school_committee_2024-04-25_seq-001): vote, Committee reclassified Director of Student Services to Assistant Superintendent of Student Services and hired Lisa Marie Ippolito pending contract.
 
 > "The committee aims to submit a final draft to the Select Board by January 2026 for town meeting approval, with potential implementation by 2028."  ([select_board 2025-09-24](#entry-select_board_2025-09-24_006))
 
@@ -194,10 +194,10 @@ A smaller set of entries addresses cost sharing and joint service arrangements a
 
 Notable attempts:
 
-- [school_committee 2023-05-18](#entry-school_committee_2023-05-18_seq-002): vote, Committee approved 4-0 an updated Memorandum of Understanding between the School Committee and Park and Recreation, framed as shared-resource collaboration. ★★★
-- [select_board 2025-07-23](#entry-select_board_2025-07-23_seq-001): vote, Board unanimously approved a joint ambulance service contract among Marblehead, Swampscott, and Beauport Ambulance Services with shared response-time provisions and a 6-month opt-out notification period. ★★★★
-- [school_committee 2025-12-01](#entry-school_committee_2025-12-01_seq-002): proposal, Committee suggested exploring shared services with town departments for facilities/maintenance and establishing a permanent building committee for large capital projects. ★★★
-- [school_committee 2026-02-13](#entry-school_committee_2026-02-13_seq-003): proposal, Committee discussed a joint project with Park and Recreation at the Eveleth site, including a joint community survey and possible feasibility study. ★★★
+- [school_committee 2023-05-18](#entry-school_committee_2023-05-18_seq-002): vote, Committee approved 4-0 an updated Memorandum of Understanding between the School Committee and Park and Recreation, framed as shared-resource collaboration.
+- [select_board 2025-07-23](#entry-select_board_2025-07-23_seq-001): vote, Board unanimously approved a joint ambulance service contract among Marblehead, Swampscott, and Beauport Ambulance Services with shared response-time provisions and a 6-month opt-out notification period.
+- [school_committee 2025-12-01](#entry-school_committee_2025-12-01_seq-002): proposal, Committee suggested exploring shared services with town departments for facilities/maintenance and establishing a permanent building committee for large capital projects.
+- [school_committee 2026-02-13](#entry-school_committee_2026-02-13_seq-003): proposal, Committee discussed a joint project with Park and Recreation at the Eveleth site, including a joint community survey and possible feasibility study.
 
 > "This is a joint contract, approved by Swampscott the night before, which will provide enhanced competitiveness and include provisions for response times, performance oversight, and a 6-month notification period for municipalities to opt out. Beauport, which has experience serving multiple towns, will provide one fully staffed ALS ambulance and additional BLS coverage, with new co-branded vehicles."  ([select_board 2025-07-23](#entry-select_board_2025-07-23_seq-001))
 


### PR DESCRIPTION
## Summary
- Removes 148 trailing ★ markers from bullets on `what-have-we-tried.html`. The 1-5 rating was LLM-generated and only 3-5 were promoted, so readers saw a 5-point visual for a 3-point range, with a fuzzy 3-vs-4 boundary.
- Updates `scripts/minutes/prompts/pass3_synthesize_tried.md` so regenerating the page from the catalog will not reintroduce the marker.
- Pass 2 importance scoring still runs upstream as a promote/drop filter; it just is not surfaced in the rendered page.

## Test plan
- [ ] Preview page renders without trailing stars; bullets end at the outcome sentence.
- [ ] Content is otherwise byte-identical to prior page (verified locally: 104 insertions, 104 deletions, same line count).
- [ ] No em-dashes introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)