### PR TITLE
Persist Marblehead free cash CSV with provenance

### DIFF
--- a/data/DATA_CATALOG.md
+++ b/data/DATA_CATALOG.md
@@ -104,9 +104,9 @@ All data compiled April 2026 from primary public sources. Every number is either
 ### Free Cash - Certified and Appropriated (21 data points, FY04-FY24)
 - **What it is:** Per fiscal year: certified free cash pool available at the start of that year, free cash appropriated into that year's operating budget, and the cushion left over.
 - **File:** `marblehead_free_cash.csv`
-- **Source:** Certified column from DOR DLS Gateway FreeCash2 report. Appropriated column from `general_fund_budgetary_FY15-24.csv`, which traces each value to its ACFR original budget.
+- **Source:** Certified column from <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr> Gateway FreeCash2 report. Appropriated column from `general_fund_budgetary_FY15-24.csv`, which traces each value to its <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> original budget.
 - **Coverage:** Certified series runs FY04-FY24 (21 years). Appropriated series runs FY15-FY24 (10 years); FY04-FY14 cells are intentionally blank.
-- **Caveat:** Appropriated values FY15-FY19 reflect total budgeted fund balance use (slightly broader than pure operating free cash). FY20 onward is specifically operating draw per the post-FY20 ACFR schedule format. See per-row `notes` column.
+- **Caveat:** Appropriated values FY15-FY19 reflect total budgeted fund balance use (slightly broader than pure operating free cash). FY20 onward is specifically operating draw per the post-FY20 <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> schedule format. See per-row `notes` column.
 - **Confidence:** High. State agency report (certified) and audited budget schedules (appropriated).
 
 ## Key Single-Year Data Points (not in MASTER_DATA.csv)

--- a/data/DATA_CATALOG.md
+++ b/data/DATA_CATALOG.md
@@ -98,8 +98,16 @@ All data compiled April 2026 from primary public sources. Every number is either
 ### Employee Benefits Total (20 data points, FY05-FY24)
 - **What it is:** ACFR "Employee benefits" line from Changes in Fund Balances. Includes group health insurance, pension contributions, OPEB, workers comp, unemployment, Medicare, and other fringe benefits for all town and school employees.
 - **Source:** `employee_benefits_FY05-24.csv`, from ACFRs
-- **Caveat:** Broader than Group_Insurance alone. Overlaps with Group_Insurance and Pension_Expenditure — do NOT sum these three columns.
+- **Caveat:** Broader than Group_Insurance alone. Overlaps with Group_Insurance and Pension_Expenditure - do NOT sum these three columns.
 - **Confidence:** High. Audited.
+
+### Free Cash - Certified and Appropriated (21 data points, FY04-FY24)
+- **What it is:** Per fiscal year: certified free cash pool available at the start of that year, free cash appropriated into that year's operating budget, and the cushion left over.
+- **File:** `marblehead_free_cash.csv`
+- **Source:** Certified column from DOR DLS Gateway FreeCash2 report. Appropriated column from `general_fund_budgetary_FY15-24.csv`, which traces each value to its ACFR original budget.
+- **Coverage:** Certified series runs FY04-FY24 (21 years). Appropriated series runs FY15-FY24 (10 years); FY04-FY14 cells are intentionally blank.
+- **Caveat:** Appropriated values FY15-FY19 reflect total budgeted fund balance use (slightly broader than pure operating free cash). FY20 onward is specifically operating draw per the post-FY20 ACFR schedule format. See per-row `notes` column.
+- **Confidence:** High. State agency report (certified) and audited budget schedules (appropriated).
 
 ## Key Single-Year Data Points (not in MASTER_DATA.csv)
 

--- a/data/SOURCE_LOOKUP.md
+++ b/data/SOURCE_LOOKUP.md
@@ -246,6 +246,18 @@ Caveats:
 - 2012 and 2022 extracts are 4&ndash;5&times; larger than other years because those PDFs use unusually wide column layouts, not because they contain more content.
 - Citation pattern: *Marblehead Annual Town Report YYYY, [Department Name], page N* (use the PDF page number from the report's table of contents).
 
+## Marblehead Free Cash, FY2004&ndash;FY2024
+
+`data/marblehead_free_cash.csv` joins two series for Marblehead in one file:
+
+- **Certified free cash** (FY2004&ndash;FY2024): the unreserved fund balance certified by the Department of Revenue at the end of each prior fiscal year and made available to appropriate during that fiscal year. Pulled from the [<abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr> Gateway Certified Free Cash report](https://dlsgateway.dor.state.ma.us/reports/rdPage.aspx?rdReport=FreeCash2) (community: Marblehead, all years).
+- **Appropriated free cash** (FY2015&ndash;FY2024): the portion of the certified pool actually drawn into the operating budget that year. From `data/general_fund_budgetary_FY15-24.csv`, which traces each year to its <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> original budget schedule.
+- **Cushion**: certified minus appropriated. The unspent portion that rolled forward.
+
+Pre-FY2015 appropriated values are not in this CSV because the matching <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>-derived series only covers FY15 onward. The certified series alone for FY04&ndash;FY14 is still useful for trend context.
+
+Caveats per the underlying CSV's `notes` column: appropriated values for FY15&ndash;FY19 are total budgeted fund balance use (slightly broader than pure operating free cash). FY20 onward is specifically operating (use of free cash to reduce the tax rate) per the post-FY20 <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> schedule format. FY22 <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> captures pre-amendment original $8,792,102; the <abbr class="g" title="Finance Committee">FinCom</abbr> 2022 report shows an amended total of $8,950,000 after a $142,102 collective bargaining supplemental.
+
 ## Marblehead Independent & Current Articles (referenced across site)
 - ["Marblehead advances $122.8M budget built on cuts, defers override decisions"](https://www.marbleheadindependent.com/marblehead-advances-122-8m-budget-built-on-cuts-defers-override-decisions/) (Marblehead Independent)
 - ["Concerns over staffing cuts shape Marblehead school budget hearing"](https://www.marbleheadindependent.com/concerns-over-staffing-cuts-shape-marblehead-school-budget-hearing/) (Marblehead Independent)

--- a/data/marblehead_free_cash.csv
+++ b/data/marblehead_free_cash.csv
@@ -1,0 +1,22 @@
+fiscal_year,certified_free_cash,appropriated_free_cash,cushion,certified_source,appropriated_source,notes
+FY04,2140934,,,DOR DLS Gateway FreeCash2 report,,Certified as of ~7/1/2003 (end of FY03); available to appropriate during FY04
+FY05,2027245,,,DOR DLS Gateway FreeCash2 report,,
+FY06,719553,,,DOR DLS Gateway FreeCash2 report,,
+FY07,1979269,,,DOR DLS Gateway FreeCash2 report,,
+FY08,2440184,,,DOR DLS Gateway FreeCash2 report,,
+FY09,2925664,,,DOR DLS Gateway FreeCash2 report,,
+FY10,4030276,,,DOR DLS Gateway FreeCash2 report,,
+FY11,4266672,,,DOR DLS Gateway FreeCash2 report,,
+FY12,4595434,,,DOR DLS Gateway FreeCash2 report,,
+FY13,5899292,,,DOR DLS Gateway FreeCash2 report,,
+FY14,5609874,,,DOR DLS Gateway FreeCash2 report,,
+FY15,7862450,4988974,2873476,DOR DLS Gateway FreeCash2 report,data/general_fund_budgetary_FY15-24.csv (FY15 ACFR original budget),Appropriated value FY15-FY19 is total budgeted fund balance use (slightly broader than pure operating free cash)
+FY16,10521579,5428672,5092907,DOR DLS Gateway FreeCash2 report,data/general_fund_budgetary_FY15-24.csv (FY16 ACFR original budget),
+FY17,12326173,6640791,5685382,DOR DLS Gateway FreeCash2 report,data/general_fund_budgetary_FY15-24.csv (FY17 ACFR original budget),FinCom report gives operating-only portion as 6025000 (difference is other non-operating fund balance uses)
+FY18,13087811,7667948,5419863,DOR DLS Gateway FreeCash2 report,data/general_fund_budgetary_FY15-24.csv (FY18 ACFR original budget),First year exp > rev on ACFR-budgetary basis
+FY19,13432440,8310609,5121831,DOR DLS Gateway FreeCash2 report,data/general_fund_budgetary_FY15-24.csv (FY19 ACFR original budget),FinCom 2019 report first flags reliance as not sustainable
+FY20,12675462,8575000,4100462,DOR DLS Gateway FreeCash2 report,data/general_fund_budgetary_FY15-24.csv (FY20 ACFR original budget),New ACFR schedule format from FY20 onward; appropriated value is specifically operating (use of free cash to reduce the tax rate)
+FY21,10243709,7200000,3043709,DOR DLS Gateway FreeCash2 report,data/general_fund_budgetary_FY15-24.csv (FY21 ACFR original budget),
+FY22,11526201,8792102,2734099,DOR DLS Gateway FreeCash2 report,data/general_fund_budgetary_FY15-24.csv (FY22 ACFR original budget),FinCom 2022 report shows amended total of 8950000 after a 142102 collective bargaining supplemental
+FY23,10772495,10200000,572495,DOR DLS Gateway FreeCash2 report,data/general_fund_budgetary_FY15-24.csv (FY23 ACFR original budget),Peak appropriation year
+FY24,9079739,8000000,1079739,DOR DLS Gateway FreeCash2 report,data/general_fund_budgetary_FY15-24.csv (FY24 ACFR original budget),


### PR DESCRIPTION
## Summary
- Adds `data/marblehead_free_cash.csv`: per-FY certified pool (DOR DLS Gateway, FY04-FY24), appropriated draw (ACFR-derived, FY15-FY24), derived cushion, and per-row source columns + notes.
- Documents the file in `data/DATA_CATALOG.md` and adds a section to `data/SOURCE_LOOKUP.md`.

This is the data behind the stacked-bar free cash chart in `data/case_studies.md` (shipped in #628). Up to now those values lived only in the SVG path coordinates; this PR makes them discoverable and reusable.

## Test plan
- [ ] Cloudflare Pages preview builds clean.
- [ ] `data/DATA_CATALOG.html` shows the new "Free Cash - Certified and Appropriated" entry.
- [ ] `data/SOURCE_LOOKUP.html` shows the new "Marblehead Free Cash, FY2004-FY2024" section.
- [ ] CSV opens cleanly and FY15-FY24 cushion = certified - appropriated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)