### PR TITLE
Town Explorer: collapse filters by default

### DIFF
--- a/charts/town_explorer.html
+++ b/charts/town_explorer.html
@@ -19,12 +19,14 @@ scripts: [citations]
     padding: 2px 0;
   }
   .filter-details > summary::-webkit-details-marker { display: none; }
-  .filter-details > summary::before {
-    content: '\25B8'; font-size: 10px; color: var(--text-subtle);
-    transition: transform 0.15s; display: inline-block;
+  .filter-icon {
+    width: 13px; height: 13px; flex-shrink: 0;
+    color: var(--text-subtle); transition: color 0.15s;
   }
-  .filter-details[open] > summary::before { transform: rotate(90deg); }
+  .filter-details[open] > summary .filter-icon { color: var(--c-teal); }
   .filter-details > summary:hover { color: var(--text); }
+  .filter-details > summary:hover .filter-icon { color: var(--text); }
+  .filter-details[open] > summary:hover .filter-icon { color: var(--c-teal); }
   .filter-details > summary:focus { outline: none; }
   .filter-details > summary:focus-visible {
     outline: 2px solid var(--c-teal); outline-offset: 2px; border-radius: var(--radius-sm);
@@ -291,7 +293,7 @@ scripts: [citations]
 
 <div class="filter-bar" id="filter-bar">
   <details class="filter-details" id="filter-details">
-  <summary class="filter-summary"><span class="filter-summary-label">Filters</span><span class="filter-summary-status" id="filter-summary-status"></span></summary>
+  <summary class="filter-summary"><svg class="filter-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 5h14a1 1 0 0 1 .8 1.6L14 14v5a1 1 0 0 1-1.45.9l-2-1A1 1 0 0 1 10 18v-4L4.2 6.6A1 1 0 0 1 5 5z"/></svg><span class="filter-summary-label">Filters</span><span class="filter-summary-status" id="filter-summary-status"></span></summary>
   <div class="filter-grid">
     <div class="filter-group">
       <label>Population</label>

--- a/charts/town_explorer.html
+++ b/charts/town_explorer.html
@@ -11,10 +11,29 @@ scripts: [citations]
     box-shadow: var(--shadow-sm); padding: 16px 18px 12px;
     margin: 0 0 16px;
   }
-  .filter-bar h3 {
+  .filter-details > summary {
+    list-style: none; cursor: pointer; user-select: none;
+    display: flex; align-items: center; gap: 8px;
     font-size: 11px; font-weight: 700; text-transform: uppercase;
-    letter-spacing: 1px; color: var(--text-subtle); margin: 0 0 12px;
+    letter-spacing: 1px; color: var(--text-subtle);
+    padding: 2px 0;
   }
+  .filter-details > summary::-webkit-details-marker { display: none; }
+  .filter-details > summary::before {
+    content: '\25B8'; font-size: 10px; color: var(--text-subtle);
+    transition: transform 0.15s; display: inline-block;
+  }
+  .filter-details[open] > summary::before { transform: rotate(90deg); }
+  .filter-details > summary:hover { color: var(--text); }
+  .filter-details > summary:focus { outline: none; }
+  .filter-details > summary:focus-visible {
+    outline: 2px solid var(--c-teal); outline-offset: 2px; border-radius: var(--radius-sm);
+  }
+  .filter-summary-status {
+    font-size: 11px; font-weight: 500; color: var(--text-muted);
+    text-transform: none; letter-spacing: 0; margin-left: auto;
+  }
+  .filter-details[open] .filter-grid { margin-top: 12px; }
   .filter-grid {
     display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
     gap: 12px 16px;
@@ -271,7 +290,8 @@ scripts: [citations]
 </div>
 
 <div class="filter-bar" id="filter-bar">
-  <h3>Filters</h3>
+  <details class="filter-details" id="filter-details">
+  <summary class="filter-summary"><span class="filter-summary-label">Filters</span><span class="filter-summary-status" id="filter-summary-status"></span></summary>
   <div class="filter-grid">
     <div class="filter-group">
       <label>Population</label>
@@ -342,6 +362,7 @@ scripts: [citations]
     <button type="button" class="reset-btn" id="show-all">Show all 351</button>
     <span class="filter-count" id="filter-count"></span>
   </div>
+  </details>
   <div class="tier-bar">
     <span class="tier-label">Override tier:</span>
     <button type="button" class="tier-btn" data-tier="0">Current</button>
@@ -414,7 +435,7 @@ scripts: [citations]
   <p><strong>Default filters.</strong> Population 5,000 to 100,000 excludes hamlets and large cities (Boston, Worcester, Springfield, Lowell, Cambridge). <abbr class="g" title="Equalized Valuation">EQV</abbr>/capita capped at $1,000,000 excludes island and resort communities where seasonal property inflates per-capita valuations. Use <em>Show all 351</em> to clear both caps.</p>
   <p><strong>Column definitions.</strong> <em>Income/Cap</em>: <abbr class="g" title="Department of Revenue">DOR</abbr> per-capita income, used in Cherry Sheet aid formulas. <em>Bill/Inc</em>: average single-family tax bill divided by <abbr class="g" title="Department of Revenue">DOR</abbr> per-capita income. <em>Tax Rate</em>: residential property tax rate per $1,000 of assessed value. <em>Res %</em>: share of total property tax levy paid by residential property owners. <em>Levy/Cap</em>: total property tax levy divided by population. <em>New Growth</em>: revenue from new construction as a percentage of total levy, outside Proposition 2&frac12;'s 2.5% cap. <em>People/sq mi</em>: population divided by land area (Census TIGER 2020). <em>Levy/sq mi</em>: total property tax collected divided by land area.</p>
   <p><strong>What is <abbr class="g" title="Equalized Valuation">EQV</abbr>?</strong> The <abbr class="g" title="Department of Revenue">DOR</abbr>'s estimate of the full market value of all taxable property in a municipality, adjusted to a uniform standard across the state for apples-to-apples comparison.</p>
-  <p><strong>Presets.</strong> Each preset button sets the filter ranges to values centered on Marblehead. "Similar overall" narrows population, income, property wealth, homeowner share, and new construction simultaneously. "Similar structure" focuses on homeowner share (90%+) and new construction (under 1%). The filters are always visible, so you can see exactly what ranges are active and adjust them. No hardcoded town lists.</p>
+  <p><strong>Presets.</strong> Each preset button sets the filter ranges to values centered on Marblehead. "Similar overall" narrows population, income, property wealth, homeowner share, and new construction simultaneously. "Similar structure" focuses on homeowner share (90%+) and new construction (under 1%). Clicking a preset expands the filter panel so you can see exactly what ranges are active and adjust them. No hardcoded town lists.</p>
 </details>
 
 <script>
@@ -591,6 +612,7 @@ scripts: [citations]
 
     tbody.innerHTML = html;
     countEl.textContent = 'Showing ' + filtered.length + ' of 351';
+    updateFilterSummary();
 
     if (mhdInList && mhdRank > 0) {
       var label = COL_LABELS[sortCol] || sortCol;
@@ -752,10 +774,30 @@ scripts: [citations]
     });
   });
 
-  resetBtn.addEventListener('click', function () { activeCohort = ''; activeTier = 0; applyPreset(DEFAULTS); render(); updateCohortBtns(); updateUrl(); });
+  var filterDetails = document.getElementById('filter-details');
+  var filterStatusEl = document.getElementById('filter-summary-status');
+  function filterStateMatches(target) {
+    var f = getFilters();
+    return Object.keys(target).every(function (k) {
+      var t = target[k];
+      if (t === '' || t === null || t === undefined) return f[k] === null;
+      return f[k] === t;
+    });
+  }
+  function updateFilterSummary() {
+    if (!filterStatusEl) return;
+    var label;
+    if (filterStateMatches(DEFAULTS)) label = 'defaults';
+    else if (filterStateMatches(SHOW_ALL)) label = 'all 351';
+    else label = 'custom';
+    filterStatusEl.textContent = '· ' + label;
+  }
+  function openFilters() { if (filterDetails) filterDetails.open = true; }
+
+  resetBtn.addEventListener('click', function () { activeCohort = ''; activeTier = 0; applyPreset(DEFAULTS); render(); updateCohortBtns(); updateUrl(); openFilters(); });
   var showAllBtn = document.getElementById('show-all');
   var SHOW_ALL = { popMin: '', popMax: '', incMin: '', incMax: '', eqvMin: '', eqvMax: '', billMin: '', billMax: '', bpiMin: '', bpiMax: '', rpctMin: '', rpctMax: '', ngMin: '', ngMax: '' };
-  showAllBtn.addEventListener('click', function () { activeCohort = ''; activeTier = 0; applyPreset(SHOW_ALL); render(); updateCohortBtns(); updateUrl(); });
+  showAllBtn.addEventListener('click', function () { activeCohort = ''; activeTier = 0; applyPreset(SHOW_ALL); render(); updateCohortBtns(); updateUrl(); openFilters(); });
   function applyPreset(p) { Object.keys(p).forEach(function (k) { setInput(inputs[k], p[k]); }); }
 
   // Cohort preset buttons: set filters, not hardcoded lists
@@ -782,6 +824,7 @@ scripts: [citations]
       render();
       updateCohortBtns();
       updateUrl();
+      openFilters();
     });
   });
 
@@ -838,6 +881,7 @@ scripts: [citations]
   readUrl();
   updateSortBtns();
   updateCohortBtns();
+  if (activeCohort) openFilters();
   render();
   updateUrl();
 })();


### PR DESCRIPTION
## Summary

- Wraps the seven-input filter grid in a `<details>` element, collapsed by default. The cohort presets, override-tier toggle, rank summary, sort bar, and table now show above the fold without scrolling.
- Lifts the override-tier toggle out of the `<details>` so override scenarios (Current / Tier 1 / 2 / 3) remain a one-click action regardless of filter-panel state.
- Auto-expands the panel when the user clicks a cohort preset or loads a `?cohort=` deep link, so the applied ranges are visible and adjustable.
- Adds a status hint to the summary line: "Filters · defaults" / "· all 351" / "· custom" so users know whether filters are active without opening the panel.
- Updates the methodology copy: clicking a preset is now what surfaces the ranges, so the "always visible" claim is rephrased.

## Why

The 7-cell filter grid was the dominant element on landing — pushing the cohort presets, tier toggle, and table below the fold. The cohort presets already give a one-click discoverable path into filtered views; manual range editing is power-user territory and doesn't need to lead the page.

## Test plan
- [ ] Cold landing: filter panel is collapsed; tier toggle visible; table visible without scroll on desktop.
- [ ] Click a cohort preset → panel auto-expands and shows the ranges that got applied.
- [ ] Toggle a cohort off → panel stays open with defaults restored; status reads "defaults".
- [ ] "Show all 351" → status reads "all 351".
- [ ] Manually edit a range → status reads "custom".
- [ ] Deep link with `?cohort=overall` → panel opens on load with cohort applied.
- [ ] Mobile (≤600px / ≤400px): collapsed by default; expanding still uses 2-col / 1-col grid.
- [ ] Override tier buttons remain visible and clickable when filter panel is collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)