### PR TITLE
Make "Pick your first answer" a button that scrolls to featured

### DIFF
--- a/assets/explore.js
+++ b/assets/explore.js
@@ -534,8 +534,18 @@
     // Progress message + next button
     var msgEl = document.getElementById('statMsg');
     if (decidedCount === 0) {
-      msgEl.textContent = 'Pick your first answer';
+      msgEl.textContent = '';
       msgEl.className = 'explore-stats-msg';
+      var startBtn = document.createElement('button');
+      startBtn.type = 'button';
+      startBtn.className = 'explore-stats-next';
+      startBtn.textContent = 'Pick your first answer ↑';
+      startBtn.title = 'Jump to the first answer';
+      startBtn.addEventListener('click', function () {
+        var featured = document.getElementById('featuredQuestion');
+        if (featured) featured.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+      msgEl.appendChild(startBtn);
     } else if (decidedCount < totalCount) {
       msgEl.textContent = '';
       msgEl.className = 'explore-stats-msg';


### PR DESCRIPTION
## Summary
- The stats strip's zero-pick prompt was plain text while the 1+ pick state already had a clickable "Next →" button (#645).
- Match the symmetry: at zero picks the prompt is now a button that smooth-scrolls to the featured-question above the stats strip.
- Up arrow on the label (featured-question is above the stats strip) to mirror "Next →" for forward navigation.

## Test plan
- [ ] Clear localStorage, load homepage. The stats strip shows "Pick your first answer ↑" styled as a button.
- [ ] Scroll the featured-question off-screen, click the button, page smooth-scrolls back up to it.
- [ ] After making a first pick, the button is replaced by "N to go Next →" as before (no regression on 645).
- [ ] After deciding all questions, the message switches to the complete state as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)