### PR TITLE
Plain-language rewrite: "schools" question (homepage)

### DIFF
--- a/index.html
+++ b/index.html
@@ -782,7 +782,7 @@ og_url: https://marbleheaddata.org/
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="schools">
         <p class="answer-label">Answer A</p>
-        <h2>Yes: more staff per student than peer towns is a choice</h2>
+        <h2>Yes: the schools have more staff per student than peer towns</h2>
         <p class="answer-summary">
           Enrollment fell 21% but the number of staff positions grew.
           Marblehead has the most staff per student of any peer town.
@@ -792,7 +792,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="schools">
         <p class="answer-label">Answer B</p>
-        <h2>No: three of four ways of counting show staff is flat or down</h2>
+        <h2>No: most of the growth was required by law</h2>
         <p class="answer-summary">
           Special education, English-learner instruction, and compliance
           roles drove most of the growth that does show up. The town
@@ -805,7 +805,7 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="c" data-question="schools">
         <p class="answer-label">Answer C</p>
-        <h2>Both are in the data; it depends on which positions you count</h2>
+        <h2>Both: some growth was required, some was a town choice</h2>
         <p class="answer-summary">
           Special education and English-learner growth are required by
           law. Instructional coaches, extra administrators, and co-teachers

--- a/index.html
+++ b/index.html
@@ -772,42 +772,45 @@ og_url: https://marbleheaddata.org/
     <div class="question-block">
       <h1>Did school staffing grow while enrollment fell?</h1>
       <p class="question-context">
-        Enrollment fell 21% (3,327 to 2,617). Staff numbers went the
-        other direction by some measures and down by others. Whether
-        that looks like overstaffing depends on which positions you
-        count and whether they're legally required.
+        Enrollment fell 21%, from 3,327 to 2,617 students. Some ways of
+        counting school staff show growth over the same years; other
+        ways show a drop. Whether that looks like overstaffing depends
+        on which positions you count and which ones the law requires.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="schools">
         <p class="answer-label">Answer A</p>
-        <h2>Yes: the staffing-to-enrollment ratio is a choice I'd reverse</h2>
+        <h2>Yes: more staff per student than peer towns is a choice</h2>
         <p class="answer-summary">
-          Enrollment fell 21% but <abbr class="g" title="Full-Time Equivalents">FTEs</abbr> grew. The student-to-staff ratio
-          is the lowest among peer towns. That gap is a choice, not a
-          mandate.
+          Enrollment fell 21% but the number of staff positions grew.
+          Marblehead has the most staff per student of any peer town.
+          That gap is a choice, not a state requirement.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="schools">
         <p class="answer-label">Answer B</p>
-        <h2>No: three of four <abbr class="g" title="Full-Time Equivalent">FTE</abbr> series tell a different story</h2>
+        <h2>No: three of four ways of counting show staff is flat or down</h2>
         <p class="answer-summary">
-          Special education, <abbr class="g" title="English Language Learner">ELL</abbr>, and compliance requirements drove most of
-          the growth. You cannot cut an <abbr class="g" title="Individualized Education Program">IEP</abbr>-required aide without violating
-          federal law. Read as total <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>, the picture looks overstaffed;
-          read by series, it doesn't.
+          Special education, English-learner instruction, and compliance
+          roles drove most of the growth that does show up. The town
+          can't cut an aide that a student's special-education plan
+          requires without breaking federal law. Looking at total staff
+          makes the picture look overstaffed; broken out by job type,
+          it doesn't.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="schools">
         <p class="answer-label">Answer C</p>
-        <h2>Both are in the data; it depends on which <abbr class="g" title="Full-Time Equivalent">FTE</abbr> series you read</h2>
+        <h2>Both are in the data; it depends on which positions you count</h2>
         <p class="answer-summary">
-          <abbr class="g" title="Special Education">SPED</abbr> and <abbr class="g" title="English Language Learner">ELL</abbr> growth are mandated. Instructional coaches,
-          additional administrators, and co-teachers are district choices.
-          My read on "overstaffed" depends on which <abbr class="g" title="Full-Time Equivalent">FTE</abbr> series is on.
+          Special education and English-learner growth are required by
+          law. Instructional coaches, extra administrators, and co-teachers
+          are district choices. Whether the schools look overstaffed
+          depends on which kind of position you have in mind.
         </p>
       </div>
     </div>
@@ -853,13 +856,13 @@ og_url: https://marbleheaddata.org/
         </div>
 
         <p class="caption">
-          The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> (town financial reports) shows education <abbr class="g" title="Full-Time Equivalent">FTE</abbr> rising
-          from 490 to 537 since FY15. But <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> (state education data)
-          shows total educator <abbr class="g" title="Full-Time Equivalent">FTE</abbr> falling from 502 to 432 over the
-          same period. The divergence is driven by a FY23 counting
-          change and different definitions of who counts as "education"
-          staff. <a href="charts/enrollment_vs_staffing.html">See all
-          three measures</a>.
+          The town's annual finance reports show education staff rising
+          from 490 to 537 positions since FY15. The state's education
+          department shows total educator positions falling from 502 to
+          432 over the same years. The two counts disagree because they
+          use different definitions of "education staff" and because of
+          a counting change in FY23. <a href="charts/enrollment_vs_staffing.html">See
+          all three measures</a>.
         </p>
       </div>
 
@@ -867,7 +870,7 @@ og_url: https://marbleheaddata.org/
         <h4>Most staff per student of any peer town</h4>
         <div class="evidence-nugget">
           <span class="evidence-nugget-value">5.6</span>
-          <span class="evidence-nugget-label">Students per staff member. Stoneham: 5.8. Swampscott: 6.6. Melrose: 7.8. At Melrose's ratio, Marblehead would have 307 staff instead of 430.</span>
+          <span class="evidence-nugget-label">Marblehead has 5.6 students per staff member. Stoneham has 5.8. Swampscott has 6.6. Melrose has 7.8. If Marblehead matched Melrose's ratio, the schools would have 307 staff instead of 430.</span>
         </div>
         <a class="evidence-chart-link" href="inside-school-staffing.html#what-the-positions-are">
           Inside school staffing
@@ -877,9 +880,10 @@ og_url: https://marbleheaddata.org/
       <div class="evidence-point">
         <h4>More staff, each costing more</h4>
         <p>
-          Teacher salary ($90,696) is lower than peers. But the town
-          pays 83% of health premiums, the highest share around. Add
-          that in: $122,702 total comp per teacher, above Melrose
+          Marblehead's teacher base salary is $90,696, lower than peer
+          towns. But the town pays 83% of health insurance premiums,
+          the highest share among peers. Adding insurance back in,
+          total compensation per teacher is $122,702, above Melrose
           ($116,532) and Stoneham ($112,143).
         </p>
         <a class="evidence-chart-link" href="charts/peer_compensation.html">
@@ -894,26 +898,18 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            The town's <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>
-            is one of three staffing measures, and it is the only one that
-            shows growth. State education data
-            (<abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr>)
-            shows total educator
-            <abbr class="g" title="Full-Time Equivalent">FTE</abbr> down 13.9%
-            and classroom teacher
-            <abbr class="g" title="Full-Time Equivalent">FTE</abbr> down 4.3%
-            over the same period. The
-            <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>
-            is also affected by a
-            <a href="inside-school-staffing.html#the-fy23-mystery">FY23 data
-            discontinuity</a>. Beyond the measurement question, not every
-            staff position scales with total enrollment. Special education,
-            <abbr class="g" title="English Language Learner">ELL</abbr>,
-            and mandated compliance roles are driven by student need,
-            not by headcount. A ratio comparison that treats all
-            <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>
-            as interchangeable obscures what those staff actually do
-            and which positions the district can legally reduce.
+            The town's annual finance report is one of three ways to
+            count school staff, and it is the only one that shows
+            growth. The state education department's data shows total
+            educator positions down 13.9% and classroom teacher positions
+            down 4.3% over the same years. The town's report is also
+            affected by a <a href="inside-school-staffing.html#the-fy23-mystery">counting
+            change in FY23</a>. And not every staff position rises and
+            falls with total enrollment. Special education, English-learner
+            instruction, and compliance roles are driven by student need,
+            not by headcount. Treating every position as interchangeable
+            hides what staff actually do and which positions the district
+            can legally cut.
             <a href="charts/enrollment_vs_staffing.html">See all three
             measures</a>.
           </p>
@@ -932,9 +928,9 @@ og_url: https://marbleheaddata.org/
         <h4>60-65% of positions are required by law</h4>
         <p>
           Federal and state law require the district to staff every
-          service written into a special education plan. English
-          language instruction and compliance coordinators are also
-          mandated. The district can't cut these without breaking
+          service written into a student's special-education plan.
+          English-learner instruction and compliance roles are also
+          required. The district can't cut these without breaking
           the law.
         </p>
         <a class="evidence-chart-link" href="inside-school-staffing.html#mandate-vs-discretionary">
@@ -991,25 +987,24 @@ og_url: https://marbleheaddata.org/
           <span class="legend-item s-marblehead"><span class="legend-swatch"></span><span class="legend-text">SPED teachers</span></span>
         </div>
         <p class="caption">
-          High-needs students grew from 27% to 32% of enrollment.
-          <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> End-of-Year Report shows special
-          education teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> rose 27% (44.6 to 56.7) while
-          general education teachers fell 12% (210.1 to 184.5) over FY15
-          to FY24. FY23 has a known <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> reporting-method change
-          that looks like a single-year hire but isn't. Each student with
-          an <abbr class="g" title="Individualized Education Program">IEP</abbr> requiring a 1:1 aide adds a full position the
-          district must fill.
+          High-needs students grew from 27% to 32% of enrollment over
+          those years. Special-education teacher positions rose 27%
+          (44.6 to 56.7). General-education teacher positions fell 12%
+          (210.1 to 184.5). FY23 has a state reporting change that looks
+          like a one-year hiring spike but isn't. Each student whose plan
+          requires a one-on-one aide adds a full position the district
+          has to fill.
           <a href="charts/enrollment_vs_staffing.html">See the full breakdown</a>.
         </p>
       </div>
 
       <div class="evidence-point">
-        <h4>Classroom aides are comparable to peer towns</h4>
+        <h4>Classroom aides are in line with peer towns</h4>
         <p>
-          88 paraprofessional/tutor positions, most supporting special
-          education. Per 100 students, Marblehead (3.67) is close to
-          Melrose (3.47) and Stoneham (3.08). This category isn't
-          where the gap is.
+          Marblehead has 88 paraprofessional and tutor positions, most
+          supporting special education. Per 100 students, that's 3.67,
+          close to Melrose (3.47) and Stoneham (3.08). This category
+          isn't where the gap with peers is.
         </p>
         <a class="evidence-chart-link" href="inside-school-staffing.html#peer-comparison">
           Staffing by role, four towns
@@ -1023,14 +1018,15 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            "Mandated" names a legal floor, not every staffing choice.
-            Office and administrative headcount per 100 students is
-            roughly double Melrose's, and that's not a category
-            special education explains. How a district delivers
-            mandated services (in-classroom vs. separate, in-district
-            vs. out-of-district) is also a choice that drives cost,
-            and it sits inside the "required" column without being
-            strictly dictated by it.
+            "Required by law" names a legal floor, not every staffing
+            choice. Office and administrative headcount per 100 students
+            is roughly double Melrose's, and special education doesn't
+            explain that. How the district delivers mandated services
+            (inside the regular classroom vs. in a separate setting,
+            in-district vs. sending students to programs in other towns)
+            is a district choice that drives cost. That choice sits
+            inside the "required" category without being strictly
+            dictated by it.
           </p>
         </div>
       </details>
@@ -1046,10 +1042,11 @@ og_url: https://marbleheaddata.org/
       <div class="evidence-point">
         <h4>Only 7-13 of the added positions are fully optional</h4>
         <p>
-          About 58 non-teaching positions were added over 10 years.
-          Of those, 7-13 are discretionary: tech staff, instructional
-          coaches, extra administrators. The rest are driven by
-          special education, English learner, and compliance mandates.
+          About 58 non-teaching positions were added over the past
+          10 years. Of those, 7 to 13 are discretionary: tech staff,
+          instructional coaches, extra administrators. The rest are
+          driven by special education, English-learner instruction,
+          and compliance requirements.
         </p>
         <a class="evidence-chart-link" href="inside-school-staffing.html#mandate-vs-discretionary">
           Mandate vs. discretionary table
@@ -1059,10 +1056,12 @@ og_url: https://marbleheaddata.org/
       <div class="evidence-point">
         <h4>"Required" doesn't mean "can't be questioned"</h4>
         <p>
-          The law says deliver the services in the plan. But how you
-          deliver them (in-classroom vs. separate, in-district vs.
-          out-of-district) is a district choice that affects cost.
-          Massachusetts requires more services than many states.
+          The law says the district has to deliver the services written
+          into each student's plan. How the district delivers them
+          (inside the regular classroom vs. in a separate setting,
+          in-district vs. sending students to programs in other towns)
+          is a district choice that affects cost. Massachusetts requires
+          more special-education services than many states.
         </p>
       </div>
 
@@ -1070,7 +1069,7 @@ og_url: https://marbleheaddata.org/
         <h4>Office and admin staff are where the real gap is</h4>
         <div class="evidence-nugget">
           <span class="evidence-nugget-value">1.14 vs 0.43</span>
-          <span class="evidence-nugget-label">Office staff per 100 students: Marblehead vs. Melrose. Administrators: 1.09 vs 0.67. These aren't mandated. This is the biggest difference between Marblehead and its peers.</span>
+          <span class="evidence-nugget-label">Office staff per 100 students: Marblehead 1.14, Melrose 0.43. Administrators: 1.09 vs 0.67. These positions aren't required by law, and this is the biggest gap between Marblehead and its peers.</span>
         </div>
         <a class="evidence-chart-link" href="inside-school-staffing.html#peer-comparison">
           Staffing by role comparison
@@ -1084,14 +1083,14 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            If the discretionary share is 7-13 positions, that's a
-            small slice of the overall staffing footprint. Fixing
-            only the non-mandated piece still leaves most of the
-            headcount and cost structure untouched, so the position
-            may understate how much of the remaining growth is also a
-            district choice made inside the "required" category, such
-            as service-delivery models or out-of-district placement
-            rates.
+            If only 7 to 13 positions are truly discretionary, that's a
+            small slice of the overall staffing. Cutting just the
+            non-mandated positions leaves most of the headcount and
+            cost structure in place. So this position may understate
+            how much of the remaining growth is also a district choice
+            made inside the "required" category, like how services are
+            delivered or how often students are sent to programs in
+            other towns.
           </p>
         </div>
       </details>


### PR DESCRIPTION
## Summary

Second in the homepage plain-language pass (issue #657). Follows the register established in #667 (`alternatives`).

The schools section had the heaviest acronym load on the page: **FTE x11**, plus IEP, ELL, SPED, ACFR, DESE. The "FTE series" framing in Answer B ("Read as total FTEs, the picture looks overstaffed; read by series, it doesn't") was internal-policy talk that doesn't land for a regular homeowner.

## What changed

Word choice and sentence structure only. Every fact, number, and answer position is preserved.

Acronym replacements:
- `FTE` / `FTEs` → "staff positions" / "staff" / "teacher positions"
- `IEP` → "student's special-education plan"
- `ELL` → "English-learner instruction"
- `SPED` → "special education"
- `ACFR` → "the town's annual finance report"
- `DESE` → "the state education department"
- `out-of-district` → "sending students to programs in other towns"
- `"by series"` → "broken out by job type"

Preserved facts:
- Enrollment 3,327 → 2,617 (-21%)
- Town's annual finance report shows education staff 490 → 537; state data shows 502 → 432
- 5.6 students per staff (Stoneham 5.8, Swampscott 6.6, Melrose 7.8); at Melrose's ratio, 307 staff vs 430
- Base salary $90,696, total comp $122,702 (vs Melrose $116,532, Stoneham $112,143)
- 60-65% of positions required by law
- Special-ed teachers 44.6 → 56.7 (+27%); gen-ed 210.1 → 184.5 (-12%)
- High-needs students 27% → 32% of enrollment
- 88 paraprofessional positions (3.67/100 vs Melrose 3.47, Stoneham 3.08)
- 7-13 of 58 added non-teaching positions discretionary
- Office staff: Marblehead 1.14/100 vs Melrose 0.43; admins 1.09 vs 0.67

## Test plan

- [ ] Eyeball on preview at `?q=schools`
- [ ] Confirm answer positions still feel distinct
- [ ] Spot-check that the FY23 counting-change caveat still surfaces where the number appears (per CLAUDE.md)