### PR TITLE
Featured-question: widen to match in-question width

### DIFF
--- a/assets/explore.css
+++ b/assets/explore.css
@@ -63,7 +63,14 @@
      votes-strip so the first action is obvious above the fold. */
   .featured-question {
     display: none;
-    margin: 0 0 32px;
+    /* Break out of .explore-landing's 640px cap so the three answer cards
+       share the same width as the in-question screens (~856px on desktop).
+       Without this, the featured cards squeeze to ~190px each and the
+       layout visibly shifts when the visitor dives in. break-out is half
+       the difference between the stage content width and the landing cap,
+       clamped to 0 on viewports narrower than the cap. */
+    --break-out: max(0px, (min(100vw, var(--chart-max)) - 2 * var(--gutter) - 640px) / 2);
+    margin: 0 calc(var(--break-out) * -1) 32px;
     padding: 20px 20px 16px;
     border: 1.5px solid var(--c-teal);
     border-radius: var(--radius-md);
@@ -91,13 +98,7 @@
     line-height: 1.55;
     margin: 0 0 16px;
   }
-  /* Featured cards stay stacked on every viewport. The .explore-landing
-     caps at 640px, so the desktop flex-row in `.answers` (min-width:600px)
-     squeezes three cards into ~190px each — too narrow for the 17px h2,
-     and uneven content lengths leave the shortest card with empty space
-     from flex-stretch. Stacking gives each card the full width. */
   .featured-question .featured-answers {
-    flex-direction: column;
     margin-bottom: 20px;
   }
   .featured-answers-prompt {

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -91,8 +91,14 @@
     line-height: 1.55;
     margin: 0 0 16px;
   }
+  /* Featured cards stay stacked on every viewport. The .explore-landing
+     caps at 640px, so the desktop flex-row in `.answers` (min-width:600px)
+     squeezes three cards into ~190px each — too narrow for the 17px h2,
+     and uneven content lengths leave the shortest card with empty space
+     from flex-stretch. Stacking gives each card the full width. */
   .featured-question .featured-answers {
-    margin-bottom: 8px;
+    flex-direction: column;
+    margin-bottom: 20px;
   }
   .featured-answers-prompt {
     margin: 0;


### PR DESCRIPTION
## Summary
- The featured-question lives inside the 640px-cap `.explore-landing`, so the three answer cards squeezed to ~190px each on desktop. The h2s wrapped to 3-4 lines and the shortest card had empty space from flex-stretch.
- Fix: break the featured-question out of the 640px cap so its width matches the in-question screens (~856px on desktop). Same width on the homepage as after diving in, so no layout shift.
- Done with a `--break-out` custom property that pulls the featured-question's horizontal margins negative by half the gap between `.explore-stage`'s content width and the landing cap, clamped to 0 on narrow viewports.
- Also bumps the gap below the answer cards from 8px to 20px so they stop touching the dashed prompt box on mobile + desktop.

## Test plan
- [ ] Desktop: featured-question now spans the full chart-max width; three cards side-by-side, headings on 1-2 lines, prompt strip has clear breathing room above it.
- [ ] Click into the question and confirm card width is the same as the featured layout (no shift).
- [ ] Mobile (< 700px): featured-question fills viewport - gutter*2 (no negative margin), cards stack, prompt gap is comfortable.
- [ ] No horizontal scroll on any viewport width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)