### PR TITLE
Bump to v1.2.0: statewide overrides, landscape comparables

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Marblehead Budget Data
 description: Open data and charts about Marblehead, MA municipal finances
-last_updated: April 16, 2026
-version: "1.1.0"
+last_updated: April 24, 2026
+version: "1.2.0"
 url: https://marbleheaddata.org
 baseurl: ""
 

--- a/data/changelog.html
+++ b/data/changelog.html
@@ -28,14 +28,14 @@ body_class: doc-page
         <td>Statewide override history chart</td>
         <td>Override history limited to 14 peer towns</td>
         <td>New page: 4,640 override ballot questions across 305 MA municipalities, FY1990 to FY2027. Three panels: volume per year, pass rate trend, and median amount (per-question and per-election).</td>
-        <td>Data scraped from full MA DOR DLS Prop 2&frac12; Override/Underride Database (all 94 pages)</td>
+        <td>Data scraped from full MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr> Prop 2&frac12; Override/Underride Database (all 94 pages)</td>
         <td><a href="../charts/statewide_overrides.html">Overrides Over Time</a></td>
       </tr>
       <tr>
         <td>Override landscape: every $6M+ override ever</td>
         <td>No size-based comparables for Marblehead's tiers</td>
         <td>New page: pass rate by override size bucket, plus table of all 55 overrides of $6M+ ever attempted in MA. Marblehead's three tiers ($9M, $12M, $15M) inserted at their positions among comparables. Tier 3 at $15M would be the 4th largest override ever attempted.</td>
-        <td>MA DOR DLS Prop 2&frac12; database, per-election aggregation</td>
+        <td>MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr> Prop 2&frac12; database, per-election aggregation</td>
         <td><a href="../charts/override_landscape.html">Override Landscape</a></td>
       </tr>
     </tbody>

--- a/data/changelog.html
+++ b/data/changelog.html
@@ -10,6 +10,37 @@ body_class: doc-page
 
   <p>This is not a meeting recap. It is a data audit trail: a way to see how the numbers on this site have shifted over time and why. Entries are sourced from public video, official presentations, and primary documents. Where auto-generated captions were the initial source, claims are cross-referenced against primary documents before appearing on topic pages.</p>
 
+  <h2 id="apr-24-2026">April 24, 2026</h2>
+  <p>Statewide override data and comparables</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>What changed</th>
+        <th>Before</th>
+        <th>After</th>
+        <th>Who / why</th>
+        <th>See</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Statewide override history chart</td>
+        <td>Override history limited to 14 peer towns</td>
+        <td>New page: 4,640 override ballot questions across 305 MA municipalities, FY1990 to FY2027. Three panels: volume per year, pass rate trend, and median amount (per-question and per-election).</td>
+        <td>Data scraped from full MA DOR DLS Prop 2&frac12; Override/Underride Database (all 94 pages)</td>
+        <td><a href="../charts/statewide_overrides.html">Overrides Over Time</a></td>
+      </tr>
+      <tr>
+        <td>Override landscape: every $6M+ override ever</td>
+        <td>No size-based comparables for Marblehead's tiers</td>
+        <td>New page: pass rate by override size bucket, plus table of all 55 overrides of $6M+ ever attempted in MA. Marblehead's three tiers ($9M, $12M, $15M) inserted at their positions among comparables. Tier 3 at $15M would be the 4th largest override ever attempted.</td>
+        <td>MA DOR DLS Prop 2&frac12; database, per-election aggregation</td>
+        <td><a href="../charts/override_landscape.html">Override Landscape</a></td>
+      </tr>
+    </tbody>
+  </table>
+
   <h2 id="apr-15-2026">April 15, 2026</h2>
   <p>Select Board override presentation (final version) and <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> staffing data</p>
 


### PR DESCRIPTION
## Summary

- Version bump 1.1.0 -> 1.2.0
- Last updated: April 24, 2026
- Changelog entry for the two new pages added today:
  - Statewide override history (4,640 votes, 305 towns)
  - Override landscape ($6M+ comparables table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)