### PR TITLE
Cite Circuit Breaker takeaway numbers inline (#580, #581)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3421,6 +3421,7 @@ og_url: https://marbleheaddata.org/
           <span class="evidence-nugget-value">$1,054</span>
           <span class="evidence-nugget-label">Average claim in 2022 -- just 37% of the $2,820 cap. For seniors who don't file at all, the offset is zero.</span>
         </div>
+        <p class="source">Claim count (418) and average credit ($1,054), TY2022: <a href="https://www.mass.gov/doc/senior-circuit-breaker-credit-usage-by-town-2001-2022/download">MA DOR, Senior Circuit Breaker Credit Usage by Town, 2001&ndash;2022</a>. Eligible-household estimate (~1,158) derived from US Census Bureau, ACS 2019&ndash;2023 5-year estimates, tables B19037 and B25007, Marblehead town. Maximum credit ($2,820): <a href="https://www.mass.gov/technical-information-release/tir-25-7-annual-update-of-real-estate-tax-credit-for-certain-persons-age-65-and-older">MA DOR TIR 25-7</a> (TY2025).</p>
       </div>
 
       <div class="evidence-point">

--- a/index.html
+++ b/index.html
@@ -3421,7 +3421,7 @@ og_url: https://marbleheaddata.org/
           <span class="evidence-nugget-value">$1,054</span>
           <span class="evidence-nugget-label">Average claim in 2022 -- just 37% of the $2,820 cap. For seniors who don't file at all, the offset is zero.</span>
         </div>
-        <p class="source">Claim count (418) and average credit ($1,054), TY2022: <a href="https://www.mass.gov/doc/senior-circuit-breaker-credit-usage-by-town-2001-2022/download">MA DOR, Senior Circuit Breaker Credit Usage by Town, 2001&ndash;2022</a>. Eligible-household estimate (~1,158) derived from US Census Bureau, ACS 2019&ndash;2023 5-year estimates, tables B19037 and B25007, Marblehead town. Maximum credit ($2,820): <a href="https://www.mass.gov/technical-information-release/tir-25-7-annual-update-of-real-estate-tax-credit-for-certain-persons-age-65-and-older">MA DOR TIR 25-7</a> (TY2025).</p>
+        <p class="source">Claim count (418) and average credit ($1,054), TY2022: <a href="https://www.mass.gov/doc/senior-circuit-breaker-credit-usage-by-town-2001-2022/download">MA <abbr class="g" title="Department of Revenue">DOR</abbr>, Senior Circuit Breaker Credit Usage by Town, 2001&ndash;2022</a>. Eligible-household estimate (~1,158) derived from US Census Bureau, <abbr class="g" title="American Community Survey">ACS</abbr> 2019&ndash;2023 5-year estimates, tables B19037 and B25007, Marblehead town. Maximum credit ($2,820): <a href="https://www.mass.gov/technical-information-release/tir-25-7-annual-update-of-real-estate-tax-credit-for-certain-persons-age-65-and-older">MA DOR <abbr class="g" title="Technical Information Release">TIR</abbr> 25-7</a> (TY2025).</p>
       </div>
 
       <div class="evidence-point">

--- a/senior-tax-relief.html
+++ b/senior-tax-relief.html
@@ -368,6 +368,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
   <div class="takeaway takeaway--neutral">
     Only 418 Marblehead seniors claimed the Circuit Breaker in 2022, out of roughly 1,158 senior households under the income limit. The average credit was $1,054. If you are 65 or older and your household income is under $75,000 (single), $94,000 (head of household), or $112,000 (joint), you may be leaving money on the table.
   </div>
+  <p class="source">Claim count and average credit (TY2022): <a href="https://www.mass.gov/doc/senior-circuit-breaker-credit-usage-by-town-2001-2022/download">MA <abbr class="g" title="Department of Revenue">DOR</abbr>, Senior Circuit Breaker Credit Usage by Town, 2001&ndash;2022</a>. Eligible household estimate (~1,158) derived from US Census Bureau, ACS 2019&ndash;2023 5-year estimates, tables B19037 and B25007, Marblehead town. Income limits: <a href="https://www.mass.gov/info-details/massachusetts-senior-circuit-breaker-tax-credit">Mass.gov Senior Circuit Breaker</a> (TY2025 thresholds, adjusted annually for inflation).</p>
 
   <nav class="page-toc" aria-label="On this page">
     <span class="page-toc-label">On this page</span>


### PR DESCRIPTION
## Summary
- Adds `<p class="source">` directly under the Circuit Breaker takeaway on `senior-tax-relief.html` so a reader scanning the box can verify the 418 / 1,158 / $1,054 / $75k-$94k-$112k numbers without scrolling.
- Adds the same source paragraph under the matching evidence block on `index.html` (the "36% claimed / $1,054 average" nuggets).
- No new data -- lifts citations that already existed elsewhere on the page (senior-tax-relief.html lines 416, 536, 582) up to where the numbers first appear.

Closes #580 and #581 (they are duplicate issues on the same takeaway).

## Test plan
- [ ] Preview: takeaway on `senior-tax-relief.html` shows a `.source` line with three links (DOR usage dataset, ACS derivation note, Mass.gov Circuit Breaker page).
- [ ] Preview: seniors evidence block on `index.html` shows a `.source` line under the "average claim is $1,054" nugget.
- [ ] Content guardrails CI passes (no em-dashes introduced).

Generated with [Claude Code](https://claude.com/claude-code)