### PR TITLE
Scenario vs tier comparison + clean tier highlighting

### DIFF
--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -296,6 +296,21 @@ title: "Deficit Dynamics Model"
     stroke-dasharray: 3 3;
     opacity: 0.5;
   }
+  .dm-svg .dm-exp-baseline-line {
+    fill: none;
+    stroke: var(--c-buoy);
+    stroke-width: 1.5;
+    stroke-dasharray: 1 4;
+    opacity: 0.4;
+  }
+  .dm-svg .dm-end-label-baseline {
+    fill: var(--c-buoy);
+    opacity: 0.6;
+    font-weight: 400;
+    font-style: italic;
+  }
+  body.dm-tour-active .dm-exp-baseline-line,
+  body.dm-tour-active .dm-end-label-baseline { display: none; }
   .dm-svg .dm-cuts-fill {
     fill: var(--c-buoy);
     opacity: 0.08;
@@ -700,6 +715,7 @@ title: "Deficit Dynamics Model"
   <text id="dm-boundary-label-r" class="dm-boundary-label"></text>
   <path id="dm-rev-hist" class="dm-rev-line"></path>
   <path id="dm-exp-hist" class="dm-exp-line"></path>
+  <path id="dm-exp-baseline" class="dm-exp-baseline-line dm-hidden"></path>
   <path id="dm-rev-proj" class="dm-rev-line dm-line-proj"></path>
   <path id="dm-exp-proj" class="dm-exp-line dm-line-proj"></path>
   <circle id="dm-crossover-dot" class="dm-crossover-dot dm-hidden" r="4"></circle>
@@ -711,6 +727,7 @@ title: "Deficit Dynamics Model"
   <text id="dm-end-rev" class="dm-end-label dm-end-label-rev"></text>
   <text id="dm-end-exp" class="dm-end-label dm-end-label-exp"></text>
   <text id="dm-end-constrained" class="dm-end-label dm-end-label-exp dm-hidden"></text>
+  <text id="dm-end-baseline" class="dm-end-label dm-end-label-baseline dm-hidden"></text>
   <g id="dm-legend"></g>
   <g id="dm-hover-g" class="dm-hidden">
     <line id="dm-hover-line" class="dm-hover-line"></line>
@@ -1240,7 +1257,17 @@ An override on its own buys time. It does not change the slope of either line.
     var rev = data.rev;
     var exp = data.exp;
 
-    computeYRange(rev, exp);
+    // Compute the matching-tier baseline once so we can include its expense
+    // values in the y-range (the ghost line can sit higher than the live
+    // expense line, e.g. when a scenario reduces growth) and reuse the
+    // result later when drawing the ghost line itself.
+    var baselineRender = null;
+    if (currentStance && currentStance !== 'bridge') {
+      var baselineRenderOver = stanceOverride[currentStance] || 0;
+      baselineRender = computeBaselineData(baselineRenderOver);
+    }
+
+    computeYRange(rev, baselineRender ? exp.concat(baselineRender.exp) : exp);
     drawMainGrid();
 
     document.getElementById('dm-rev-hist').setAttribute('d', buildPath(rev, 0, lastHistIdx, xScale, yScale));
@@ -1326,6 +1353,33 @@ An override on its own buys time. It does not change the slope of either line.
       }
     } else {
       constrainedEl.classList.add('dm-hidden');
+    }
+
+    // Ghost line: matching tier baseline expense projection, shown alongside
+    // the live expense line when a scenario is active so the wedge between
+    // them is visible directly on the chart.
+    var baselineEl = document.getElementById('dm-exp-baseline');
+    var endBaselineEl = document.getElementById('dm-end-baseline');
+    if (baselineRender) {
+      var bLastIdx = nYears - 1;
+      baselineEl.setAttribute('d', buildPath(baselineRender.exp, lastHistIdx, bLastIdx, xScale, yScale));
+      baselineEl.classList.remove('dm-hidden');
+      var bLabel = baselineRenderOver > 0
+        ? tierLabelForOverride(baselineRenderOver) + ' alone'
+        : 'No-override baseline';
+      var bEndY = yScale(baselineRender.exp[bLastIdx]) + 4;
+      var bExpEndY = yScale(exp[bLastIdx]) + 4;
+      if (Math.abs(bEndY - bExpEndY) < 12) {
+        bEndY = bExpEndY + (baselineRender.exp[bLastIdx] > exp[bLastIdx] ? 12 : -12);
+      }
+      endBaselineEl.setAttribute('x', xScale(bLastIdx) + 6);
+      endBaselineEl.setAttribute('y', bEndY);
+      endBaselineEl.setAttribute('text-anchor', 'start');
+      endBaselineEl.textContent = bLabel;
+      endBaselineEl.classList.remove('dm-hidden');
+    } else {
+      baselineEl.classList.add('dm-hidden');
+      endBaselineEl.classList.add('dm-hidden');
     }
 
     // End labels
@@ -1484,9 +1538,9 @@ An override on its own buys time. It does not change the slope of either line.
     return 'No override';
   }
   // Run compute() with all modifiers reset to defaults except the override
-  // value. Returns the FY40 gap (exp - rev) for that baseline. State is
-  // saved and restored so the live chart isn't disturbed.
-  function computeBaselineFy40Gap(overrideValue) {
+  // value. Returns the full result (rev/exp arrays etc.) for that baseline.
+  // State is saved and restored so the live chart isn't disturbed.
+  function computeBaselineData(overrideValue) {
     var saved = {
       rev: revGrowthEl.value, exp: expGrowthEl.value,
       over: overrideEl.value, ratch: ratchetEl.value,
@@ -1504,7 +1558,6 @@ An override on its own buys time. It does not change the slope of either line.
     fy27StepEl.value = 0;
     forcedEquilibriumActive = false;
     var data = compute();
-    var gap = data.exp[nYears - 1] - data.rev[nYears - 1];
     revGrowthEl.value = saved.rev;
     expGrowthEl.value = saved.exp;
     overrideEl.value = saved.over;
@@ -1514,7 +1567,7 @@ An override on its own buys time. It does not change the slope of either line.
     wageOffsetEl.value = saved.wage;
     fy27StepEl.value = saved.fy27;
     forcedEquilibriumActive = saved.forced;
-    return gap;
+    return data;
   }
   var stanceNotes = {
     'bridge': 'Buys roughly 5 years of headroom, then the gap reopens on the same slope. Politically hard: Marblehead voters have rejected every operating override attempt since 2006 (2011, 2022, 2023, 2025 all failed).',
@@ -1573,7 +1626,8 @@ An override on its own buys time. It does not change the slope of either line.
 
     if (currentStance && currentStance !== 'bridge') {
       var baselineOver = stanceOverride[currentStance] || 0;
-      var baselineGap = computeBaselineFy40Gap(baselineOver);
+      var baselineData = computeBaselineData(baselineOver);
+      var baselineGap = baselineData.exp[nYears - 1] - baselineData.rev[nYears - 1];
       var liveData = compute();
       var liveGap = liveData.exp[nYears - 1] - liveData.rev[nYears - 1];
       var delta = baselineGap - liveGap;

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -690,14 +690,7 @@ title: "Deficit Dynamics Model"
   <div class="dm-hint" id="dm-gap-hint">Pick a tier or scenario below to see how it changes.</div>
 </div>
 
-<div class="dm-readout" id="dm-stance-readout" style="display: none; margin-top: 8px;">
-  <div class="dm-readout-line dm-stance-readout-label">Scenario modeled</div>
-  <div class="dm-readout-line" id="dm-stance-explainer"></div>
-  <div class="dm-readout-line dm-stance-readout-label dm-stance-realism-label-row" id="dm-stance-realism-label" style="display: none;">Realism</div>
-  <div class="dm-readout-line" id="dm-stance-realism" style="display: none;"></div>
-</div>
-
-<svg class="dm-svg" viewBox="0 0 880 460" role="img" aria-labelledby="dm-title dm-desc">
+<svg class="dm-svg" id="dm-chart-svg" viewBox="0 0 880 460" role="img" aria-labelledby="dm-title dm-desc">
   <title id="dm-title">Revenue and expense lines, FY15 actual through FY40 projected</title>
   <desc id="dm-desc">Two lines showing actual revenue and expenses from FY15 to FY24, then projected forward to FY40. A shaded region highlights the deficit where expenses exceed revenue, which began in FY18.</desc>
   <g id="dm-grid"></g>
@@ -776,6 +769,13 @@ title: "Deficit Dynamics Model"
     <span class="dm-scenario-title" id="dm-show-more-title">+ 8 more scenarios &rarr;</span>
     <span class="dm-scenario-desc">Sliders and assumptions</span>
   </button>
+</div>
+
+<div class="dm-readout" id="dm-stance-readout" style="display: none;">
+  <div class="dm-readout-line dm-stance-readout-label">Scenario modeled</div>
+  <div class="dm-readout-line" id="dm-stance-explainer"></div>
+  <div class="dm-readout-line dm-stance-readout-label dm-stance-realism-label-row" id="dm-stance-realism-label" style="display: none;">Realism</div>
+  <div class="dm-readout-line" id="dm-stance-realism" style="display: none;"></div>
 </div>
 
 <details class="dm-advanced-controls" id="dm-advanced">
@@ -1682,7 +1682,7 @@ An override on its own buys time. It does not change the slope of either line.
   });
 
   // Stance scenario buttons
-  var chartScrollTarget = document.getElementById('dm-chart-scroll-target');
+  var chartScrollTarget = document.getElementById('dm-chart-svg');
   var reducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)');
   document.querySelectorAll('.dm-stance-btn').forEach(function(btn) {
     btn.addEventListener('click', function() {

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -693,8 +693,6 @@ title: "Deficit Dynamics Model"
 <div class="dm-readout" id="dm-stance-readout" style="display: none; margin-top: 8px;">
   <div class="dm-readout-line dm-stance-readout-label">Scenario modeled</div>
   <div class="dm-readout-line" id="dm-stance-explainer"></div>
-  <div class="dm-readout-line dm-stance-readout-label dm-stance-realism-label-row" id="dm-stance-compare-label" style="display: none;">vs baseline</div>
-  <div class="dm-readout-line" id="dm-stance-compare" style="display: none;"></div>
   <div class="dm-readout-line dm-stance-readout-label dm-stance-realism-label-row" id="dm-stance-realism-label" style="display: none;">Realism</div>
   <div class="dm-readout-line" id="dm-stance-realism" style="display: none;"></div>
 </div>
@@ -1573,6 +1571,21 @@ An override on its own buys time. It does not change the slope of either line.
       parts.push('At these growth rates, expenses rise no faster than revenue, so the lines do not re-cross.');
     }
 
+    if (currentStance && currentStance !== 'bridge') {
+      var baselineOver = stanceOverride[currentStance] || 0;
+      var baselineGap = computeBaselineFy40Gap(baselineOver);
+      var liveData = compute();
+      var liveGap = liveData.exp[nYears - 1] - liveData.rev[nYears - 1];
+      var delta = baselineGap - liveGap;
+      var deltaAbs = Math.abs(delta);
+      if (deltaAbs >= 0.05) {
+        var compareLabel = tierLabelForOverride(baselineOver);
+        if (baselineOver > 0) compareLabel = compareLabel + ' alone';
+        var direction = delta > 0 ? 'smaller' : 'larger';
+        parts.push('vs <strong>' + compareLabel + '</strong>: <strong>$' + deltaAbs.toFixed(1) + 'M</strong> ' + direction + ' FY40 gap.');
+      }
+    }
+
     var realismLabel = document.getElementById('dm-stance-realism-label');
     var realismEl = document.getElementById('dm-stance-realism');
     var note = currentStance && stanceNotes[currentStance];
@@ -1583,31 +1596,6 @@ An override on its own buys time. It does not change the slope of either line.
     } else {
       realismLabel.style.display = 'none';
       realismEl.style.display = 'none';
-    }
-
-    var compareLabel = document.getElementById('dm-stance-compare-label');
-    var compareEl = document.getElementById('dm-stance-compare');
-    if (currentStance && currentStance !== 'bridge') {
-      var baselineOver = stanceOverride[currentStance] || 0;
-      var baselineGap = computeBaselineFy40Gap(baselineOver);
-      var liveData = compute();
-      var liveGap = liveData.exp[nYears - 1] - liveData.rev[nYears - 1];
-      var delta = baselineGap - liveGap;
-      var deltaAbs = Math.abs(delta);
-      if (deltaAbs >= 0.05) {
-        var label = tierLabelForOverride(baselineOver);
-        if (baselineOver > 0) label = label + ' alone';
-        var direction = delta > 0 ? 'smaller' : 'larger';
-        compareEl.innerHTML = 'vs <strong>' + label + '</strong>: <strong>$' + deltaAbs.toFixed(1) + 'M</strong> ' + direction + ' FY40 gap.';
-        compareLabel.style.display = '';
-        compareEl.style.display = '';
-      } else {
-        compareLabel.style.display = 'none';
-        compareEl.style.display = 'none';
-      }
-    } else {
-      compareLabel.style.display = 'none';
-      compareEl.style.display = 'none';
     }
 
     if (parts.length > 0 || note) {

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -788,13 +788,6 @@ title: "Deficit Dynamics Model"
   </button>
 </div>
 
-<div class="dm-readout" id="dm-stance-readout" style="display: none;">
-  <div class="dm-readout-line dm-stance-readout-label">Scenario modeled</div>
-  <div class="dm-readout-line" id="dm-stance-explainer"></div>
-  <div class="dm-readout-line dm-stance-readout-label dm-stance-realism-label-row" id="dm-stance-realism-label" style="display: none;">Realism</div>
-  <div class="dm-readout-line" id="dm-stance-realism" style="display: none;"></div>
-</div>
-
 <details class="dm-advanced-controls" id="dm-advanced">
 <summary class="dm-advanced-summary">Show more scenarios and controls <span class="dm-advanced-summary-hint">(8 more scenarios, sliders, assumptions)</span></summary>
 <span class="dm-scenario-group-label">More scenarios</span>
@@ -896,6 +889,13 @@ title: "Deficit Dynamics Model"
 </div>
 </details>
 </details>
+
+<div class="dm-readout" id="dm-stance-readout" style="display: none;">
+  <div class="dm-readout-line dm-stance-readout-label">Scenario modeled</div>
+  <div class="dm-readout-line" id="dm-stance-explainer"></div>
+  <div class="dm-readout-line dm-stance-readout-label dm-stance-realism-label-row" id="dm-stance-realism-label" style="display: none;">Realism</div>
+  <div class="dm-readout-line" id="dm-stance-realism" style="display: none;"></div>
+</div>
 
 <a class="dm-embed-link" id="dm-embed-link" href="deficit_model.html">Explore the full interactive model &rarr;</a>
 

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -693,6 +693,8 @@ title: "Deficit Dynamics Model"
 <div class="dm-readout" id="dm-stance-readout" style="display: none; margin-top: 8px;">
   <div class="dm-readout-line dm-stance-readout-label">Scenario modeled</div>
   <div class="dm-readout-line" id="dm-stance-explainer"></div>
+  <div class="dm-readout-line dm-stance-readout-label dm-stance-realism-label-row" id="dm-stance-compare-label" style="display: none;">vs baseline</div>
+  <div class="dm-readout-line" id="dm-stance-compare" style="display: none;"></div>
   <div class="dm-readout-line dm-stance-readout-label dm-stance-realism-label-row" id="dm-stance-realism-label" style="display: none;">Realism</div>
   <div class="dm-readout-line" id="dm-stance-realism" style="display: none;"></div>
 </div>
@@ -1469,6 +1471,53 @@ An override on its own buys time. It does not change the slope of either line.
   }
 
   var currentStance = null;
+  // Override amount baked into each scenario's defaults. Used to pick the
+  // "vs Tier X alone" comparison baseline shown in the readout.
+  var stanceOverride = {
+    'bridge': 15,
+    'skeptic': 15,
+    'override-plus-hc': 15,
+    'permanent-close': 12
+  };
+  function tierLabelForOverride(v) {
+    if (v === 15) return 'Tier 3';
+    if (v === 12) return 'Tier 2';
+    if (v === 9) return 'Tier 1';
+    return 'No override';
+  }
+  // Run compute() with all modifiers reset to defaults except the override
+  // value. Returns the FY40 gap (exp - rev) for that baseline. State is
+  // saved and restored so the live chart isn't disturbed.
+  function computeBaselineFy40Gap(overrideValue) {
+    var saved = {
+      rev: revGrowthEl.value, exp: expGrowthEl.value,
+      over: overrideEl.value, ratch: ratchetEl.value,
+      cuts: positionCuts, hc: hcShareEl.value,
+      wage: wageOffsetEl.value, fy27: fy27StepEl.value,
+      forced: forcedEquilibriumActive
+    };
+    revGrowthEl.value = 3.5;
+    expGrowthEl.value = 4.0;
+    overrideEl.value = overrideValue;
+    ratchetEl.value = 5;
+    positionCuts = 0;
+    hcShareEl.value = 83;
+    wageOffsetEl.value = 50;
+    fy27StepEl.value = 0;
+    forcedEquilibriumActive = false;
+    var data = compute();
+    var gap = data.exp[nYears - 1] - data.rev[nYears - 1];
+    revGrowthEl.value = saved.rev;
+    expGrowthEl.value = saved.exp;
+    overrideEl.value = saved.over;
+    ratchetEl.value = saved.ratch;
+    positionCuts = saved.cuts;
+    hcShareEl.value = saved.hc;
+    wageOffsetEl.value = saved.wage;
+    fy27StepEl.value = saved.fy27;
+    forcedEquilibriumActive = saved.forced;
+    return gap;
+  }
   var stanceNotes = {
     'bridge': 'Buys roughly 5 years of headroom, then the gap reopens on the same slope. Politically hard: Marblehead voters have rejected every operating override attempt since 2006 (2011, 2022, 2023, 2025 all failed).',
     'skeptic': 'Same $15M, but spent in year one rather than stretched. Consistent with historical behavior, where new levy authority tends to be absorbed by the next contract cycle.',
@@ -1536,6 +1585,31 @@ An override on its own buys time. It does not change the slope of either line.
       realismEl.style.display = 'none';
     }
 
+    var compareLabel = document.getElementById('dm-stance-compare-label');
+    var compareEl = document.getElementById('dm-stance-compare');
+    if (currentStance && currentStance !== 'bridge') {
+      var baselineOver = stanceOverride[currentStance] || 0;
+      var baselineGap = computeBaselineFy40Gap(baselineOver);
+      var liveData = compute();
+      var liveGap = liveData.exp[nYears - 1] - liveData.rev[nYears - 1];
+      var delta = baselineGap - liveGap;
+      var deltaAbs = Math.abs(delta);
+      if (deltaAbs >= 0.05) {
+        var label = tierLabelForOverride(baselineOver);
+        if (baselineOver > 0) label = label + ' alone';
+        var direction = delta > 0 ? 'smaller' : 'larger';
+        compareEl.innerHTML = 'vs <strong>' + label + '</strong>: <strong>$' + deltaAbs.toFixed(1) + 'M</strong> ' + direction + ' FY40 gap.';
+        compareLabel.style.display = '';
+        compareEl.style.display = '';
+      } else {
+        compareLabel.style.display = 'none';
+        compareEl.style.display = 'none';
+      }
+    } else {
+      compareLabel.style.display = 'none';
+      compareEl.style.display = 'none';
+    }
+
     if (parts.length > 0 || note) {
       stanceEl.innerHTML = parts.map(function(p) {
         return '<div class="dm-readout-clause">' + p + '</div>';
@@ -1590,12 +1664,15 @@ An override on its own buys time. It does not change the slope of either line.
   var tierBtns = document.querySelectorAll('.dm-tier-buttons button');
   function updateTierActive() {
     var val = parseFloat(overrideEl.value);
+    var scenarioActive = !!(currentStance && stanceNotes[currentStance]);
     tierBtns.forEach(function(b) {
       var p = b.dataset.preset;
-      var match = (p === 'baseline' && val === 0) ||
-                  (p === 'tier1' && val === 9) ||
-                  (p === 'tier2' && val === 12) ||
-                  (p === 'tier3' && val === 15);
+      var match = !scenarioActive && (
+        (p === 'baseline' && val === 0) ||
+        (p === 'tier1' && val === 9) ||
+        (p === 'tier2' && val === 12) ||
+        (p === 'tier3' && val === 15)
+      );
       b.classList.toggle('dm-tier-active', match);
     });
   }


### PR DESCRIPTION
## What this fixes

Clicking "Override, then reform" set override=\$15M, which also lit up the Tier 3 button. From a glance you couldn't tell which state you were actually in. And even with cleaner highlighting, you couldn't tell *what the reform layer is worth* without flipping back to Tier 3 and trying to remember the FY40 number.

## Two changes

**1. Tier buttons deactivate when a scenario is active.** \`updateTierActive()\` now checks \`currentStance\`; if it's set, no tier button is highlighted. The tier-button click handler already cleared \`currentStance\`, and slider drags / cuts buttons already do too — so the active state belongs to whichever control was touched last.

**2. "vs baseline" line in the stance readout.** When a scenario is active, the readout shows e.g.:

> vs **Tier 3 alone**: **\$2.1M** smaller FY40 gap.

Baseline mapping:
- **Tier 3** for scenarios that bake in \$15M override: skeptic, override-plus-hc
- **Tier 2** for scenarios that bake in \$12M: permanent-close
- **No override** for everything else (hold-line, healthcare, cuts, etc.)
- Skipped entirely for **bridge**, which IS Tier 3 alone (delta = 0)

## Mechanics

A new \`computeBaselineFy40Gap(overrideValue)\` saves slider state, resets to defaults except the chosen override, runs \`compute()\`, reads the FY40 gap from the result, and restores state. The save/restore is invisible to the live chart because no render happens in between.

## Test plan

- [ ] Click "Override, then reform" — only that card is highlighted, Tier 3 button is not. Readout shows "vs Tier 3 alone: \$X.XM smaller FY40 gap"
- [ ] Click "Override spent immediately" — readout shows larger (skeptic absorbs the override fast)
- [ ] Click "Hold the line" — readout shows "vs No override"
- [ ] Click "Override buys time" (bridge) — readout has no compare line (delta is ~0)
- [ ] Click Tier 3 directly — Tier 3 lit, no scenario card lit
- [ ] Drag a slider while a scenario is active — scenario clears, compare line disappears
- [ ] \`?stance=skeptic\` URL — compare line appears at load

🤖 Generated with [Claude Code](https://claude.com/claude-code)