### PR TITLE
Bump to v1.3.0; add release-notes page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Marblehead Budget Data
 description: Open data and charts about Marblehead, MA municipal finances
-last_updated: April 24, 2026
-version: "1.2.0"
+last_updated: April 27, 2026
+version: "1.3.0"
 url: https://marbleheaddata.org
 baseurl: ""
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: Marblehead Budget Data
 description: Open data and charts about Marblehead, MA municipal finances
-last_updated: April 27, 2026
+last_updated: April 26, 2026
 version: "1.3.0"
 url: https://marbleheaddata.org
 baseurl: ""

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,5 +6,5 @@
     <a href="https://github.com/agbaber/marblehead/issues/new?title=Correction%3A+">Report an issue</a>
   </nav>
   <p class="footer-meta">Built by a Marblehead resident &middot; Updated {{ site.last_updated }}</p>
-  <p class="footer-version"><a href="https://github.com/agbaber/marblehead/releases">v{{ site.version }}</a></p>
+  <p class="footer-version"><a href="{{ '/' | relative_url }}data/release-notes.html">v{{ site.version }}</a></p>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,5 +6,5 @@
     <a href="https://github.com/agbaber/marblehead/issues/new?title=Correction%3A+">Report an issue</a>
   </nav>
   <p class="footer-meta">Built by a Marblehead resident &middot; Updated {{ site.last_updated }}</p>
-  <p class="footer-version"><a href="{{ '/' | relative_url }}data/release-notes.html">v{{ site.version }}</a></p>
+  <p class="footer-version"><a href="/data/release-notes.html">v{{ site.version }}</a></p>
 </footer>

--- a/data/release-notes.html
+++ b/data/release-notes.html
@@ -11,14 +11,14 @@ body_class: doc-page
 <p>Three different histories are kept, each with a different purpose:</p>
 
 <ul>
-  <li><strong>Release notes</strong> (this page) &mdash; site versions, grouped by theme. Best place to skim "what's new since I last looked."</li>
-  <li><strong><a href="changelog.html">Data changelog</a></strong> &mdash; primary-source events: meetings, rating actions, state certifications. Records what data changed and why, with before/after values.</li>
-  <li><strong><a href="https://github.com/agbaber/marblehead/commits/main">Git commit history</a></strong> &mdash; every change, in order, with diffs. Authoritative.</li>
+  <li><strong>Release notes</strong> (this page) &ndash; site versions, grouped by theme. Best place to skim "what's new since I last looked."</li>
+  <li><strong><a href="/data/changelog.html">Data changelog</a></strong> &ndash; primary-source events: meetings, rating actions, state certifications. Records what data changed and why, with before/after values.</li>
+  <li><strong><a href="https://github.com/agbaber/marblehead/commits/main">Git commit history</a></strong> &ndash; every change, in order, with diffs. Authoritative.</li>
 </ul>
 
 <p>Versioning follows <a href="https://semver.org/">SemVer</a> loosely: major for site-wide reorganizations, minor for new pages or substantial features, patch for fixes and copy.</p>
 
-<h2 id="v1-3-0">v1.3.0 &mdash; April 26, 2026</h2>
+<h2 id="v1-3-0">v1.3.0 &ndash; April 26, 2026</h2>
 <p>Plain-language pass on the homepage, three new pages, and local Jekyll dev wired up.</p>
 
 <h3>New pages</h3>
@@ -68,7 +68,7 @@ body_class: doc-page
   <li>"forty-five years on" &rarr; "forty-five years later" (<a href="https://github.com/agbaber/marblehead/pull/695">#695</a>)</li>
 </ul>
 
-<h2 id="v1-2-0">v1.2.0 &mdash; April 24, 2026</h2>
+<h2 id="v1-2-0">v1.2.0 &ndash; April 24, 2026</h2>
 <p>Statewide override comparables. Marblehead's three tiers placed in MA-wide context.</p>
 <ul>
   <li>Statewide override history chart: 4,640 ballot questions across 305 MA municipalities, FY1990&ndash;FY2027, with per-question and per-election medians (<a href="https://github.com/agbaber/marblehead/pull/649">#649</a>, <a href="https://github.com/agbaber/marblehead/pull/650">#650</a>)</li>
@@ -80,12 +80,12 @@ body_class: doc-page
   <li>Deficit model: scenario-set refresh (<a href="https://github.com/agbaber/marblehead/pull/601">#601</a>); "Show me how this works" guided tour (<a href="https://github.com/agbaber/marblehead/pull/579">#579</a>)</li>
   <li>April 15 Select Board override deck ingested; calculator updated to phase-in schedule (<a href="https://github.com/agbaber/marblehead/pull/582">#582</a>, <a href="https://github.com/agbaber/marblehead/pull/589">#589</a>, <a href="https://github.com/agbaber/marblehead/pull/593">#593</a>)</li>
   <li>Minutes catalog Phase 2: 331-row catalog and extraction pipeline (<a href="https://github.com/agbaber/marblehead/pull/614">#614</a>, <a href="https://github.com/agbaber/marblehead/pull/615">#615</a>)</li>
-  <li>DLS Schedule A scraper + peer deficit curves chart (<a href="https://github.com/agbaber/marblehead/pull/594">#594</a>)</li>
+  <li><abbr class="g" title="Division of Local Services">DLS</abbr> Schedule A scraper + peer deficit curves chart (<a href="https://github.com/agbaber/marblehead/pull/594">#594</a>)</li>
   <li>Case law note: <em>Emerson v. Boston</em> on fee-vs-tax durability for Q2 trash (<a href="https://github.com/agbaber/marblehead/pull/590">#590</a>, <a href="https://github.com/agbaber/marblehead/pull/611">#611</a>, <a href="https://github.com/agbaber/marblehead/pull/618">#618</a>)</li>
   <li>Style cleanup pass: meta-narration stripped, content guardrails enforced (<a href="https://github.com/agbaber/marblehead/pull/621">#621</a>, <a href="https://github.com/agbaber/marblehead/pull/629">#629</a>)</li>
 </ul>
 
-<h2 id="v1-1-0">v1.1.0 &mdash; April 16, 2026</h2>
+<h2 id="v1-1-0">v1.1.0 &ndash; April 16, 2026</h2>
 <p>Major frontend refactor, CI, PR previews, and the verification network.</p>
 <ul>
   <li>Extract 1,894 lines of explore JS and 1,702 lines of explore CSS from <code>index.html</code> into separate assets (<a href="https://github.com/agbaber/marblehead/pull/534">#534</a>, <a href="https://github.com/agbaber/marblehead/pull/544">#544</a>)</li>
@@ -100,5 +100,5 @@ body_class: doc-page
   <li>Neighbor verification network with passkey auth (initial drop)</li>
 </ul>
 
-<h2 id="v1-0">v1.0 &mdash; April 12, 2026</h2>
+<h2 id="v1-0">v1.0 &ndash; April 12, 2026</h2>
 <p>First version-tagged release. Site reached its current shape after the Jekyll layouts refactor and community-pulse polish; the footer version marker was added in the same window. Pre-v1.0 history is in the <a href="https://github.com/agbaber/marblehead/commits/main">git log</a>.</p>

--- a/data/release-notes.html
+++ b/data/release-notes.html
@@ -18,7 +18,7 @@ body_class: doc-page
 
 <p>Versioning follows <a href="https://semver.org/">SemVer</a> loosely: major for site-wide reorganizations, minor for new pages or substantial features, patch for fixes and copy.</p>
 
-<h2 id="v1-3-0">v1.3.0 &mdash; April 27, 2026</h2>
+<h2 id="v1-3-0">v1.3.0 &mdash; April 26, 2026</h2>
 <p>Plain-language pass on the homepage, three new pages, and local Jekyll dev wired up.</p>
 
 <h3>New pages</h3>
@@ -44,6 +44,7 @@ body_class: doc-page
   <li>Scenario vs. tier comparison + clean tier highlighting (<a href="https://github.com/agbaber/marblehead/pull/671">#671</a>)</li>
   <li>Gap-chart case studies preview (<a href="https://github.com/agbaber/marblehead/pull/628">#628</a>)</li>
   <li>125 documents scraped from marbleheadschools.org: <abbr class="g" title="Collective Bargaining Agreement">CBA</abbr>s, FY27 budget, superintendent contract (<a href="https://github.com/agbaber/marblehead/pull/680">#680</a>)</li>
+  <li>"How are positions actually funded?" section added to inside-school-staffing (<a href="https://github.com/agbaber/marblehead/pull/697">#697</a>)</li>
 </ul>
 
 <h3>UX &amp; navigation</h3>
@@ -67,7 +68,7 @@ body_class: doc-page
   <li>"forty-five years on" &rarr; "forty-five years later" (<a href="https://github.com/agbaber/marblehead/pull/695">#695</a>)</li>
 </ul>
 
-<h2 id="v1-2-0">v1.2.0 &mdash; April 25, 2026</h2>
+<h2 id="v1-2-0">v1.2.0 &mdash; April 24, 2026</h2>
 <p>Statewide override comparables. Marblehead's three tiers placed in MA-wide context.</p>
 <ul>
   <li>Statewide override history chart: 4,640 ballot questions across 305 MA municipalities, FY1990&ndash;FY2027, with per-question and per-election medians (<a href="https://github.com/agbaber/marblehead/pull/649">#649</a>, <a href="https://github.com/agbaber/marblehead/pull/650">#650</a>)</li>

--- a/data/release-notes.html
+++ b/data/release-notes.html
@@ -1,0 +1,103 @@
+---
+title: "Release notes"
+og_title: "Release notes"
+og_description: "Site release history. What changed between versions of marbleheaddata.org, grouped by release. Pairs with the data changelog (which logs primary-source events) and the GitHub commit history (which logs every change)."
+body_class: doc-page
+---
+<h1>Release notes</h1>
+
+<p class="page-lead">A grouped view of what landed in each release of <a href="/">marbleheaddata.org</a>. The current site version appears in the footer.</p>
+
+<p>Three different histories are kept, each with a different purpose:</p>
+
+<ul>
+  <li><strong>Release notes</strong> (this page) &mdash; site versions, grouped by theme. Best place to skim "what's new since I last looked."</li>
+  <li><strong><a href="changelog.html">Data changelog</a></strong> &mdash; primary-source events: meetings, rating actions, state certifications. Records what data changed and why, with before/after values.</li>
+  <li><strong><a href="https://github.com/agbaber/marblehead/commits/main">Git commit history</a></strong> &mdash; every change, in order, with diffs. Authoritative.</li>
+</ul>
+
+<p>Versioning follows <a href="https://semver.org/">SemVer</a> loosely: major for site-wide reorganizations, minor for new pages or substantial features, patch for fixes and copy.</p>
+
+<h2 id="v1-3-0">v1.3.0 &mdash; April 27, 2026</h2>
+<p>Plain-language pass on the homepage, three new pages, and local Jekyll dev wired up.</p>
+
+<h3>New pages</h3>
+<ul>
+  <li><a href="/after-the-no-vote.html">After the no-vote</a>: did Marblehead find the money the last time an override failed? (<a href="https://github.com/agbaber/marblehead/pull/678">#678</a>)</li>
+  <li>Prop 2&frac12; history storybook page (<a href="https://github.com/agbaber/marblehead/pull/681">#681</a>)</li>
+  <li>Level-funding mechanism analysis and retrospective (<a href="https://github.com/agbaber/marblehead/pull/658">#658</a>)</li>
+</ul>
+
+<h3>Plain-language pass on homepage questions (complete)</h3>
+<p>All 15 homepage answer sections rewritten across seven PRs. The "alternatives" section (<a href="https://github.com/agbaber/marblehead/pull/667">#667</a>) is the register reference for the rest.</p>
+<ul>
+  <li>Single-question rewrites: alternatives (<a href="https://github.com/agbaber/marblehead/pull/667">#667</a>), schools (<a href="https://github.com/agbaber/marblehead/pull/669">#669</a>), levy (<a href="https://github.com/agbaber/marblehead/pull/672">#672</a>), again (<a href="https://github.com/agbaber/marblehead/pull/675">#675</a>), moneygone (<a href="https://github.com/agbaber/marblehead/pull/676">#676</a>)</li>
+  <li>Moderate-touch batch: override, servicelevel, voteno, trash, library, trust (<a href="https://github.com/agbaber/marblehead/pull/687">#687</a>)</li>
+  <li>Light-touch batch: taxrank, mycost, size, seniors (<a href="https://github.com/agbaber/marblehead/pull/690">#690</a>)</li>
+</ul>
+
+<h3>Data &amp; analysis</h3>
+<ul>
+  <li>FY23 <abbr class="g" title="Full-Time Equivalent">FTE</abbr> jump resolved: ruled out new hires, narrowed the unknown (<a href="https://github.com/agbaber/marblehead/pull/694">#694</a>)</li>
+  <li>FY26 share-of-spending breakdown added to "where has the money gone" (<a href="https://github.com/agbaber/marblehead/pull/663">#663</a>)</li>
+  <li>Squeeze-mechanism finding reconciled across five pages (<a href="https://github.com/agbaber/marblehead/pull/664">#664</a>)</li>
+  <li>Scenario vs. tier comparison + clean tier highlighting (<a href="https://github.com/agbaber/marblehead/pull/671">#671</a>)</li>
+  <li>Gap-chart case studies preview (<a href="https://github.com/agbaber/marblehead/pull/628">#628</a>)</li>
+  <li>125 documents scraped from marbleheadschools.org: <abbr class="g" title="Collective Bargaining Agreement">CBA</abbr>s, FY27 budget, superintendent contract (<a href="https://github.com/agbaber/marblehead/pull/680">#680</a>)</li>
+</ul>
+
+<h3>UX &amp; navigation</h3>
+<ul>
+  <li>Votes-strip: countdown badges restored (<a href="https://github.com/agbaber/marblehead/pull/684">#684</a>); Town Meeting line gained time and location (<a href="https://github.com/agbaber/marblehead/pull/685">#685</a>) and a Google Maps link (<a href="https://github.com/agbaber/marblehead/pull/691">#691</a>); description paragraphs stripped (<a href="https://github.com/agbaber/marblehead/pull/689">#689</a>); footer note centered (<a href="https://github.com/agbaber/marblehead/pull/693">#693</a>); street address dropped (<a href="https://github.com/agbaber/marblehead/pull/692">#692</a>); parallel where-line for Election Day (<a href="https://github.com/agbaber/marblehead/pull/686">#686</a>)</li>
+  <li>"Pick your first answer" made clickable, scrolls to featured (<a href="https://github.com/agbaber/marblehead/pull/673">#673</a>)</li>
+  <li>Featured-question width matched to in-question width (<a href="https://github.com/agbaber/marblehead/pull/670">#670</a>)</li>
+  <li>Tax-bill toggle inlined into readout, stale hints updated (<a href="https://github.com/agbaber/marblehead/pull/668">#668</a>)</li>
+  <li>Town Explorer: filters collapsed by default (<a href="https://github.com/agbaber/marblehead/pull/683">#683</a>)</li>
+  <li>Deficit model: simple-mode disclosure (<a href="https://github.com/agbaber/marblehead/pull/660">#660</a>)</li>
+</ul>
+
+<h3>Infrastructure</h3>
+<ul>
+  <li>Local Jekyll dev + Playwright smoke against localhost (<a href="https://github.com/agbaber/marblehead/pull/682">#682</a>)</li>
+  <li>Local dev flow documented in <code>CLAUDE.md</code> (<a href="https://github.com/agbaber/marblehead/pull/688">#688</a>)</li>
+</ul>
+
+<h3>Copy</h3>
+<ul>
+  <li>"forty-five years on" &rarr; "forty-five years later" (<a href="https://github.com/agbaber/marblehead/pull/695">#695</a>)</li>
+</ul>
+
+<h2 id="v1-2-0">v1.2.0 &mdash; April 25, 2026</h2>
+<p>Statewide override comparables. Marblehead's three tiers placed in MA-wide context.</p>
+<ul>
+  <li>Statewide override history chart: 4,640 ballot questions across 305 MA municipalities, FY1990&ndash;FY2027, with per-question and per-election medians (<a href="https://github.com/agbaber/marblehead/pull/649">#649</a>, <a href="https://github.com/agbaber/marblehead/pull/650">#650</a>)</li>
+  <li>Override landscape page: every $6M+ override ever attempted in MA (55 of them); Marblehead's three tiers inserted at their positions among comparables</li>
+  <li>Town Explorer additions: density and levy-per-sq-mi columns (<a href="https://github.com/agbaber/marblehead/pull/648">#648</a>); sticky thead and "Show all 351" button (<a href="https://github.com/agbaber/marblehead/pull/651">#651</a>)</li>
+  <li>Question pages polish: key-stats blocks, chart links, read-next (<a href="https://github.com/agbaber/marblehead/pull/635">#635</a>)</li>
+  <li>Meeting video index, AI summarizer, homepage section (<a href="https://github.com/agbaber/marblehead/pull/636">#636</a>)</li>
+  <li>Lint CI: first workflow with three Tier 1 guardrails (<a href="https://github.com/agbaber/marblehead/pull/600">#600</a>), then Tier 2 content guardrails (<a href="https://github.com/agbaber/marblehead/pull/605">#605</a>)</li>
+  <li>Deficit model: scenario-set refresh (<a href="https://github.com/agbaber/marblehead/pull/601">#601</a>); "Show me how this works" guided tour (<a href="https://github.com/agbaber/marblehead/pull/579">#579</a>)</li>
+  <li>April 15 Select Board override deck ingested; calculator updated to phase-in schedule (<a href="https://github.com/agbaber/marblehead/pull/582">#582</a>, <a href="https://github.com/agbaber/marblehead/pull/589">#589</a>, <a href="https://github.com/agbaber/marblehead/pull/593">#593</a>)</li>
+  <li>Minutes catalog Phase 2: 331-row catalog and extraction pipeline (<a href="https://github.com/agbaber/marblehead/pull/614">#614</a>, <a href="https://github.com/agbaber/marblehead/pull/615">#615</a>)</li>
+  <li>DLS Schedule A scraper + peer deficit curves chart (<a href="https://github.com/agbaber/marblehead/pull/594">#594</a>)</li>
+  <li>Case law note: <em>Emerson v. Boston</em> on fee-vs-tax durability for Q2 trash (<a href="https://github.com/agbaber/marblehead/pull/590">#590</a>, <a href="https://github.com/agbaber/marblehead/pull/611">#611</a>, <a href="https://github.com/agbaber/marblehead/pull/618">#618</a>)</li>
+  <li>Style cleanup pass: meta-narration stripped, content guardrails enforced (<a href="https://github.com/agbaber/marblehead/pull/621">#621</a>, <a href="https://github.com/agbaber/marblehead/pull/629">#629</a>)</li>
+</ul>
+
+<h2 id="v1-1-0">v1.1.0 &mdash; April 16, 2026</h2>
+<p>Major frontend refactor, CI, PR previews, and the verification network.</p>
+<ul>
+  <li>Extract 1,894 lines of explore JS and 1,702 lines of explore CSS from <code>index.html</code> into separate assets (<a href="https://github.com/agbaber/marblehead/pull/534">#534</a>, <a href="https://github.com/agbaber/marblehead/pull/544">#544</a>)</li>
+  <li>Extract landing, question nav, and notes panel into Jekyll includes (<a href="https://github.com/agbaber/marblehead/pull/545">#545</a>)</li>
+  <li>Cloudflare Pages PR previews (<a href="https://github.com/agbaber/marblehead/pull/552">#552</a>)</li>
+  <li>CI: Jekyll build + smoke tests against localhost (<a href="https://github.com/agbaber/marblehead/pull/532">#532</a>, <a href="https://github.com/agbaber/marblehead/pull/540">#540</a>)</li>
+  <li>Override vote history chart (<a href="https://github.com/agbaber/marblehead/pull/531">#531</a>)</li>
+  <li>Town Explorer: debt exclusions, three-way vote toggle, override pass-rate column</li>
+  <li>Deficit model: absorption slider, hover tooltips, scenario stories (<a href="https://github.com/agbaber/marblehead/pull/536">#536</a>)</li>
+  <li>Browse-first flow: read evidence before committing a pick (<a href="https://github.com/agbaber/marblehead/pull/522">#522</a>)</li>
+  <li>Verify dashboard redesign with branch hero, network list, invite CTA (<a href="https://github.com/agbaber/marblehead/pull/511">#511</a>); discoverable-credential passkey sign-in (<a href="https://github.com/agbaber/marblehead/pull/518">#518</a>)</li>
+  <li>Neighbor verification network with passkey auth (initial drop)</li>
+</ul>
+
+<h2 id="v1-0">v1.0 &mdash; April 12, 2026</h2>
+<p>First version-tagged release. Site reached its current shape after the Jekyll layouts refactor and community-pulse polish; the footer version marker was added in the same window. Pre-v1.0 history is in the <a href="https://github.com/agbaber/marblehead/commits/main">git log</a>.</p>


### PR DESCRIPTION
## Summary

- Site version `1.2.0` → `1.3.0`; `last_updated` April 24 → April 27, 2026.
- New `data/release-notes.html`: site-version history grouped by theme. Distinguished from:
  - `data/changelog.html` (primary-source events: meetings, rating actions, state certifications), and
  - the GitHub commit history (every change, with diffs).
- v1.3.0 entry covers 34 PRs since v1.2.0: three new pages (After the no-vote, Prop 2½ history storybook, level-funding retrospective), the homepage plain-language pass (now complete across all 15 question sections), local Jekyll dev + Playwright smoke (#682, #688), and assorted UX/data work.
- Older versions (v1.2.0, v1.1.0, v1.0) get condensed retrospective summaries — the page is most useful going forward.
- Footer version link redirected from the empty GitHub releases tab to the new on-site page so it's actually discoverable.

## Why bump now

It's been 3 days and 34 PRs since the v1.2.0 bump on April 25. New pages + complete plain-language pass + new dev infra justify a minor bump under the loose-SemVer convention noted on the page (major = site-wide reorganization, minor = new pages or substantial features, patch = fixes/copy).

## Proof of work

Cannot capture local screenshot proof — Ruby/Bundler aren't installed on this sandbox, so `bundle exec jekyll serve` won't run. Cloudflare Pages PR preview is the verification surface.

**To verify before merging:**
- [ ] Open the Cloudflare preview, click the footer `v1.3.0` badge → should land on the new release-notes page (not GitHub).
- [ ] Skim the v1.3.0 section: PR links resolve, no broken anchors.
- [ ] Confirm `data/changelog.html` still renders unchanged (only mentioned, not edited).
- [ ] Footer on any page shows `Updated April 27, 2026 · v1.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)