### PR TITLE
Restore votes-strip countdown badges (lost in #544)

### DIFF
--- a/assets/explore.js
+++ b/assets/explore.js
@@ -2388,3 +2388,23 @@
   })();
 
 })();
+
+(function () {
+  var spans = document.querySelectorAll('.votes-strip-countdown[data-date]');
+  var now = new Date();
+  now.setHours(0, 0, 0, 0);
+  spans.forEach(function (el) {
+    var target = new Date(el.getAttribute('data-date') + 'T00:00:00');
+    var diff = Math.ceil((target - now) / 86400000);
+    if (diff > 1) {
+      el.textContent = diff + ' days away';
+    } else if (diff === 1) {
+      el.textContent = 'tomorrow';
+    } else if (diff === 0) {
+      el.textContent = 'today';
+    } else {
+      el.textContent = 'complete';
+      el.classList.add('past');
+    }
+  });
+})();


### PR DESCRIPTION
## Summary

The "X days away" badges next to **Town Meeting (May 4)** and **Election Day (Jun 9)** on the homepage stopped rendering after #544 extracted the inline JS out of `index.html`. The little IIFE that read `data-date` and wrote text into `.votes-strip-countdown` spans never made the trip into `assets/explore.js`.

The markup (`_includes/explore-landing.html:18,24`) and the styling (`assets/explore.css:1688-1704`) were both still present. The CSS rule `.votes-strip-countdown:empty { display: none }` made the regression silent — empty pills hid themselves instead of flickering, so nobody noticed.

This restores the original 14-line IIFE (from #345 / #420) at the bottom of `assets/explore.js`. Today is Apr 26, so once merged the strip will read "Mon, May 4 · 8 days away" and "Tue, Jun 9 · 44 days away".

## Test plan

- [ ] Hit the preview URL homepage, confirm both teal pills render with day counts
- [ ] Inspect the spans and confirm `data-date` is being read