### PR TITLE
Clean up votes-strip: drop descriptions, link out instead

### DIFF
--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -18,17 +18,15 @@
           <div class="votes-strip-step-when">Mon, May 4 &middot; 7:00 PM <span class="votes-strip-countdown" data-date="2026-05-04"></span></div>
           <div class="votes-strip-step-what">Annual Town Meeting</div>
           <p class="votes-strip-step-where">Marblehead High School Field House, 2 Humphrey St</p>
-          <p class="votes-strip-step-desc">Residents vote yes or no on sending the override to the ballot as three tiers, ceiling $15M. A no ends the override here.</p>
         </div>
         <div class="votes-strip-arrow" aria-hidden="true">&rarr;</div>
         <div class="votes-strip-step">
           <div class="votes-strip-step-when">Tue, Jun 9 <span class="votes-strip-countdown" data-date="2026-06-09"></span></div>
           <div class="votes-strip-step-what">Annual Town Election</div>
           <p class="votes-strip-step-where">Your assigned precinct &middot; <a class="votes-strip-link" href="https://www.sec.state.ma.us/VoterRegistrationSearch/MyVoterRegStatus.aspx">find yours</a></p>
-          <p class="votes-strip-step-desc">If Town Meeting sends it forward, voters pick the tier at the ballot. The highest tier with a majority sets the amount.</p>
         </div>
       </div>
-      <p class="votes-strip-note">Either vote can end the override. <a class="votes-strip-link" href="what-you-can-do.html#your-two-votes">How the two votes work together &rarr;</a></p>
+      <p class="votes-strip-note">Either vote can end the override. <a class="votes-strip-link" href="what-you-can-do.html#your-two-votes">What each vote decides &rarr;</a></p>
     </div>
 
     <!-- Stats strip: progress + engagement + reset -->

--- a/assets/explore.css
+++ b/assets/explore.css
@@ -1713,12 +1713,6 @@
     font-size: 12px;
     line-height: 1.4;
     color: var(--text-subtle);
-    margin: 0 0 6px;
-  }
-  .votes-strip-step-desc {
-    font-size: 12px;
-    line-height: 1.5;
-    color: var(--text-muted);
     margin: 0;
   }
   .votes-strip-arrow {


### PR DESCRIPTION
## Summary

The strip was carrying four stacked text blocks per card (when, what, where, desc) and read busy. The descriptions duplicated what the linked-out explainer already covers, so drop them.

After:

\`\`\`
TWO VOTES DECIDE THE OVERRIDE

MON, MAY 4 · 7:00 PM  [8 days]  →   TUE, JUN 9                  [44 days]
Annual Town Meeting                  Annual Town Election
Marblehead High School Field         Your assigned precinct · find yours
House, 2 Humphrey St

Either vote can end the override. What each vote decides →
\`\`\`

Three lines per card, parallel structure across both votes. The procedural distinction (TM authorizes; ballot picks the tier) now lives entirely on the linked page (\`what-you-can-do.html#your-two-votes\`), and the link text is updated from "How the two votes work together" to "What each vote decides" so the link advertises the content it now carries.

Also removes the unused \`.votes-strip-step-desc\` CSS rule.

## Test plan

- [ ] Both cards render at roughly equal height (small natural variance from the wrapped address is OK)
- [ ] "What each vote decides" link still scrolls to the procedural section
- [ ] Mobile (≤540px stacked) looks clean