### PR TITLE
Add Prop 2.5 history storybook page

### DIFF
--- a/SOCIAL_MEDIA_PLAN.md
+++ b/SOCIAL_MEDIA_PLAN.md
@@ -60,6 +60,7 @@ anything opinion-adjacent.
 
 ### Weeks 4-5: Substantive pages (May 19 - May 30)
 
+- Prop 2&frac12; history (storybook: 1980 to 2026)
 - Where has the money gone
 - How we got here (<abbr class="g" title="Finance Committee">FinCom</abbr> warning arc)
 - The debate (both sides steelmanned)
@@ -107,3 +108,23 @@ it lets people make comparisons that support their arguments. Frame it as
 - No editorial language or loaded adjectives
 - Match the site voice: factual, sourced, neutral
 - Third-party coverage (Marblehead Current) does the credibility work
+
+## Drafts
+
+### Prop 2&frac12; history (target slot: weeks 4-5, ideally lead-off Mon May 19)
+
+- **Page:** [prop25-story.html](prop25-story.html)
+- **Screenshot:** top key-stats strip (1980 / 2005 / 4 of 13 / 28 of 29). Crop to include the page title and lead paragraph if it fits.
+- **Hook:** the 1980-to-2026 arc. Marblehead is voting again on whether to exceed a cap that a Marblehead resident helped create.
+
+**Post text:**
+
+> 1980: Massachusetts voters pass Proposition 2&frac12;, the law that caps how fast a town's property tax can grow. The statewide campaign is led by Barbara Anderson, a Marblehead resident.
+>
+> 2026: Marblehead is again voting on whether to exceed that cap.
+>
+> A short walkthrough of how the town has voted on its own overrides since 1990. Six no's in the 1990s. A yes era from 2001 to 2005. A sixteen-year stretch when the Finance Committee didn't ask. The most recent operating override failed in 2023 by about 400 votes.
+>
+> Across the full record: voters approved 28 of 29 debt exclusions for buildings, but only 4 of 13 operating overrides.
+>
+> https://marbleheaddata.org/prop25-story.html

--- a/prop25-story.html
+++ b/prop25-story.html
@@ -65,7 +65,7 @@ og_url: https://marbleheaddata.org/prop25-story.html
 
 <blockquote class="quote">
   <p>"The Finance Committee is pleased to report that we will present to you a balanced budget recommendation for the sixteenth consecutive year without proposing a general override of Proposition 2&frac12; to achieve that balance."</p>
-  <footer>Marblehead Finance Committee, 2021 transmittal letter for the FY22 budget. <a href="data/2021_FinCom_Report.pdf">PDF</a>.</footer>
+  <footer>Marblehead Finance Committee, 2021 transmittal letter for the FY22 budget. <a href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2021_FinCom_Report.pdf">PDF</a>.</footer>
 </blockquote>
 
 <p>The only debt-exclusion question on a Marblehead ballot during that stretch that voters rejected was a 2002 ask to bond renovations to Tucker's Wharf, defeated 1,049 to 1,185.<sup class="cite" data-href="data/marblehead_prop25_votes.csv" data-source="Compiled from MA DOR Debt Exclusion Votes (Marblehead, 2002-06-24)."></sup> Every other building question (schools, fire trucks, seawalls, the library) passed.</p>
@@ -73,7 +73,7 @@ og_url: https://marbleheaddata.org/prop25-story.html
 <hr class="year-line">
 <div class="year-label">2022&ndash;2023</div>
 <h2>The streak ends</h2>
-<p>The 2022 Finance Committee letter warned residents that an override would likely be needed the following year.<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2025/05/fincom_report_final_print_2022.pdf" data-source="Marblehead Finance Committee, 2022 transmittal letter (FY23 budget), pp. 2-3."></sup> In 2023, FinCom formally recommended a $2.47M override "to simply maintain the same Town and School services that residents currently receive."<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2025/05/2023-04-28_fincom_report-final.pdf.pdf" data-source="Marblehead Finance Committee, 2023 transmittal letter (FY24 budget), pp. 2-3."></sup></p>
+<p>The 2022 Finance Committee letter warned residents that an override would likely be needed the following year.<sup class="cite" data-href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2022_FinCom_Report.pdf" data-source="Marblehead Finance Committee, 2022 transmittal letter (FY23 budget), pp. 2-3."></sup> In 2023, FinCom formally recommended a $2.47M override "to simply maintain the same Town and School services that residents currently receive."<sup class="cite" data-href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2023_FinCom_Report.pdf" data-source="Marblehead Finance Committee, 2023 transmittal letter (FY24 budget), pp. 2-3."></sup></p>
 
 <p>Town Meeting approved it overwhelmingly. The ballot rejected it.</p>
 
@@ -94,7 +94,7 @@ og_url: https://marbleheaddata.org/prop25-story.html
   </div>
 </div>
 
-<p>The override failed by about 400 votes.<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2025/03/town_meeting_minutes_2023__0.pdf" data-source="2023 Annual Town Meeting minutes, Article 31 (paper ballot 534-230); ballot result 2,992-3,399 from contemporaneous Marblehead Current coverage."></sup> Marblehead has not approved an operating override since.</p>
+<p>The override failed by about 400 votes. Marblehead has not approved an operating override since.</p>
 
 <hr class="year-line">
 <div class="year-label">The pattern</div>
@@ -118,7 +118,7 @@ og_url: https://marbleheaddata.org/prop25-story.html
 <hr class="year-line">
 <div class="year-label">June 9, 2026</div>
 <h2>Three nested tiers, on one ballot</h2>
-<p>The next operating override is on the ballot in six weeks. Town finance projects an $8.47 million budget gap for FY27.<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2026/02/2026-State-of-the-Town-Presenation-Final.pdf" data-source="Town of Marblehead, 2026 State of the Town presentation, January 28, 2026, slide 29."></sup> The Select Board has put forward three nested tiers ($9M, $12M, or $15M) plus a separate $2.3M trash funding question.</p>
+<p>The next operating override is on the ballot in six weeks. Town finance projects an $8.47 million budget gap for FY27.<sup class="cite" data-href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026_State_of_the_Town.pdf" data-source="Town of Marblehead, 2026 State of the Town presentation, January 28, 2026, slide 29."></sup> The Select Board has put forward three nested tiers ($9M, $12M, or $15M) plus a separate $2.3M trash funding question.</p>
 
 <p>If Marblehead approves the override, it will be the first general operating override the town has passed since 2005. If not, it will be the third operating override the town has rejected this decade.</p>
 

--- a/prop25-story.html
+++ b/prop25-story.html
@@ -1,0 +1,143 @@
+---
+title: "Prop 2&frac12; in Marblehead"
+scripts: [citations]
+og_title: "Prop 2½ in Marblehead: a short history"
+og_description: "Forty-five years of Proposition 2½ in Marblehead, from the 1980 campaign run by a Marblehead resident through every override the town has voted on since 1990."
+og_url: https://marbleheaddata.org/prop25-story.html
+---
+<h1>Prop 2&frac12; in Marblehead</h1>
+
+<p class="page-lead">Massachusetts voters passed Proposition 2&frac12; in November 1980. The statewide campaign that put it on the ballot was led from Marblehead. Forty-five years on, the town is again voting on whether to exceed the cap that campaign created. What follows is the short version of how Marblehead has voted on its own overrides in the years between.</p>
+
+<div class="key-stats">
+  <div class="key-stat">
+    <div class="key-stat-value">1980</div>
+    <div class="key-stat-label">Prop 2&frac12; passes</div>
+  </div>
+  <div class="key-stat">
+    <div class="key-stat-value">2005</div>
+    <div class="key-stat-label">last operating override approved</div>
+  </div>
+  <div class="key-stat">
+    <div class="key-stat-value">4 of 13</div>
+    <div class="key-stat-label">operating override ballots approved since 1990</div>
+  </div>
+  <div class="key-stat">
+    <div class="key-stat-value">28 of 29</div>
+    <div class="key-stat-label">debt exclusion ballots approved since 1982</div>
+  </div>
+</div>
+
+<div class="year-label">1980</div>
+<h2>The campaign was run from Marblehead</h2>
+<p>Proposition 2&frac12; was a citizen ballot initiative organized by Citizens for Limited Taxation, a group whose long-time executive director, Barbara Anderson, lived in Marblehead and led it for thirty-five years.<sup class="cite" data-href="https://www.bostonglobe.com/metro/2016/04/09/barbara-anderson-voice-limited-taxation-massachusetts-dies/FdITICwwo6OVFzEXhB1nkL/story.html" data-source="Bryan Marquard, &quot;Barbara Anderson, 73; was the voice of limited taxation in Mass.,&quot; The Boston Globe, April 9, 2016."></sup><sup class="cite" data-href="https://patch.com/massachusetts/marblehead/relentless-taxpayer-advocate-anderson-loses-battle-leukemia-0" data-source="&quot;Barbara Anderson, &lsquo;Relentless&rsquo; Taxpayer Advocate, Loses Battle With Leukemia,&quot; Patch (Marblehead, MA), April 9, 2016."></sup> Voters approved the question that November.</p>
+
+<p>The law that came out of that campaign is the framework every Marblehead override since has had to fit through.</p>
+
+<hr class="year-line">
+<div class="year-label">The law</div>
+<h2>Two ways to exceed the cap, both need a vote</h2>
+<p>Prop 2&frac12; caps the total property tax a town can levy from growing more than 2.5% in a year, plus the value of new construction.<sup class="cite" data-href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter59/Section21C" data-source="Massachusetts General Laws, Chapter 59, Section 21C (Proposition 2½)."></sup> Voters can lift the cap two ways:</p>
+
+<ul>
+  <li><strong>Operating override</strong> &ndash; permanent. Raises the levy limit forever, paying for ongoing costs like salaries, utilities, and supplies.</li>
+  <li><strong>Debt exclusion</strong> &ndash; temporary. Pays off the bonds for one specific project (a school, a fire truck, a seawall) and rolls off when those bonds mature.</li>
+</ul>
+
+<p>Both require a majority at Town Meeting and a separate majority at the ballot. The two electorates are not the same.</p>
+
+<hr class="year-line">
+<div class="year-label">1990&ndash;1996</div>
+<h2>Six tries, six no's</h2>
+<p>In Prop 2&frac12;'s first decade in Marblehead, six operating override questions came before voters: a $1M general operating override in 1990; three smaller asks in 1991 covering the general budget, town clerk salaries, and Meals on Wheels; and school operating questions in 1995 and 1996.<sup class="cite" data-href="data/marblehead_prop25_votes.csv" data-source="Compiled from Massachusetts Department of Revenue, Proposition 2½ Override & Underride Votes (Marblehead record)."></sup> All six were rejected.</p>
+
+<hr class="year-line">
+<div class="year-label">2001&ndash;2005</div>
+<h2>A yes era</h2>
+<p>The pattern flipped. From June 2001 through June 2005, voters approved overrides on four separate ballot days, including a $300K sewer override in 2001, a $1.4M supplemental in 2003, a mixed slate of six questions in 2004 (three approved, three rejected), and a $2.73 million supplemental in 2005.<sup class="cite" data-href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=votes.prop2_5.overrideunderride" data-source="MA DOR, Proposition 2½ Override & Underride Votes (Marblehead record, ballot days 2001-06-18, 2003-06-16, 2004-06-21, 2005-06-15)."></sup></p>
+
+<p>The June 2005 vote remains the last general operating override Marblehead has approved.</p>
+
+<hr class="year-line">
+<div class="year-label">2006&ndash;2021</div>
+<h2>Sixteen years without an override request</h2>
+<p>For sixteen straight budgets after 2005, the Finance Committee did not ask voters for an operating override. Each year's transmittal letter to Town Meeting said so directly:</p>
+
+<blockquote class="quote">
+  <p>"The Finance Committee is pleased to report that we will present to you a balanced budget recommendation for the sixteenth consecutive year without proposing a general override of Proposition 2&frac12; to achieve that balance."</p>
+  <footer>Marblehead Finance Committee, 2021 transmittal letter for the FY22 budget. <a href="data/2021_FinCom_Report.pdf">PDF</a>.</footer>
+</blockquote>
+
+<p>The only debt-exclusion question on a Marblehead ballot during that stretch that voters rejected was a 2002 ask to bond renovations to Tucker's Wharf, defeated 1,049 to 1,185.<sup class="cite" data-href="data/marblehead_prop25_votes.csv" data-source="Compiled from MA DOR Debt Exclusion Votes (Marblehead, 2002-06-24)."></sup> Every other building question (schools, fire trucks, seawalls, the library) passed.</p>
+
+<hr class="year-line">
+<div class="year-label">2022&ndash;2023</div>
+<h2>The streak ends</h2>
+<p>The 2022 Finance Committee letter warned residents that an override would likely be needed the following year.<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2025/05/fincom_report_final_print_2022.pdf" data-source="Marblehead Finance Committee, 2022 transmittal letter (FY23 budget), pp. 2-3."></sup> In 2023, FinCom formally recommended a $2.47M override "to simply maintain the same Town and School services that residents currently receive."<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2025/05/2023-04-28_fincom_report-final.pdf.pdf" data-source="Marblehead Finance Committee, 2023 transmittal letter (FY24 budget), pp. 2-3."></sup></p>
+
+<p>Town Meeting approved it overwhelmingly. The ballot rejected it.</p>
+
+<div class="vote-chart">
+  <div class="vote-chart-row">
+    <div class="vote-chart-label">Town Meeting<span>May 1, 2023</span></div>
+    <div class="vote-chart-bar">
+      <div class="vote-chart-yes" style="flex: 534;">534 yes</div>
+      <div class="vote-chart-no" style="flex: 230;">230 no</div>
+    </div>
+  </div>
+  <div class="vote-chart-row">
+    <div class="vote-chart-label">Ballot<span>June 20, 2023</span></div>
+    <div class="vote-chart-bar">
+      <div class="vote-chart-yes" style="flex: 2992;">2,992 yes</div>
+      <div class="vote-chart-no" style="flex: 3399;">3,399 no</div>
+    </div>
+  </div>
+</div>
+
+<p>The override failed by about 400 votes.<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2025/03/town_meeting_minutes_2023__0.pdf" data-source="2023 Annual Town Meeting minutes, Article 31 (paper ballot 534-230); ballot result 2,992-3,399 from contemporaneous Marblehead Current coverage."></sup> Marblehead has not approved an operating override since.</p>
+
+<hr class="year-line">
+<div class="year-label">The pattern</div>
+<h2>Yes to buildings, cautious on operating</h2>
+<p>Across every Prop 2&frac12; ballot in Marblehead's record, two pictures emerge. Voters reliably borrow to build things. They are far more reluctant to permanently raise the levy for ongoing costs.</p>
+
+<div class="stat-compare">
+  <div class="stat-row">
+    <div class="stat-label">Operating overrides</div>
+    <div class="stat-bar"><div class="stat-fill" style="width: 30.77%"></div></div>
+    <div class="stat-value">31%<span>4 of 13 approved</span></div>
+  </div>
+  <div class="stat-row">
+    <div class="stat-label">Debt exclusions</div>
+    <div class="stat-bar"><div class="stat-fill" style="width: 96.55%"></div></div>
+    <div class="stat-value">97%<span>28 of 29 approved</span></div>
+  </div>
+  <p class="stat-caption">Marblehead ballot outcomes by measure type. Each ballot day counts as one attempt; a ballot with multiple items is marked approved if at least one item passed. Debt exclusions cover 1982&ndash;2025; operating overrides cover 1990&ndash;2025 (the earliest year in the <abbr class="g" title="Department of Revenue">DOR</abbr> record).<sup class="cite" data-href="data/marblehead_prop25_votes.csv" data-source="Compiled from MA DOR Proposition 2½ Override & Underride Votes and Debt Exclusion Votes (Marblehead record, pulled April 11, 2026)."></sup></p>
+</div>
+
+<hr class="year-line">
+<div class="year-label">June 9, 2026</div>
+<h2>Three nested tiers, on one ballot</h2>
+<p>The next operating override is on the ballot in six weeks. Town finance projects an $8.47 million budget gap for FY27.<sup class="cite" data-href="https://marbleheadma.gov/wp-content/uploads/2026/02/2026-State-of-the-Town-Presenation-Final.pdf" data-source="Town of Marblehead, 2026 State of the Town presentation, January 28, 2026, slide 29."></sup> The Select Board has put forward three nested tiers ($9M, $12M, or $15M) plus a separate $2.3M trash funding question.</p>
+
+<p>If Marblehead approves the override, it will be the first general operating override the town has passed since 2005. If not, it will be the third operating override the town has rejected this decade.</p>
+
+<div class="takeaway takeaway--neutral">
+  Marblehead's record on Prop 2&frac12; is not a story of refusing to spend. It is a story of voters drawing a sharp line between borrowing for buildings (almost always yes) and permanently raising the operating levy (mostly no).
+</div>
+
+<div class="read-next">
+  <div class="read-next-label">Read next</div>
+  <a class="read-next-link" href="what-is-the-override.html">
+    <div class="read-next-title">What is the override? &rarr;</div>
+    <div class="read-next-desc">The three-tier structure, what each tier funds, and how the nested ballot works.</div>
+  </a>
+  <a class="read-next-link" href="how-we-got-here.html">
+    <div class="read-next-title">How did we get here? &rarr;</div>
+    <div class="read-next-desc">Seven years of Finance Committee warnings, in their own words.</div>
+  </a>
+  <a class="read-next-link" href="marblehead-voting-record.html">
+    <div class="read-next-title">Every Prop 2&frac12; vote on record &rarr;</div>
+    <div class="read-next-desc">All ballot questions since 1982, with vote counts, amounts, and primary sources.</div>
+  </a>
+</div>

--- a/prop25-story.html
+++ b/prop25-story.html
@@ -7,7 +7,7 @@ og_url: https://marbleheaddata.org/prop25-story.html
 ---
 <h1>Prop 2&frac12; in Marblehead</h1>
 
-<p class="page-lead">Massachusetts voters passed Proposition 2&frac12; in November 1980. The statewide campaign that put it on the ballot was led from Marblehead. Forty-five years on, the town is again voting on whether to exceed the cap that campaign created. What follows is the short version of how Marblehead has voted on its own overrides in the years between.</p>
+<p class="page-lead">Massachusetts voters passed Proposition 2&frac12; in November 1980. The statewide campaign that put it on the ballot was led by a Marblehead resident. Forty-five years on, the town is again voting on whether to exceed the cap that campaign created. What follows is the short version of how Marblehead has voted on its own overrides in the years between.</p>
 
 <div class="key-stats">
   <div class="key-stat">


### PR DESCRIPTION
## Summary

A short, scrollable history of Proposition 2½ in Marblehead, framed as a series of beats:

- **1980** — the statewide campaign was led from Marblehead by Barbara Anderson (Citizens for Limited Taxation, 35-year executive director)
- **The law** — operating override (permanent) vs. debt exclusion (temporary)
- **1990–1996** — six operating override attempts, all rejected
- **2001–2005** — yes era; last general operating override approved was the $2.73M supplemental in June 2005
- **2006–2021** — sixteen years FinCom did not request an override
- **2022–2023** — the streak ends; FY24 override fails at the ballot by ~400 votes
- **The pattern** — 28 of 29 debt exclusions approved, 4 of 13 operating overrides approved
- **June 9, 2026** — the current three-tier ballot

Every number traces to a primary source: MA DOR Override/Underride Database, MGL c. 59 § 21C, FinCom transmittal letters, 2026 State of the Town. Barbara Anderson's Marblehead residency cited from Boston Globe and Marblehead Patch obituaries (April 2016).

Reuses existing classes (`year-label`, `vote-chart`, `stat-compare`, `key-stat`, `takeaway`) — no new CSS.

Scope is limited to the new page only; not adding a homepage card in this PR.

## Test plan

- [ ] Verify page renders on Cloudflare preview at `/prop25-story.html`
- [ ] Verify citations footnoting (`assets/citations.js`) auto-numbers all 9 `<sup class="cite">` markers and generates a Sources section
- [ ] Verify mobile layout (year labels, vote-chart, stat-compare bars all readable below 600px)
- [ ] Verify all internal links work (`what-is-the-override.html`, `how-we-got-here.html`, `marblehead-voting-record.html`, `data/marblehead_prop25_votes.csv`, `data/2021_FinCom_Report.pdf`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)