### PR TITLE
Add CSS safety net for bare ul/ol on chart pages

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -206,6 +206,13 @@ Rationale: internal links help readers explore the site; external links take the
 - No undefined municipal-finance acronyms; first use on a page needs `<abbr class="g" title="...">`
 - No case names, statute citations, program names, bill numbers, or legal-test shorthand used as referents before a plain-English gloss introduces what they are
 - No bare-text internal references where a hyperlink to the other page belongs
+- No bare `<ul>` or `<ol>` on chart pages. The global `* { padding: 0 }` reset
+  in `assets/site.css` zeroes default list padding, so `list-style: outside`
+  bullets render in (or beyond) the `.container`'s left padding. Use
+  `<ul class="tldr">` for muted bullet lists in chart explainers, or
+  `body_class: doc-page` for markdown doc pages. There is also a safety-net
+  rule for un-classed lists inside `.container`, but the `tldr` styling is
+  what matches the muted card-paragraph aesthetic.
 - No inline external links in the reading flow; use `<sup class="cite">` footnotes via `assets/citations.js`
 - No standalone CPI/inflation comparisons as the sole or primary benchmark for a
   municipal cost category. CPI may appear when it is one of several benchmarks

--- a/assets/site.css
+++ b/assets/site.css
@@ -781,6 +781,22 @@ ul.tldr li { margin-bottom: 9px; }
 ul.tldr li:last-child { margin-bottom: 0; }
 ul.tldr li strong { color: var(--text); }
 
+/* Safety net: the global `* { padding: 0 }` reset zeroes default <ul>/<ol>
+   padding, so a bare <ul> inside a chart .container renders bullets in the
+   container's left padding (or outside it). Restore an indent for any
+   un-classed list inside .container so bullets stay inside the surface.
+   Bespoke list classes (.tldr, .tier-list, .question-list, etc.) override
+   this with their own padding rules. */
+.container > ul:not([class]),
+.container > ol:not([class]),
+.container > details > ul:not([class]),
+.container > details > ol:not([class]) {
+  padding-left: 22px;
+  list-style: disc;
+}
+.container > ol:not([class]),
+.container > details > ol:not([class]) { list-style: decimal; }
+
 p {
   font-size: 1.0rem; color: var(--text-muted);
   line-height: 1.65; margin-bottom: 14px;


### PR DESCRIPTION
## Summary

- Restore `padding-left: 22px` for un-classed `<ul>`/`<ol>` directly under `.container` (and inside `.container > details`), so bare bullet lists on chart pages stop escaping the container.
- The global `* { padding: 0 }` reset in `assets/site.css` zeroes default list padding. Combined with `list-style: outside`, that puts bullets in (or outside) the container's left padding. Other chart pages dodge this with `<ul class=\"tldr\">`, but new pages keep tripping the trap (most recently `levy_limit_vs_levy.html`).
- Bespoke list classes (`.tldr`, `.tier-list`, `.question-list`, etc.) are unaffected because the selector excludes `[class]`.
- Adds a `STYLE_GUIDE.md` "What Not To Do" entry pointing future authors at `<ul class=\"tldr\">` for muted bullets.

## Test plan

- [ ] Open the preview deploy and confirm existing `ul.tldr` lists (e.g. `charts/statewide_overrides.html`, `charts/override_history.html`) look unchanged.
- [ ] Confirm bare `<ul>` blocks on `charts/peer_compensation.html` and `charts/enrollment_vs_staffing.html` now render bullets inside the container's left padding instead of in/beyond it.
- [ ] `npm run test:local` passes (52 / 0).