### PR TITLE
Balance votes-strip: add precinct line to Election Day step

### DIFF
--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -24,6 +24,7 @@
         <div class="votes-strip-step">
           <div class="votes-strip-step-when">Tue, Jun 9 <span class="votes-strip-countdown" data-date="2026-06-09"></span></div>
           <div class="votes-strip-step-what">Annual Town Election</div>
+          <p class="votes-strip-step-where">Your assigned precinct &middot; <a class="votes-strip-link" href="https://www.sec.state.ma.us/VoterRegistrationSearch/MyVoterRegStatus.aspx">find yours</a></p>
           <p class="votes-strip-step-desc">If Town Meeting sends it forward, voters pick the tier at the ballot. The highest tier with a majority sets the amount.</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

#685 added an address line under the Town Meeting step but left the Election Day step bare, so the left card was visibly taller than the right. This adds a parallel \`.votes-strip-step-where\` line to the June 9 step pointing to the state OVR precinct lookup.

End result on the homepage:

| Town Meeting | Town Election |
|---|---|
| Mon, May 4 · 7:00 PM | Tue, Jun 9 |
| **Annual Town Meeting** | **Annual Town Election** |
| Marblehead High School Field House, 2 Humphrey St | Your assigned precinct · find yours |
| Residents vote yes or no on... | If Town Meeting sends it forward... |

Same OVR link is already used on \`what-you-can-do.html\`. Polling hours intentionally left out — no primary source verified.

## Test plan

- [ ] Confirm the two cards are now roughly the same height on desktop
- [ ] Confirm the "find yours" link opens the OVR lookup
- [ ] Confirm mobile (≤540px stacked) still reads cleanly