### PR TITLE
Tighten homepage subheader copy

### DIFF
--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -2,7 +2,7 @@
   <div class="explore-landing">
     <div class="explore-landing-head">
       <h1>Do we need an override?</h1>
-      <p>Each question shows the strongest case for every answer. Pick the one you agree with. Your picks build into a set of positions you can review or share.</p>
+      <p>Read each answer and pick a stance. You'll get a set of positions you can review or share.</p>
     </div>
 
     <!-- First-visit onboarding: Q1 expanded inline so the first action is visible

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ title: "Marblehead Budget Data"
 body_class: explore-page
 community_pulse: off-sections
 og_title: "Marblehead Budget Data"
-og_description: Each question shows the strongest case for every answer. Pick the one you agree with. Your picks build into a set of positions you can review or share.
+og_description: Read each answer and pick a stance. You'll get a set of positions you can review or share.
 og_url: https://marbleheaddata.org/
 ---
 {% include nav.html %}


### PR DESCRIPTION
## Summary
- Replace the homepage subheader and matching og_description with shorter, more direct copy.
- Old: "Each question shows the strongest case for every answer. Pick the one you agree with. Your picks build into a set of positions you can review or share."
- New: "Read each answer and pick a stance. You'll get a set of positions you can review or share."

## Test plan
- [ ] Eyeball the homepage on the Cloudflare preview to confirm the new subheader renders.
- [ ] Confirm OG description is updated when the page is shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)