### PR TITLE
Add time and location to Town Meeting line on homepage

### DIFF
--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -15,8 +15,9 @@
       <p class="votes-strip-label">Two votes decide the override</p>
       <div class="votes-strip-steps">
         <div class="votes-strip-step">
-          <div class="votes-strip-step-when">Mon, May 4 <span class="votes-strip-countdown" data-date="2026-05-04"></span></div>
+          <div class="votes-strip-step-when">Mon, May 4 &middot; 7:00 PM <span class="votes-strip-countdown" data-date="2026-05-04"></span></div>
           <div class="votes-strip-step-what">Annual Town Meeting</div>
+          <p class="votes-strip-step-where">Marblehead High School Field House, 2 Humphrey St</p>
           <p class="votes-strip-step-desc">Residents vote yes or no on sending the override to the ballot as three tiers, ceiling $15M. A no ends the override here.</p>
         </div>
         <div class="votes-strip-arrow" aria-hidden="true">&rarr;</div>

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -1709,6 +1709,12 @@
     line-height: 1.35;
     margin-bottom: 4px;
   }
+  .votes-strip-step-where {
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--text-subtle);
+    margin: 0 0 6px;
+  }
   .votes-strip-step-desc {
     font-size: 12px;
     line-height: 1.5;


### PR DESCRIPTION
## Summary

The Town Meeting step in the homepage votes strip now shows when and where:

- **Mon, May 4 · 7:00 PM** (countdown badge sits to the right)
- *Annual Town Meeting*
- **Marblehead High School Field House, 2 Humphrey St**
- Residents vote yes or no on sending the override to the ballot as three tiers, ceiling \$15M.

Address comes from the town's published 2026 Annual Town Meeting notice.

The Election Day step (June 9) is left untouched on purpose — polling happens at multiple precinct locations, not a single address. Happy to add precinct lookup language separately if you want.

## Files

- \`_includes/explore-landing.html\` — append "· 7:00 PM" to the May 4 line, add a new \`.votes-strip-step-where\` element with the building/address.
- \`assets/explore.css\` — add a small style rule for \`.votes-strip-step-where\` (12px, subtle color, sits between the title and description).

## Test plan

- [ ] Hit the preview URL and confirm the May 4 step renders with time + address
- [ ] Confirm mobile (≤540px stacked) layout still looks right
- [ ] Confirm the Jun 9 step is unchanged