### PR TITLE
Add private feedback form (Turnstile + Slack)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -152,9 +152,12 @@ jobs:
           # and relative-up links (../) are skipped - the first two aren't
           # ours to validate, the third depends on the referring page's
           # directory which isn't known to a repo-root check.
+          # Skip hrefs containing Liquid blocks ({{ ... }} or {% ... %});
+          # those resolve at build time and can't be validated statically.
           internal_links=$(printf '%s\n' "$added" \
             | grep -oE 'href="[^"#?]+\.html[^"]*"' \
             | sed 's/href="//; s/"$//' \
+            | grep -vE '\{\{|\{%' \
             | sort -u \
             || true)
           for link in $internal_links; do
@@ -185,6 +188,7 @@ jobs:
           anchor_refs=$(printf '%s\n' "$added" \
             | grep -oE 'href="[^"]+#[^"]+"' \
             | sed 's/href="//; s/"$//' \
+            | grep -vE '\{\{|\{%' \
             | sort -u \
             || true)
           for ref in $anchor_refs; do

--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,10 @@ version: "1.3.0"
 url: https://marbleheaddata.org
 baseurl: ""
 
+# Cloudflare Turnstile site key (public; paired with the
+# TURNSTILE_SECRET secret on the Pages project). Used by feedback.html.
+turnstile_site_key: ""
+
 plugins: []
 
 defaults:

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ baseurl: ""
 
 # Cloudflare Turnstile site key (public; paired with the
 # TURNSTILE_SECRET secret on the Pages project). Used by feedback.html.
-turnstile_site_key: ""
+turnstile_site_key: "0x4AAAAAADEi6Ymsaf-lEIvW"
 
 plugins: []
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,6 +3,7 @@
     <a href="{{ '/' | relative_url }}about.html">About</a>
     <a href="{{ '/' | relative_url }}privacy.html">Privacy</a>
     <a href="https://github.com/agbaber/marblehead">Source</a>
+    <a href="{{ '/' | relative_url }}feedback.html?from={{ page.url | uri_escape }}">Send feedback</a>
     <a href="https://github.com/agbaber/marblehead/issues/new?title=Correction%3A+">Report an issue</a>
   </nav>
   <p class="footer-meta">Built by a Marblehead resident &middot; Updated {{ site.last_updated }}</p>

--- a/feedback.html
+++ b/feedback.html
@@ -1,0 +1,177 @@
+---
+title: "Send feedback"
+og_title: "Send feedback"
+---
+<style>
+  .feedback-form {
+    max-width: 620px;
+    margin: 24px 0 8px;
+  }
+  .feedback-form .field {
+    display: block;
+    margin-bottom: 18px;
+  }
+  .feedback-form .field-label {
+    display: block;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 6px;
+  }
+  .feedback-form .field-hint {
+    display: block;
+    font-size: 12px;
+    color: var(--text-subtle);
+    margin-top: 4px;
+  }
+  .feedback-form input[type="text"],
+  .feedback-form textarea {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font: inherit;
+    color: var(--text);
+    background: var(--surface);
+    box-sizing: border-box;
+  }
+  .feedback-form textarea {
+    min-height: 160px;
+    resize: vertical;
+    line-height: 1.5;
+  }
+  .feedback-form input[type="text"]:focus,
+  .feedback-form textarea:focus {
+    outline: 2px solid var(--c-navy);
+    outline-offset: -1px;
+  }
+  .feedback-form .turnstile-wrap {
+    margin: 4px 0 18px;
+    min-height: 65px;
+  }
+  .feedback-form button {
+    padding: 10px 22px;
+    border: 1px solid var(--c-navy);
+    background: var(--c-navy);
+    color: #fff;
+    border-radius: 6px;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .feedback-form button:hover { opacity: 0.92; }
+  .feedback-form button:disabled { opacity: 0.5; cursor: not-allowed; }
+  .feedback-status {
+    margin-top: 14px;
+    font-size: 14px;
+    min-height: 20px;
+  }
+  .feedback-status.is-error { color: #b00020; }
+  .feedback-status.is-ok { color: #006633; }
+  .feedback-meta {
+    font-size: 13px;
+    color: var(--text-subtle);
+    margin-top: 28px;
+  }
+</style>
+
+<h1>Send feedback</h1>
+
+<p>This form goes to a private Slack channel I read. It is not posted publicly anywhere on the site.</p>
+
+<p>Use it for typos, factual errors, missing sources, suggestions, or anything you would rather not file as a public GitHub issue.</p>
+
+<form class="feedback-form" id="feedback-form" novalidate>
+  <label class="field">
+    <span class="field-label">Your name (optional)</span>
+    <input type="text" name="name" maxlength="100" autocomplete="name">
+    <span class="field-hint">Leave blank to send anonymously.</span>
+  </label>
+
+  <label class="field">
+    <span class="field-label">Message</span>
+    <textarea name="message" rows="7" maxlength="2000" required></textarea>
+    <span class="field-hint">Up to 2000 characters.</span>
+  </label>
+
+  <input type="hidden" name="page" id="feedback-page">
+
+  <div class="turnstile-wrap cf-turnstile" data-sitekey="{{ site.turnstile_site_key }}"></div>
+
+  <button type="submit" id="feedback-submit">Send feedback</button>
+
+  <p class="feedback-status" id="feedback-status" role="status" aria-live="polite"></p>
+</form>
+
+<p class="feedback-meta">
+  Prefer a public record? <a href="https://github.com/agbaber/marblehead/issues/new?title=Feedback%3A+">Open a GitHub issue</a> instead.
+</p>
+
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+<script>
+  (function () {
+    var form = document.getElementById('feedback-form');
+    var status = document.getElementById('feedback-status');
+    var submit = document.getElementById('feedback-submit');
+    var pageInput = document.getElementById('feedback-page');
+
+    var params = new URLSearchParams(window.location.search);
+    pageInput.value = params.get('from') || document.referrer || '';
+
+    function setStatus(text, kind) {
+      status.className = 'feedback-status' + (kind ? ' is-' + kind : '');
+      status.textContent = text;
+    }
+
+    form.addEventListener('submit', async function (e) {
+      e.preventDefault();
+      setStatus('', null);
+
+      var message = form.message.value.trim();
+      if (!message) {
+        setStatus('Message cannot be empty.', 'error');
+        return;
+      }
+
+      var tokenInput = form.querySelector('[name="cf-turnstile-response"]');
+      var turnstileToken = tokenInput ? tokenInput.value : '';
+      if (!turnstileToken) {
+        setStatus('Please complete the captcha.', 'error');
+        return;
+      }
+
+      submit.disabled = true;
+      setStatus('Sending...', null);
+
+      try {
+        var resp = await fetch('/api/feedback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: form.name.value,
+            message: message,
+            page: pageInput.value,
+            turnstileToken: turnstileToken
+          })
+        });
+
+        var data = {};
+        try { data = await resp.json(); } catch (_) {}
+
+        if (resp.ok && data.ok) {
+          setStatus('Thanks. Your feedback was delivered.', 'ok');
+          form.reset();
+          if (window.turnstile && tokenInput) {
+            window.turnstile.reset();
+          }
+        } else {
+          setStatus(data.error || 'Something went wrong. Please try again.', 'error');
+          submit.disabled = false;
+        }
+      } catch (err) {
+        setStatus('Network error. Please try again.', 'error');
+        submit.disabled = false;
+      }
+    });
+  })();
+</script>

--- a/functions/api/feedback.js
+++ b/functions/api/feedback.js
@@ -1,0 +1,119 @@
+// Cloudflare Pages Function for the private feedback form on
+// /feedback.html. POST a JSON body, we verify the Turnstile token
+// with Cloudflare's siteverify endpoint and forward the message to
+// a Slack incoming webhook. No persistence; Slack is the inbox.
+//
+// Required secrets (Cloudflare Pages → Settings → Variables and Secrets):
+//   SLACK_WEBHOOK_URL  — incoming-webhook URL for the destination channel
+//   TURNSTILE_SECRET   — server-side Turnstile secret key
+
+const MAX_MESSAGE = 2000;
+const MAX_NAME = 100;
+const MAX_PAGE = 500;
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid request body' }, 400);
+  }
+
+  const message = typeof body.message === 'string' ? body.message.trim() : '';
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  const page = typeof body.page === 'string' ? body.page.trim() : '';
+  const token = typeof body.turnstileToken === 'string' ? body.turnstileToken : '';
+
+  if (!message) return json({ error: 'Message is required' }, 400);
+  if (message.length > MAX_MESSAGE) return json({ error: `Message too long (max ${MAX_MESSAGE} characters)` }, 400);
+  if (name.length > MAX_NAME) return json({ error: 'Name too long' }, 400);
+  if (page.length > MAX_PAGE) return json({ error: 'Page reference too long' }, 400);
+  if (!token) return json({ error: 'Captcha token missing' }, 400);
+
+  if (!env.TURNSTILE_SECRET || !env.SLACK_WEBHOOK_URL) {
+    return json({ error: 'Server is not configured' }, 500);
+  }
+
+  const ip = request.headers.get('cf-connecting-ip') || '';
+
+  const verifyResp = await fetch(
+    'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        secret: env.TURNSTILE_SECRET,
+        response: token,
+        remoteip: ip,
+      }),
+    }
+  );
+
+  if (!verifyResp.ok) {
+    return json({ error: 'Captcha verification unavailable' }, 502);
+  }
+
+  const verifyData = await verifyResp.json().catch(() => ({}));
+  if (!verifyData.success) {
+    return json({ error: 'Captcha failed; please try again' }, 400);
+  }
+
+  const country = request.headers.get('cf-ipcountry') || 'unknown';
+  const ua = (request.headers.get('user-agent') || 'unknown').slice(0, 200);
+
+  const safeMessage = message.replace(/```/g, "'''");
+  const slackPayload = {
+    text: `Feedback from marbleheaddata.org${name ? ` — ${name}` : ''}`,
+    blocks: [
+      {
+        type: 'header',
+        text: { type: 'plain_text', text: 'Feedback from marbleheaddata.org' },
+      },
+      {
+        type: 'section',
+        fields: [
+          { type: 'mrkdwn', text: `*From:*\n${name || '_anonymous_'}` },
+          { type: 'mrkdwn', text: `*Page:*\n${page || '_unknown_'}` },
+        ],
+      },
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: '*Message:*\n```' + safeMessage + '```' },
+      },
+      {
+        type: 'context',
+        elements: [
+          { type: 'mrkdwn', text: `IP: ${ip} • Country: ${country} • UA: ${ua}` },
+        ],
+      },
+    ],
+  };
+
+  const slackResp = await fetch(env.SLACK_WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(slackPayload),
+  });
+
+  if (!slackResp.ok) {
+    return json({ error: 'Could not deliver message' }, 502);
+  }
+
+  return json({ ok: true });
+}
+
+export async function onRequest() {
+  return json({ error: 'Method not allowed' }, 405);
+}
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- New `/feedback.html` page with a name + message form, gated by Cloudflare Turnstile
- Cloudflare Pages Function at `/api/feedback` verifies the Turnstile token and forwards the message to a private Slack incoming webhook (no persistence)
- Footer gets a "Send feedback" link that passes the originating page via `?from=<url>`
- `_config.yml` exposes `turnstile_site_key` for the public widget key

Why a private channel in addition to the existing GitHub-issue link: lets readers send things they would not file publicly (typos, half-formed thoughts, soft suggestions). Friction is still present — message + captcha — so it self-selects for real signal, not drive-by reactions.

## Setup still required (one-time, via Cloudflare dashboard)

1. **Turnstile** (Cloudflare → Turnstile → Add site for `marbleheaddata.org`):
   - Set `turnstile_site_key` in `_config.yml` to the public site key
   - Add `TURNSTILE_SECRET` as an encrypted env var on the `marbleheaddata-preview` Pages project
2. **Slack incoming webhook** (api.slack.com/apps → New app → Incoming Webhooks → channel):
   - Add `SLACK_WEBHOOK_URL` as an encrypted env var on the same Pages project
3. Redeploy (a new push to this branch will pick up env-var changes on the preview)

## Test plan

- [ ] Footer "Send feedback" link appears and routes to `/feedback.html?from=<page>`
- [ ] Form renders the Turnstile widget once the site key is set
- [ ] Submitting with empty message shows inline error (no network)
- [ ] Submitting without solving the captcha shows inline error (no network)
- [ ] Successful submission posts a structured Slack message containing name, page, and message body
- [ ] Length cap (2000 chars) is enforced server-side
- [ ] Smoke tests still pass (53/0 locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)