### PR TITLE
Add PR template requiring Proof of Work

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,19 @@
 ## Summary
 <what changed and why>
 
+## Preview & How to Test
+
+- **Preview URL**: <full URL to the deployed preview — wait until the deploy is green before pasting; update via PR edit if needed>
+- **Specific paths/screens to check**:
+  1. <e.g. https://preview-url/some/page>
+  2. <another path or modal>
+- **Expected behavior**: <what the reviewer should see / what changed>
+- **Edge cases worth poking**:
+  - <off-the-happy-path case 1>
+  - <case 2>
+
 ## Proof of Work
-<required — see Definition of Done in CLAUDE.md>
+<required — see Definition of Done in box CLAUDE.md>
 
 - [ ] Screenshot / curl output / test output captured against the actual change
 - [ ] Committed to the branch (e.g. `proof/<branch>.png`) and referenced below
@@ -11,4 +22,3 @@
 
 ## Risk
 <what could break and how I would notice>
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+<what changed and why>
+
+## Proof of Work
+<required — see Definition of Done in CLAUDE.md>
+
+- [ ] Screenshot / curl output / test output captured against the actual change
+- [ ] Committed to the branch (e.g. `proof/<branch>.png`) and referenced below
+
+<paste / embed proof here>
+
+## Risk
+<what could break and how I would notice>
+


### PR DESCRIPTION
Adds .github/pull_request_template.md per the box-wide Definition of Done in ~/.claude/CLAUDE.md.

## Proof of Work

This change is documentation-only (a markdown template). Verified by viewing the file on the branch: https://github.com/agbaber/marblehead/blob/add-pr-template/.github/pull_request_template.md