### PR TITLE
Add social media plan

### DIFF
--- a/SOCIAL_MEDIA_PLAN.md
+++ b/SOCIAL_MEDIA_PLAN.md
@@ -61,7 +61,7 @@ anything opinion-adjacent.
 ### Weeks 4-5: Substantive pages (May 19 - May 30)
 
 - Where has the money gone
-- How we got here (FinCom warning arc)
+- How we got here (<abbr class="g" title="Finance Committee">FinCom</abbr> warning arc)
 - The debate (both sides steelmanned)
 - Senior tax relief
 - What is the override
@@ -104,6 +104,6 @@ it lets people make comparisons that support their arguments. Frame it as
 ## Tone rules
 
 - No opinion on how people should vote
-- No "shocking" or editorial framing
+- No editorial language or loaded adjectives
 - Match the site voice: factual, sourced, neutral
 - Third-party coverage (Marblehead Current) does the credibility work

--- a/SOCIAL_MEDIA_PLAN.md
+++ b/SOCIAL_MEDIA_PLAN.md
@@ -1,0 +1,109 @@
+# Social Media Plan
+
+Marblehead Data Facebook page, created April 24, 2026.
+47 days to the June 9 override vote.
+
+## Page setup
+
+- **Name:** Marblehead Data
+- **Category:** Reference Website + Community Organization
+- **Action button:** Learn More -> marbleheaddata.org
+- **Profile pic:** Lighthouse favicon on navy `#1B3A57`, 512x512
+- **Cover photo:** Sustainability chart (revenue vs expenses, FY18 lines-cross)
+
+## Why Facebook
+
+- 26% of site traffic (122/462 visitors in first 30 days) comes from Facebook
+- The override debate is happening in Marblehead Facebook groups
+- Instagram is a poor fit (3 visitors, data-heavy content, no in-post links)
+- WhatsApp is group-chat based, not public discovery
+- No paid ads -- organic sharing in FB groups is the growth lever
+
+## Traffic baseline (first 30 days, Apr 12-24)
+
+| Metric | Value |
+|---|---|
+| Unique visitors | 462 |
+| Pageviews | 3,432 |
+| Bounce rate | 20.8% |
+| Avg session duration | 9m 49s |
+| Mobile / Desktop | 57% / 40% |
+| Peak day | Monday |
+| Top source after direct | Facebook (26%) |
+
+## Posting cadence
+
+3x/week: Monday, Wednesday, Friday mornings. Monday is peak traffic day.
+
+## Content calendar
+
+The order is deliberate: tools first to build trust, then how the site
+works, then substantive override-adjacent content last.
+
+### Weeks 1-2: Data tools (Apr 24 - May 9)
+
+| Date | Page | Status |
+|---|---|---|
+| Thu Apr 24 | Town Explorer (launch post) | Posted |
+| Thu Apr 24 | Marblehead Current article (shared on page) | Posted |
+| Wed Apr 30 | Deficit model (interactive sliders) | |
+| Fri May 2 | Four-town tax rate comparison | |
+| Mon May 5 | Enrollment vs staffing | |
+| Wed May 7 | Revenue vs expenses (sustainability) | |
+| Fri May 9 | About / sources / methodology | |
+
+### Week 3: How the site works (May 12-16)
+
+Reinforce sourcing and neutrality. Show the data catalog, explain
+primary vs secondary sources. Build credibility before touching
+anything opinion-adjacent.
+
+### Weeks 4-5: Substantive pages (May 19 - May 30)
+
+- Where has the money gone
+- How we got here (FinCom warning arc)
+- The debate (both sides steelmanned)
+- Senior tax relief
+- What is the override
+- Inside school staffing
+
+### Weeks 6-7: Pre-vote (Jun 2-6)
+
+- Re-share top performers (check PostHog for which posts drove clicks)
+- Share any new pages built in the interim
+- Final post Fri Jun 6: roundup linking the homepage
+
+## Post format
+
+- Post from personal account (Andrew Baber) in groups; from the page on the page
+- One link per post (to the site, not to the FB page)
+- Attach a screenshot image -- more feed real estate than link preview cards
+- Branded screenshot template: navy `#1B3A57` frame, lighthouse, URL (Canva)
+- Mention the page with @ tag at the end for discoverability
+
+## Group posting order
+
+1. General Marblehead community group (neutral ground)
+2. Pro-override or town services groups (friendly, builds followers)
+3. Anti-override group last (after page has traction)
+
+For anti-override groups, lead with the Town Explorer tool specifically --
+it lets people make comparisons that support their arguments. Frame it as
+"here's a data tool," not "here's a site about the override."
+
+## Key decisions
+
+- Lead with tools first, override content last
+- No Facebook link on the site until 50+ followers
+- No email collection before June 9
+- No Instagram, no WhatsApp, no paid ads
+- Screenshots should use neutral default views (no pre-sorted conclusions)
+- Every post links to a specific page, not just the homepage
+  (exception: group introduction posts link to homepage)
+
+## Tone rules
+
+- No opinion on how people should vote
+- No "shocking" or editorial framing
+- Match the site voice: factual, sourced, neutral
+- Third-party coverage (Marblehead Current) does the credibility work

--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ defaults:
 exclude:
   - README.md
   - STYLE_GUIDE.md
+  - SOCIAL_MEDIA_PLAN.md
   - LICENSE
   - docs/
   - data/acfr/


### PR DESCRIPTION
## Summary
- Adds `SOCIAL_MEDIA_PLAN.md` with 7-week Facebook posting calendar, growth tactics, and tone rules for the pre-override-vote period (through June 9, 2026)
- Excludes it from the Jekyll build in `_config.yml`

## Test plan
- [ ] Verify `SOCIAL_MEDIA_PLAN.md` does not appear on the built site

🤖 Generated with [Claude Code](https://claude.com/claude-code)