### PR TITLE
Wrap Town Meeting address in a Google Maps link

### DIFF
--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -17,7 +17,7 @@
         <div class="votes-strip-step">
           <div class="votes-strip-step-when">Mon, May 4 &middot; 7:00 PM <span class="votes-strip-countdown" data-date="2026-05-04"></span></div>
           <div class="votes-strip-step-what">Annual Town Meeting</div>
-          <p class="votes-strip-step-where">Marblehead High School Field House, 2 Humphrey St</p>
+          <p class="votes-strip-step-where"><a class="votes-strip-link" href="https://www.google.com/maps/search/?api=1&amp;query=Marblehead+High+School+Field+House+2+Humphrey+St+Marblehead+MA">Marblehead High School Field House, 2 Humphrey St</a></p>
         </div>
         <div class="votes-strip-arrow" aria-hidden="true">&rarr;</div>
         <div class="votes-strip-step">


### PR DESCRIPTION
## Summary

Wraps the "Marblehead High School Field House, 2 Humphrey St" line in the homepage votes-strip in a Google Maps search URL. Tap from mobile opens the user's default maps app — iOS users with Apple Maps as default still land in Apple Maps thanks to the \`?api=1&query=...\` form.

URL: \`https://www.google.com/maps/search/?api=1&query=Marblehead+High+School+Field+House+2+Humphrey+St+Marblehead+MA\`

## Test plan

- [ ] Click the address on desktop → opens Google Maps in a new tab
- [ ] Tap the address on iPhone → opens Apple Maps (or Google Maps if default)
- [ ] Address still reads as a single visual line (now teal/underlined)