### PR TITLE
Plain-language rewrite: "again" question (homepage)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2166,33 +2166,34 @@ og_url: https://marbleheaddata.org/
     <div class="answers">
       <div class="answer-card" data-answer="a" data-question="again">
         <p class="answer-label">Answer A</p>
-        <h2>Not soon: a sized-well override holds for several years</h2>
+        <h2>Not soon: a big enough override buys several years</h2>
         <p class="answer-summary">
-          The tiers were designed as a multi-year correction, and the
-          higher ones build capacity to absorb future cost growth without
-          a near-term return to voters. The bridge looks durable to me.
+          The tiers were sized to cover multiple years of growth. Tier 2
+          and Tier 3 add cushion above the immediate gap, which absorbs
+          some of the future cost growth without forcing the town back
+          to voters anytime soon.
         </p>
       </div>
 
       <div class="answer-card" data-answer="b" data-question="again">
         <p class="answer-label">Answer B</p>
-        <h2>Soon: the math pulls ahead of any tier within a year or two</h2>
+        <h2>Soon: even Tier 3 gets eaten by cost growth in a few years</h2>
         <p class="answer-summary">
-          Health insurance and pensions don't stop growing when the
-          override passes. Even Tier 3 bridges the gap briefly before
-          expenses pull ahead again, so I expect the next vote sooner
-          than the tier label suggests.
+          Health insurance and pensions keep growing whether the override
+          passes or not. Even Tier 3 fills the gap for only a couple of
+          years before expenses pull ahead again. The next override vote
+          comes sooner than the tier label suggests.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="again">
         <p class="answer-label">Answer C</p>
-        <h2>Depends: it turns on what reform happens while the override runs</h2>
+        <h2>Depends: it turns on what the town does with the time</h2>
         <p class="answer-summary">
-          The override buys time. Whether that time turns into slope-bending
-          reform (benefits, commercial growth, staffing) or just gets
-          ratcheted into new spending is the variable that decides when the
-          next vote is needed.
+          The override buys time. Whether the town uses that time to
+          actually slow cost growth (the insurance share, commercial
+          growth, staffing) or lets the new revenue get absorbed into
+          new spending decides how soon the next override vote comes.
         </p>
       </div>
     </div>
@@ -2207,10 +2208,10 @@ og_url: https://marbleheaddata.org/
       <div class="evidence-point">
         <h4>Three tiers, three strategies</h4>
         <p>
-          Tier 1 ($9M) restores what was cut. Tier 2 ($12M) stabilizes
-          recurring costs. Tier 3 ($15M) adds a cushion for future
-          growth. The tiers were scoped to match the Finance
-          Committee's three-year deficit forecast (FY26-FY28).
+          Tier 1 ($9M) restores what was cut. Tier 2 ($12M) covers
+          ongoing cost growth. Tier 3 ($15M) adds a cushion for future
+          growth on top. The Finance Committee sized the tiers to
+          match its three-year deficit forecast for FY26 through FY28.
         </p>
         <a class="evidence-chart-link" href="what-is-the-override.html">
           What is the override
@@ -2218,12 +2219,12 @@ og_url: https://marbleheaddata.org/
       </div>
 
       <div class="evidence-point">
-        <h4>Deficits are projected only under the no-override scenario</h4>
+        <h4>The town only projects shortfalls if the override fails</h4>
         <p>
-          The FinCom's three-year forecast shows structural deficits
-          only if the override fails. At Tier 2 or 3, the near-term
-          gap is bridged and the town doesn't need to come back to
-          voters for several years.
+          The Finance Committee's three-year forecast shows ongoing
+          budget shortfalls only if the override fails. At Tier 2 or
+          Tier 3, the near-term gap is bridged and the town doesn't
+          need to come back to voters for several years.
         </p>
         <a class="evidence-chart-link" href="how-we-got-here.html">
           How we got here
@@ -2237,14 +2238,13 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            "Sized to last" assumes cost growth stays within
-            <abbr class="g" title="Finance Committee">FinCom</abbr>'s
-            projections. Health insurance premiums rose 11% for FY27
-            alone, well above the 5%/year assumption in the
-            sustainability chart. Even Tier 3 only bridges the gap
-            briefly in the published projection before reopening by
-            FY30, so the multi-year cushion may be thinner than the
-            tier framing suggests.
+            "Sized to last" assumes cost growth stays close to the
+            Finance Committee's projections. Health insurance premiums
+            rose 11% for FY27 alone, well above the 5% per year the
+            sustainability chart assumes. Even Tier 3 only bridges the
+            gap briefly before the gap reopens by FY30 in the town's
+            own projection. The multi-year cushion may be thinner than
+            the tier framing suggests.
           </p>
         </div>
       </details>
@@ -2261,36 +2261,52 @@ og_url: https://marbleheaddata.org/
         <h4>The gap reopens even at Tier 3</h4>
 
         <div class="chart-wrapper">
-          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue vs expenses FY24-FY30, gap growing.">
+          <svg class="chart" viewBox="0 0 560 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Revenue stacks rise slowly while the expense line rises faster, FY24 to FY30. A Tier 3 override phases in over FY27, FY28, and FY29, pushing total revenue up to roughly meet the expense line. Expenses keep climbing and the gap reopens by FY30.">
             <line class="axis-base" x1="60" y1="200" x2="500" y2="200"/>
             <line class="grid-minor" x1="60" y1="160" x2="500" y2="160"/>
             <line class="grid-minor" x1="60" y1="120" x2="500" y2="120"/>
             <line class="grid-minor" x1="60" y1="80" x2="500" y2="80"/>
+            <line class="grid-minor" x1="60" y1="40" x2="500" y2="40"/>
             <text class="tick-label" x="53" y="204" text-anchor="end">$80M</text>
             <text class="tick-label" x="53" y="164" text-anchor="end">$100M</text>
             <text class="tick-label" x="53" y="124" text-anchor="end">$120M</text>
             <text class="tick-label" x="53" y="84" text-anchor="end">$140M</text>
-            <text class="tick-label tick-label--major" x="94" y="220" text-anchor="middle">FY24</text>
-            <text class="tick-label tick-label--major" x="234" y="220" text-anchor="middle">FY27</text>
+            <text class="tick-label" x="53" y="44" text-anchor="end">$160M</text>
+            <text class="tick-label tick-label--major" x="84" y="220" text-anchor="middle">FY24</text>
+            <text class="tick-label tick-label--major" x="264" y="220" text-anchor="middle">FY27</text>
             <text class="tick-label tick-label--major" x="444" y="220" text-anchor="middle">FY30</text>
-            <rect class="data-fill s-revenue" x="80" y="123" width="28" height="77"/>
-            <rect class="data-fill s-revenue" x="150" y="112" width="28" height="88" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="220" y="103" width="28" height="97" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="290" y="94" width="28" height="106" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="360" y="86" width="28" height="114" opacity="0.65"/>
-            <rect class="data-fill s-revenue" x="430" y="78" width="28" height="122" opacity="0.65"/>
-            <polyline class="data-line data-line--bold s-neutral" points="94,120 164,105 234,72 304,52 374,32 444,12"/>
-            <circle class="data-dot s-neutral" cx="94" cy="120" r="3"/>
-            <circle class="data-dot s-neutral" cx="444" cy="12" r="4"/>
-            <text class="annotation" x="460" y="18">expenses</text>
-            <text class="annotation" x="460" y="82">revenue</text>
+
+            <!-- Base revenue bars, ~2.5%/yr growth -->
+            <rect class="data-fill s-revenue" x="70" y="124" width="28" height="76"/>
+            <rect class="data-fill s-revenue" x="130" y="118" width="28" height="82" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="190" y="112" width="28" height="88" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="250" y="106" width="28" height="94" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="310" y="100" width="28" height="100" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="370" y="93" width="28" height="107" opacity="0.65"/>
+            <rect class="data-fill s-revenue" x="430" y="87" width="28" height="113" opacity="0.65"/>
+
+            <!-- Tier 3 override phased in over FY27-FY29 then steady -->
+            <rect class="data-fill s-tier-3" x="250" y="97" width="28" height="9" opacity="0.85"/>
+            <rect class="data-fill s-tier-3" x="310" y="79" width="28" height="21" opacity="0.85"/>
+            <rect class="data-fill s-tier-3" x="370" y="63" width="28" height="30" opacity="0.85"/>
+            <rect class="data-fill s-tier-3" x="430" y="56" width="28" height="31" opacity="0.85"/>
+
+            <!-- Expense line, ~5%/yr growth -->
+            <polyline class="data-line data-line--bold s-neutral" points="84,120 144,108 204,95 264,82 324,68 384,54 444,38"/>
+            <circle class="data-dot s-neutral" cx="84" cy="120" r="3"/>
+            <circle class="data-dot s-neutral" cx="444" cy="38" r="4"/>
+
+            <text class="annotation" x="464" y="44">expenses</text>
+            <text class="annotation" x="324" y="32" text-anchor="middle">override phases in FY27-FY29</text>
           </svg>
         </div>
 
         <p class="caption">
-          Expenses grow at ~5%/year. Revenue grows at ~2.5%. An
-          override adds a fixed amount that doesn't grow. By FY30
-          the gap reopens even at Tier 3. Tier 1 reopens sooner.
+          Expenses grow at about 5% a year. Base revenue grows at 2.5%.
+          An override adds a fixed amount on top that doesn't keep
+          growing. Tier 3 phases in over FY27-FY29 and pushes total
+          revenue up to roughly meet the expense line. By FY30 the gap
+          reopens even with Tier 3 in place. Tier 1 reopens sooner.
         </p>
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Sustainability projections
@@ -2303,9 +2319,10 @@ og_url: https://marbleheaddata.org/
       <div class="evidence-point">
         <h4>Melrose is the preview</h4>
         <p>
-          Melrose rejected $7.7M in 2024. Eighteen months later they
-          passed $13.5M, 75% more. Each delay makes the next ask bigger
-          because the underlying costs keep compounding.
+          Melrose rejected a $7.7M override in 2024. Eighteen months
+          later they passed $13.5M, which is 75% bigger. Every delay
+          makes the next ask bigger because the underlying costs keep
+          compounding.
         </p>
         <a class="evidence-chart-link" href="data/case_studies">
           Override case studies
@@ -2321,12 +2338,12 @@ og_url: https://marbleheaddata.org/
           <p>
             The projections assume 5% expense growth and 3% revenue
             growth. Those are illustrative inputs, not forecasts. If
-            healthcare inflation moderates, if benefits get
-            renegotiated at the next contract, or if new growth
-            picks up, the gap reopens later or smaller. The
-            arithmetic is real, but the inputs aren't fixed, and
-            "the math says we will" treats a projection as a
-            certainty.
+            healthcare costs moderate, if benefits get renegotiated at
+            the next contract, or if new construction picks up, the
+            gap reopens later or smaller than the chart suggests. The
+            arithmetic is real, but the inputs aren't fixed. Treating
+            a projection as a certainty is the catch in "the math says
+            we will."
           </p>
         </div>
       </details>
@@ -2345,17 +2362,22 @@ og_url: https://marbleheaddata.org/
           Both sides agree costs will keep rising. The question is
           whether the breathing room from the override gets used to
           change the cost structure (insurance negotiations, staffing
-          model, budget transparency) or just delays the next ask.
+          changes, budget transparency) or just delays the next
+          override vote.
         </p>
       </div>
 
       <div class="evidence-point">
         <h4>Reform options that don't require an override</h4>
         <p>
-          Premium split renegotiation (Marblehead pays 83%, peers
-          pay 50-80%). State budget review (free, never requested).
-          Detailed department-level reporting (format change, no vote
-          needed). None are fast, but none are impossible.
+          Premium split renegotiation (Marblehead pays 83%, peers pay
+          50-80%). Lowering the share usually means bargaining higher
+          wages in exchange, but the swap still slows total cost growth
+          over time because insurance grows faster than salaries. A
+          free state review of the town's finances (never requested).
+          More detailed department-level budget reporting (a formatting
+          choice, no vote needed). None of these are fast, but none of
+          them are impossible.
         </p>
         <a class="evidence-chart-link" href="what-you-can-do.html#better-oversight">
           Reform options
@@ -2372,16 +2394,14 @@ og_url: https://marbleheaddata.org/
         </summary>
         <div class="counter-argument-body">
           <p>
-            Treating reform as the intervening variable assumes the
-            political prerequisites exist. Premium-split
-            renegotiation requires both sides of collective
-            bargaining to agree. A
-            <abbr class="g" title="Division of Local Services">DLS</abbr>
-            review has to be requested. Budget-format changes need
-            someone inside the process to prioritize them. Betting on
-            reform after an override is betting that politics does
-            something it hasn't yet, which is exactly what Answer B
-            says cannot be counted on.
+            Treating reform as the deciding factor assumes the political
+            conditions for reform exist. Premium-split renegotiation
+            needs both sides of the union contract to agree. A free
+            state review has to be requested. Budget format changes
+            need someone inside the process to push for them. Betting
+            on reform after an override means betting the politics
+            will do something it hasn't done yet, which is exactly
+            what Answer B says you can't count on.
           </p>
         </div>
       </details>


### PR DESCRIPTION
## Summary

Fourth in the homepage plain-language pass (issue #657). Follows the register established in #667 (`alternatives`), #669 (`schools`), and #672 (`levy`).

`again` was 4th worst on the density ranking. Heaviest jargon: "slope-bending reform," "ratcheted into new spending is the variable that decides when the next vote is needed," "treating reform as the intervening variable assumes the political prerequisites exist."

## What changed

- **All three answer headers** lead with the claim (memory `feedback_answer_headers_lead_with_claim`)
- **Evidence B chart** updated to match the new levy chart visualization: phased-in Tier 3 override pushing total revenue toward the expense line, then expenses continuing past it. Same SVG geometry as #672.
- **Wage-offset qualifier** added to Evidence C's "Reform options" point (memory `feedback_wage_offset`)
- Killed: "slope-bending reform," "ratcheted into," "intervening variable," "political prerequisites," "sized-well"

All facts preserved (tier sizes $9M/$12M/$15M, FinCom 5%/yr assumption, FY27 11% actual premium increase, Melrose $7.7M→$13.5M case study, etc.).

## Test plan

- [ ] Eyeball at `?q=again` on preview
- [ ] Confirm Evidence B chart matches the levy section's chart visually
- [ ] Confirm wage-offset qualifier reads naturally