### PR TITLE
Fix 404 source link on General Government chart

### DIFF
--- a/charts/general_government_over_time.html
+++ b/charts/general_government_over_time.html
@@ -80,7 +80,7 @@ og_url: https://marbleheaddata.org/charts/general_government_over_time.html
 
 <div class="caption">
   <p>Marblehead's general government spending grew from $1.73M in FY02 to $3.31M in FY24, a 92% increase. Total town expenditures grew 94% over the same period. The US <abbr class="g" title="Consumer Price Index for All Urban Consumers">CPI-U</abbr> rose 74%. General government tracked total spending closely and slightly outpaced inflation.</p>
-  <p>Source: <a href="https://www.mass.gov/info-details/dls-public-databases-and-data-tools" rel="external">Massachusetts <abbr class="g" title="Department of Revenue">DOR</abbr> Division of Local Services Schedule A</a> (per-municipality expenditures by function) and <a href="https://www.bls.gov/cpi/" rel="external"><abbr class="g" title="Bureau of Labor Statistics">BLS</abbr> CPI-U</a>. Local file: <code>data/peer_schedule_a_expenditures.csv</code>, <code>data/cpi_us.csv</code>.</p>
+  <p>Source: <a href="https://dls-gw.dor.state.ma.us/reports/rdPage.aspx?rdReport=ScheduleA.GenFund_MAIN" rel="external">Massachusetts <abbr class="g" title="Department of Revenue">DOR</abbr> Division of Local Services Schedule A</a> (per-municipality expenditures by function) and <a href="https://www.bls.gov/cpi/" rel="external"><abbr class="g" title="Bureau of Labor Statistics">BLS</abbr> CPI-U</a>. Local file: <code>data/peer_schedule_a_expenditures.csv</code>, <code>data/cpi_us.csv</code>.</p>
 </div>
 
 <div class="tldr">


### PR DESCRIPTION
## Summary

The "Source" caption link under View 1 on the new General Government Over Time chart pointed to `mass.gov/info-details/dls-public-databases-and-data-tools`, which returns 404. The page is gone from mass.gov.

Replaced with the direct DLS Schedule A report URL (`dls-gw.dor.state.ma.us/reports/rdPage.aspx?rdReport=ScheduleA.GenFund_MAIN`), which is what `data/SOURCE_LOOKUP.md` already cites for this dataset and which actually loads the form residents would use to verify the numbers themselves. Verified 202 OK.

## Preview URL

Cloudflare Pages preview will appear in the sticky comment.

**Reviewer paths:**
- `/charts/general_government_over_time` — click the "Source" link in the View 1 caption; it should load the DLS Schedule A form, not a 404.

## Test plan

- [ ] Cloudflare preview deploys
- [ ] Source link in View 1 caption loads the DLS report (not 404)

## Proof of Work

`curl -sI` against both URLs:
- Old: `https://www.mass.gov/info-details/dls-public-databases-and-data-tools` → HTTP/2 404
- New: `https://dls-gw.dor.state.ma.us/reports/rdPage.aspx?rdReport=ScheduleA.GenFund_MAIN` → HTTP/2 202