### PR TITLE
Refresh H.4225 status: signed as Chapter 67 of the Acts of 2026

### DIFF
--- a/senior-tax-relief.html
+++ b/senior-tax-relief.html
@@ -330,7 +330,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
   }
 </style>
 <h1>What relief can seniors claim?</h1>
-  <p>Two programs can reduce what a Marblehead senior pays in property tax. The state Senior Circuit Breaker refunds up to <strong>$2,820</strong> per year and is available today.<sup class="cite" data-href="https://www.mass.gov/technical-information-release/tir-25-7-annual-update-of-real-estate-tax-credit-for-certain-persons-age-65-and-older" data-source="MA DOR TIR 25-7, annual update of the Senior Circuit Breaker credit cap for TY2025"></sup> A local exemption approved by Marblehead Town Meeting in May 2025 (Article 28, now H.4225) would stack on top of it; the bill passed the Massachusetts House on March 30, 2026 and is awaiting Senate action.<sup class="cite" data-href="https://malegislature.gov/Bills/194/H4225" data-source="MA House Bill H.4225 (means-tested senior property tax exemption for Marblehead), bill history page"></sup></p>
+  <p>Two programs can reduce what a Marblehead senior pays in property tax. The state Senior Circuit Breaker refunds up to <strong>$2,820</strong> per year and is available today.<sup class="cite" data-href="https://www.mass.gov/technical-information-release/tir-25-7-annual-update-of-real-estate-tax-credit-for-certain-persons-age-65-and-older" data-source="MA DOR TIR 25-7, annual update of the Senior Circuit Breaker credit cap for TY2025"></sup> A local exemption approved by Marblehead Town Meeting in May 2025 (Article 28, now H.4225) stacks on top of it; the bill was signed into law on April 29, 2026 as Chapter 67 of the Acts of 2026.<sup class="cite" data-href="https://malegislature.gov/Laws/SessionLaws/Acts/2026/Chapter67" data-source="MA Acts of 2026, Chapter 67, &quot;An Act authorizing the town of Marblehead to establish a means-tested senior citizen property tax exemption,&quot; approved April 29, 2026"></sup> The local exemption still requires Select Board implementation regulations before applications can open.</p>
 
   <div class="sr-calc" id="calculator">
     <div class="calc-input">
@@ -366,7 +366,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
           <button class="tab active" data-art28="0">Off</button>
           <button class="tab" data-art28="1">On</button>
         </div>
-        <span class="sr-toggle-note" id="sr-art28-note" style="display:none;">Not yet law. Awaiting Senate action.</span>
+        <span class="sr-toggle-note" id="sr-art28-note" style="display:none;">Signed into law April 29, 2026 (Chapter 67 of the Acts of 2026). Applications open after the Select Board adopts implementation regulations.</span>
       </div>
       <div class="sr-toggle-group">
         <label>I am a renter</label>
@@ -386,7 +386,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
     <p class="tldr-label">TL;DR</p>
     <ul>
       <li><strong>Circuit Breaker (state, available now):</strong> Refundable credit up to <strong>$2,820/year</strong> for homeowners 65+ with MA income below $75k (single), $94k (HoH), or $112k (joint), and home assessed at or below $1,298,000. Claimed on Schedule CB with your state tax return.</li>
-      <li><strong>Means-tested exemption (local, pending):</strong> Article 28 / H.4225 stacks on top of the Circuit Breaker for longtime Marblehead seniors. Passed Town Meeting May 2025 with ~93% support. Passed the MA House March 30, 2026. Currently awaiting Senate action.</li>
+      <li><strong>Means-tested exemption (local, pending implementation):</strong> Article 28 / H.4225 stacks on top of the Circuit Breaker for longtime Marblehead seniors. Passed Town Meeting May 2025 with ~93% support. Passed the MA House March 30, 2026 and the MA Senate April 21, 2026. Signed into law April 29, 2026 as Chapter 67 of the Acts of 2026. Applications open after the Select Board adopts implementation regulations.</li>
       <li><strong>How many claim it:</strong> 418 Marblehead seniors filed for the Circuit Breaker in TY2022, receiving an average of $1,054. With ~1,158 senior households under the $75k income limit, the credit is likely underclaimed.</li>
       <li><strong>Override twist:</strong> The Circuit Breaker formula is based on the <em>excess</em> of tax over 10% of income, so the credit grows when the tax bill grows. For seniors not yet at the $2,820 cap, the state absorbs part of an override hit automatically.</li>
       <li><strong>No operating-budget tradeoff:</strong> The local exemption is paid for from the tax overlay, not the operating budget. It does not compete with schools or services.</li>
@@ -526,7 +526,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
       <span class="cut-item-amount">$1,291,000</span>
     </div>
     <div class="cut-item">
-      <span class="cut-item-name">Average single-family assessment (FY25, prior year)<span class="cut-item-note">Relevant for Article 28 eligibility: if H.4225 is enacted, applicants' homes must be at or below the prior year's average.</span></span>
+      <span class="cut-item-name">Average single-family assessment (FY25, prior year)<span class="cut-item-note">Relevant for Article 28 eligibility under H.4225: applicants' homes must be at or below the prior year's average.</span></span>
       <span class="cut-item-amount">$1,217,000</span>
     </div>
     <div class="cut-item">
@@ -602,7 +602,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
       <span class="cut-item-name">Home assessed value at or below the prior year's Marblehead average single-family assessment<span class="cut-item-note">For FY26, the relevant prior-year average is $1,217,000 (FY25).</span></span>
     </div>
     <div class="cut-item">
-      <span class="cut-item-name">Does not have "excessive assets"<span class="cut-item-note">Definition to be set by the Select Board in regulation if H.4225 becomes law.</span></span>
+      <span class="cut-item-name">Does not have "excessive assets"<span class="cut-item-note">Definition to be set by the Select Board in regulation. H.4225 was signed into law April 29, 2026 as Chapter 67 of the Acts of 2026; Select Board regulations are pending.</span></span>
     </div>
     <p class="source">Source: <a href="https://marbleheadma.gov/wp-content/uploads/2025/05/2026-Annual-Town-Meeting-Finance-Committee-Annual-Report.pdf">2025 Town Meeting <abbr class="g" title="Finance Committee">FinCom</abbr> Report</a>, Article 28 sections 1-2.</p>
   </div>
@@ -616,7 +616,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
   </div>
 
   <div class="card">
-    <h3>Legislative status (as of April 10, 2026)</h3>
+    <h3>Legislative status (as of April 29, 2026)</h3>
     <div class="cut-item">
       <span class="cut-item-name">May 5, 2025: Passed at Marblehead Town Meeting, ~93% support</span>
     </div>
@@ -636,13 +636,25 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
       <span class="cut-item-name">April 1, 2026: Received in the Senate, placed in Orders of the Day</span>
     </div>
     <div class="cut-item">
-      <span class="cut-item-name">As of April 10, 2026: Not yet signed into law</span>
+      <span class="cut-item-name">April 15, 2026: Senate read second time and ordered to third reading</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">April 21, 2026: Senate passed to be engrossed</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">April 23, 2026: Enacted and laid before the Governor</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">April 29, 2026: Signed by the Governor as Chapter 67 of the Acts of 2026</span>
+    </div>
+    <div class="cut-item">
+      <span class="cut-item-name">Next: Select Board adopts implementation regulations (income limits, asset definition, exemption cap), then the Assessor's Office opens applications</span>
     </div>
     <p class="source">Source: <a href="https://malegislature.gov/Bills/194/H4225">MA Legislature Bill H.4225</a>. Sponsors: Rep. Jenny Armini and Sen. Brendan Crighton. Check the bill page for current status; this timeline is a snapshot.</p>
   </div>
 
   <div class="term">
-    <p><strong>Why did this need a home rule petition?</strong> Under Article 89, Section 7 of the Massachusetts Constitution (the Home Rule Amendment), cities and towns cannot create their own property tax exemptions. Taxation is reserved to the state legislature. MA General Laws Chapter 59, Section 5 lists every exemption a municipality is allowed to grant (by "clause" number). Anything outside that pre-authorized menu requires the legislature to pass a "special act" for the specific town. Marblehead's means-tested exemption goes beyond existing Clause 41C, so it needs H.4225 to be enacted before it can take effect.</p>
+    <p><strong>Why did this need a home rule petition?</strong> Under Article 89, Section 7 of the Massachusetts Constitution (the Home Rule Amendment), cities and towns cannot create their own property tax exemptions. Taxation is reserved to the state legislature. MA General Laws Chapter 59, Section 5 lists every exemption a municipality is allowed to grant (by "clause" number). Anything outside that pre-authorized menu requires the legislature to pass a "special act" for the specific town. Marblehead's means-tested exemption goes beyond existing Clause 41C, so it needed H.4225 to be enacted before it could take effect; the legislature did that on April 29, 2026 as Chapter 67 of the Acts of 2026. Implementation now waits on Select Board regulations.</p>
   </div>
 
   <div class="term">
@@ -779,7 +791,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
   </details>
 
   <h2 data-stance-section="override-connection" id="override-connection">5. The override connection</h2>
-  <p>For a qualifying Marblehead senior, the combination of the state Circuit Breaker ($2,820 max) and, if H.4225 is enacted, the local Article 28 exemption (Select Board-set cap, first-year funded at $200,000 town-wide from the overlay) can exceed $4,000 per year in combined relief for households at the lower end of the income range. For a household receiving the full state credit and a modest local exemption, that is more than the roughly $1,500 per year an operating override is projected to add to a median bill.</p>
+  <p>For a qualifying Marblehead senior, the combination of the state Circuit Breaker ($2,820 max) and, once the Select Board adopts regulations under the newly enacted H.4225, the local Article 28 exemption (Select Board-set cap, first-year funded at $200,000 town-wide from the overlay) can exceed $4,000 per year in combined relief for households at the lower end of the income range. For a household receiving the full state credit and a modest local exemption, that is more than the roughly $1,500 per year an operating override is projected to add to a median bill.</p>
 
   <p>Two points worth holding in mind when reading the override debate:</p>
 
@@ -820,7 +832,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
 
   <div class="card">
     <h3>Article 28 / H.4225 local exemption</h3>
-    <p>Not yet available. If the bill is signed into law by the governor, the Select Board will establish regulations, set the annual cap, and open applications. Applications would then go through the Assessor's Office on the same schedule as other exemptions. Watch the <a href="https://malegislature.gov/Bills/194/H4225">H.4225 bill page</a> for current status, and the town website for implementation announcements.</p>
+    <p>Not yet available. The bill was signed into law on April 29, 2026 as <a href="https://malegislature.gov/Laws/SessionLaws/Acts/2026/Chapter67">Chapter 67 of the Acts of 2026</a>. The Select Board will next establish regulations, set the annual cap, and open applications, after which applications will go through the Assessor's Office on the same schedule as other exemptions. Watch the town website for implementation announcements.</p>
   </div>
 
   <div class="read-next">
@@ -841,7 +853,7 @@ og_url: https://marbleheaddata.org/senior-tax-relief.html
 
   <details class="notes">
     <summary>Sources and methodology</summary>
-    <p>Circuit Breaker figures are for tax year 2025 (filed in 2026), per <a href="https://www.mass.gov/technical-information-release/tir-25-7-annual-update-of-real-estate-tax-credit-for-certain-persons-age-65-and-older">MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Technical Information Release">TIR</abbr> 25-7</a> and <a href="https://www.mass.gov/info-details/massachusetts-senior-circuit-breaker-tax-credit">Mass.gov Senior Circuit Breaker</a>. These amounts are indexed to inflation and change annually. Article 28 warrant text, veteran exemption amounts, and Marblehead FY2026 budget figures are from the <a href="https://marbleheadma.gov/wp-content/uploads/2025/05/2026-Annual-Town-Meeting-Finance-Committee-Annual-Report.pdf">2025 Annual Town Meeting Finance Committee Report</a>. H.4225 bill status snapshot from <a href="https://malegislature.gov/Bills/194/H4225">malegislature.gov</a> as of April 10, 2026. Town Meeting passage of Article 28 at ~93% per <a href="https://itemlive.com/2025/05/11/marblehead-town-meeting-passes-key-articles/">Itemlive, "Marblehead Town Meeting passes key articles" (May 11, 2025)</a>. FY2026 tax rate of $8.60/$1,000 per <a href="https://marbleheadcurrent.org/2025/12/02/town-lowers-tax-rate-average-bill-still-set-to-increase/">Marblehead Current (Dec 2, 2025)</a>. Median Marblehead single-family assessed value of roughly $1,010,000 per MA <abbr class="g" title="Division of Local Services">DLS</abbr>. Home rule constitutional reference: <a href="https://malegislature.gov/Laws/Constitution">MA Constitution, Article 89 of the Articles of Amendment</a>. Clause framework: <a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter59/Section5"><abbr class="g" title="Massachusetts General Laws">MGL</abbr> c. 59 s. 5</a>.</p>
+    <p>Circuit Breaker figures are for tax year 2025 (filed in 2026), per <a href="https://www.mass.gov/technical-information-release/tir-25-7-annual-update-of-real-estate-tax-credit-for-certain-persons-age-65-and-older">MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Technical Information Release">TIR</abbr> 25-7</a> and <a href="https://www.mass.gov/info-details/massachusetts-senior-circuit-breaker-tax-credit">Mass.gov Senior Circuit Breaker</a>. These amounts are indexed to inflation and change annually. Article 28 warrant text, veteran exemption amounts, and Marblehead FY2026 budget figures are from the <a href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026_FinCom_Report.pdf">2025 Annual Town Meeting Finance Committee Report</a>. H.4225 was signed into law on April 29, 2026 as <a href="https://malegislature.gov/Laws/SessionLaws/Acts/2026/Chapter67">Chapter 67 of the Acts of 2026</a>; bill history page at <a href="https://malegislature.gov/Bills/194/H4225">malegislature.gov</a>. Town Meeting passage of Article 28 at ~93% per <a href="https://itemlive.com/2025/05/11/marblehead-town-meeting-passes-key-articles/">Itemlive, "Marblehead Town Meeting passes key articles" (May 11, 2025)</a>. FY2026 tax rate of $8.60/$1,000 per <a href="https://marbleheadcurrent.org/2025/12/02/town-lowers-tax-rate-average-bill-still-set-to-increase/">Marblehead Current (Dec 2, 2025)</a>. Median Marblehead single-family assessed value of roughly $1,010,000 per MA <abbr class="g" title="Division of Local Services">DLS</abbr>. Home rule constitutional reference: <a href="https://malegislature.gov/Laws/Constitution">MA Constitution, Article 89 of the Articles of Amendment</a>. Clause framework: <a href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter59/Section5"><abbr class="g" title="Massachusetts General Laws">MGL</abbr> c. 59 s. 5</a>.</p>
     <p>Senior demographic data (household counts, income distribution, homeownership rates) from US Census Bureau, American Community Survey 2019-2023 5-year estimates, tables B19037 (age of householder by income) and B25007 (tenure by age of householder), for Marblehead town, Essex County, MA. These are survey estimates with margins of error typical for a town of ~20,000. Circuit Breaker claim counts and total credits from <a href="https://www.mass.gov/doc/senior-circuit-breaker-credit-usage-by-town-2001-2022/download">MA DOR, Senior Circuit Breaker Credit Usage by Town, 2001-2022</a> (TY2022, preliminary).</p>
     <p>Clause 41C, 41A, and 17D current Marblehead amounts and limits are pending confirmation from the Board of Assessors. This page will be updated when those figures are verified from a primary source. In the meantime, residents should contact the Assessor's Office directly for eligibility determination.</p>
     <p>Nothing on this page is tax advice. It is a civic information resource. Talk to a tax professional, the Assessor's Office, or the Council on Aging (781-631-6240) for help with your individual situation.</p>


### PR DESCRIPTION
## Summary

H.4225 was signed into law by Governor Healey on **April 29, 2026 as Chapter 67 of the Acts of 2026**. The original PR ("awaiting Governor's signature") was opened before that happened. This refresh updates every reference on `senior-tax-relief.html`:

- **Intro paragraph** — "signed into law April 29, 2026 as Chapter 67 of the Acts of 2026"
- **Calculator toggle note** — "Signed into law. Applications open after the Select Board adopts implementation regulations."
- **TL;DR card** — full timeline through the signing
- **Eligibility list** — "if H.4225 is enacted" becomes "under H.4225"
- **Legislative status timeline** — adds April 15 / 21 / 23 / 29 entries and a "next steps" row for Select Board regulations
- **Home-rule explainer** — past-tense "needed H.4225 to be enacted"
- **Combined-relief paragraph** — "once the Select Board adopts regulations under the newly enacted H.4225"
- **Application card** — "The bill was signed into law on April 29, 2026"
- **Sources paragraph** — H.4225 sentence rewritten; swaps the `marbleheadma.gov/wp-content` URL for the `source-archive-v1` GitHub release URL (clears the content-guardrails lint)

The original PR also touched `index.html`. That portion is dropped: the homepage was reworked into a scrolling-infographic landing page on main (#755 and later), which removed the seniors evidence section the PR was editing.

## Preview

- **Branch URL:** https://h4225-status.marbleheaddata-preview.pages.dev/senior-tax-relief
- Scroll to (a) the intro paragraph, (b) the Article 28 calculator toggle, (c) the "Legislative status" card, (d) the "Article 28 / H.4225 local exemption" card near the bottom, and (e) the "Sources and methodology" details for the swapped archive URL.

## Test plan

- [ ] Preview deploy builds clean
- [ ] All 9 H.4225 references read as "signed, Chapter 67" or "implementation pending Select Board regulations" (no remaining "awaiting Senate" / "awaiting Governor")
- [ ] Sources paragraph uses `source-archive-v1` URL, not `marbleheadma.gov/wp-content`

🤖 Generated with [Claude Code](https://claude.com/claude-code)