### PR TITLE
Build prod site via Actions so search index ships

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,66 @@
+name: Deploy to GitHub Pages
+
+# Replaces GitHub Pages' default Jekyll-only auto-build so we can run
+# Pagefind on the built _site/ before publishing. Without this, the
+# search index files under /pagefind/ are missing on prod and the
+# search modal shows an "index not built" hint to real visitors.
+#
+# One-time setup required (cannot be done in workflow):
+#   Repo Settings → Pages → Build and deployment → Source =
+#   "GitHub Actions". Otherwise actions/deploy-pages errors with
+#   "Get Pages site failed".
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Only one prod deploy at a time; cancel a stale in-flight run if a
+# newer commit lands on main.
+concurrency:
+  group: pages-prod
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - uses: actions/configure-pages@v5
+
+      - name: Build site with Jekyll
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+
+      - name: Build Pagefind search index
+        run: npx -y pagefind@1.4.0 --site _site
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/assets/search.js
+++ b/assets/search.js
@@ -57,7 +57,7 @@
       if (!modal.dataset.errShown) {
         modal.dataset.errShown = '1';
         var note = document.createElement('p');
-        note.textContent = 'Search index not built. Run `npm run preview:search` locally, or wait for the PR preview.';
+        note.textContent = 'Search is temporarily unavailable. Use the navigation links above to find what you need.';
         note.style.cssText = 'padding:12px;color:var(--text-subtle);font-size:0.875rem;';
         modal.querySelector('#search').appendChild(note);
       }


### PR DESCRIPTION
## Summary

Replaces the GitHub Pages default Jekyll-only auto-build with a custom Actions workflow that runs `bundle exec jekyll build`, then `pagefind`, then publishes via `actions/deploy-pages`. After this lands (and the settings flip below), the search modal on prod will actually work — right now real visitors who click the search icon see "Search index not built. Run `npm run preview:search`...", which is dev-language leaking to prod.

Also softens the `search.js` fallback message from that dev hint to a user-friendly "Search is temporarily unavailable. Use the navigation links above..." in case the index ever 404s for any reason.

## REQUIRED one-time settings change before this works

You have to flip the Pages source from "Deploy from a branch" to "GitHub Actions" yourself (I can't do this from CI):

1. Go to **Settings → Pages** on the repo
2. Under **Build and deployment → Source**, choose **GitHub Actions**

Without that flip, the new workflow will fail with `Get Pages site failed` because `actions/deploy-pages` can't publish to a Pages site that's still configured for branch deploys.

## Order of operations (no downtime)

1. Merge this PR. The push to main triggers the new workflow, but `deploy-pages` errors out because Pages source is still "branch". Meanwhile the existing auto-build still fires and updates prod normally — site stays up.
2. Flip Pages source to "GitHub Actions" in Settings.
3. Re-run the failed workflow (or push any commit, or `gh workflow run pages.yml`). This time it succeeds. `/pagefind/` ships. Search works.

If you'd rather flip the setting first, that also works — the only quirk is that no prod deploy will happen between the flip and the merge, since both auto-build and the new workflow are off / not yet present. With ~5 minutes between flip and merge it's irrelevant.

## What this doesn't change

- Hosting platform: still GitHub Pages
- DNS: no change, marbleheaddata.org keeps the same CNAME
- Preview deploys: untouched, still go to Cloudflare Pages via `preview.yml`
- Build inputs: same Gemfile, same Jekyll config

## Test plan

- [ ] Merge.
- [ ] Watch the Actions run; expect it to fail with "Get Pages site failed" until the settings flip.
- [ ] Flip Pages source to "GitHub Actions" in repo Settings.
- [ ] Re-run the failed workflow (Actions tab → Deploy to GitHub Pages → Re-run jobs).
- [ ] Wait ~2 min for completion.
- [ ] Visit https://marbleheaddata.org, click the search icon (or Cmd+K).
- [ ] Modal opens, type "OPEB", confirm results show.
- [ ] Sanity-check that home, /charts/town_explorer.html, /data/master-data.html still render fine.

## Edge cases worth poking

- Page navigation that previously worked (deep links, charts loading) — should be byte-identical to the old build.
- Custom domain (CNAME → marbleheaddata.org) — `actions/upload-pages-artifact` preserves `_site/CNAME`, so the custom domain should follow through.
- Workflow concurrency — `concurrency: pages-prod` with `cancel-in-progress: false` means parallel pushes will queue, not stomp.

## Proof of work

I can't validate this on the box (no way to deploy from a worktree to prod GH Pages). What I did verify:
- The workflow YAML is shaped exactly like the official GH-recommended pattern (`actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages`)
- `npm run build` already produces a working `_site/pagefind/` locally
- The same `npx pagefind --site _site` step is already proven on every PR preview via `preview.yml`

The first deploy attempt is the real test. If anything goes sideways, the existing auto-build is the rollback — flip Pages source back to "Deploy from a branch" and prod returns to current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)