### PR TITLE
Plain-language rewrite: "levy" question (homepage)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1344,36 +1344,52 @@ og_url: https://marbleheaddata.org/
         <h4>The gap reopens after every override</h4>
 
         <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue vs expenses FY24-FY30, gap growing.">
+          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue stacks rise slowly while the expense line rises faster, FY24 to FY30. A Tier 2 override at FY27 pushes total revenue up to meet the expense line, but expenses keep climbing past it so the gap reopens by FY30.">
             <line class="axis-base" x1="60" y1="200" x2="500" y2="200"/>
             <line class="grid-minor" x1="60" y1="160" x2="500" y2="160"/>
             <line class="grid-minor" x1="60" y1="120" x2="500" y2="120"/>
             <line class="grid-minor" x1="60" y1="80" x2="500" y2="80"/>
+            <line class="grid-minor" x1="60" y1="40" x2="500" y2="40"/>
             <text class="tick-label" x="53" y="204" text-anchor="end">$80M</text>
             <text class="tick-label" x="53" y="164" text-anchor="end">$100M</text>
             <text class="tick-label" x="53" y="124" text-anchor="end">$120M</text>
             <text class="tick-label" x="53" y="84" text-anchor="end">$140M</text>
-            <text class="tick-label tick-label--major" x="94" y="220" text-anchor="middle">FY24</text>
-            <text class="tick-label tick-label--major" x="234" y="220" text-anchor="middle">FY27</text>
+            <text class="tick-label" x="53" y="44" text-anchor="end">$160M</text>
+            <text class="tick-label tick-label--major" x="84" y="220" text-anchor="middle">FY24</text>
+            <text class="tick-label tick-label--major" x="264" y="220" text-anchor="middle">FY27</text>
             <text class="tick-label tick-label--major" x="444" y="220" text-anchor="middle">FY30</text>
-            <rect class="data-fill s-revenue" x="80" y="123" width="28" height="77"/>
-            <rect class="data-fill s-revenue" x="150" y="112" width="28" height="88" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="220" y="103" width="28" height="97" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="290" y="94" width="28" height="106" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="360" y="86" width="28" height="114" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="430" y="78" width="28" height="122" opacity="0.65"/>
-            <polyline class="data-line data-line--bold s-neutral" points="94,120 164,105 234,72 304,52 374,32 444,12"/>
-            <circle class="data-dot s-neutral" cx="94" cy="120" r="3"/>
-            <circle class="data-dot s-neutral" cx="444" cy="12" r="4"/>
-            <text class="annotation" x="460" y="18">expenses</text>
-            <text class="annotation" x="460" y="82">revenue</text>
+
+            <!-- Base revenue bars, ~2.5%/yr growth -->
+            <rect class="data-fill s-revenue" x="70" y="124" width="28" height="76"/>
+            <rect class="data-fill s-revenue" x="130" y="118" width="28" height="82" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="190" y="112" width="28" height="88" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="250" y="106" width="28" height="94" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="310" y="100" width="28" height="100" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="370" y="93" width="28" height="107" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="430" y="87" width="28" height="113" opacity="0.65"/>
+
+            <!-- Override stack starting FY27 -->
+            <rect class="data-fill s-tier-2" x="250" y="82" width="28" height="24" opacity="0.85"/>
+            <rect class="data-fill s-tier-2" x="310" y="75" width="28" height="25" opacity="0.85"/>
+            <rect class="data-fill s-tier-2" x="370" y="68" width="28" height="25" opacity="0.85"/>
+            <rect class="data-fill s-tier-2" x="430" y="61" width="28" height="26" opacity="0.85"/>
+
+            <!-- Expense line, ~5%/yr growth -->
+            <polyline class="data-line data-line--bold s-neutral" points="84,120 144,108 204,95 264,82 324,68 384,54 444,38"/>
+            <circle class="data-dot s-neutral" cx="84" cy="120" r="3"/>
+            <circle class="data-dot s-neutral" cx="444" cy="38" r="4"/>
+
+            <text class="annotation" x="464" y="44">expenses</text>
+            <text class="annotation" x="264" y="32" text-anchor="middle">override hits FY27</text>
+            <line class="annotation-line" x1="264" y1="38" x2="264" y2="78"/>
           </svg>
         </div>
 
         <p class="caption">
-          An override fills the gap once. But as long as costs grow at
-          5% and revenue grows at 2.5%, the gap reopens. Real changes
-          on the cost side (the insurance share, staffing levels, total
+          At FY27 the override pushes revenue up to meet the expense
+          line. But as long as costs grow at 5% and revenue grows at
+          2.5%, the gap reopens within a few years. Real changes on
+          the cost side (the insurance share, staffing levels, total
           compensation) are what slow the cost growth.
         </p>
         <a class="evidence-chart-link" href="charts/sustainability.html">

--- a/index.html
+++ b/index.html
@@ -1104,44 +1104,50 @@ og_url: https://marbleheaddata.org/
   <section class="question-screen" data-topic="levy">
 
     <div class="question-block">
-      <h1>How can town income keep up with cost growth?</h1>
+      <h1>Why doesn't the 2.5% tax cap cover the budget?</h1>
       <p class="question-context">
-        Town income grows through two channels: the Prop 2&frac12; levy cap
-        (2.5%/year) and new growth (new construction and renovations added
-        to the tax base). Health insurance, pensions, and contracted
-        salaries grow faster than the cap, and new growth in Marblehead
-        is small enough that it doesn't close the difference on its own.
+        Town tax revenue grows two ways. Proposition 2&frac12; lets the
+        levy rise 2.5% a year. New construction and renovations add a
+        bit more on top. Health insurance, pensions, and union
+        contracts grow faster than that, and Marblehead doesn't have
+        enough new construction to make up the difference.
       </p>
     </div>
 
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="levy">
         <p class="answer-label">Answer A</p>
-        <h2>I want override revenue because costs outrun 2.5% structurally</h2>
+        <h2>Costs grow faster than 2.5%, so overrides fill the gap</h2>
         <p class="answer-summary">
-          Health insurance grows 7-11% per year, pensions ~9%. A 2.5%
-          revenue cap plus modest new growth cannot keep up with costs the
-          town does not set, so overrides are the mechanism the law leaves.
+          Health insurance grows 7-11% a year. Pensions grow about 9%.
+          A 2.5% revenue cap plus a small amount of new construction
+          can't keep up with costs the town doesn't control. Overrides
+          are the only revenue tool the law gives the town to make up
+          the difference.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="levy">
         <p class="answer-label">Answer B</p>
-        <h2>I want spending brought down to what 2.5% plus new growth supports</h2>
+        <h2>Bring spending down to what the cap allows instead</h2>
         <p class="answer-summary">
-          The cap is the only structural check. Instead of raising revenue to
-          match cost growth, I'd rather reshape the spending that outruns the
-          cap, starting with the levers the town actually controls.
+          The 2.5% cap is the only built-in check on town spending.
+          Instead of raising revenue to match cost growth, the town
+          should rein in the spending that grew faster than the cap,
+          starting with the things the town controls locally
+          (premium splits, staffing levels, total compensation).
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="levy">
         <p class="answer-label">Answer C</p>
-        <h2>I want both: override now, and reform before the next one</h2>
+        <h2>Override now, then slow cost growth before the next vote</h2>
         <p class="answer-summary">
-          The mechanics are real, but a yes should not let the slope issues
-          drift. New revenue plus benefits reform and new-growth work is
-          the package I'd accept.
+          The math is real: costs grow faster than the cap. But the
+          override shouldn't be allowed to delay work on the cost
+          drivers. New revenue together with benefits reform and steps
+          to grow the commercial tax base is the package that closes
+          the gap and keeps it closed.
         </p>
       </div>
     </div>
@@ -1175,10 +1181,11 @@ og_url: https://marbleheaddata.org/
         </div>
 
         <p class="caption">
-          Both indexed to FY06 = 100. Health insurance spending more than
-          doubled. The levy grew at a similar total rate, but the levy funds
-          everything, not just insurance. As insurance takes a larger share,
-          less is left for services.
+          Both lines start at the same level in FY06. Health insurance
+          spending more than doubled by FY27. The levy grew at a similar
+          total rate, but the levy pays for everything, not just
+          insurance. As insurance takes a bigger share, less is left
+          for services.
         </p>
         <a class="evidence-chart-link" href="charts/healthcare_costs.html">
           Full healthcare cost chart
@@ -1200,7 +1207,7 @@ og_url: https://marbleheaddata.org/
         <h4>New growth doesn't close the difference either</h4>
         <div class="evidence-nugget">
           <span class="evidence-nugget-value">0.54%</span>
-          <span class="evidence-nugget-label">Marblehead's five-year average new growth rate -- lowest in the peer set. Peninsula geography, historic districts, and zoning limit new construction. Revenue ceiling: ~3% (2.5% levy cap + 0.54% new growth). Health insurance alone grows faster.</span>
+          <span class="evidence-nugget-label">Marblehead's new construction adds about 0.54% to the tax base each year, the lowest among peer towns. The peninsula, the historic districts, and the zoning rules limit how much can be built. Revenue ceiling: about 3% per year (2.5% from the cap plus 0.54% from new construction). Health insurance grows faster than that on its own.</span>
         </div>
       </div>
 
@@ -1211,13 +1218,13 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            Towns with similar external cost pressures manage without
-            annual overrides. What varies isn't the presence of the
-            costs, it's the local choices about premium splits,
-            staffing composition, and total compensation that
-            determine how much of the 2.5% plus new growth is
-            spoken for. The cap exposes those choices; it doesn't
-            create them.
+            Towns facing similar cost pressures manage without annual
+            overrides. The costs themselves don't vary that much from
+            town to town. What varies is the local choices about
+            premium splits, staffing levels, and total compensation.
+            Those choices decide how much of the 2.5% revenue increase
+            is already spoken for. The cap exposes the choices; it
+            doesn't create them.
           </p>
         </div>
       </details>
@@ -1226,7 +1233,7 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence B: cap is the check -->
     <div class="evidence" data-evidence="levy-b">
       <div class="evidence-header">
-        <h3>The case for "reshape spending, not the cap"</h3>
+        <h3>The case for "rein in spending, don't override the cap"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 
@@ -1256,12 +1263,12 @@ og_url: https://marbleheaddata.org/
         </div>
 
         <p class="caption">
-          The levy grew 53% from FY12 to FY24 while <abbr class="g" title="Consumer Price Index for All Urban Consumers">CPI-U</abbr> grew 37%.
-          Property taxes have been rising faster than general inflation,
-          because the 2.5% cap compounds to ~34.5% over twelve years and
-          new growth (new construction added to the grand list) adds the
-          rest. The cap bounds the per-year increase, not the long-run
-          total.
+          The levy grew 53% from FY12 to FY24 while general inflation
+          (<abbr class="g" title="Consumer Price Index for All Urban Consumers">CPI-U</abbr>) grew 37%.
+          Property taxes have risen faster than overall prices because
+          the 2.5% cap compounds to about 34.5% over twelve years and
+          new construction adds more on top. The cap limits the
+          per-year increase, not the long-run total.
         </p>
         <a class="evidence-chart-link" href="charts/levy_vs_bill.html">
           Full levy, bill, and inflation chart
@@ -1269,33 +1276,36 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>The spending levers the town actually controls</h4>
+        <h4>The spending levers the town controls</h4>
         <p>
-          The cap constrains revenue; cost growth is where discipline
-          has to happen. Levers the town sets locally, not the state:
+          The cap limits revenue. Cost growth is where the town has to
+          apply discipline. Things the town sets locally, not the state:
         </p>
         <ul>
           <li>
-            <strong>Health-insurance premium split.</strong> Marblehead
+            <strong>Health insurance premium split.</strong> Marblehead
             pays 83% of employee premiums. State law allows 50-99%;
-            Hingham pays 50%. Moving to 75% would save roughly $1M/yr.
+            Hingham pays 50%. Lowering the share saves on premiums but
+            usually means bargaining higher wages in exchange. The
+            swap still slows total cost growth over time because
+            insurance grows faster than salaries.
           </li>
           <li>
-            <strong>Staffing composition.</strong> Student-to-staff ratio
-            is the lowest among peer towns. Office and administrative
+            <strong>Staffing levels.</strong> Marblehead has more staff
+            per student than any peer town. Office and administrative
             staff run well above peer averages.
           </li>
           <li>
-            <strong>Total compensation.</strong> Teacher salary runs
-            below peers; total compensation runs above, because of the
-            premium split plus benefits structure. The package is
-            negotiable at each contract cycle.
+            <strong>Total compensation.</strong> Teacher base salary is
+            below peers, but total compensation is above peers because
+            of the 83% insurance share and the benefits structure. The
+            whole package gets renegotiated at each contract cycle.
           </li>
           <li>
-            <strong>Budget discipline.</strong> Requesting an MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr>
-            review is free and has never been requested. Line-item
-            transparency in the budget reporting format is also a town
-            choice.
+            <strong>Budget transparency.</strong> The state will do a
+            free, independent review of the town's finances. Marblehead
+            has never asked for one. How much detail the budget
+            includes is also up to the town.
           </li>
         </ul>
         <a class="evidence-chart-link" href="what-has-the-town-done.html">
@@ -1310,14 +1320,14 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            The cap constrains revenue, not spending. When revenue
-            can't meet contractual obligations the town cannot
-            unilaterally change (pensions, <abbr class="g" title="Group Insurance Commission">GIC</abbr>
+            The cap limits revenue, not spending. When revenue can't
+            cover obligations the town can't change on its own
+            (pensions, <abbr class="g" title="Group Insurance Commission">GIC</abbr>
             premiums, debt service), the cap forces cuts to services
-            residents use rather than restraining the cost drivers
-            that caused the squeeze. Inflation-beating growth in the
-            bill reflects what's happening above the cap, not
-            evidence the cap is loose.
+            residents actually use, not to the cost drivers that caused
+            the squeeze. The bill rising faster than inflation reflects
+            what's growing above the cap, not evidence that the cap
+            itself is loose.
           </p>
         </div>
       </details>
@@ -1361,10 +1371,10 @@ og_url: https://marbleheaddata.org/
         </div>
 
         <p class="caption">
-          An override bridges the gap once. But as long as costs grow at
-          5% and revenue grows at 2.5%, the gap reopens. Structural
-          levers on the cost side (<abbr class="g" title="Group Insurance Commission">GIC</abbr> premium splits, staffing model,
-          total compensation) are what change the slope.
+          An override fills the gap once. But as long as costs grow at
+          5% and revenue grows at 2.5%, the gap reopens. Real changes
+          on the cost side (the insurance share, staffing levels, total
+          compensation) are what slow the cost growth.
         </p>
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Full sustainability projections
@@ -1380,13 +1390,12 @@ og_url: https://marbleheaddata.org/
           <p>
             The compromise position names both truths but doesn't
             answer the timing question: can reform happen fast enough
-            to matter for FY27? Benefits reform takes contract
-            cycles, state aid reform takes years, and zoning changes
-            take longer still. If the deficit is now and reform is
+            to matter for FY27? Benefits reform happens at contract
+            renewals. State aid reform takes years. Zoning changes
+            take longer still. When the deficit is now and reform is
             slow, "both" tends to resolve in practice as "override
-            now, reform eventually" &ndash; which is the outcome
-            Answer A says is required and Answer B says repeats
-            the pattern.
+            now, reform eventually," which is the outcome Answer A
+            says is required and Answer B says repeats the pattern.
           </p>
         </div>
       </details>

--- a/index.html
+++ b/index.html
@@ -1185,7 +1185,10 @@ og_url: https://marbleheaddata.org/
           spending more than doubled by FY27. The levy grew at a similar
           total rate, but the levy pays for everything, not just
           insurance. As insurance takes a bigger share, less is left
-          for services.
+          for services. The FY24 dip is a one-time effect: the state
+          insurance pool swapped Marblehead onto a cheaper plan that
+          year, but per-employee premiums still rose and the rate
+          increases resumed in FY26.
         </p>
         <a class="evidence-chart-link" href="charts/healthcare_costs.html">
           Full healthcare cost chart

--- a/index.html
+++ b/index.html
@@ -1344,7 +1344,7 @@ og_url: https://marbleheaddata.org/
         <h4>The gap reopens after every override</h4>
 
         <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue stacks rise slowly while the expense line rises faster, FY24 to FY30. A Tier 2 override at FY27 pushes total revenue up to meet the expense line, but expenses keep climbing past it so the gap reopens by FY30.">
+          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue stacks rise slowly while the expense line rises faster, FY24 to FY30. A Tier 3 override phases in over FY27, FY28, and FY29, pushing total revenue up to roughly meet the expense line. Expenses keep climbing and the gap reopens by FY30.">
             <line class="axis-base" x1="60" y1="200" x2="500" y2="200"/>
             <line class="grid-minor" x1="60" y1="160" x2="500" y2="160"/>
             <line class="grid-minor" x1="60" y1="120" x2="500" y2="120"/>
@@ -1368,11 +1368,11 @@ og_url: https://marbleheaddata.org/
             <rect class="data-fill s-revenue" x="370" y="93" width="28" height="107" opacity="0.65"/>
             <rect class="data-fill s-revenue" x="430" y="87" width="28" height="113" opacity="0.65"/>
 
-            <!-- Override stack starting FY27 -->
-            <rect class="data-fill s-tier-2" x="250" y="82" width="28" height="24" opacity="0.85"/>
-            <rect class="data-fill s-tier-2" x="310" y="75" width="28" height="25" opacity="0.85"/>
-            <rect class="data-fill s-tier-2" x="370" y="68" width="28" height="25" opacity="0.85"/>
-            <rect class="data-fill s-tier-2" x="430" y="61" width="28" height="26" opacity="0.85"/>
+            <!-- Tier 3 override phased in over FY27-FY29 then steady -->
+            <rect class="data-fill s-tier-3" x="250" y="97" width="28" height="9" opacity="0.85"/>
+            <rect class="data-fill s-tier-3" x="310" y="79" width="28" height="21" opacity="0.85"/>
+            <rect class="data-fill s-tier-3" x="370" y="63" width="28" height="30" opacity="0.85"/>
+            <rect class="data-fill s-tier-3" x="430" y="56" width="28" height="31" opacity="0.85"/>
 
             <!-- Expense line, ~5%/yr growth -->
             <polyline class="data-line data-line--bold s-neutral" points="84,120 144,108 204,95 264,82 324,68 384,54 444,38"/>
@@ -1380,16 +1380,16 @@ og_url: https://marbleheaddata.org/
             <circle class="data-dot s-neutral" cx="444" cy="38" r="4"/>
 
             <text class="annotation" x="464" y="44">expenses</text>
-            <text class="annotation" x="264" y="32" text-anchor="middle">override hits FY27</text>
-            <line class="annotation-line" x1="264" y1="38" x2="264" y2="78"/>
+            <text class="annotation" x="324" y="32" text-anchor="middle">override phases in FY27-FY29</text>
           </svg>
         </div>
 
         <p class="caption">
-          At FY27 the override pushes revenue up to meet the expense
-          line. But as long as costs grow at 5% and revenue grows at
-          2.5%, the gap reopens within a few years. Real changes on
-          the cost side (the insurance share, staffing levels, total
+          An override doesn't hit all at once. It phases in over three
+          years, partially closing the gap in FY27 and reaching full
+          strength in FY29. But as long as costs grow at 5% and revenue
+          grows at 2.5%, the gap reopens by FY30. Real changes on the
+          cost side (the insurance share, staffing levels, total
           compensation) are what slow the cost growth.
         </p>
         <a class="evidence-chart-link" href="charts/sustainability.html">


### PR DESCRIPTION
## Summary

Third in the homepage plain-language pass (issue #657). Follows the register established in #667 (`alternatives`) and #669 (`schools`).

`levy` was 3rd worst on the density ranking. Heaviest issues were abstract framing ("the mechanism the law leaves," "the levers the town actually controls," "slope issues") plus a question heading that subtly favored Answer A's framing ("How can town income keep up with cost growth?" assumes the goal is keeping up, which Answer B disputes).

## What changed

- **Question heading** is now neutrally framed to all three answers: "Why doesn't the 2.5% tax cap cover the budget?"
- **Headers lead with the claim** per the rule from #669 (memory `feedback_answer_headers_lead_with_claim`)
- **Wage-offset qualifier** applied to the insurance lever in Evidence B's bulleted list and the Evidence C chart caption (memory `feedback_wage_offset`)
- Killed: "structurally," "the mechanism the law leaves," "indexed to FY06 = 100," "grand list," "slope issues," DOR/DLS acronym chain

All facts preserved:
- Health insurance 7-11%/yr, pensions ~9%
- $2.18M FY27 new levy, $2.11M to insurance and pensions
- 0.54% new growth (lowest in peer set)
- Levy +53% FY12-FY24 vs CPI-U +37% (12-year compound 34.5%)
- 83% premium share, Hingham 50%

## Test plan

- [ ] Eyeball at `?q=levy` on preview
- [ ] Confirm new question heading reads neutrally (doesn't favor any answer)
- [ ] Confirm wage-offset qualifier reads naturally where it appears