### PR TITLE
Level-funding mechanism analysis and retrospective

### DIFF
--- a/data/level_funding_mechanism.md
+++ b/data/level_funding_mechanism.md
@@ -138,7 +138,7 @@ decoded values within +/-$0.05M). FY18 vs. FY24:
   Building, <abbr class="g" title="Marblehead High School">MHS</abbr> roof/<abbr class="g" title="Heating, Ventilation, and Air Conditioning">HVAC</abbr>), not operating-budget pressure. Pension
   budgetary line is small in absolute terms ($1.65M Δ). Public Safety
   growth is mostly Police and Fire wages with collective bargaining
-  COLAs.
+  <abbr class="g" title="Cost of Living Adjustment">COLA</abbr>s.
 
 - **Schools (the largest absolute mover, +$8.71M) grew slightly *below*
   CPI** at +23.3%, even while enrollment dropped ~16%. This means
@@ -179,7 +179,7 @@ decoded values within +/-$0.05M). FY18 vs. FY24:
    stay flat in nominal terms? Need line-by-line from FinCom Annual
    Reports for FY18-FY26.
 
-2. **Wage growth from collective bargaining.** COLAs in MOAs/MOUs run
+2. **Wage growth from collective bargaining.** COLAs in <abbr class="g" title="Memorandum of Agreement">MOA</abbr>s/<abbr class="g" title="Memorandum of Understanding">MOU</abbr>s run
    2-3.5%/yr. With ~190 town employees on payroll, that's $300k-$500k
    per year of structural cost growth on a flat top-line. The Public
    Safety +38.8% growth strongly suggests wages are doing most of the

--- a/data/level_funding_mechanism.md
+++ b/data/level_funding_mechanism.md
@@ -1,0 +1,230 @@
+---
+title: "What Actually Squeezed Marblehead's Operating Budget, FY18-FY27"
+body_class: doc-page
+sitemap: false
+---
+
+# What actually squeezed Marblehead's operating budget, FY18 to FY27
+
+*Working analysis. Not a public page. Compiled 2026-04-24 while attempting
+to visualize "level-funded cuts." The popular narrative blames healthcare
+and pensions; the data does not support that for the FY18-FY27 window.
+Documenting the finding so the override conversation can be honest.*
+
+## The popular narrative
+
+The dominant override-debate framing is: "healthcare and pension costs are
+exploding, eating the budget, forcing cuts to operations." It is the lead
+sentence in many local news pieces and FinCom transmittal letters.
+
+## What the data says
+
+Compound annual growth rates over the FY18-FY27 window:
+
+| Series | Period | CAGR | vs. levy growth |
+|---|---|---:|---|
+| **Property tax levy** | FY18-FY27 | **+2.97%/yr** | baseline |
+| **Group insurance (healthcare)** | FY18-FY27 | **+2.76%/yr** | -0.21 pp |
+| **Pension assessment** | FY18-FY24 | **+0.91%/yr** | -2.06 pp |
+| **CPI-U (US, all items)** | FY18-FY24 | **+3.78%/yr** | +0.81 pp |
+
+Healthcare grew *slower* than the levy. Pensions grew *much* slower than the
+levy in the FY18-FY27 window (the aggressive pension-funding catch-up
+happened in FY15-FY21 and tapered after).
+
+CPI grew *faster* than the levy, by about 80 basis points per year.
+
+## The implication
+
+If healthcare and pensions both grew below the rate of allowed levy growth,
+they *cannot* be the mechanism that forced operating cuts. Their share of
+the general fund actually *decreased* over the window:
+
+- HC share of general fund FY18: 16.0% ($13.1M / $81.8M)
+- HC share of general fund FY24: 13.6% ($13.9M / $102.3M)
+
+The thing that grew faster than the levy is **CPI**. So whichever line items
+tracked CPI rather than the levy cap absorbed the pressure:
+
+- Materials and supplies (roads, parts, paper, food, fuel)
+- Vendor contracts (engineering, legal, IT, software)
+- Utilities (electricity, gas, water)
+- Equipment (vehicles, machinery, tools)
+- Outsourced services (cleaning, IT, professional)
+
+These line items live inside operating department budgets. When those
+budgets are "level-funded" in nominal dollars, CPI eats their real
+purchasing power at roughly 80 basis points per year above the levy cap,
+plus the full gap between zero nominal growth and CPI when the budget is
+actually level.
+
+A budget held flat at $533,544 (Energy Reserve, FY11-FY20) loses 100% of
+CPI inflation in real purchasing power each year. Over 10 years at ~2.5%
+CPI, that's ~22% lost purchasing power before the line was zeroed in FY26.
+
+## Why the mismatch with the public narrative
+
+A few hypotheses worth investigating:
+
+1. **The public narrative is anchored on FY27 specifically.** Healthcare
+   spiked +11% in the FY27 budget proposal (from $15.1M FY26 to $16.75M
+   FY27). That's the single year people are seeing now. It is not
+   representative of the FY18-FY26 period that preceded it.
+
+2. **Pension catch-up FY15-FY21 was real but ended.** Pension assessment
+   went from $6.2M (FY15) to $16.0M (FY21), then dropped to ~$10-12M for
+   FY22-FY24. The catch-up phase shaped a generation of FinCom narratives
+   that did not update when pensions stabilized.
+
+3. **It is rhetorically easier to blame named state mandates** (GIC,
+   PERAC) than to explain that operating departments are being eaten by
+   general inflation on level-funded line items. The first has a villain;
+   the second is mechanical and abstract.
+
+4. **The headline number on free cash usage masks the structural issue.**
+   $10.2M (FY23) of free cash papered over the hole. As that drops to
+   $5M (FY27), the structural gap becomes visible all at once.
+
+## What this implies for the override case
+
+The most defensible version of the "we have been cutting services to keep
+the levy flat" claim is not:
+
+> "Healthcare and pensions are eating the budget, leaving nothing for
+> services."
+
+It is:
+
+> "Marblehead's operating departments have been held to flat or
+> near-flat nominal budgets for nine years. Over that window, CPI ran
+> 80 basis points hotter per year than the levy could grow. The
+> resulting real-dollar erosion (~25-30% over the window for fully
+> level-funded line items) is what drove the documented attrition: 9
+> net positions lost, the Engineering Department zeroed, Energy Reserve
+> ($533,544 flat for 10 years) eliminated, the SRO program ended, Fire
+> on 96-hour shifts."
+
+This is more boring than "healthcare crisis," but it is what the data
+supports.
+
+## Question 5 explored: where the +$20M of GF growth actually went
+
+Decomposed from the polygon-encoded data on `where-has-the-money-gone.html`,
+calibrated against the prose (which states FY15-FY26 totals matching the
+decoded values within +/-$0.05M). FY18 vs. FY24:
+
+| Category | FY18 ($M) | FY24 ($M) | Δ ($M) | % of GF growth | Growth rate |
+|---|---:|---:|---:|---:|---:|
+| Schools | 37.45 | 46.16 | +8.71 | 42.5% | +23.3% |
+| Debt payments | 7.15 | 11.00 | +3.85 | 18.8% | **+53.8%** |
+| Public Safety | 8.16 | 11.32 | +3.16 | 15.4% | **+38.8%** |
+| Everything else | 14.39 | 16.37 | +1.97 | 9.6% | +13.7% |
+| Pensions (budgetary) | 2.89 | 4.54 | +1.65 | 8.1% | **+57.1%** |
+| Health insurance | 11.74 | 12.88 | +1.15 | 5.6% | +9.8% |
+| **TOTAL** | **81.78** | **102.27** | **+20.49** | **100%** | **+25.1%** |
+
+**CPI growth FY18-FY24:** +24.9% (6-yr CAGR 3.78%/yr).
+
+### What this tells us
+
+- **Total GF growth (+25.1%) almost exactly matched CPI (+24.9%).** In
+  real-dollar terms the general fund was *flat per dollar of inflation*.
+  All "growth" was just keeping up with the cost of doing the same
+  things.
+
+- **Three categories outpaced CPI:** Debt payments (+53.8%), Pensions on
+  the budgetary line (+57.1%), and Public Safety (+38.8%). Debt growth
+  reflects voter-approved capital exclusions (Bell School, Mary Alley
+  Building, MHS roof/HVAC), not operating-budget pressure. Pension
+  budgetary line is small in absolute terms ($1.65M Δ). Public Safety
+  growth is mostly Police and Fire wages with collective bargaining
+  COLAs.
+
+- **Schools (the largest absolute mover, +$8.71M) grew slightly *below*
+  CPI** at +23.3% — even while enrollment dropped ~16%. This means
+  per-pupil real spending modestly increased. Schools were not held
+  flat; but they did not run away either.
+
+- **The squeeze concentrates in "Everything else"** (+13.7% over 6
+  years vs CPI +24.9%) — DPW, library, Council on Aging, general
+  government, state and county charges, public works support, etc.
+  Real-dollar decline of about 9 percentage points over the window.
+  This bucket is where the documented attrition (Engineering eliminated,
+  DPW lost 12, etc.) actually lives.
+
+### Methodology notes
+
+- "Health insurance" in the decoded chart is $11.74M FY18, lower than
+  the FinCom-reported group insurance budget of $13.12M FY18. The
+  chart appears to use a tighter definition (perhaps employee health
+  premiums only, excluding self-insurance trust contributions or OPEB
+  pay-as-you-go). For a published chart we would need to reconcile
+  with the FinCom line. The directional finding (HC growing slower
+  than CPI) holds under either definition.
+- "Pensions (budgetary)" is $2.89M FY18, far below the $11.83M PERAC
+  assessment in `pension_expenditure_FY15-24.csv`. The chart's
+  "budgetary basis" likely shows only the General Fund operating
+  appropriation for pension-related items (employer share, COLA
+  funding, OPEB pay-go) and excludes the actuarial Essex Regional
+  contribution which may be carried as a separate fund.
+- All decoded numbers carry +/-$0.05M precision per the source CSV's
+  notes column. Re-extract from ACFR General Fund schedules for any
+  published claim.
+
+## Other open questions to investigate
+
+1. **Department-level operating budget growth FY18-FY27.** Without
+   benefits and pensions baked in, did the "Everything else" bucket's
+   sub-departments (DPW, library, COA, general government) actually
+   stay flat in nominal terms? Need line-by-line from FinCom Annual
+   Reports for FY18-FY26.
+
+2. **Wage growth from collective bargaining.** COLAs in MOAs/MOUs run
+   2-3.5%/yr. With ~190 town employees on payroll, that's $300k-$500k
+   per year of structural cost growth on a flat top-line. The Public
+   Safety +38.8% growth strongly suggests wages are doing most of the
+   work in that bucket; need to confirm with department-level salary
+   detail.
+
+3. **The FY27 cliff decomposition.** What does the $8.47M FY27 deficit
+   actually consist of? How much is healthcare jump, how much is the
+   end of free-cash bandaid, how much is wages, how much is pensions
+   reverting?
+
+4. **Peer-town comparison.** Did Swampscott / Melrose / Stoneham see
+   the same pattern (HC and pensions sub-CPI, operations squeezed by
+   inflation)? Or is Marblehead structurally different?
+
+5. **Reconcile the "Health insurance" and "Pensions" chart numbers
+   with FinCom assessment numbers.** Resolves the methodology note
+   above and would let us publish a clean version of this analysis.
+
+## Sources used in this analysis
+
+- `data/marblehead_levy.csv` — town total levy by fiscal year
+- `data/group_insurance_FY14-27.csv` — FinCom-reported healthcare cost
+- `data/pension_expenditure_FY15-24.csv` — Essex pension assessment
+- `data/cpi_us.csv` — US BLS CPI-U
+- `data/general_fund_spending_FY15-26.csv` — total general fund spending
+- `data/savings_measures_compiled.md` — staff attrition, level-funded items
+- CLAUDE.md memory note `project_healthcare_trend_vs_cliff` — corroborates
+  the FY18-FY26 sub-CPI HC growth finding
+- CLAUDE.md memory note `feedback_data_accuracy` — corrects FY26 HC to
+  $15.1M and FY27 deficit to $8.47M
+
+## Caveats
+
+- Pension data has GASB volatility; the FY22 drop ($10.4M from $16.0M
+  the prior year) is likely an accounting artifact, not a real cost
+  decrease. The CAGR figure absorbs this noise.
+- General fund spending FY15-FY26 was decoded from chart polygons and
+  is precision ~+/-$50K. Re-extract from ACFR General Fund schedules
+  for any published claims.
+- Healthcare FY24 ($13.9M) and FY25 ($13.7M) appear lower than the
+  underlying trend; CLAUDE memory `feedback_data_accuracy` flags FY26
+  as $15.1M (corrected upward from a $13.6M stale reference). Treat
+  the FY24-FY25 dips as suspect until verified against primary FinCom
+  reports.
+- This is a back-of-envelope analysis from existing CSVs in the repo.
+  No primary FinCom reports were re-opened. Treat as a working
+  hypothesis, not a published finding.

--- a/data/level_funding_mechanism.md
+++ b/data/level_funding_mechanism.md
@@ -15,18 +15,18 @@ Documenting the finding so the override conversation can be honest.*
 
 The dominant override-debate framing is: "healthcare and pension costs are
 exploding, eating the budget, forcing cuts to operations." It is the lead
-sentence in many local news pieces and FinCom transmittal letters.
+sentence in many local news pieces and <abbr class="g" title="Finance Committee">FinCom</abbr> transmittal letters.
 
 ## What the data says
 
 Compound annual growth rates over the FY18-FY27 window:
 
-| Series | Period | CAGR | vs. levy growth |
+| Series | Period | <abbr class="g" title="Compound Annual Growth Rate">CAGR</abbr> | vs. levy growth |
 |---|---|---:|---|
 | **Property tax levy** | FY18-FY27 | **+2.97%/yr** | baseline |
 | **Group insurance (healthcare)** | FY18-FY27 | **+2.76%/yr** | -0.21 pp |
 | **Pension assessment** | FY18-FY24 | **+0.91%/yr** | -2.06 pp |
-| **CPI-U (US, all items)** | FY18-FY24 | **+3.78%/yr** | +0.81 pp |
+| **<abbr class="g" title="Consumer Price Index">CPI</abbr>-U (US, all items)** | FY18-FY24 | **+3.78%/yr** | +0.81 pp |
 
 Healthcare grew *slower* than the levy. Pensions grew *much* slower than the
 levy in the FY18-FY27 window (the aggressive pension-funding catch-up
@@ -40,7 +40,7 @@ If healthcare and pensions both grew below the rate of allowed levy growth,
 they *cannot* be the mechanism that forced operating cuts. Their share of
 the general fund actually *decreased* over the window:
 
-- HC share of general fund FY18: 16.0% ($13.1M / $81.8M)
+- <abbr class="g" title="Health Care">HC</abbr> share of general fund FY18: 16.0% ($13.1M / $81.8M)
 - HC share of general fund FY24: 13.6% ($13.9M / $102.3M)
 
 The thing that grew faster than the levy is **CPI**. So whichever line items
@@ -76,8 +76,8 @@ A few hypotheses worth investigating:
    FY22-FY24. The catch-up phase shaped a generation of FinCom narratives
    that did not update when pensions stabilized.
 
-3. **It is rhetorically easier to blame named state mandates** (GIC,
-   PERAC) than to explain that operating departments are being eaten by
+3. **It is rhetorically easier to blame named state mandates** (<abbr class="g" title="Group Insurance Commission">GIC</abbr>,
+   <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>) than to explain that operating departments are being eaten by
    general inflation on level-funded line items. The first has a villain;
    the second is mechanical and abstract.
 
@@ -101,13 +101,13 @@ It is:
 > resulting real-dollar erosion (~25-30% over the window for fully
 > level-funded line items) is what drove the documented attrition: 9
 > net positions lost, the Engineering Department zeroed, Energy Reserve
-> ($533,544 flat for 10 years) eliminated, the SRO program ended, Fire
+> ($533,544 flat for 10 years) eliminated, the <abbr class="g" title="School Resource Officer">SRO</abbr> program ended, Fire
 > on 96-hour shifts."
 
-This is more boring than "healthcare crisis," but it is what the data
+This is more boring than "healthcare emergency," but it is what the data
 supports.
 
-## Question 5 explored: where the +$20M of GF growth actually went
+## Question 5 explored: where the +$20M of <abbr class="g" title="General Fund">GF</abbr> growth actually went
 
 Decomposed from the polygon-encoded data on `where-has-the-money-gone.html`,
 calibrated against the prose (which states FY15-FY26 totals matching the
@@ -135,18 +135,18 @@ decoded values within +/-$0.05M). FY18 vs. FY24:
 - **Three categories outpaced CPI:** Debt payments (+53.8%), Pensions on
   the budgetary line (+57.1%), and Public Safety (+38.8%). Debt growth
   reflects voter-approved capital exclusions (Bell School, Mary Alley
-  Building, MHS roof/HVAC), not operating-budget pressure. Pension
+  Building, <abbr class="g" title="Marblehead High School">MHS</abbr> roof/<abbr class="g" title="Heating, Ventilation, and Air Conditioning">HVAC</abbr>), not operating-budget pressure. Pension
   budgetary line is small in absolute terms ($1.65M Δ). Public Safety
   growth is mostly Police and Fire wages with collective bargaining
   COLAs.
 
 - **Schools (the largest absolute mover, +$8.71M) grew slightly *below*
-  CPI** at +23.3% — even while enrollment dropped ~16%. This means
+  CPI** at +23.3%, even while enrollment dropped ~16%. This means
   per-pupil real spending modestly increased. Schools were not held
   flat; but they did not run away either.
 
 - **The squeeze concentrates in "Everything else"** (+13.7% over 6
-  years vs CPI +24.9%) — DPW, library, Council on Aging, general
+  years vs CPI +24.9%), <abbr class="g" title="Department of Public Works">DPW</abbr>, library, Council on Aging, general
   government, state and county charges, public works support, etc.
   Real-dollar decline of about 9 percentage points over the window.
   This bucket is where the documented attrition (Engineering eliminated,
@@ -157,25 +157,25 @@ decoded values within +/-$0.05M). FY18 vs. FY24:
 - "Health insurance" in the decoded chart is $11.74M FY18, lower than
   the FinCom-reported group insurance budget of $13.12M FY18. The
   chart appears to use a tighter definition (perhaps employee health
-  premiums only, excluding self-insurance trust contributions or OPEB
+  premiums only, excluding self-insurance trust contributions or <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr>
   pay-as-you-go). For a published chart we would need to reconcile
   with the FinCom line. The directional finding (HC growing slower
   than CPI) holds under either definition.
 - "Pensions (budgetary)" is $2.89M FY18, far below the $11.83M PERAC
   assessment in `pension_expenditure_FY15-24.csv`. The chart's
   "budgetary basis" likely shows only the General Fund operating
-  appropriation for pension-related items (employer share, COLA
+  appropriation for pension-related items (employer share, <abbr class="g" title="Cost of Living Adjustment">COLA</abbr>
   funding, OPEB pay-go) and excludes the actuarial Essex Regional
   contribution which may be carried as a separate fund.
 - All decoded numbers carry +/-$0.05M precision per the source CSV's
-  notes column. Re-extract from ACFR General Fund schedules for any
+  notes column. Re-extract from <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> General Fund schedules for any
   published claim.
 
 ## Other open questions to investigate
 
 1. **Department-level operating budget growth FY18-FY27.** Without
    benefits and pensions baked in, did the "Everything else" bucket's
-   sub-departments (DPW, library, COA, general government) actually
+   sub-departments (DPW, library, <abbr class="g" title="Council on Aging">COA</abbr>, general government) actually
    stay flat in nominal terms? Need line-by-line from FinCom Annual
    Reports for FY18-FY26.
 
@@ -201,20 +201,20 @@ decoded values within +/-$0.05M). FY18 vs. FY24:
 
 ## Sources used in this analysis
 
-- `data/marblehead_levy.csv` — town total levy by fiscal year
-- `data/group_insurance_FY14-27.csv` — FinCom-reported healthcare cost
-- `data/pension_expenditure_FY15-24.csv` — Essex pension assessment
-- `data/cpi_us.csv` — US BLS CPI-U
-- `data/general_fund_spending_FY15-26.csv` — total general fund spending
-- `data/savings_measures_compiled.md` — staff attrition, level-funded items
-- CLAUDE.md memory note `project_healthcare_trend_vs_cliff` — corroborates
+- `data/marblehead_levy.csv`, town total levy by fiscal year
+- `data/group_insurance_FY14-27.csv`, FinCom-reported healthcare cost
+- `data/pension_expenditure_FY15-24.csv`, Essex pension assessment
+- `data/cpi_us.csv`, US <abbr class="g" title="Bureau of Labor Statistics">BLS</abbr> CPI-U
+- `data/general_fund_spending_FY15-26.csv`, total general fund spending
+- `data/savings_measures_compiled.md`, staff attrition, level-funded items
+- CLAUDE.md memory note `project_healthcare_trend_vs_cliff`, corroborates
   the FY18-FY26 sub-CPI HC growth finding
-- CLAUDE.md memory note `feedback_data_accuracy` — corrects FY26 HC to
+- CLAUDE.md memory note `feedback_data_accuracy`, corrects FY26 HC to
   $15.1M and FY27 deficit to $8.47M
 
 ## Caveats
 
-- Pension data has GASB volatility; the FY22 drop ($10.4M from $16.0M
+- Pension data has <abbr class="g" title="Governmental Accounting Standards Board">GASB</abbr> volatility; the FY22 drop ($10.4M from $16.0M
   the prior year) is likely an accounting artifact, not a real cost
   decrease. The CAGR figure absorbs this noise.
 - General fund spending FY15-FY26 was decoded from chart polygons and

--- a/docs/analysis/2026-04-24-level-funding-mechanism.md
+++ b/docs/analysis/2026-04-24-level-funding-mechanism.md
@@ -1,9 +1,3 @@
----
-title: "What Actually Squeezed Marblehead's Operating Budget, FY18-FY27"
-body_class: doc-page
-sitemap: false
----
-
 # What actually squeezed Marblehead's operating budget, FY18 to FY27
 
 *Working analysis. Not a public page. Compiled 2026-04-24 while attempting

--- a/docs/experiments/2026-04-24-visualizing-level-funded-cuts.md
+++ b/docs/experiments/2026-04-24-visualizing-level-funded-cuts.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-24
 **Status:** Experiment retrospective
-**Working artifacts:** `data/level_funding_mechanism.md`, PR #653
+**Working artifacts:** `docs/analysis/2026-04-24-level-funding-mechanism.md`, PR #658
 **Outcome:** No chart shipped. One analytical finding worth keeping.
 
 ## What we set out to do
@@ -135,7 +135,7 @@ Two sentences. Honest. Specific. Argues with itself rather than offering a sloga
 
 ## Working artifacts
 
-- `data/level_funding_mechanism.md` (this branch): the analytical memo with the math
+- `docs/analysis/2026-04-24-level-funding-mechanism.md` (this branch): the analytical memo with the math
 - `charts/positions-lost.html` (this branch): the failed dots chart, kept for reference
 - `docs/superpowers/specs/2026-04-24-positions-lost-chart-design.md`: original spec
 - `docs/superpowers/plans/2026-04-24-positions-lost-chart.md`: the implementation plan

--- a/docs/experiments/2026-04-24-visualizing-level-funded-cuts.md
+++ b/docs/experiments/2026-04-24-visualizing-level-funded-cuts.md
@@ -1,0 +1,154 @@
+# Visualizing level-funded cuts: a failed chart and an unexpected finding
+
+**Date:** 2026-04-24
+**Status:** Experiment retrospective
+**Working artifacts:** `data/level_funding_mechanism.md`, PR #653
+**Outcome:** No chart shipped. One analytical finding worth keeping.
+
+## What we set out to do
+
+The opening question, verbatim: *"i cant stop thinking about 'level-funded' cuts that have been happening (https://marbleheaddata.org/what-have-we-tried.html), how can we visualize this? it seems like people not be aware that just to stay afloat (pre-override) we've been cutting services just to keep the budget balanced."*
+
+The thesis to communicate:
+
+> "Marblehead has been cutting services for years to keep the levy from rising. Residents do not realize this. A visualization would make the silent cuts visible."
+
+Two assumptions baked into that thesis: (1) the cuts are real and substantial, (2) they have a cause that visualizes well. Neither survived contact with the data.
+
+## Attempt 1: the dots chart
+
+### The pitch
+
+Hand-authored SVG chart at `charts/positions-lost.html`. One filled circle per FTE position still funded, one outlined circle per position eliminated, grouped by department. The thesis: "every outlined dot is a job that used to exist and doesn't anymore."
+
+Spec: `docs/superpowers/specs/2026-04-24-positions-lost-chart-design.md` (committed to PR #653). Plan: `docs/superpowers/plans/2026-04-24-positions-lost-chart.md`.
+
+### Process
+
+Standard brainstorming flow: clarifying questions, three approaches presented (dot grid / slopegraph / cards), user picked dots. Wrote spec, wrote plan, executed via subagents in three phases (data verification, chart scaffold + rows, caption + page link).
+
+### What surfaced during data verification (Phase A)
+
+The Phase A data-verification agent caught a spec error: Community Development was going to be "4 to 1 over FY18-FY27" in the chart, but the department was *created* in FY26. Trajectory is 0 → 4 → 1 over the window. A net *gain* of 1 position. Showing "4 to 1" would have been rhetorical sleight of hand.
+
+The row was removed; "All other" residual was recalculated to ~134 → ~139 (net +5) accounting for the HR director hire (FY24), CD&P creation (FY26), and procurement director (FY26). Net town-wide stayed at -9.
+
+This was already a warning sign about the underlying thesis: *some* departments lost positions, but other departments grew. The net is small.
+
+### Why the chart did not work
+
+Built it, pushed to Cloudflare preview, took screenshots at desktop (1280px) and mobile (375px).
+
+**Desktop:** loss rows (DPW, Police, Engineering) read clearly at the top of the chart. Fire callout fits. The "All other" row was originally rendered as 139 filled dots, which visually dominated the page (a wall of black dots between the named-loss rows and the total). Inline edit converted "All other" to a text-only callout; that fix improved the layout.
+
+**The actual problem**, on viewing the final preview:
+
+- "199 → 190 over 9 years" reads as "1 position per year, no big deal." A skeptic skimming the chart concludes the cuts were not substantial.
+- The Town total row (190 filled dots, 9 outlined dots in the corner) visually shouts "we mostly held the line."
+- The honest "All other +5" disclosure pre-empts the obvious "but you also added jobs" rebuttal, but it also softens the story.
+- The chart visualizes the *outcome* (FTE count) when the user's actual frame was the *mechanism* (level-funded budgets). Headcount is the wrong hero. By the time someone is "lost," the budget has been losing real purchasing power for years before the position even comes off the books.
+
+The user's reaction to the preview: *"idk how helpful this is."*
+
+That was the right reaction. The chart was honest, accurate, and unhelpful.
+
+### What we wasted, what we didn't
+
+Wasted: ~3 phases of subagent work building the chart. Spec, plan, six dot rows, captions, citations, parent-page link. ~6 commits on a branch we are unlikely to merge.
+
+Did not waste: the data verification itself (caught the Community Development misframe; that finding survives independently of any chart). And the experience of building it, which made the next attempt sharper.
+
+## Attempt 2: the budget squeeze chart
+
+### The pitch
+
+Pivot from outcome to mechanism. Stacked area chart of general fund composition over FY18-FY27. The thesis: "mandatory costs (healthcare, pensions, debt service) ate the levy growth, leaving the discretionary share to shrink. That contraction is the silent cut."
+
+This was Story B, kicking around since the very beginning of the conversation when both A (headcount) and B (purchasing power) were on the table.
+
+### What stopped it before a single SVG line was written
+
+Pulled the actual data from `data/general_fund_spending_FY15-26.csv`, `data/group_insurance_FY14-27.csv`, `data/pension_expenditure_FY15-24.csv`, `data/cpi_us.csv`, and `data/marblehead_levy.csv`.
+
+Did the math:
+
+| Series | FY18-FY27 CAGR |
+|---|---:|
+| Property tax levy | +2.97%/yr |
+| Healthcare (group insurance) | +2.76%/yr |
+| Pension assessment FY18-FY24 | +0.91%/yr |
+| CPI-U | +3.78%/yr |
+
+Healthcare grew *slower* than the levy. Pensions grew *much* slower than the levy. As shares of the general fund, both *decreased* over the window (HC 16.0% → 13.6%; pension share also fell).
+
+The squeeze chart concept does not survive this data. Mandatory costs did not squeeze operations over FY18-FY26. The CLAUDE.md memory note `project_healthcare_trend_vs_cliff` was already pointing at this for healthcare specifically (HC grew slower than CPI over FY12-FY26); the fuller analysis generalizes it.
+
+This was a real "data resists desired story" moment. The override talking points commonly blame healthcare and pensions. The data does not back that up for this window.
+
+## The unexpected finding
+
+If healthcare and pensions did not eat the budget, what did? Decomposed the +$20M FY18-FY24 general fund growth from the polygon-encoded data on `where-has-the-money-gone.html`:
+
+| Category | FY18 ($M) | FY24 ($M) | Δ ($M) | Growth rate | vs CPI (24.9%) |
+|---|---:|---:|---:|---:|---|
+| Schools | 37.45 | 46.16 | +8.71 | +23.3% | slightly below |
+| Debt payments | 7.15 | 11.00 | +3.85 | +53.8% | well above |
+| Public Safety | 8.16 | 11.32 | +3.16 | +38.8% | above |
+| Pensions (budgetary) | 2.89 | 4.54 | +1.65 | +57.1% | well above |
+| Health insurance | 11.74 | 12.88 | +1.15 | +9.8% | well below |
+| **Everything else** | **14.39** | **16.37** | **+1.97** | **+13.7%** | **9 pp below** |
+| Total | 81.78 | 102.27 | +20.49 | +25.1% | basically at CPI |
+
+**The squeeze concentrates in "Everything else."** That bucket (DPW, library, Council on Aging, general government, public works support, state and county charges) was held to roughly half the rate of CPI growth over six years. About 9 percentage points of real-dollar decline.
+
+That is where the documented attrition (Engineering eliminated, DPW down 12, library hours, COA staffing) actually lives. Not in healthcare. Not in pensions. Not even in schools or public safety.
+
+Schools held to slightly below CPI even with enrollment dropping 16%, which means per-pupil real spending modestly *increased*. Schools are expensive because of structural inflation on a smaller student base, not because spending grew.
+
+Debt payments grew +54%, but that growth is almost entirely from voter-approved capital exclusions (Bell PK-3, Mary A. Alley, MHS roof/HVAC, Abbot Library, fire pumper, Fort Sewall). Each was its own separate yes vote. That money was never available for operations; it was specifically authorized for buildings.
+
+Public Safety grew +39%, mostly Police and Fire wages with collective bargaining COLAs.
+
+## What we would do differently
+
+The original ask presupposed a chart was the right deliverable. Two attempts at a chart both ran into trouble. The deliverable that would actually serve the original goal is not a new chart at all: it is a sharper opening paragraph on the existing `what-has-the-town-done.html` page.
+
+That page already documents the staffing cuts, the consolidations, the level-funded items. What it lacks is a framing sentence that explains *why* this happened. We now have one:
+
+> "Marblehead's general fund grew at the rate of inflation over FY18-FY24. Schools, the largest single category, held to inflation. Public Safety wages and voter-approved capital debt grew faster. The 'everything else' bucket of operations (DPW, library, Council on Aging, general government) was held to half the rate of inflation. That is where the documented cuts and unfilled positions came from."
+
+Two sentences. Honest. Specific. Argues with itself rather than offering a slogan.
+
+## Lessons
+
+1. **Popular narratives about budget pressure can be wrong.** The "healthcare and pensions are eating the budget" framing is dominant in local override-debate coverage. For Marblehead's FY18-FY26 window the data does not support it. This is a finding worth surfacing publicly even though it cuts against the rhetorical preference of override proponents. Honesty is the editorial stance.
+
+2. **A narrow, specific claim beats a broad, vague one.** "9 positions cut over 9 years" is true but reads as small. "DPW lost 12 of 31 workers, Engineering eliminated, library hours reduced, COA staffing trimmed, all because the 'everything else' bucket was held to half of CPI growth" is also true and reads as substantial. Same data, different framing, very different effect.
+
+3. **Visualization is not always the right deliverable.** When the data resists a single dramatic story, prose can do the work better than a chart. The dots chart was honest but unpersuasive; the right move was to abandon it rather than add visual flourishes to compensate. Two sentences of sharp prose would do more for the override conversation than any chart we considered.
+
+4. **Data verification before design pays for itself.** The Phase A agent caught the Community Development misframe before it shipped. The squeeze chart was killed before any SVG was written. Both saves came from doing the math before building the visual. The cheapest fix is the one made before code is written.
+
+5. **The squeeze mechanism worth communicating is real, just narrow.** Operating departments outside schools, public safety, and capital debt have been held to roughly half the rate of inflation for six years. That is the actual cut. It is a smaller story than "healthcare crisis is eating Marblehead" but it is the true one.
+
+6. **Charts that hide their math invite the wrong rebuttal.** The dots chart visualized 9 net positions lost. The skeptic's rebuttal: "that is one position per year, hardly a crisis." Without surfacing the *real* mechanism (CPI eating level-funded budgets across a specific bucket of departments), the chart left the rebuttal stronger than the claim.
+
+## Working artifacts
+
+- `data/level_funding_mechanism.md` (this branch): the analytical memo with the math
+- `charts/positions-lost.html` (this branch): the failed dots chart, kept for reference
+- `docs/superpowers/specs/2026-04-24-positions-lost-chart-design.md`: original spec
+- `docs/superpowers/plans/2026-04-24-positions-lost-chart.md`: the implementation plan
+- PR #653: branch where everything above lives. Likely to be closed without merge.
+- CLAUDE.md memory `project_squeeze_mechanism`: persistent record of the finding for future sessions
+- CLAUDE.md memory `project_healthcare_trend_vs_cliff`: pre-existing memory that pointed at the HC piece of this finding
+
+## What to do with this experiment
+
+Three paths forward, in increasing ambition:
+
+1. **Stop here.** The finding is captured in the memo and memory; future work can build on it.
+2. **Do the small page rewrite.** Open a new small PR that adds the two-sentence framing to `what-has-the-town-done.html`. No new chart, no new data. ~30 minutes of work. Probably the highest-value next step.
+3. **Make this experiment public on the site.** Lift portions of this retrospective into a methodology page, alongside `bias-audit.html`. Demonstrates analytical transparency. Useful for civic-data credibility. Slower; needs polish for public consumption.
+
+Recommendation: do #2 first. Decide on #3 separately, when not in the immediate aftermath of having spent a day on a chart that did not ship.


### PR DESCRIPTION
## Summary

Two working documents capturing what came out of the level-funding chart experiment.

- `data/level_funding_mechanism.md` is the analytical memo. Headline finding: the squeeze on operating departments did NOT come from healthcare (+9.8% over 6 years) or pensions (+0.91%/yr). Both grew slower than the levy. The squeeze concentrates in the "Everything else" bucket (DPW, library, COA, general government), held to +13.7% over 6 years vs CPI +24.9%. ~9 percentage points of real-dollar decline. That is where the documented attrition actually lives.

- `docs/experiments/2026-04-24-visualizing-level-funded-cuts.md` is a retrospective on the experiment: original ask, two failed chart attempts, why each didn't work, the unexpected finding, lessons. First entry in a new `docs/experiments/` directory for retrospective writeups (vs. forward-looking specs/plans).

Both are working documents, not public pages.

## Why this PR (and not PR #653)

PR #653 was the original chart-building branch. The chart attempts didn't survive contact with the data. This PR carries forward only the work worth keeping (memo + retrospective). PR #653 will be closed without merging once this lands.

## Test plan

- [ ] Skim the memo's key tables and confirm the math feels right
- [ ] Skim the retrospective and decide whether the framing is honest enough to keep
- [ ] No site-rendered changes; nothing to preview visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)