### PR TITLE
Plain-language batch: 5 moderate-touch question sections (override, servicelevel, voteno, trash, library, trust)

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,9 +308,6 @@ og_url: https://marbleheaddata.org/
         <a class="evidence-chart-link" href="charts/sustainability.html">
           Full sustainability projections
         </a>
-        <a class="evidence-chart-link" href="charts/deficit_model.html">
-          Build your own deficit projection
-        </a>
         <a class="evidence-chart-link" href="charts/budget_flow.html">
           Where the money goes: spending by category
         </a>
@@ -3008,7 +3005,7 @@ og_url: https://marbleheaddata.org/
             <text class="tick-label" x="140" y="48" text-anchor="end" font-size="12">Library</text>
             <rect class="data-fill s-neutral" x="145" y="36" width="103" height="16" rx="3"/>
             <text class="end-label" x="254" y="48" font-size="11"> -43%</text>
-            <text class="tick-label" x="140" y="74" text-anchor="end" font-size="12">Recreation, Cemetery, Council on Aging</text>
+            <text class="tick-label" x="140" y="74" text-anchor="end" font-size="12">Smaller departments</text>
             <rect class="data-fill s-neutral" x="145" y="62" width="24" height="16" rx="3"/>
             <text class="end-label" x="175" y="74" font-size="11"> positions cut</text>
           </svg>

--- a/index.html
+++ b/index.html
@@ -48,8 +48,9 @@ og_url: https://marbleheaddata.org/
         <p class="answer-label">Answer B</p>
         <h2>I need reform before I fund an override</h2>
         <p class="answer-summary">
-          Structural issues, staffing choices, and the 83% health-insurance
-          premium split were set long before FY27. I want benefits reform or
+          Staff grew while enrollment fell, total compensation runs above
+          peer towns, and the town pays 83% of health-insurance premiums.
+          All three were set long before FY27. I want benefits reform or
           an independent review on the table before I add revenue.
         </p>
       </div>
@@ -60,8 +61,8 @@ og_url: https://marbleheaddata.org/
         <h2>I'll fund the override only if reform runs alongside it</h2>
         <p class="answer-summary">
           The gap is part structure, part choices. My yes depends on a visible
-          commitment to slope-bending reform while the override runs, so we
-          don't just defer the same vote.
+          commitment to real changes in the cost structure while the override
+          runs, so we don't just defer the same vote.
         </p>
       </div>
 
@@ -164,9 +165,9 @@ og_url: https://marbleheaddata.org/
             policy choices the town made over time: the 83% premium
             split, the staffing composition, the pace of hiring. "Locked
             in" is accurate for the FY27 budget cycle but not for a
-            five-year planning horizon. Treating a 12-week crunch as
-            evidence of inevitability skips the question of why longer
-            levers weren't pulled earlier.
+            five-year planning horizon. Treating the next budget year
+            as the only frame skips the question of why the slower
+            fixes weren't pursued earlier.
           </p>
         </div>
       </details>
@@ -389,8 +390,8 @@ og_url: https://marbleheaddata.org/
         <p class="answer-summary">
           An override should deliver something beyond preservation, whether
           that's stronger staffing ratios, restored hours, or service quality
-          peer towns provide today. Loss-aversion framing understates what's
-          on offer.
+          peer towns provide today. Calling it just "preventing cuts"
+          undersells what the override would actually fund.
         </p>
       </div>
 
@@ -488,11 +489,12 @@ og_url: https://marbleheaddata.org/
       <div class="evidence-point">
         <h4>Override framing anchors on loss, not gain</h4>
         <p>
-          Most public materials describe the override as "preventing cuts."
-          A Tier 3 override also funds spending the no-override budget does
-          not: restored positions, <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr> contributions, capital room.
-          Calling it loss-avoidance hides the preservation-plus-improvement
-          option on the ballot.
+          Most coverage describes the override as "preventing cuts."
+          A Tier 3 override also funds things the no-override budget
+          doesn't: restored positions, contributions to the retiree
+          health trust, and room for capital projects. The "just
+          avoiding cuts" framing hides what's actually on offer:
+          preservation plus improvements.
         </p>
         <a class="evidence-chart-link" href="where-has-the-money-gone.html">
           Where the money has gone, and what the tiers would add
@@ -550,12 +552,12 @@ og_url: https://marbleheaddata.org/
 
       <div class="answer-card" data-answer="b" data-question="voteno">
         <p class="answer-label">Answer B</p>
-        <h2>I think the cuts set off losses the budget understates</h2>
+        <h2>The cuts trigger losses the budget doesn't show</h2>
         <p class="answer-summary">
-          Staff leave for higher-paying districts, institutional knowledge
+          Staff leave for higher-paying districts, experience and know-how
           walks out with them, and the next override ends up larger. Peer
-          towns that voted no saw effects the first-year budget did not
-          price in.
+          towns that voted no saw effects the first-year budget didn't
+          account for.
         </p>
       </div>
 
@@ -564,8 +566,9 @@ og_url: https://marbleheaddata.org/
         <h2>I'm voting no because it's the only pressure for reform</h2>
         <p class="answer-summary">
           I'd rather accept the published cuts than approve an override
-          that lets the cost-driver conversation get deferred again. A no
-          vote is the lever I have to force that conversation.
+          that lets the conversation about what's driving costs get put
+          off again. A no vote is the lever I have to force that
+          conversation.
         </p>
       </div>
     </div>
@@ -708,11 +711,12 @@ og_url: https://marbleheaddata.org/
           <span class="evidence-nugget-label">Expense growth the town needs to hit to close the gap without repeated overrides.</span>
         </div>
         <p>
-          Insurance reform (~$1M/yr from moving the premium split from
-          83% to 75%), staffing review, and competitive bidding could
-          bend expense growth from the recent 5% trend toward 3.5%.
-          At that rate, expenses converge back toward revenue. The
-          override buys time but doesn't produce the bend.
+          Lowering the insurance share from 83% to 75% could save about
+          $1M a year, though it usually means bargaining higher wages
+          in exchange. Staffing changes and competitive bidding can
+          also bend expense growth from the recent 5% trend toward
+          3.5%. At that rate, expenses converge back toward revenue.
+          The override buys time but doesn't produce the bend.
         </p>
         <a class="evidence-chart-link" href="charts/deficit_model.html">
           Drag the slider and see when the lines converge
@@ -2667,8 +2671,8 @@ og_url: https://marbleheaddata.org/
         <p class="answer-summary">
           Below the ~$1.21M break-even, the levy route saves my household
           money. The median home ($1.01M) saves about $46/yr; a $500K
-          home saves ~$165/yr. Value-scaled payment is the fairness
-          principle I'd apply.
+          home saves ~$165/yr. Paying based on home value matches my
+          idea of fair.
         </p>
       </div>
 
@@ -2676,20 +2680,20 @@ og_url: https://marbleheaddata.org/
         <p class="answer-label">Answer B</p>
         <h2>Flat fee: fairer because the service is the same</h2>
         <p class="answer-summary">
-          Above the ~$1.21M break-even the flat fee saves money, and the
-          fairness principle I'd apply is that every household gets the
-          same pickup. A $2M home saves ~$184/yr; a $3M home ~$417/yr.
+          Above the ~$1.21M break-even the flat fee saves money, and to
+          me fair means every household pays the same for the same
+          pickup. A $2M home saves ~$184/yr; a $3M home ~$417/yr.
         </p>
       </div>
 
       <div class="answer-card" data-answer="c" data-question="trash">
         <p class="answer-label">Answer C</p>
-        <h2>I'll decide Question 2 on its own, but the trash-budget carve-out still needs an answer</h2>
+        <h2>I'll decide Question 2 on its own; the budget carve-out is a separate concern</h2>
         <p class="answer-summary">
           Trash was already in the budget. The Select Board carved it out,
           freeing $1.15M for other spending. My Q2 vote is about the
           levy-vs-fee split; where the $1.15M went is a separate
-          trust-and-transparency question.
+          question about trust.
         </p>
       </div>
     </div>
@@ -2734,8 +2738,8 @@ og_url: https://marbleheaddata.org/
             fall, change, or get renegotiated, a fee can be adjusted
             or dropped; the raised levy ceiling stays in place
             regardless. Asking who pays for the same service is only
-            one axis of "fair"; how reversible the commitment is, is
-            another.
+            one axis of "fair"; how easy it is to undo the commitment
+            is another.
           </p>
         </div>
       </details>
@@ -2890,7 +2894,8 @@ og_url: https://marbleheaddata.org/
           locked by union contracts. Health-insurance rates are set by the
           <abbr class="g" title="Group Insurance Commission">GIC</abbr>.
           The library has no union, no state funding floor, and voluntary
-          accreditation. 43% is what's structurally left, not a preference.
+          accreditation. 43% is what's legally available to cut, not the
+          town's preference.
         </p>
       </div>
 
@@ -2965,9 +2970,9 @@ og_url: https://marbleheaddata.org/
       <div class="evidence-point">
         <h4>What the town legally cannot cut</h4>
         <p>
-          Pensions (<abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr>-mandated, +$463K in FY27), debt service
-          (contractual bond payments), and Essex Tech assessment (set by
-          the regional district). These lines go up regardless of the
+          Pensions (state-mandated schedule, +$463K in FY27), debt service
+          (contractual bond payments), and the Essex Tech assessment (set
+          by the regional district). These lines go up regardless of the
           override outcome.
         </p>
       </div>
@@ -3121,8 +3126,8 @@ og_url: https://marbleheaddata.org/
         <p class="answer-summary">
           Meetings are poorly attended, budgets are presented as
           take-it-or-leave-it, and few residents have the time to audit
-          200-page financial reports. I don't feel the existing oversight
-          is enough to justify more revenue.
+          200-page financial reports. The oversight that exists isn't
+          enough for me to back more revenue.
         </p>
       </div>
 
@@ -3162,10 +3167,11 @@ og_url: https://marbleheaddata.org/
       <div class="evidence-point">
         <h4>Independent audits and state oversight</h4>
         <p>
-          The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> is audited by an independent firm (clean opinion
-          every year). <abbr class="g" title="Massachusetts Department of Revenue">MA DOR</abbr> reviews tax rates and certifies free
-          cash. <abbr class="g" title="Public Employee Retirement Administration Commission">PERAC</abbr> audits the pension fund. These are not
-          self-reported numbers.
+          The town's annual finance report is audited by an independent
+          firm (clean opinion every year). The state Department of
+          Revenue reviews tax rates and certifies free cash. The state
+          pension oversight agency audits the pension fund. These are
+          not self-reported numbers.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

Sixth in the homepage plain-language pass (issue #657). Bundled batch covering the moderate-touch sections that didn't need full rewrites.

**Bundling justification:** The worst-5 sections (alternatives/schools/levy/again/moneygone) each got their own dedicated PR. These 5 only had 1-3 stiff lines each. Per-PR overhead would have dominated the actual edit work.

## What changed

About 18 surgical edits across 5 sections. All facts and answer positions preserved.

**override** — abstract opener "Structural issues" replaced with the actual three drivers; "slope-bending reform" → "real changes in the cost structure"; "12-week crunch" → "next budget year"

**servicelevel** — "Loss-aversion framing" → "Calling it just 'preventing cuts' undersells what the override would actually fund"; OPEB acronym expanded inline

**voteno** — Answer B header tightened; "institutional knowledge" → "experience and know-how"; "did not price in" → "didn't account for"; **wage-offset qualifier** added to the "$1M/yr premium split" claim per memory `feedback_wage_offset`

**trash** — both A and B fairness-principle openers rewritten in plain English; Answer C header shortened; "trust-and-transparency question" → "separate question about trust"

**library** — "structurally left, not a preference" → "legally available to cut, not the town's preference"; PERAC-mandated → "state-mandated schedule"

**trust** — Answer B summary rephrased; ACFR/MA DOR/PERAC collapsed into plain English

## Test plan

- [ ] Eyeball each of the 5 sections on the preview at `?q=override`, `?q=servicelevel`, `?q=voteno`, `?q=trash`, `?q=library`, `?q=trust`
- [ ] Confirm wage-offset qualifier reads naturally in voteno Evidence C