### PR TITLE
Add "After the no-vote" page: did Marblehead find the money?

### DIFF
--- a/after-the-no-vote.html
+++ b/after-the-no-vote.html
@@ -7,7 +7,36 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
 ---
 <h1>After the no-vote: did Marblehead find the money?</h1>
 
+  <div class="key-stats">
+    <div class="key-stat">
+      <div class="key-stat-value">2 of 2</div>
+      <div class="key-stat-label">Recent Marblehead overrides defeated (2022, 2023)</div>
+    </div>
+    <div class="key-stat">
+      <div class="key-stat-value">~$4.7M</div>
+      <div class="key-stat-label">Free cash drawn down to absorb the gap, FY23&ndash;FY25</div>
+    </div>
+    <div class="key-stat">
+      <div class="key-stat-value">$10.2M &rarr; $5M</div>
+      <div class="key-stat-label">Free cash operating draw, FY23 peak to FY27 proposed</div>
+    </div>
+    <div class="key-stat">
+      <div class="key-stat-value">5 of 7</div>
+      <div class="key-stat-label">Peer MA towns where threatened cuts actually landed</div>
+    </div>
+  </div>
+
   <p class="page-lead">Two of the most common objections to the override are "they'll find the money" and "the threatened cuts won't really happen." Marblehead has run the test twice, in June 2022 and June 2023. The honest answer is that yes, the town did find the money both times, at a real and traceable cost: about $4.7M of <abbr class="g" title="The certified unreserved fund balance from the prior fiscal year, appropriated into the next year's operating budget">free cash</abbr> drawdown across FY23 to FY25, partial school workforce attrition, one-time superintendent separation savings, and new local-option taxes. The mechanism worked twice. The reserves it ran on are now nearly gone.</p>
+
+  <div class="takeaway takeaway--neutral">
+    <p><strong>The short version.</strong></p>
+    <ul>
+      <li>The June 2022 school override was for <em>adding</em> things, so its defeat is a weak test of "find the money." Nothing existing was eliminated because nothing existing was at stake.</li>
+      <li>The June 2023 general government override <em>is</em> a real test. The cuts mostly happened: school side by attrition (staff resigned for jobs in other districts before the school year), town side by leaving already-vacant positions vacant.</li>
+      <li>The money came from free cash, not creative budgeting. The peak operating draw of $10.2M (FY23) is projected at $5M for FY27. The Finance Committee has called this draw "unsustainable" in writing every year since 2019.</li>
+      <li>In 5 of 7 peer MA towns surveyed, the threatened position cuts actually landed. The exceptions (Belmont, Newton) leaned on one-time pandemic relief and unusually large free-cash positions that are not available again.</li>
+    </ul>
+  </div>
 
   <nav class="page-toc" aria-label="On this page">
     <span class="page-toc-label">On this page</span>
@@ -35,6 +64,10 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
   </div>
 
   <h2 data-stance-section="what-was-threatened" id="what-was-threatened">June 2023: what was threatened pre-vote</h2>
+
+  <div class="takeaway takeaway--neutral">
+    <p><strong>33 school positions plus 6 town positions plus facility maintenance, named and itemized.</strong> The town side included Kezer's pre-vote concession that most of the named cuts were already vacant.</p>
+  </div>
 
   <p>The pre-vote impact list was concrete and itemized. Town Administrator Thatcher Kezer and Superintendent John Buckey both put names and dollars on what would be lost.</p>
 
@@ -65,6 +98,10 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
 
   <h2 data-stance-section="what-happened" id="what-happened">What actually happened</h2>
 
+  <div class="takeaway takeaway--neutral">
+    <p><strong>School cuts mostly happened, by attrition rather than layoff. Town vacancies stayed vacant.</strong> Neither the "they didn't really cut anything" story nor the "everything threatened was implemented as written" story matches.</p>
+  </div>
+
   <p>The override failed. The cuts that followed do not match a simple "they didn't really cut anything" story, and they also do not match a "everything in the threat list was implemented as written" story.</p>
 
   <div class="card">
@@ -81,7 +118,9 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
 
   <h2 data-stance-section="where-the-money-came-from" id="where-the-money-came-from">Where the money came from</h2>
 
-  <p>Four mechanisms absorbed the $2.5M the override would have raised, plus the cost of services that survived the cut list. None of the four scales to a third use.</p>
+  <div class="takeaway takeaway--neutral">
+    <p><strong>Free cash drawdown, voluntary attrition, the Buckey separation, and new local-option taxes.</strong> Four mechanisms absorbed the $2.5M the override would have raised. None of the four scales to a third use.</p>
+  </div>
 
   <div class="card">
     <h3>1. Free cash drawdown ($4.7M cumulative across FY23 to FY25)</h3>
@@ -133,6 +172,10 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
 
   <h2 data-stance-section="third-try" id="third-try">What's different about a third try</h2>
 
+  <div class="takeaway takeaway--neutral">
+    <p><strong>The four conditions that made "find the money" work in 2023 do not hold for FY27.</strong> Free cash is half its FY23 peak, the superintendent line is settled, voluntary attrition would now mean losing teachers the district wants to keep, and local-option taxes are already in the baseline.</p>
+  </div>
+
   <p>The "find the money" play in 2023 worked because Marblehead started with $10.2M of free cash in the operating budget, an active superintendent who could be parted with, identified staff who could leave on their own, and untapped local-option taxes. None of those four conditions hold for FY27.</p>
 
   <ul>
@@ -145,6 +188,10 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
   <p>None of this proves a third "find the money" round is impossible. It does mean the menu is shorter. The 2023 free-cash drawdown plus the Buckey separation plus the local-option-tax additions plus the attrition windfall together added up to roughly the size of the override the town had voted down. There is no obvious 2026 equivalent of those four levers in combination.</p>
 
   <h2 data-stance-section="other-towns" id="other-towns">What other Massachusetts towns did</h2>
+
+  <div class="takeaway takeaway--neutral">
+    <p><strong>Four post-failure patterns. In 5 of 7 peer towns surveyed, the threatened position cuts actually landed.</strong> The two exceptions (Belmont, Newton) leaned on one-time pandemic relief and unusually large free-cash positions that are not available to Marblehead.</p>
+  </div>
 
   <p>Looking beyond Marblehead, recent failed overrides in peer Massachusetts towns fall into four post-failure patterns. The same town can show more than one pattern over time.</p>
 
@@ -176,6 +223,10 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
   <p>For the full town-by-town walkthrough of Melrose, Stoneham, Easton, and Newton, see <a href="data/case_studies">override case studies</a>. For the structural archetypes that explain why some Massachusetts towns run frequent overrides while others do not, see <a href="why-not-elsewhere.html">why do some MA towns run overrides and others don't</a>.</p>
 
   <h2 data-stance-section="honest-concessions" id="honest-concessions">Honest concessions to the skeptic</h2>
+
+  <div class="takeaway takeaway--neutral">
+    <p><strong>The "they'll find the money" objection was empirically correct in Marblehead twice in a row.</strong> Where it breaks down is on extrapolation: the specific mechanisms that absorbed 2022 and 2023 are not available a third time.</p>
+  </div>
 
   <p>The "they'll find the money" objection is not a strawman. It was empirically correct in Marblehead twice in a row, and it has been correct in some peer towns for a few years at a time.</p>
 

--- a/after-the-no-vote.html
+++ b/after-the-no-vote.html
@@ -250,7 +250,7 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
         <div class="cut-row-dollar">$5.0M</div>
       </div>
     </div>
-    <p class="source">Source: Marblehead FinCom Annual Reports for FY22 through FY27, Article "Available Funds Appropriate to Reduce Tax Rate" line. See <a href="data/free_cash_operating_history.csv">data/free_cash_operating_history.csv</a> for the per-year traceback. The FY26 bounce was driven by one-time interest income and revised local receipts; FY27 returns to a $5M draw with the structural gap re-emerging.</p>
+    <p class="source">Source: Marblehead <abbr class="g" title="Finance Committee">FinCom</abbr> Annual Reports for FY22 through FY27, Article "Available Funds Appropriate to Reduce Tax Rate" line. See <a href="data/free_cash_operating_history.csv">data/free_cash_operating_history.csv</a> for the per-year traceback. The FY26 bounce was driven by one-time interest income and revised local receipts; FY27 returns to a $5M draw with the structural gap re-emerging.</p>
   </div>
 
   <div class="card">
@@ -335,13 +335,13 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
     <li><strong>Reading's smaller, transparently-allocated re-ask shows that voter rejection can shape better proposals.</strong> Voters did not "find the money" in Reading, but they also did not just rubber-stamp the original size. The $4.15M that passed was a different proposal, not the same one re-presented.</li>
   </ul>
 
-  <p>Where the skeptic claim breaks down is on extrapolation: "they found the money before, so they'll find it again." Marblehead's free-cash trajectory ($10.2M peak, $5M FY27 proposed) and the case-study record (5 of 7 peer towns implementing the threatened cuts; ARPA and ESSER not coming back) say that the specific mechanisms that absorbed 2022 and 2023 are not available a third time. The structural deficit that the Finance Committee has been writing about every year since 2019 is the same deficit; the reserves used to bridge it are smaller.</p>
+  <p>Where the skeptic claim breaks down is on extrapolation: "they found the money before, so they'll find it again." Marblehead's free-cash trajectory ($10.2M peak, $5M FY27 proposed) and the case-study record (5 of 7 peer towns implementing the threatened cuts; <abbr class="g" title="American Rescue Plan Act">ARPA</abbr> and <abbr class="g" title="Elementary and Secondary School Emergency Relief">ESSER</abbr> not coming back) say that the specific mechanisms that absorbed 2022 and 2023 are not available a third time. The structural deficit that the Finance Committee has been writing about every year since 2019 is the same deficit; the reserves used to bridge it are smaller.</p>
 
   <div class="read-next">
     <div class="read-next-label">Read next</div>
     <a class="read-next-link" href="no-override-budget.html">
       <div class="read-next-title">What's in the no-override budget? &rarr;</div>
-      <div class="read-next-desc">The 22 town positions, 18.25 school FTEs, and 43% library reduction that make up the FY27 balanced-without-override plan.</div>
+      <div class="read-next-desc">The 22 town positions, 18.25 school <abbr class="g" title="Full-Time Equivalent positions">FTE</abbr>s, and 43% library reduction that make up the FY27 balanced-without-override plan.</div>
     </a>
     <a class="read-next-link" href="how-we-got-here.html">
       <div class="read-next-title">How did we get here? &rarr;</div>
@@ -359,7 +359,7 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
 
   <details class="notes">
     <summary>Sources and methodology</summary>
-    <p>Vote totals are from the <a href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride">MA DOR Proposition 2½ Override and Underride Votes</a> database, mirrored locally as <a href="data/marblehead_prop25_votes.csv">data/marblehead_prop25_votes.csv</a> and <a href="data/dor_override_history_all.csv">data/dor_override_history_all.csv</a>. Marblehead free-cash history is in <a href="data/free_cash_operating_history.csv">data/free_cash_operating_history.csv</a>, traced to FinCom Annual Reports for FY22 through FY27.</p>
+    <p>Vote totals are from the <a href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride">MA <abbr class="g" title="Department of Revenue">DOR</abbr> Proposition 2½ Override and Underride Votes</a> database, mirrored locally as <a href="data/marblehead_prop25_votes.csv">data/marblehead_prop25_votes.csv</a> and <a href="data/dor_override_history_all.csv">data/dor_override_history_all.csv</a>. Marblehead free-cash history is in <a href="data/free_cash_operating_history.csv">data/free_cash_operating_history.csv</a>, traced to <abbr class="g" title="Finance Committee">FinCom</abbr> Annual Reports for FY22 through FY27.</p>
     <p>Pre-vote impact lists are reconstructed from contemporaneous Marblehead Current, Patch, and Item Live coverage (March through June 2023) and from Marblehead School Committee minutes for March 13, March 21, and June 29, 2023. Post-vote outcomes are from School Committee minutes for July 6, August 11, and September 21, 2023, and from subsequent Marblehead Current reporting through January 2024.</p>
     <p>Comparable-town facts cite the local newspaper of record for each town. The four-pattern frame is descriptive, not exhaustive: a town may show more than one pattern over time (Belmont showed pattern 1 then pattern 4; Easton has shown pattern 2 twice with a possible pattern 4 ahead).</p>
   </details>

--- a/after-the-no-vote.html
+++ b/after-the-no-vote.html
@@ -5,6 +5,35 @@ og_title: "After the no-vote: did Marblehead find the money?"
 og_description: "What happened after Marblehead's two recent failed overrides (2022 and 2023). The pre-vote threats, what actually got cut, where the money came from, and why the same play cannot run a third time."
 og_url: https://marbleheaddata.org/after-the-no-vote.html
 ---
+<style>
+  /* Page-scoped: scannable bullet list inside a takeaway. */
+  .tldr-list {
+    list-style: none;
+    padding: 0;
+    margin: 6px 0 0;
+  }
+  .tldr-list li {
+    position: relative;
+    padding: 10px 0 10px 22px;
+    border-top: 1px solid var(--divider);
+    line-height: 1.55;
+  }
+  .tldr-list li:first-child { border-top: none; padding-top: 4px; }
+  .tldr-list li:last-child { padding-bottom: 0; }
+  .tldr-list li::before {
+    content: "";
+    position: absolute;
+    left: 4px;
+    top: 18px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--c-teal);
+  }
+  .tldr-list li:first-child::before { top: 12px; }
+  .tldr-list li strong,
+  .tldr-list li em { color: var(--text); }
+</style>
 <h1>After the no-vote: did Marblehead find the money?</h1>
 
   <div class="key-stats">
@@ -30,7 +59,7 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
 
   <div class="takeaway takeaway--neutral">
     <p><strong>The short version.</strong></p>
-    <ul>
+    <ul class="tldr-list">
       <li>The June 2022 school override was for <em>adding</em> things, so its defeat is a weak test of "find the money." Nothing existing was eliminated because nothing existing was at stake.</li>
       <li>The June 2023 general government override <em>is</em> a real test. The cuts mostly happened: school side by attrition (staff resigned for jobs in other districts before the school year), town side by leaving already-vacant positions vacant.</li>
       <li>The money came from free cash, not creative budgeting. The peak operating draw of $10.2M (FY23) is projected at $5M for FY27. The Finance Committee has called this draw "unsustainable" in writing every year since 2019.</li>

--- a/after-the-no-vote.html
+++ b/after-the-no-vote.html
@@ -33,6 +33,65 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
   .tldr-list li:first-child::before { top: 12px; }
   .tldr-list li strong,
   .tldr-list li em { color: var(--text); }
+
+  /* Page-scoped: 2-column "key: value" grid for structured threat lists.
+     Replaces bullet lists where the content is already shaped like a table. */
+  .threat-grid {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 10px 18px;
+    margin: 10px 0 12px;
+    font-size: 0.9375rem;
+    line-height: 1.5;
+  }
+  .threat-grid dt {
+    font-weight: 600;
+    color: var(--text);
+    padding: 6px 0;
+    border-top: 1px solid var(--divider);
+  }
+  .threat-grid dd {
+    margin: 0;
+    color: var(--text-muted);
+    padding: 6px 0;
+    border-top: 1px solid var(--divider);
+  }
+  .threat-grid dt:first-of-type,
+  .threat-grid dd:first-of-type { border-top: none; padding-top: 2px; }
+  @media (max-width: 600px) {
+    .threat-grid {
+      grid-template-columns: 1fr;
+      gap: 0;
+    }
+    .threat-grid dt { padding-bottom: 0; }
+    .threat-grid dd { border-top: none; padding-top: 0; padding-bottom: 10px; }
+    .threat-grid dt:not(:first-of-type) { border-top: 1px solid var(--divider); padding-top: 10px; }
+  }
+
+  /* Page-scoped: compact short-item list inside a card. Lighter than
+     .tldr-list (no dividers); intentional teal dot, indented to clear
+     the card padding. Use for short, parallel bullet items. */
+  .scan-list {
+    list-style: none;
+    padding: 0;
+    margin: 8px 0 12px;
+  }
+  .scan-list li {
+    position: relative;
+    padding: 4px 0 4px 18px;
+    line-height: 1.5;
+  }
+  .scan-list li::before {
+    content: "";
+    position: absolute;
+    left: 2px;
+    top: 13px;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--c-teal);
+    opacity: 0.7;
+  }
 </style>
 <h1>After the no-vote: did Marblehead find the money?</h1>
 
@@ -102,26 +161,36 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
 
   <div class="card">
     <h3>School side: 33 positions plus programs</h3>
-    <ul>
-      <li><strong>High School:</strong> freshman coaches, paraprofessionals, freshman sports</li>
-      <li><strong>Veterans Middle:</strong> librarian, world-language and Latin teacher</li>
-      <li><strong>Village:</strong> physical education teacher, music teacher, two classroom teachers</li>
-      <li><strong>Brown:</strong> special education teacher, tutor, lunch and recess paraprofessionals</li>
-      <li><strong>Glover:</strong> front office clerk, lunch and recess paraprofessionals, reading tutor</li>
-      <li><strong>District-wide:</strong> tech support, custodian, <abbr class="g" title="Human Resources">HR</abbr> director, payroll coordinator</li>
-    </ul>
+    <dl class="threat-grid">
+      <dt>High School</dt>
+      <dd>Freshman coaches, paraprofessionals, freshman sports</dd>
+      <dt>Veterans Middle</dt>
+      <dd>Librarian, world-language and Latin teacher</dd>
+      <dt>Village</dt>
+      <dd>Physical education teacher, music teacher, two classroom teachers</dd>
+      <dt>Brown</dt>
+      <dd>Special education teacher, tutor, lunch and recess paraprofessionals</dd>
+      <dt>Glover</dt>
+      <dd>Front office clerk, lunch and recess paraprofessionals, reading tutor</dd>
+      <dt>District-wide</dt>
+      <dd>Tech support, custodian, <abbr class="g" title="Human Resources">HR</abbr> director, payroll coordinator</dd>
+    </dl>
     <p>Reduced-services budget total: $44,782,273. Level-services would have been $45,971,790.<sup class="cite" data-href="https://www.itemlive.com/2023/03/22/in-marblehead-33-school-jobs-could-be-cut/" data-source="Item Live, &quot;In Marblehead: 33 school jobs could be cut&quot; (March 22, 2023): itemized list of threatened school positions. Reduced and level-services budget figures: Marblehead School Committee minutes, March 21, 2023."></sup></p>
     <p>Superintendent Buckey on the paraprofessional cuts in particular: "Elimination of paraprofessionals... to have to eliminate that position is gut wrenching."<sup class="cite" data-href="https://www.itemlive.com/2023/03/22/in-marblehead-33-school-jobs-could-be-cut/" data-source="Item Live, &quot;In Marblehead: 33 school jobs could be cut&quot; (March 22, 2023): Buckey quote on paraprofessional eliminations."></sup></p>
   </div>
 
   <div class="card">
     <h3>Town side: 6 positions plus facility maintenance</h3>
-    <ul>
-      <li>3 fire positions</li>
-      <li>2 police positions</li>
-      <li>1 <abbr class="g" title="Department of Public Works">DPW</abbr> position</li>
-      <li>Reduced facility maintenance</li>
-    </ul>
+    <dl class="threat-grid">
+      <dt>Fire</dt>
+      <dd>3 positions</dd>
+      <dt>Police</dt>
+      <dd>2 positions</dd>
+      <dt><abbr class="g" title="Department of Public Works">DPW</abbr></dt>
+      <dd>1 position</dd>
+      <dt>Facilities</dt>
+      <dd>Reduced maintenance budget</dd>
+    </dl>
     <p>The most important pre-vote framing on the town side came from Kezer himself, who said publicly that the override was needed to avoid "eliminating positions in public safety and town departments that are mostly currently vacant."<sup class="cite" data-href="https://patch.com/massachusetts/marblehead/marblehead-2-5-million-tax-override-wins-town-meeting-support" data-source="Patch, &quot;Marblehead $2.5 Million Tax Override Wins Town Meeting Support&quot; (May 2, 2023): Kezer pre-vote statement that town-side cuts target positions &quot;mostly currently vacant.&quot;"></sup> That single sentence does most of the work in answering the "scare tactics" question for the town side: the threatened municipal cuts were honest about their own caveat.</p>
   </div>
 
@@ -207,7 +276,7 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
 
   <p>The "find the money" play in 2023 worked because Marblehead started with $10.2M of free cash in the operating budget, an active superintendent who could be parted with, identified staff who could leave on their own, and untapped local-option taxes. None of those four conditions hold for FY27.</p>
 
-  <ul>
+  <ul class="tldr-list">
     <li><strong>Free cash is much smaller.</strong> The FY27 proposed draw is $5M, half the FY23 peak, and even that draw assumes a Free Cash certification roughly in the $7M range. Above-trend interest income and one-time receipts that propped up the FY26 draw are not projected to repeat.</li>
     <li><strong>The Superintendent line has already been turned over.</strong> Cresta's interim role and the subsequent permanent hire mean the one-time savings from a separation are not on the table for FY27. The district is also at a point in the contract cycle where step increases and contractual <abbr class="g" title="Cost of Living Adjustment">COLA</abbr>s are pulling the school appropriation up, not down.</li>
     <li><strong>Voluntary attrition this time means losing teachers Marblehead wants to keep.</strong> The 2023 wave was concentrated on positions the district had identified as cuttable. The FY27 no-override budget reduces 18.25 school <abbr class="g" title="Full-Time Equivalent positions">FTE</abbr>s, of which roughly 9.3 are filled and 8.95 are vacant; resignations among the 9.3 filled positions are not a windfall, they are a hiring problem in a tight regional teacher market.<sup class="cite" data-href="no-override-budget.html" data-source="Marblehead 2026 site, &quot;What's in the no-override budget?&quot;: 18.25 school FTE figure, 9.3 filled and 8.95 vacant breakdown."></sup></li>
@@ -259,7 +328,7 @@ og_url: https://marbleheaddata.org/after-the-no-vote.html
 
   <p>The "they'll find the money" objection is not a strawman. It was empirically correct in Marblehead twice in a row, and it has been correct in some peer towns for a few years at a time.</p>
 
-  <ul>
+  <ul class="tldr-list">
     <li><strong>No catastrophic service collapse followed either Marblehead vote.</strong> Schools opened, fire trucks rolled, police patrolled. Skeptics who said "the sky won't fall" were right about the immediate horizon.</li>
     <li><strong>Most named municipal positions in 2023 were already vacant.</strong> Kezer admitted this on the record before the vote. After defeat, those vacancies stayed vacant.</li>
     <li><strong>Belmont 2021 is the cleanest evidence that "find the money" can buy real time.</strong> A no-vote camp who said the cuts wouldn't materialize was literally correct for about three years, because of an unrepeatable federal cash injection.</li>

--- a/after-the-no-vote.html
+++ b/after-the-no-vote.html
@@ -1,0 +1,216 @@
+---
+title: "After the no-vote: did Marblehead find the money?"
+scripts: [citations]
+og_title: "After the no-vote: did Marblehead find the money?"
+og_description: "What happened after Marblehead's two recent failed overrides (2022 and 2023). The pre-vote threats, what actually got cut, where the money came from, and why the same play cannot run a third time."
+og_url: https://marbleheaddata.org/after-the-no-vote.html
+---
+<h1>After the no-vote: did Marblehead find the money?</h1>
+
+  <p class="page-lead">Two of the most common objections to the override are "they'll find the money" and "the threatened cuts won't really happen." Marblehead has run the test twice, in June 2022 and June 2023. The honest answer is that yes, the town did find the money both times, at a real and traceable cost: about $4.7M of <abbr class="g" title="The certified unreserved fund balance from the prior fiscal year, appropriated into the next year's operating budget">free cash</abbr> drawdown across FY23 to FY25, partial school workforce attrition, one-time superintendent separation savings, and new local-option taxes. The mechanism worked twice. The reserves it ran on are now nearly gone.</p>
+
+  <nav class="page-toc" aria-label="On this page">
+    <span class="page-toc-label">On this page</span>
+    <a href="#two-tests">The two test cases</a>
+    <a href="#what-was-threatened">June 2023: what was threatened</a>
+    <a href="#what-happened">What actually happened</a>
+    <a href="#where-the-money-came-from">Where the money came from</a>
+    <a href="#third-try">What's different about a third try</a>
+    <a href="#other-towns">What other MA towns did</a>
+    <a href="#honest-concessions">Honest concessions</a>
+  </nav>
+
+  <h2 data-stance-section="two-tests" id="two-tests">The two test cases</h2>
+
+  <p>Marblehead voters rejected an operating override in June 2022 and again in June 2023.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride" data-source="MA DOR Proposition 2½ Override and Underride Votes (Marblehead). FY23 school override $3,051,093 lost June 21, 2022 (1,802-3,929); FY24 general government override $2,472,056 lost June 20, 2023 (2,996-3,414)."></sup> The two votes are not equivalent tests of the "find the money" claim.</p>
+
+  <div class="card">
+    <h3>June 2022: $3.05M school override (lost 1,802 to 3,929)</h3>
+    <p>This vote is a weak test of the skeptic's claim. The override was structured to <em>add</em> things, not to preserve existing ones: $1.13M for new personnel, $585K for safety improvements, $282K for curriculum, $375K for tuition-free kindergarten, $497K for benefits on the new staff, plus the often-debated DEI Director position.<sup class="cite" data-href="https://patch.com/massachusetts/marblehead/marblehead-school-tax-override-vote-fails-landslide" data-source="Patch, &quot;Marblehead School Tax Override Vote Fails In Landslide&quot; (June 22, 2022): line items in the $3.05M ask."></sup> When it failed, those things did not happen. Nothing existing was eliminated. Anyone arguing "remember 2022, the threats were exaggerated" is right that no cliff appeared, and is also right that no cuts were actually threatened.</p>
+  </div>
+
+  <div class="card">
+    <h3>June 2023: $2.47M general government override (lost 2,996 to 3,414)</h3>
+    <p>This is the real natural experiment. The override was bundled across schools, fire, police, <abbr class="g" title="Department of Public Works">DPW</abbr>, and facilities, and pre-vote messaging named specific positions and programs that would be cut if it failed. About 400 votes separated the two sides.<sup class="cite" data-href="https://marbleheadcurrent.org/2023/06/20/marblehead-voters-reject-2-5m-general-override/" data-source="Marblehead Current, &quot;Marblehead voters reject $2.5M general override&quot; (June 20, 2023): vote totals and post-defeat statements from Superintendent Buckey, Fire Chief Gilliland, Select Board Chair Grader."></sup> The rest of this page focuses on what was promised and what arrived after this vote.</p>
+  </div>
+
+  <h2 data-stance-section="what-was-threatened" id="what-was-threatened">June 2023: what was threatened pre-vote</h2>
+
+  <p>The pre-vote impact list was concrete and itemized. Town Administrator Thatcher Kezer and Superintendent John Buckey both put names and dollars on what would be lost.</p>
+
+  <div class="card">
+    <h3>School side: 33 positions plus programs</h3>
+    <ul>
+      <li><strong>High School:</strong> freshman coaches, paraprofessionals, freshman sports</li>
+      <li><strong>Veterans Middle:</strong> librarian, world-language and Latin teacher</li>
+      <li><strong>Village:</strong> physical education teacher, music teacher, two classroom teachers</li>
+      <li><strong>Brown:</strong> special education teacher, tutor, lunch and recess paraprofessionals</li>
+      <li><strong>Glover:</strong> front office clerk, lunch and recess paraprofessionals, reading tutor</li>
+      <li><strong>District-wide:</strong> tech support, custodian, <abbr class="g" title="Human Resources">HR</abbr> director, payroll coordinator</li>
+    </ul>
+    <p>Reduced-services budget total: $44,782,273. Level-services would have been $45,971,790.<sup class="cite" data-href="https://www.itemlive.com/2023/03/22/in-marblehead-33-school-jobs-could-be-cut/" data-source="Item Live, &quot;In Marblehead: 33 school jobs could be cut&quot; (March 22, 2023): itemized list of threatened school positions. Reduced and level-services budget figures: Marblehead School Committee minutes, March 21, 2023."></sup></p>
+    <p>Superintendent Buckey on the paraprofessional cuts in particular: "Elimination of paraprofessionals... to have to eliminate that position is gut wrenching."<sup class="cite" data-href="https://www.itemlive.com/2023/03/22/in-marblehead-33-school-jobs-could-be-cut/" data-source="Item Live, &quot;In Marblehead: 33 school jobs could be cut&quot; (March 22, 2023): Buckey quote on paraprofessional eliminations."></sup></p>
+  </div>
+
+  <div class="card">
+    <h3>Town side: 6 positions plus facility maintenance</h3>
+    <ul>
+      <li>3 fire positions</li>
+      <li>2 police positions</li>
+      <li>1 <abbr class="g" title="Department of Public Works">DPW</abbr> position</li>
+      <li>Reduced facility maintenance</li>
+    </ul>
+    <p>The most important pre-vote framing on the town side came from Kezer himself, who said publicly that the override was needed to avoid "eliminating positions in public safety and town departments that are mostly currently vacant."<sup class="cite" data-href="https://patch.com/massachusetts/marblehead/marblehead-2-5-million-tax-override-wins-town-meeting-support" data-source="Patch, &quot;Marblehead $2.5 Million Tax Override Wins Town Meeting Support&quot; (May 2, 2023): Kezer pre-vote statement that town-side cuts target positions &quot;mostly currently vacant.&quot;"></sup> That single sentence does most of the work in answering the "scare tactics" question for the town side: the threatened municipal cuts were honest about their own caveat.</p>
+  </div>
+
+  <h2 data-stance-section="what-happened" id="what-happened">What actually happened</h2>
+
+  <p>The override failed. The cuts that followed do not match a simple "they didn't really cut anything" story, and they also do not match a "everything in the threat list was implemented as written" story.</p>
+
+  <div class="card">
+    <h3>School side: cuts mostly happened, by attrition rather than layoff</h3>
+    <p>Identified-for-cut staff resigned over the spring and summer of 2023 rather than wait through layoff procedures. The school department's own September 2023 financial report described the result this way: "Higher savings in Unemployment due to identifying positions that would be cut if the override didn't pass which led to employees seeking employment elsewhere prior to the start of the school year."<sup class="cite" data-href="https://www.marbleheadschools.org/" data-source="Marblehead School Committee minutes, September 21, 2023: report from Acting Superintendent Cresta on FY23 surplus and unemployment savings linked to pre-school-year resignations of identified-for-cut staff."></sup></p>
+    <p>The functional outcome on the school side: most of the 33 positions did go away. Class sizes and paraprofessional coverage absorbed the gap. The Veterans Middle School librarian was indeed gone. Freshman sports came back only because Town Meeting approved a $12-per-athlete user-fee increase that raised about $26K of new revenue.<sup class="cite" data-href="https://marbleheadcurrent.org/2023/06/30/everythings-on-the-table-school-board-to-revisit-layoffs-demise-of-freshman-sports/" data-source="Marblehead Current, &quot;'Everything's on the table': School board to revisit layoffs, demise of freshman sports&quot; (June 30, 2023): Acting Superintendent Cresta on revisiting the cut list, $500K FY23 surplus, freshman sports user-fee mechanism."></sup></p>
+  </div>
+
+  <div class="card">
+    <h3>Town side: vacancies stayed vacant; no incumbent layoff was reported</h3>
+    <p>Because Kezer had said pre-vote that the named municipal cuts were "mostly currently vacant," the post-vote outcome was straightforward: those vacancies stayed vacant. Fire Chief Jason Gilliland told the Marblehead Current on the night of the vote that "we have open positions that we'll have to fill with overtime."<sup class="cite" data-href="https://marbleheadcurrent.org/2023/06/20/marblehead-voters-reject-2-5m-general-override/" data-source="Marblehead Current, &quot;Marblehead voters reject $2.5M general override&quot; (June 20, 2023): Fire Chief Jason Gilliland on overtime coverage."></sup> No incumbent fire, police, or <abbr class="g" title="Department of Public Works">DPW</abbr> employee layoff appeared in subsequent FY24 reporting.</p>
+    <p>The slow attrition of police and <abbr class="g" title="Department of Public Works">DPW</abbr> headcounts that has been described in 2026 reporting (police down from 32 to 30 sworn officers, <abbr class="g" title="Department of Public Works">DPW</abbr> down from "more than 30 to 19 over the years") is a multi-year drift, not a one-time response to the failed June 2023 vote.</p>
+  </div>
+
+  <h2 data-stance-section="where-the-money-came-from" id="where-the-money-came-from">Where the money came from</h2>
+
+  <p>Four mechanisms absorbed the $2.5M the override would have raised, plus the cost of services that survived the cut list. None of the four scales to a third use.</p>
+
+  <div class="card">
+    <h3>1. Free cash drawdown ($4.7M cumulative across FY23 to FY25)</h3>
+    <p>Free cash is the certified surplus from the prior fiscal year, appropriated into the next year's operating budget. The Finance Committee has been calling this draw "unsustainable" in writing since 2019. The actual operating draws:</p>
+    <div class="cut-list">
+      <div class="cut-row">
+        <div class="cut-row-name">FY23 (peak)</div>
+        <div class="cut-row-bar-wrap"><div class="cut-row-bar" style="width: 100%;"></div></div>
+        <div class="cut-row-dollar">$10.2M</div>
+      </div>
+      <div class="cut-row">
+        <div class="cut-row-name">FY24</div>
+        <div class="cut-row-bar-wrap"><div class="cut-row-bar" style="width: 78%;"></div></div>
+        <div class="cut-row-dollar">$8.0M</div>
+      </div>
+      <div class="cut-row">
+        <div class="cut-row-name">FY25</div>
+        <div class="cut-row-bar-wrap"><div class="cut-row-bar" style="width: 54%;"></div></div>
+        <div class="cut-row-dollar">$5.5M</div>
+      </div>
+      <div class="cut-row">
+        <div class="cut-row-name">FY26</div>
+        <div class="cut-row-bar-wrap"><div class="cut-row-bar" style="width: 69%;"></div></div>
+        <div class="cut-row-dollar">$7.0M</div>
+      </div>
+      <div class="cut-row">
+        <div class="cut-row-name">FY27 (proposed)</div>
+        <div class="cut-row-bar-wrap"><div class="cut-row-bar" style="width: 49%;"></div></div>
+        <div class="cut-row-dollar">$5.0M</div>
+      </div>
+    </div>
+    <p class="source">Source: Marblehead FinCom Annual Reports for FY22 through FY27, Article "Available Funds Appropriate to Reduce Tax Rate" line. See <a href="data/free_cash_operating_history.csv">data/free_cash_operating_history.csv</a> for the per-year traceback. The FY26 bounce was driven by one-time interest income and revised local receipts; FY27 returns to a $5M draw with the structural gap re-emerging.</p>
+  </div>
+
+  <div class="card">
+    <h3>2. Voluntary attrition</h3>
+    <p>School staff identified for elimination resigned for jobs in other districts before the school year began. The district reported "higher savings in Unemployment" because it never had to formally lay them off. This is genuine "find the money" cash, but it has costs that show up later: replacement staff start at lower seniority, taking a wage saving in year one in exchange for a longer raise schedule and a less experienced workforce.</p>
+  </div>
+
+  <div class="card">
+    <h3>3. Buckey separation savings ($250K to $350K, one-time)</h3>
+    <p>Acting Superintendent Cresta reported in August 2023 that the Buckey separation produced "savings due to lower than anticipated unemployment related costs and savings due to new hiring related costs" of an estimated $250K to $350K for FY24.<sup class="cite" data-href="https://www.marbleheadschools.org/" data-source="Marblehead School Committee minutes, August 11, 2023: Acting Superintendent Cresta on $250-$350K savings related to Buckey departure (lower unemployment + new hiring transition)."></sup> That money is not available again.</p>
+  </div>
+
+  <div class="card">
+    <h3>4. New local-option taxes (FY25 onward)</h3>
+    <p>By January 2024, Kezer had said publicly that the FY25 budget could be balanced without an override by reducing the free-cash draw and proposing local-option meals and rooms taxes worth roughly $800K to $1M annually.<sup class="cite" data-href="https://marbleheadcurrent.org/2024/01/24/town-administrator-says-no-override-needed-for-municipal-budget/" data-source="Marblehead Current, &quot;Town administrator says no override needed for municipal budget&quot; (January 24, 2024): Kezer FY25 strategy combining ~$5M free cash draw and local-option meals/rooms taxes (~$800K-$1M)."></sup> Kezer also said in the same interview: "We're not out of the woods, in a long-term sense, of dealing with our structural deficit. Very likely at some point our only option is going to be an override."</p>
+  </div>
+
+  <h2 data-stance-section="third-try" id="third-try">What's different about a third try</h2>
+
+  <p>The "find the money" play in 2023 worked because Marblehead started with $10.2M of free cash in the operating budget, an active superintendent who could be parted with, identified staff who could leave on their own, and untapped local-option taxes. None of those four conditions hold for FY27.</p>
+
+  <ul>
+    <li><strong>Free cash is much smaller.</strong> The FY27 proposed draw is $5M, half the FY23 peak, and even that draw assumes a Free Cash certification roughly in the $7M range. Above-trend interest income and one-time receipts that propped up the FY26 draw are not projected to repeat.</li>
+    <li><strong>The Superintendent line has already been turned over.</strong> Cresta's interim role and the subsequent permanent hire mean the one-time savings from a separation are not on the table for FY27. The district is also at a point in the contract cycle where step increases and contractual <abbr class="g" title="Cost of Living Adjustment">COLA</abbr>s are pulling the school appropriation up, not down.</li>
+    <li><strong>Voluntary attrition this time means losing teachers Marblehead wants to keep.</strong> The 2023 wave was concentrated on positions the district had identified as cuttable. The FY27 no-override budget reduces 18.25 school <abbr class="g" title="Full-Time Equivalent positions">FTE</abbr>s, of which roughly 9.3 are filled and 8.95 are vacant; resignations among the 9.3 filled positions are not a windfall, they are a hiring problem in a tight regional teacher market.<sup class="cite" data-href="no-override-budget.html" data-source="Marblehead 2026 site, &quot;What's in the no-override budget?&quot;: 18.25 school FTE figure, 9.3 filled and 8.95 vacant breakdown."></sup></li>
+    <li><strong>Local-option taxes are already turned on.</strong> The meals and rooms taxes Kezer described in January 2024 are now in the FY26 baseline. They are part of the run-rate that produces the $8.47M FY27 gap, not a tool against it.</li>
+  </ul>
+
+  <p>None of this proves a third "find the money" round is impossible. It does mean the menu is shorter. The 2023 free-cash drawdown plus the Buckey separation plus the local-option-tax additions plus the attrition windfall together added up to roughly the size of the override the town had voted down. There is no obvious 2026 equivalent of those four levers in combination.</p>
+
+  <h2 data-stance-section="other-towns" id="other-towns">What other Massachusetts towns did</h2>
+
+  <p>Looking beyond Marblehead, recent failed overrides in peer Massachusetts towns fall into four post-failure patterns. The same town can show more than one pattern over time.</p>
+
+  <div class="card">
+    <h3>1. Find one-time money</h3>
+    <p><strong>Belmont</strong> rejected a $6.4M override in April 2021. The "calamitous" pre-vote threats did not materialize for about three years because the town deployed roughly $9M of one-time pandemic relief (<abbr class="g" title="American Rescue Plan Act">ARPA</abbr> and <abbr class="g" title="Elementary and Secondary School Emergency Relief">ESSER</abbr>) across FY22 to FY24. A Belmont Voice retrospective quoted one official: "It wouldn't have been $8.4 if the one in '21 had passed."<sup class="cite" data-href="https://belmontvoice.org/override-chronicles-belmonts-8-4m-decision-looms/" data-source="Belmont Voice, &quot;Override Chronicles: Belmont's $8.4M decision looms&quot; (2024): timeline from $6.4M April 2021 failure to $8.4M April 2024 success, with ARPA/ESSER as the bridge mechanism."></sup> When the federal money ran out, Belmont returned in April 2024 and approved an $8.4M override, 31% larger than the 2021 ask.</p>
+    <p><strong>Newton</strong> rejected a $9.2M operating override in March 2023, drew on an unusually large free cash position, and as of April 2026 has not put another operating override on the ballot. A two-week teachers' strike followed in winter 2024; the resulting four-year contract committed roughly $53M in additional salary expense over four years, more than the override would have raised.<sup class="cite" data-href="https://www.bostonglobe.com/2024/02/11/metro/newton-teachers-strike-ends-contract-deal/" data-source="Boston Globe, &quot;Newton teachers strike ends with contract deal&quot; (February 11, 2024): four-year contract terms; cost commentary."></sup></p>
+  </div>
+
+  <div class="card">
+    <h3>2. Absorb the cuts and don't return</h3>
+    <p><strong>Easton</strong> rejected a $4.4M operating override in June 2016 and did not put another operating override on the ballot for nine years, managing within the levy limit through service erosion that the town's own current override page describes as "a decade of austere budgets" with forced overtime in police and fire.<sup class="cite" data-href="https://www.easton.ma.us/override/" data-source="Town of Easton MA, FY27 Operational Override page: characterizes the post-2016 period as &quot;a decade of austere budgets&quot; with structural staffing erosion."></sup> A $7.3M override in June 2025 also failed. Easton is now back on the ballot for FY27 with another override request.</p>
+  </div>
+
+  <div class="card">
+    <h3>3. Come back smaller and more transparent</h3>
+    <p><strong>Reading</strong> rejected a $7.5M general operating override in October 2016, then returned in April 2018 with a $4.15M ask broken out per department in the campaign materials (schools $2.65M, public safety $1.05M, general government $317K, library $127K). It passed 5,117-3,392.<sup class="cite" data-href="https://thereadingpost.com/2018/02/12/letter-yes-for-an-override-in-reading/" data-source="The Reading Post, &quot;Letter: Yes for an Override in Reading&quot; (February 12, 2018): per-department allocation of the $4.15M ask. DOR row: WIN, 5,117-3,392, single ballot question."></sup> The ballot question was a single override, not a menu of separate questions; the "earmarking" was messaging discipline rather than ballot structure.</p>
+  </div>
+
+  <div class="card">
+    <h3>4. Come back larger after damage compounds</h3>
+    <p><strong>Melrose</strong> rejected a $7.7M override in June 2024, cut 61.4 <abbr class="g" title="Full-Time Equivalent positions">FTE</abbr>s across two budgets, and passed a $13.5M override 17 months later, 75% larger than the original ask.<sup class="cite" data-href="https://commonwealthbeacon.org/government/local-government/after-a-prop-2-%C2%BD-defeat-last-year-melrose-passes-13-5-million-override/" data-source="Commonwealth Beacon, &quot;After a Prop 2½ defeat last year, Melrose passes $13.5 million override&quot; (November 2025): 61.4 FTE figure, $13.5M passing tier, 6,018-5,052 result."></sup></p>
+    <p><strong>Westford</strong> rejected a $4.2M operating override in May 2024. By mid-May 2024, 60 employees were impacted through layoffs or reassignments: 20 teacher layoffs, 3 administration layoffs, 22 teacher reassignments, 2 administration reassignments. The FY26 schools budget proposed cutting another 21.4 <abbr class="g" title="Full-Time Equivalent positions">FTE</abbr>s and reducing interventionists by approximately 39%. District administrators warned that one-time runway from revolving accounts is good for "three to four years."<sup class="cite" data-href="https://westfordcat.org/2024/12/district-fy26-budget-proposal-includes-expanded-special-education-programs-interventionist-cuts/" data-source="WestfordCAT, &quot;District FY26 budget proposal includes expanded special education programs, interventionist cuts&quot; (December 2024): post-failure FTE impact, FY26 follow-on cuts, three-to-four-year runway warning."></sup></p>
+    <p><strong>Ipswich</strong> rejected a $2.75M school override in May 2014 by 62 votes. The school committee then cut $1.1M from the FY15 budget, an 11% staffing reduction including 23 teachers and teaching assistants. In May 2015, voters approved a $2.9M school override 2,750-1,973, a 14-point margin and the fastest reversal in this set.<sup class="cite" data-href="https://www.bostonglobe.com/metro/regionals/north/2014/05/31/prop-override-for-school-system-budget-fails-votes/stgrCQqZ3EohNjozXhxFvL/story.html" data-source="Boston Globe, May 31, 2014: Ipswich May 20, 2014 ballot result, 2,131-2,069. May 2015 follow-up: Salem News, &quot;Ipswich voters approve $2.9M school budget override&quot; (May 2015): $2.9M passes 2,750-1,973."></sup></p>
+  </div>
+
+  <p>The first three patterns are sometimes used to argue that an override can be safely rejected; the fourth is the cautionary case. In five of the seven peer towns surveyed (Westford, Melrose, Ipswich, Newton, Easton), the threatened position cuts actually landed at roughly the size and shape pre-vote materials described. Belmont is the cleanest counter-example, and it is also the case with the largest unrepeatable backfill.</p>
+
+  <p>For the full town-by-town walkthrough of Melrose, Stoneham, Easton, and Newton, see <a href="data/case_studies">override case studies</a>. For the structural archetypes that explain why some Massachusetts towns run frequent overrides while others do not, see <a href="why-not-elsewhere.html">why do some MA towns run overrides and others don't</a>.</p>
+
+  <h2 data-stance-section="honest-concessions" id="honest-concessions">Honest concessions to the skeptic</h2>
+
+  <p>The "they'll find the money" objection is not a strawman. It was empirically correct in Marblehead twice in a row, and it has been correct in some peer towns for a few years at a time.</p>
+
+  <ul>
+    <li><strong>No catastrophic service collapse followed either Marblehead vote.</strong> Schools opened, fire trucks rolled, police patrolled. Skeptics who said "the sky won't fall" were right about the immediate horizon.</li>
+    <li><strong>Most named municipal positions in 2023 were already vacant.</strong> Kezer admitted this on the record before the vote. After defeat, those vacancies stayed vacant.</li>
+    <li><strong>Belmont 2021 is the cleanest evidence that "find the money" can buy real time.</strong> A no-vote camp who said the cuts wouldn't materialize was literally correct for about three years, because of an unrepeatable federal cash injection.</li>
+    <li><strong>Reading's smaller, transparently-allocated re-ask shows that voter rejection can shape better proposals.</strong> Voters did not "find the money" in Reading, but they also did not just rubber-stamp the original size. The $4.15M that passed was a different proposal, not the same one re-presented.</li>
+  </ul>
+
+  <p>Where the skeptic claim breaks down is on extrapolation: "they found the money before, so they'll find it again." Marblehead's free-cash trajectory ($10.2M peak, $5M FY27 proposed) and the case-study record (5 of 7 peer towns implementing the threatened cuts; ARPA and ESSER not coming back) say that the specific mechanisms that absorbed 2022 and 2023 are not available a third time. The structural deficit that the Finance Committee has been writing about every year since 2019 is the same deficit; the reserves used to bridge it are smaller.</p>
+
+  <div class="read-next">
+    <div class="read-next-label">Read next</div>
+    <a class="read-next-link" href="no-override-budget.html">
+      <div class="read-next-title">What's in the no-override budget? &rarr;</div>
+      <div class="read-next-desc">The 22 town positions, 18.25 school FTEs, and 43% library reduction that make up the FY27 balanced-without-override plan.</div>
+    </a>
+    <a class="read-next-link" href="how-we-got-here.html">
+      <div class="read-next-title">How did we get here? &rarr;</div>
+      <div class="read-next-desc">The Finance Committee's transmittal-letter arc from the first 2019 deficit warning to the 2026 three-tier override.</div>
+    </a>
+    <a class="read-next-link" href="data/case_studies">
+      <div class="read-next-title">Override case studies &rarr;</div>
+      <div class="read-next-desc">Full Melrose, Stoneham, Easton, and Newton walkthroughs with timelines, charts, and Marblehead context.</div>
+    </a>
+    <a class="read-next-link" href="the-debate.html">
+      <div class="read-next-title">Both sides of the override debate &rarr;</div>
+      <div class="read-next-desc">The strongest version of each case across the six tensions in the FY27 debate.</div>
+    </a>
+  </div>
+
+  <details class="notes">
+    <summary>Sources and methodology</summary>
+    <p>Vote totals are from the <a href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride">MA DOR Proposition 2½ Override and Underride Votes</a> database, mirrored locally as <a href="data/marblehead_prop25_votes.csv">data/marblehead_prop25_votes.csv</a> and <a href="data/dor_override_history_all.csv">data/dor_override_history_all.csv</a>. Marblehead free-cash history is in <a href="data/free_cash_operating_history.csv">data/free_cash_operating_history.csv</a>, traced to FinCom Annual Reports for FY22 through FY27.</p>
+    <p>Pre-vote impact lists are reconstructed from contemporaneous Marblehead Current, Patch, and Item Live coverage (March through June 2023) and from Marblehead School Committee minutes for March 13, March 21, and June 29, 2023. Post-vote outcomes are from School Committee minutes for July 6, August 11, and September 21, 2023, and from subsequent Marblehead Current reporting through January 2024.</p>
+    <p>Comparable-town facts cite the local newspaper of record for each town. The four-pattern frame is descriptive, not exhaustive: a town may show more than one pattern over time (Belmont showed pattern 1 then pattern 4; Easton has shown pattern 2 twice with a possible pattern 4 ahead).</p>
+  </details>

--- a/how-we-got-here.html
+++ b/how-we-got-here.html
@@ -126,6 +126,10 @@ scripts: [citations]
       <div class="read-next-title">What's in the no-override budget? &rarr;</div>
       <div class="read-next-desc">The specific staffing and service cuts in the FY27 balanced budget without an override, line by line.</div>
     </a>
+    <a class="read-next-link" href="after-the-no-vote.html">
+      <div class="read-next-title">After the no-vote: did Marblehead find the money? &rarr;</div>
+      <div class="read-next-desc">The 2022 and 2023 overrides both failed. What was threatened pre-vote, what actually got cut, and where the money came from.</div>
+    </a>
     <a class="read-next-link" href="charts/sustainability.html">
       <div class="read-next-title">Revenue vs. spending over time &rarr;</div>
       <div class="read-next-desc">Interactive chart: general fund revenue, expenses, and free cash usage since FY01.</div>

--- a/no-override-budget.html
+++ b/no-override-budget.html
@@ -237,7 +237,7 @@ og_url: https://marbleheaddata.org/no-override-budget.html
   <p>Full details and sources for each town:</p>
   <a class="btn-link" href="data/case_studies">Override case studies</a>
 
-  <p>For a broader look at how 21 Massachusetts peer towns compare on residential tax share, new growth, and override history, see <a href="why-not-elsewhere.html">why do some MA towns run overrides and others don't</a>.</p>
+  <p>For a broader look at how 21 Massachusetts peer towns compare on residential tax share, new growth, and override history, see <a href="why-not-elsewhere.html">why do some MA towns run overrides and others don't</a>. For Marblehead's own two recent failed overrides (2022 and 2023), what was threatened pre-vote, what actually got cut, and where the money came from, see <a href="after-the-no-vote.html">after the no-vote: did Marblehead find the money?</a></p>
 
   <div class="read-next">
     <div class="read-next-label">Read next</div>

--- a/the-debate.html
+++ b/the-debate.html
@@ -608,6 +608,10 @@ og_url: https://marbleheaddata.org/the-debate.html
       <div class="read-next-title">How did we get here? &rarr;</div>
       <div class="read-next-desc">Seven years of Finance Committee warnings, in their own words. The FY27 override was predicted, in writing, as far back as 2019.</div>
     </a>
+    <a class="read-next-link" href="after-the-no-vote.html">
+      <div class="read-next-title">After the no-vote: did Marblehead find the money? &rarr;</div>
+      <div class="read-next-desc">Marblehead rejected overrides in 2022 and 2023. What was threatened, what actually got cut, and where the money came from. Plus four post-failure patterns from peer MA towns.</div>
+    </a>
     <a class="read-next-link" href="what-you-can-do.html">
       <div class="read-next-title">What can you do? &rarr;</div>
       <div class="read-next-desc">Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight.</div>


### PR DESCRIPTION
## Summary

New page (`after-the-no-vote.html`) addressing two of the most common skeptic objections to the override: "they'll find the money" and "the threatened cuts won't really happen."

Marblehead has run the test twice — failed overrides in June 2022 ($3.05M school) and June 2023 ($2.47M general government). The page documents:

- **What was threatened pre-vote** (33 school positions, 6 town positions, facilities) with named programs and direct quotes from Superintendent Buckey, Town Administrator Kezer, and Fire Chief Gilliland.
- **What actually got cut** (most school positions vacated by attrition rather than layoff per SC minutes 9/21/2023; town-side cuts were "mostly currently vacant" per Kezer's pre-vote admission).
- **Where the money came from** (free cash drawdown $10.2M → $5M projected, Buckey separation savings, voluntary attrition, new meals/rooms taxes).
- **Why a third try is different** (the four mechanisms that worked twice are largely depleted).
- **A four-pattern frame** from peer MA towns: find one-time money (Belmont 2021, Newton 2023), absorb and don't return (Easton 2016/2025), return smaller and more transparent (Reading 2018), return larger after damage compounds (Melrose 2024, Westford 2024, Ipswich 2014).
- **Honest concessions** to the skeptic case where it has been empirically correct.

Cross-links added from `the-debate.html`, `how-we-got-here.html`, and `no-override-budget.html`.

## Test plan

- [ ] Preview deploy renders the new page with citations.js Sources section
- [ ] Page TOC anchors work
- [ ] Read-next links from the-debate, how-we-got-here, and no-override-budget all resolve to the new page
- [ ] No em-dashes (verified: grep clean)
- [ ] No editorial language flagged terms (verified: grep clean)
- [ ] Mobile rendering of `.cut-list` free-cash bars looks reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)