### PR TITLE
Reword "forty-five years on" -> "forty-five years later"

### DIFF
--- a/prop25-story.html
+++ b/prop25-story.html
@@ -7,7 +7,7 @@ og_url: https://marbleheaddata.org/prop25-story.html
 ---
 <h1>Prop 2&frac12; in Marblehead</h1>
 
-<p class="page-lead">Massachusetts voters passed Proposition 2&frac12; in November 1980. The statewide campaign that put it on the ballot was led by a Marblehead resident. Forty-five years on, the town is again voting on whether to exceed the cap that campaign created. What follows is the short version of how Marblehead has voted on its own overrides in the years between.</p>
+<p class="page-lead">Massachusetts voters passed Proposition 2&frac12; in November 1980. The statewide campaign that put it on the ballot was led by a Marblehead resident. Forty-five years later, the town is again voting on whether to exceed the cap that campaign created. What follows is the short version of how Marblehead has voted on its own overrides in the years between.</p>
 
 <div class="key-stats">
   <div class="key-stat">


### PR DESCRIPTION
## Summary
- Small wording change in the `prop25-story.html` page-lead: "Forty-five years on" -> "Forty-five years later".

## Test plan
- [ ] Eyeball the page-lead on the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)