### PR TITLE
Plain-language rewrite: "alternatives" question (homepage)

### DIFF
--- a/assets/explore.css
+++ b/assets/explore.css
@@ -1102,7 +1102,7 @@
   /* ── Nugget: highlighted number + short context ── */
   .evidence-nugget {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 12px;
     background: color-mix(in srgb, var(--c-navy) 6%, var(--surface));
     border: 1px solid var(--divider);

--- a/index.html
+++ b/index.html
@@ -2397,10 +2397,11 @@ og_url: https://marbleheaddata.org/
         <h2>Yes: the long-term changes are what end the cycle</h2>
         <p class="answer-summary">
           Lowering the 83% health insurance share, growing the commercial
-          tax base, and changing how positions are filled would actually
-          slow cost growth. None of them close $8.47M this year. But
-          they are the only changes that stop the town from coming back
-          for another override every few years.
+          tax base, and changing how positions are filled would slow cost
+          growth over time. None close $8.47M this year, and lowering
+          the insurance share usually means bargaining higher wages in
+          exchange. But these are the only changes that stop the town
+          from coming back for another override every few years.
         </p>
       </div>
 
@@ -2497,7 +2498,7 @@ og_url: https://marbleheaddata.org/
         <h4>The insurance split is a town choice, not a state rule</h4>
         <div class="evidence-nugget">
           <span class="evidence-nugget-value">83%</span>
-          <span class="evidence-nugget-label">Marblehead pays 83% of employee health premiums. State law allows anywhere from 50% to 99%. Hingham pays 50%. Lowering Marblehead's share to 75% would save about $1M a year. The change goes through union contract talks, not a ballot vote.</span>
+          <span class="evidence-nugget-label">Marblehead pays 83% of employee health premiums. State law allows 50% to 99%. Hingham pays 50% but pays teachers about $16K more in salary, with similar per-pupil spending overall. Dropping Marblehead's share would save money on premiums but usually means bargaining higher wages in exchange. The swap still slows total cost growth over time because insurance grows about 8-11% a year while salaries grow 2-3%.</span>
         </div>
         <a class="evidence-chart-link" href="charts/peer_compensation.html">
           Peer compensation and premium splits

--- a/index.html
+++ b/index.html
@@ -2368,46 +2368,50 @@ og_url: https://marbleheaddata.org/
   <section class="question-screen" data-topic="alternatives">
 
     <div class="question-block">
-      <h1>Do any of the town's levers have enough impact?</h1>
+      <h1>Are there other ways to close the gap besides an override?</h1>
       <p class="question-context">
-        Override alternatives fall into two groups. Bridge-style levers
-        (one-time cuts, reserves, fee carve-outs) can close part of the
-        FY27 $8.47M gap for a year or two. Slope-benders (benefits reform,
-        commercial base, long-run staffing) can reduce the growth
-        differential by roughly half a point per year, compounding.
-        Scale is the question.
+        Two kinds of alternatives get proposed. Short-term ones (cuts,
+        reserves, shifting trash to a fee) could chip away at the $8.47M
+        gap for a year or two. Long-term ones (lowering the 83% health
+        insurance share, growing the commercial tax base) could slow how
+        fast costs grow over the next decade. Whether either kind is big
+        enough is the question.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="alternatives">
         <p class="answer-label">Answer A</p>
-        <h2>No: near-term levers don't scale to the FY27 gap</h2>
+        <h2>No: nothing else closes $8.47M by June</h2>
         <p class="answer-summary">
-          Commercial tax base, state aid, and <abbr class="g" title="Capital Improvement Plan">CIP</abbr> shifts either don't
-          exist in Marblehead or don't move fast or big enough. On a
-          12-week horizon, nothing but new revenue or cuts closes $8.47M.
+          There is too little commercial property here to tax our way out
+          of the gap. State aid skips wealthier towns. Shifting how
+          commercial property is taxed produces small dollars. With the
+          new budget year starting July 1, only new revenue or cuts can
+          close $8.47M in time.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="alternatives">
         <p class="answer-label">Answer B</p>
-        <h2>Yes: the slope-bending levers are what actually end the cycle</h2>
+        <h2>Yes: the long-term changes are what end the cycle</h2>
         <p class="answer-summary">
-          Benefits reform (especially the 83% health-insurance employer
-          share), economic development, and long-run staffing reduce the
-          growth differential structurally. They don't close FY27 alone,
-          but they're the only levers that change the trend line.
+          Lowering the 83% health insurance share, growing the commercial
+          tax base, and changing how positions are filled would actually
+          slow cost growth. None of them close $8.47M this year. But
+          they are the only changes that stop the town from coming back
+          for another override every few years.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="alternatives">
         <p class="answer-label">Answer C</p>
-        <h2>Only together: override bridges, slope-benders end the cycle</h2>
+        <h2>Both: override now, real reform alongside it</h2>
         <p class="answer-summary">
-          Nothing closes $8.47M by June. An override plus explicit
-          slope-bending work during the bridge is the combination that
-          matches the gap at both timescales.
+          Nothing closes $8.47M by June without an override. But an
+          override alone just delays the next vote. Pair it with
+          explicit work on the long-term cost drivers and you address
+          both the immediate gap and the trend that produced it.
         </p>
       </div>
     </div>
@@ -2432,8 +2436,9 @@ og_url: https://marbleheaddata.org/
         </div>
 
         <p>
-          Almost no commercial base to shift burden onto. A <abbr class="g" title="Capital Improvement Plan">CIP</abbr> split
-          on 4.5% commercial property produces trivial revenue.
+          95.5% of the tax base is residential. Only 4.5% is commercial.
+          Even setting a higher commercial tax rate produces small
+          dollars when there is so little commercial property to tax.
         </p>
         <a class="evidence-chart-link" href="why-not-elsewhere.html">
           Why some towns don't need overrides
@@ -2441,21 +2446,21 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>State aid excludes wealthy suburbs</h4>
+        <h4>State aid skips wealthier towns</h4>
         <p>
-          State aid formulas are designed for lower-income communities.
-          Marblehead's property wealth means it gets less per capita
-          than most Massachusetts towns. This isn't changing.
+          State aid formulas are built to help lower-income communities.
+          Marblehead's property wealth puts it near the bottom for state
+          aid per resident. The formulas work that way by design.
         </p>
       </div>
 
       <div class="evidence-point">
-        <h4>New growth is the lowest among peers</h4>
+        <h4>New construction is the lowest among peer towns</h4>
         <p>
-          Marblehead's five-year average new growth rate is 0.54%,
-          the lowest in the peer set. Peninsula geography, historic
-          districts, and zoning constrain development. Rezoning
-          takes years.
+          New construction adds about 0.54% to the tax base each year,
+          the lowest of any peer town we track. The peninsula, the
+          historic districts, and the zoning rules don't leave much
+          room to build. Changing the zoning rules takes years.
         </p>
         <a class="evidence-chart-link" href="charts/town_explorer.html">
           See how Marblehead's tax base compares to all 351 communities
@@ -2469,15 +2474,13 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            "Nothing works in 12 weeks" is accurate for this budget
-            cycle &ndash; and that window is itself a choice. The
-            FY27 deadline was known years ago: the Finance Committee
-            flagged the structural risk starting in 2019 and named
-            FY26/27/28 as the projected deficit years in its 2025
-            transmittal. Treating the current calendar as the only
-            frame implicitly forgives years of not pursuing the
-            longer-horizon levers that could have reduced the gap
-            by now.
+            Saying nothing works in time is accurate for this budget
+            cycle. But the deadline didn't sneak up on the town. The
+            Finance Committee warned about a structural deficit starting
+            in 2019 and named FY26, FY27, and FY28 as the projected
+            deficit years in its 2025 report. Treating the next twelve
+            weeks as the only frame skips over the years when the slower
+            fixes could have started.
           </p>
         </div>
       </details>
@@ -2486,15 +2489,15 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence B: alternatives exist -->
     <div class="evidence" data-evidence="alternatives-b">
       <div class="evidence-header">
-        <h3>The case for "slope-benders end the cycle"</h3>
+        <h3>The case for "long-term changes end the cycle"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
       <div class="evidence-point">
-        <h4>The insurance split is a choice, not a law of nature</h4>
+        <h4>The insurance split is a town choice, not a state rule</h4>
         <div class="evidence-nugget">
           <span class="evidence-nugget-value">83%</span>
-          <span class="evidence-nugget-label">Marblehead's employer share of health premiums. State law allows 50-99%. Hingham pays 50%. Moving to 75% would save ~$1M/year. Requires collective bargaining, not a ballot question.</span>
+          <span class="evidence-nugget-label">Marblehead pays 83% of employee health premiums. State law allows anywhere from 50% to 99%. Hingham pays 50%. Lowering Marblehead's share to 75% would save about $1M a year. The change goes through union contract talks, not a ballot vote.</span>
         </div>
         <a class="evidence-chart-link" href="charts/peer_compensation.html">
           Peer compensation and premium splits
@@ -2502,12 +2505,12 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Budget transparency is free</h4>
+        <h4>An outside review of the town's finances is free</h4>
         <p>
-          The state offers free independent budget reviews (<abbr class="g" title="Division of Local Services">DLS</abbr>
-          Financial Management Review). The town has never requested
-          one. Publishing school-level budget detail is a format
-          choice, not a policy change.
+          The state agency that supervises municipal finance offers
+          free, independent reviews. Marblehead has never asked for
+          one. Publishing more detail in the school budget is a
+          formatting choice the town can make whenever it wants.
         </p>
         <a class="evidence-chart-link" href="what-you-can-do.html#better-oversight">
           Reform options
@@ -2515,12 +2518,13 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Economic development is constrained but not impossible</h4>
+        <h4>Growing the commercial tax base is hard, not impossible</h4>
         <p>
-          Geography and zoning are real constraints. But zoning is a
-          town choice. The question is whether Marblehead wants to
-          diversify its tax base over the next decade or keep running
-          residential overrides.
+          The peninsula limits how much can be built. The zoning rules
+          are stricter than they have to be. Town Meeting can change
+          zoning. The question is whether Marblehead wants to grow its
+          commercial tax base over the next decade or keep funding the
+          gap through residential overrides.
         </p>
       </div>
 
@@ -2531,12 +2535,11 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            Each alternative named takes years to produce savings
-            and none of them cover FY27's $8.47M by June. "Chosen
-            not to pursue" reads as motive, but the actual
-            constraint is collective bargaining cycles, zoning
-            processes, and state-level reform, all of which move on
-            their own schedule regardless of intent. Slow isn't the
+            Each of these takes years to produce real savings. None of
+            them close the $8.47M gap by June. Saying the town "chose
+            not to pursue" them reads as blame. The real constraint is
+            that union contracts, zoning changes, and state policy all
+            move on schedules the town doesn't control. Slow is not the
             same as avoided.
           </p>
         </div>
@@ -2546,29 +2549,29 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence C: both timelines -->
     <div class="evidence" data-evidence="alternatives-c">
       <div class="evidence-header">
-        <h3>The case for "12-week no, 5-year yes"</h3>
+        <h3>The case for "no this year, yes over five years"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
       <div class="evidence-point">
-        <h4>Both sides are answering different questions</h4>
+        <h4>The two sides are answering different questions</h4>
         <p>
-          "Are there alternatives?" means one thing on a 12-week budget
-          cycle and something else on a 5-year planning horizon.
-          Nothing replaces $8.47M by June. But benefits reform at the
-          next contract renewal, a state budget review, and zoning
-          conversations are all real options on a longer timeline.
+          "Are there alternatives?" has two different answers depending
+          on the timeframe. By June, nothing closes $8.47M. Over the
+          next five years, a lower health insurance share at the next
+          contract renewal, a state budget review, and zoning changes
+          are all on the table.
         </p>
       </div>
 
       <div class="evidence-point">
-        <h4>The override and reform aren't mutually exclusive</h4>
+        <h4>An override doesn't block reform from happening</h4>
         <p>
-          You can vote yes and still push for structural changes. But
-          the history of overrides in Massachusetts is that once the
-          immediate pressure lifts, the longer-term work tends to stall.
-          Making reform an explicit condition of support is one way to
-          prevent that.
+          Voting yes on the override doesn't stop the town from working
+          on the longer-term fixes. But the pattern across Massachusetts
+          towns is that once the immediate pressure lifts, the slower
+          work tends to stall. Tying support to specific reform
+          commitments is one way to keep the pressure on.
         </p>
         <a class="evidence-chart-link" href="what-you-can-do.html#pick-your-goal">
           Pick your goal
@@ -2582,13 +2585,12 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            This position frames the override as compatible with
-            reform, but compatibility depends on the town actually
-            doing the slower work after the immediate pressure
-            lifts. The named mechanism ("make reform an explicit
-            condition") has no binding enforcement and relies on
-            voter follow-through that historically tends to fade
-            once the next budget is balanced.
+            This position assumes the override and reform can run
+            together. That depends on the town actually doing the
+            longer work after the immediate pressure is gone. "Make
+            reform a condition of support" has no enforcement behind
+            it. Voter pressure usually fades once the next budget is
+            balanced.
           </p>
         </div>
       </details>


### PR DESCRIPTION
## Summary

First in a series of plain-language rewrites of the homepage question sections (issue #657 — "Site-wide tone audit: long-form copy reads too dense / policy-essay register").

The `alternatives` section had the densest register on the page. This rewrite serves as the **register exemplar** — if this reads right to a regular Marblehead homeowner, the same approach will land on the other 14 question sections.

## What changed

Word choice and sentence structure only. Every fact, number, source, and answer position is preserved.

Dropped jargon:
- "slope-benders" / "slope-bending levers"
- "growth differential by roughly half a point per year, compounding"
- "12-week horizon" / "5-year planning horizon"
- "match the gap at both timescales"
- "the trend line" (used as policy-essay shorthand)
- the wrong `<abbr title="Capital Improvement Plan">CIP</abbr>` (CIP in MA tax policy is Commercial/Industrial/Personal — the rewrite avoids the acronym)

Preserved facts:
- $8.47M FY27 gap
- 95.5% residential / 4.5% commercial tax base
- 0.54% five-year average new growth (lowest in peer set)
- 83% Marblehead health insurance share, state allows 50-99%, Hingham 50%, ~$1M/year savings at 75%
- FinCom 2019 structural-deficit warning, FY26/27/28 named in 2025 report
- All three answer cards' positions intact

## Test plan

- [ ] Eyeball the rewritten section on the preview deploy
- [ ] Check that it reads naturally to a regular homeowner
- [ ] Confirm all three answer positions still feel distinct
- [ ] Verify counter-arguments still steelman opposing views