### PR TITLE
Shorten servicelevel Answer C title to balance card heights

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,7 +385,7 @@ og_url: https://marbleheaddata.org/
       <!-- Answer C -->
       <div class="answer-card" data-answer="c" data-question="servicelevel">
         <p class="answer-label">Answer C</p>
-        <h2>I'd pay more for improvements, not just to avoid cuts</h2>
+        <h2>I'd pay more to improve service</h2>
         <p class="answer-summary">
           An override should deliver something beyond preservation, whether
           that's stronger staffing ratios, restored hours, or service quality
@@ -481,7 +481,7 @@ og_url: https://marbleheaddata.org/
     <!-- Evidence C -->
     <div class="evidence" data-evidence="servicelevel-c">
       <div class="evidence-header">
-        <h3>The case for "pay more for improvements"</h3>
+        <h3>The case for "pay more to improve service"</h3>
         <button class="evidence-close">Collapse</button>
       </div>
 


### PR DESCRIPTION
## Summary
- "I'd pay more for improvements, not just to avoid cuts" was 52 chars, ~25-33% longer than A (44) and B (39), pushing C's title to 3 lines on the featured-question while A and B fit in 2.
- Flex-stretch then dragged A and B up to match C's height, leaving visible empty space at the bottom of the shorter cards.
- Shorten to "I'd pay more to improve services" (32 chars). The "not just to avoid cuts" framing stays on the page via the summary's closing line ("Loss-aversion framing understates what's on offer.").
- Evidence header h3 ("The case for ...") updated to match.

## Test plan
- [ ] Homepage featured-question: C's title now fits in 2 lines like A and B; cards visually balanced.
- [ ] Click into the servicelevel question; the in-question card matches the new copy.
- [ ] Open the C evidence panel; the h3 reads "The case for 'pay more to improve services'".

🤖 Generated with [Claude Code](https://claude.com/claude-code)