### PR TITLE
Center the votes-strip footer note

### DIFF
--- a/assets/explore.css
+++ b/assets/explore.css
@@ -1727,6 +1727,7 @@
     line-height: 1.5;
     color: var(--text-muted);
     margin: 10px 0 0;
+    text-align: center;
   }
   .votes-strip-link {
     font-weight: 600;


### PR DESCRIPTION
Single-line CSS change: `.votes-strip-note` gets `text-align: center` so the shared footer reads as a footer for both columns rather than trailing the left card.