### PR TITLE
Add 'How are positions actually funded?' section to inside-school-staffing.html

### DIFF
--- a/inside-school-staffing.html
+++ b/inside-school-staffing.html
@@ -56,6 +56,7 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
     <a href="#mandate-vs-discretionary">Mandated vs. discretionary</a>
     <a href="#peer-comparison">How Marblehead compares to peers</a>
     <a href="#the-fy23-mystery">The FY23 data jump</a>
+    <a href="#how-positions-are-funded">How positions are funded</a>
     <a href="#options">What are the options</a>
   </nav>
 
@@ -445,7 +446,7 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
 
   <h3>Where the positions likely went.</h3>
 
-  <p>Circuit Breaker (the state special-education reimbursement that pays for <abbr class="g" title="Special Education">SPED</abbr> staff) tripled the same year: $313K (FY22) to $902K (FY23), then $1.22M (FY24), $1.39M (FY25).<sup class="cite" data-href="data/schools/sc-meetings-fy26/agenda-and-materials-2-5-2026-fy27-budget-packet.txt" data-source="FY27 Superintendent's Proposed Budget packet, Revolving Funds Expenditures table FY22 through FY27"></sup> The FY27 budget shows the practice continuing today: explicit moves like <code>Move 0.5 FTE Asst Stud Srvc Dir from LEA to Tuit Rev</code> recategorize positions across funding sources.<sup class="cite" data-href="data/schools/sc-meetings-fy26/agenda-and-materials-2-5-2026-fy27-budget-packet.txt" data-source="FY27 Superintendent's Proposed Budget packet, Budget Offsets - Funding Sources page (FY27 budget reductions)"></sup> If the FY23 <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> began counting revolving-fund and grant-funded positions, the picture lines up.</p>
+  <p>Circuit Breaker (the state special-education reimbursement that pays for <abbr class="g" title="Special Education">SPED</abbr> staff) tripled the same year: $313K (FY22) to $902K (FY23), then $1.22M (FY24), $1.39M (FY25).<sup class="cite" data-href="data/schools/sc-meetings-fy26/agenda-and-materials-2-5-2026-fy27-budget-packet.txt" data-source="FY27 Superintendent's Proposed Budget packet, Revolving Funds Expenditures table FY22 through FY27"></sup> The FY27 budget shows the practice continuing today: <a href="#how-positions-are-funded">explicit moves like <code>Move 0.5 FTE Asst Stud Srvc Dir from LEA to Tuit Rev</code></a> recategorize positions across funding sources.<sup class="cite" data-href="data/schools/sc-meetings-fy26/agenda-and-materials-2-5-2026-fy27-budget-packet.txt" data-source="FY27 Superintendent's Proposed Budget packet, Budget Offsets - Funding Sources page (FY27 budget reductions)"></sup> If the FY23 <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> began counting revolving-fund and grant-funded positions, the picture lines up.</p>
 
   <h3><abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> shows the opposite trend.</h3>
 
@@ -462,7 +463,63 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
     </div>
   </details>
 
-  <!-- Section 5: Options -->
+  <!-- Section 5: How positions are funded -->
+  <h2 id="how-positions-are-funded">How are positions actually funded?</h2>
+
+  <p>The FY27 budget itemizes about $266,000 in moves where positions stay employed but switch which fund pays them. They appear in the FY27 Superintendent's Proposed Budget packet under "Efficiencies and Reductions":<sup class="cite" data-href="data/schools/sc-meetings-fy26/agenda-and-materials-2-5-2026-fy27-budget-packet.txt" data-source="FY27 Superintendent's Proposed Budget packet (2.5.2026 School Committee meeting), Efficiencies and Reductions Round 1 and Round 2 pages: position transfers from the Local Education Account to revolving and grant funds"></sup></p>
+
+  <table class="peer-table">
+    <thead>
+      <tr>
+        <th>Position</th>
+        <th>From</th>
+        <th>To</th>
+        <th>FY27 General Fund relief</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>2.0 <abbr class="g" title="Full-Time Equivalent">FTE</abbr></td>
+        <td>Local Education Account</td>
+        <td>Educatius revolving</td>
+        <td>$147,586</td>
+      </tr>
+      <tr>
+        <td>0.5 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> Asst Student Services Director</td>
+        <td>Local Education Account</td>
+        <td>Out-of-district tuition revenue</td>
+        <td>$57,680</td>
+      </tr>
+      <tr>
+        <td>0.5 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> Facilities Assistant</td>
+        <td>Local Education Account</td>
+        <td>Building rental revenue</td>
+        <td>$38,257</td>
+      </tr>
+      <tr>
+        <td>0.1 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> Asst Business Manager</td>
+        <td>Local Education Account</td>
+        <td>PK/K tuition revolving</td>
+        <td>$11,536</td>
+      </tr>
+      <tr>
+        <td>0.1 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> Asst Business Manager</td>
+        <td>Local Education Account</td>
+        <td>Federal grants</td>
+        <td>$11,536</td>
+      </tr>
+      <tr>
+        <td colspan="3">Total General Fund relief</td>
+        <td>$266,595</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>None of these positions are cut. The same employees do the same jobs, paid out of rental income, tuition revenue, and grants instead of out of property taxes. The town's level-funded directive is partly met through real position cuts (Round 1 and Round 2 in the same budget packet) and partly through accounting moves of this kind.</p>
+
+  <p>Over years, this is the mechanism behind the <a href="#the-fy23-mystery">FY23 <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> jump</a>: positions stayed employed but moved between funding buckets. The 482.69 to 537.00 leap looks consistent with a one-time consolidation that brought all the previously-moved positions into a single visible count.</p>
+
+  <!-- Section 6: Options -->
   <h2 id="options">What are the options?</h2>
 
   <p>The decomposition above suggests the discretionary slice of staffing growth is roughly 7&ndash;13 positions. That limits how much can be cut without hitting mandate-driven roles. But other levers exist.</p>

--- a/inside-school-staffing.html
+++ b/inside-school-staffing.html
@@ -466,7 +466,9 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
   <!-- Section 5: How positions are funded -->
   <h2 id="how-positions-are-funded">How are positions actually funded?</h2>
 
-  <p>The FY27 school budget lists five positions whose cost moves off property taxes onto other money the schools already collect (rent, tuition, and grants). Same people, same jobs; only the bookkeeping changes. Total cost shifted: $266,595.<sup class="cite" data-href="data/schools/sc-meetings-fy26/agenda-and-materials-2-5-2026-fy27-budget-packet.txt" data-source="FY27 Superintendent's Proposed Budget packet (2.5.2026 School Committee meeting), Efficiencies and Reductions Round 1 and Round 2 pages: position transfers from the Local Education Account to revolving and grant funds"></sup></p>
+  <p>The schools collect money from several places besides property taxes: rent on the school buildings, tuition from international students hosted at <abbr class="g" title="Marblehead High School">MHS</abbr>, tuition from out-of-district students placed in Marblehead programs, <abbr class="g" title="Pre-Kindergarten">PreK</abbr>/Kindergarten tuition, and federal grants. Each one flows into a separate account.</p>
+
+  <p>In a normal year those accounts pay for related expenses (the international-student program's own costs, building maintenance, <abbr class="g" title="Pre-Kindergarten">PreK</abbr> staffing, grant-funded programming). The FY27 budget redirects $266,595 of that money to cover five specific salaries that property taxes used to cover. The same employees keep their jobs. Whatever those accounts were doing before has $266,595 less to work with; the FY27 budget packet does not say what:<sup class="cite" data-href="data/schools/sc-meetings-fy26/agenda-and-materials-2-5-2026-fy27-budget-packet.txt" data-source="FY27 Superintendent's Proposed Budget packet (2.5.2026 School Committee meeting), Efficiencies and Reductions Round 1 and Round 2 pages list these five position transfers; the budget does not itemize what each receiving fund was previously funding"></sup></p>
 
   <table class="peer-table">
     <thead>
@@ -509,9 +511,7 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
     </tbody>
   </table>
 
-  <p>None of these positions are cut. The same employees do the same jobs, paid out of rental income, tuition, and grants instead of out of property taxes. The town's level-funded directive is partly met through real position cuts (Round 1 and Round 2 in the same budget packet) and partly through accounting moves of this kind.</p>
-
-  <p>Over years, this is the mechanism behind the <a href="#the-fy23-mystery">FY23 <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> jump</a>: positions stayed employed but moved between funding buckets. The 482.69 to 537.00 leap looks consistent with a one-time consolidation that brought all the previously-moved positions into a single visible count.</p>
+  <p>Over years, this kind of move is the likely mechanism behind the <a href="#the-fy23-mystery">FY23 <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> jump</a>: positions stayed employed but moved between accounts. The 482.69 to 537.00 leap looks consistent with a one-time consolidation that brought all the previously-moved positions into a single visible count.</p>
 
   <!-- Section 6: Options -->
   <h2 id="options">What are the options?</h2>

--- a/inside-school-staffing.html
+++ b/inside-school-staffing.html
@@ -472,8 +472,8 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
     <thead>
       <tr>
         <th>Position</th>
-        <th>Now paid by</th>
-        <th>Amount</th>
+        <th>Source of money</th>
+        <th>Cost moved off property taxes</th>
       </tr>
     </thead>
     <tbody>

--- a/inside-school-staffing.html
+++ b/inside-school-staffing.html
@@ -466,56 +466,50 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
   <!-- Section 5: How positions are funded -->
   <h2 id="how-positions-are-funded">How are positions actually funded?</h2>
 
-  <p>The FY27 budget itemizes about $266,000 in moves where positions stay employed but switch which fund pays them. They appear in the FY27 Superintendent's Proposed Budget packet under "Efficiencies and Reductions":<sup class="cite" data-href="data/schools/sc-meetings-fy26/agenda-and-materials-2-5-2026-fy27-budget-packet.txt" data-source="FY27 Superintendent's Proposed Budget packet (2.5.2026 School Committee meeting), Efficiencies and Reductions Round 1 and Round 2 pages: position transfers from the Local Education Account to revolving and grant funds"></sup></p>
+  <p>The FY27 school budget lists five positions whose cost moves off property taxes onto other money the schools already collect (rent, tuition, and grants). Same people, same jobs; only the bookkeeping changes. Total cost shifted: $266,595.<sup class="cite" data-href="data/schools/sc-meetings-fy26/agenda-and-materials-2-5-2026-fy27-budget-packet.txt" data-source="FY27 Superintendent's Proposed Budget packet (2.5.2026 School Committee meeting), Efficiencies and Reductions Round 1 and Round 2 pages: position transfers from the Local Education Account to revolving and grant funds"></sup></p>
 
   <table class="peer-table">
     <thead>
       <tr>
         <th>Position</th>
-        <th>From</th>
-        <th>To</th>
-        <th>FY27 General Fund relief</th>
+        <th>Now paid by</th>
+        <th>Amount</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>2.0 <abbr class="g" title="Full-Time Equivalent">FTE</abbr></td>
-        <td>Local Education Account</td>
-        <td>Educatius (foreign tuition) revolving<sup class="cite" data-href="data/schools/sc-meetings-fy26/agenda-and-materials-2-5-2026-fy27-budget-packet.txt" data-source="FY27 Superintendent's Proposed Budget packet, Revenues - Revolving Funds table page 65: 'Foreign Tuition' line shows revenue from this revolving account"></sup></td>
+        <td>Tuition from international students hosted at <abbr class="g" title="Marblehead High School">MHS</abbr><sup class="cite" data-href="data/schools/sc-meetings-fy26/agenda-and-materials-2-5-2026-fy27-budget-packet.txt" data-source="FY27 Superintendent's Proposed Budget packet, page 65 Revolving Funds revenue table lists 'Foreign Tuition' line; budget refers to the receiving fund as 'Educatius'"></sup></td>
         <td>$147,586</td>
       </tr>
       <tr>
-        <td>0.5 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> Asst Student Services Director</td>
-        <td>Local Education Account</td>
-        <td>Out-of-district tuition revenue</td>
+        <td>0.5 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> Assistant Student Services Director</td>
+        <td>Tuition Marblehead receives from out-of-district students</td>
         <td>$57,680</td>
       </tr>
       <tr>
         <td>0.5 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> Facilities Assistant</td>
-        <td>Local Education Account</td>
-        <td>Building rental revenue</td>
+        <td>Rent collected on school buildings</td>
         <td>$38,257</td>
       </tr>
       <tr>
-        <td>0.1 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> Asst Business Manager</td>
-        <td>Local Education Account</td>
-        <td>PK/K tuition revolving</td>
+        <td>0.1 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> Assistant Business Manager</td>
+        <td>PreK/Kindergarten tuition</td>
         <td>$11,536</td>
       </tr>
       <tr>
-        <td>0.1 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> Asst Business Manager</td>
-        <td>Local Education Account</td>
+        <td>0.1 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> Assistant Business Manager</td>
         <td>Federal grants</td>
         <td>$11,536</td>
       </tr>
       <tr>
-        <td colspan="3">Total General Fund relief</td>
+        <td colspan="2">Total cost shifted off property taxes</td>
         <td>$266,595</td>
       </tr>
     </tbody>
   </table>
 
-  <p>None of these positions are cut. The same employees do the same jobs, paid out of rental income, tuition revenue, and grants instead of out of property taxes. The town's level-funded directive is partly met through real position cuts (Round 1 and Round 2 in the same budget packet) and partly through accounting moves of this kind.</p>
+  <p>None of these positions are cut. The same employees do the same jobs, paid out of rental income, tuition, and grants instead of out of property taxes. The town's level-funded directive is partly met through real position cuts (Round 1 and Round 2 in the same budget packet) and partly through accounting moves of this kind.</p>
 
   <p>Over years, this is the mechanism behind the <a href="#the-fy23-mystery">FY23 <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> jump</a>: positions stayed employed but moved between funding buckets. The 482.69 to 537.00 leap looks consistent with a one-time consolidation that brought all the previously-moved positions into a single visible count.</p>
 

--- a/inside-school-staffing.html
+++ b/inside-school-staffing.html
@@ -481,7 +481,7 @@ og_url: https://marbleheaddata.org/inside-school-staffing.html
       <tr>
         <td>2.0 <abbr class="g" title="Full-Time Equivalent">FTE</abbr></td>
         <td>Local Education Account</td>
-        <td>Educatius revolving</td>
+        <td>Educatius (foreign tuition) revolving<sup class="cite" data-href="data/schools/sc-meetings-fy26/agenda-and-materials-2-5-2026-fy27-budget-packet.txt" data-source="FY27 Superintendent's Proposed Budget packet, Revenues - Revolving Funds table page 65: 'Foreign Tuition' line shows revenue from this revolving account"></sup></td>
         <td>$147,586</td>
       </tr>
       <tr>


### PR DESCRIPTION
## Summary

The FY23 mystery section (PR #694) explained the historical mechanism in passing. This adds a visible section showing the same mechanism running in real time: the FY27 Superintendent's Proposed Budget itemizes about $266,000 in explicit moves where positions stay employed but switch which fund pays them.

## What's added

A new h2 section `#how-positions-are-funded` between the FY23 mystery deep-dive and the Options section, with:

- A 5-row table listing the FY27 funding-source moves with dollar values (e.g., `2.0 FTE LEA → Educatius revolving: $147,586`, `0.5 FTE Facilities Assistant LEA → Building Rental Revenue: $38,257`).
- Total General Fund relief: $266,595.
- Two explanatory paragraphs: positions aren't cut, work continues from a different bucket; this is the same mechanism behind the FY23 ACFR jump, now operating in current data.

The FY23 mystery section's "Where the positions likely went" subsection links forward to the new section, and the page TOC includes the new anchor.

## Why

The original "wage-offset analysis" investigation found this mechanism is uncovered on the public site despite being explicit in the FY27 budget packet. It directly extends PR #694's analytical thread without picking a political position: just shows the accounting mechanism.

## Source

All numbers from the FY27 Superintendent's Proposed Budget packet (presented to School Committee Feb 5, 2026), now in the repo at `data/schools/sc-meetings-fy26/agenda-and-materials-2-5-2026-fy27-budget-packet.txt`.

## Test plan

- [ ] View the new section on preview deploy
- [ ] Confirm the TOC link works
- [ ] Confirm the FY23 mystery section's forward-link to the new section works
- [ ] Confirm the table renders cleanly on mobile (uses existing `peer-table` class with right-aligned numeric column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)