### PR TITLE
Drop street address from votes-strip Town Meeting line

### DIFF
--- a/_includes/explore-landing.html
+++ b/_includes/explore-landing.html
@@ -17,7 +17,7 @@
         <div class="votes-strip-step">
           <div class="votes-strip-step-when">Mon, May 4 &middot; 7:00 PM <span class="votes-strip-countdown" data-date="2026-05-04"></span></div>
           <div class="votes-strip-step-what">Annual Town Meeting</div>
-          <p class="votes-strip-step-where"><a class="votes-strip-link" href="https://www.google.com/maps/search/?api=1&amp;query=Marblehead+High+School+Field+House+2+Humphrey+St+Marblehead+MA">Marblehead High School Field House, 2 Humphrey St</a></p>
+          <p class="votes-strip-step-where"><a class="votes-strip-link" href="https://www.google.com/maps/search/?api=1&amp;query=Marblehead+High+School+Field+House+2+Humphrey+St+Marblehead+MA">Marblehead High School Field House</a></p>
         </div>
         <div class="votes-strip-arrow" aria-hidden="true">&rarr;</div>
         <div class="votes-strip-step">


### PR DESCRIPTION
## Summary

Visible text shrinks from "Marblehead High School Field House, 2 Humphrey St" to just "Marblehead High School Field House". The Google Maps URL still includes the street address so the link still resolves to the right venue.

## Test plan

- [ ] Address line fits on one line at desktop and mobile widths
- [ ] Tap/click still opens the correct location in Maps