### PR TITLE
Tighten enrollment vs staffing copy; index the SPED chart

### DIFF
--- a/charts/enrollment_vs_staffing.html
+++ b/charts/enrollment_vs_staffing.html
@@ -188,7 +188,7 @@ scripts: [chart-tooltip]
   </ul>
   <p>The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> and <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> totals should not be compared as if they measure the same thing. Use whichever fits the question: the <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> for cost footprint, the <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> total for school-side staffing, the <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> teacher count for classroom instruction.</p>
 
-  <h3>The FY23 ACFR jump is a reporting error</h3>
+  <h3>The FY23 <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> jump is a reporting error</h3>
   <p>Between FY22 and FY23 the <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>'s education FTE jumped from 483 to 537, then held at exactly 537.0 for two years. Over the same window <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> shows a small <em>decline</em> (450 to 445). Asked about the discrepancy in 2026, the town's school finance office and <abbr class="g" title="Chief Financial Officer">CFO</abbr> attributed it to a reporting error by prior administrations, not 54 new hires. Strip the jump out and all three measures point the same direction. <a href="../inside-school-staffing.html#the-fy23-mystery">More on the discrepancy</a>.</p>
 
   <h3>The teacher count masks a composition shift</h3>
@@ -218,7 +218,7 @@ scripts: [chart-tooltip]
       ]
     }
     </script>
-    <svg class="chart" viewBox="0 0 740 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Indexed chart, FY15 = 100. General education teacher FTE declines to 87.8. Special education teacher FTE rises to 127.1, after a sharp dip to 51.3 in FY20 that coincides with a corresponding rise in general education FTE.">
+    <svg class="chart" viewBox="0 0 740 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Indexed chart, FY15 = 100. General education teacher staffing declines to 87.8. Special education teacher staffing rises to 127.1, after a sharp dip to 51.3 in FY20 that coincides with a corresponding rise in general education staffing.">
       <line class="axis-base" x1="70" y1="180" x2="610" y2="180"/>
 
       <!-- 100 reference line + minor gridlines -->
@@ -348,7 +348,7 @@ scripts: [chart-tooltip]
     <p><abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> education <abbr class="g" title="Full-Time Equivalent">FTE</abbr> from "Full-time Equivalent Town Employees by Function," education row. <abbr class="g" title="Full-Time Equivalent">FTE</abbr> counts part-time employees as fractions.</p>
     <p><abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> total educator <abbr class="g" title="Full-Time Equivalent">FTE</abbr> from the Education Personnel Information Management System (<abbr class="g" title="Education Personnel Information Management System">EPIMS</abbr>), accessed via the E2C Hub Socrata API at <code>educationtocareer.data.mass.gov/resource/j5ue-xkfn.json</code>. Raw data in <code>data/dese_total_educator_fte.csv</code>.</p>
     <p><abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> by program area from <code>educationtocareer.data.mass.gov/resource/vd2f-ib9q.json</code>. Raw data in <code>data/dese_teacher_fte_by_program.csv</code>. Peer-town teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> and enrollment data in <code>data/dese_peer_teachers_enrollment.csv</code>.</p>
-    <p>The declining-enrollment / flat-staffing pattern is common across Massachusetts and is partly driven by special education mandates (IEP-required staffing), out-of-district placements ($4.6M in FY26 school budget), and federal requirements that do not scale with enrollment.</p>
+    <p>The declining-enrollment / flat-staffing pattern is common across Massachusetts and is partly driven by special education mandates (<abbr class="g" title="Individualized Education Program">IEP</abbr>-required staffing), out-of-district placements ($4.6M in FY26 school budget), and federal requirements that do not scale with enrollment.</p>
   </div>
 
   <div class="read-next">

--- a/charts/enrollment_vs_staffing.html
+++ b/charts/enrollment_vs_staffing.html
@@ -62,8 +62,8 @@ scripts: [chart-tooltip]
     Student enrollment peaked at 3,327 (FY14) and has declined 21% to 2,617 (FY24). Enrollment from <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> "Demographic and Economic Statistics" tables.
   </p>
 
-  <h2>Three measures of staffing</h2>
-  <p>How much has school staffing changed? The answer depends on which count you use. All three measures are indexed to FY15 = 100 so they can be compared on the same scale. Click a legend item to toggle it.</p>
+  <h2>Has staffing followed enrollment down?</h2>
+  <p>Three sources count school staffing three different ways. They tell three different stories. Indexed below to FY15 = 100, with enrollment plotted for reference. Click a legend item to toggle.</p>
 
   <div class="legend" id="staffing-legend">
     <span class="legend-item s-neutral" data-series="enrollment"><span class="legend-swatch"></span><span class="legend-text">Enrollment</span></span>
@@ -173,7 +173,7 @@ scripts: [chart-tooltip]
   </script>
 
   <p class="caption">
-    All four measures indexed to FY15 = 100. Over FY15&ndash;FY24, enrollment fell 19%. The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> (town financial reports) shows education staffing up 9.6%, but this is the only measure that rises and is driven by a <a href="../inside-school-staffing.html#the-fy23-mystery">FY23 data discontinuity</a>. The two <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> measures (state education data) show declines: total educator <abbr class="g" title="Full-Time Equivalent">FTE</abbr> down 13.9%, classroom teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> down 4.3%.
+    FY15&ndash;FY24, all series indexed to FY15 = 100. Enrollment fell 19%. Of the three staffing measures, both <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> (state) measures decline (total educator <abbr class="g" title="Full-Time Equivalent">FTE</abbr> &minus;13.9%, classroom teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> &minus;4.3%). The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> (town) rises 9.6%, but its FY23 jump is a <a href="../inside-school-staffing.html#the-fy23-mystery">reporting error</a> flagged below.
   </p>
 
   <details>
@@ -185,15 +185,16 @@ scripts: [chart-tooltip]
     </ul>
   </details>
 
-  <h3>Why the measures disagree</h3>
-  <p>The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> and <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> totals were similar in FY15 (490 vs. 502) but diverged sharply by FY24 (537 vs. 432). The main driver is a single event:</p>
-  <ul>
-    <li><strong>The FY23 data discontinuity.</strong> The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> jumped from 483 to 537 education <abbr class="g" title="Full-Time Equivalent">FTE</abbr> between FY22 and FY23, while <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> shows a <em>decline</em> from 450 to 445 over the same period. The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> number then held at exactly 537.0 for two consecutive years. That pattern, a sudden jump contradicted by the state data and then frozen at a round number, points to a reporting change rather than 54 actual new hires. The town's current school finance office and <abbr class="g" title="Chief Financial Officer">CFO</abbr>, asked about it in 2026, characterized it the same way. Without this jump, the <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> would show roughly flat staffing, and all three measures would point in the same direction. See <a href="../inside-school-staffing.html#the-fy23-mystery">the FY23 data jump</a> for the full analysis.</li>
-  </ul>
-  <p>The two sources also <strong>define "education staff" differently</strong>. The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> uses a broader definition of "education staff" than <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr>, though exactly which positions it includes beyond what <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> tracks is not broken out in the report. This explains why you should not expect the two numbers to match at any given point, but it does not explain why the trends point in opposite directions. The FY23 jump does.</p>
+  <h3>The FY23 ACFR jump is a reporting error</h3>
+  <p>Between FY22 and FY23 the <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>'s education FTE jumped from 483 to 537, then held at exactly 537.0 for two years. Over the same window <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> shows a small <em>decline</em> (450 to 445). Asked about the discrepancy in 2026, the town's school finance office and <abbr class="g" title="Chief Financial Officer">CFO</abbr> attributed it to a reporting error by prior administrations, not 54 new hires. Strip the jump out and all three measures point the same direction. <a href="../inside-school-staffing.html#the-fy23-mystery">More on the discrepancy</a>.</p>
 
-  <h3>Where did the teacher decline come from?</h3>
-  <p>The 4.3% drop in total teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> masks a composition shift. General education teachers fell 12.2% while special education teachers grew 27.1%:</p>
+  <h3>The teacher count masks a composition shift</h3>
+  <p>The 4.3% drop in total classroom teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> hides two opposing trends. General education teachers fell 12%; special education teachers grew 27%.</p>
+  <div class="legend">
+    <span class="legend-item s-neutral"><span class="legend-swatch"></span><span class="legend-text">General education</span></span>
+    <span class="legend-item s-marblehead"><span class="legend-swatch"></span><span class="legend-text">Special education</span></span>
+  </div>
+
   <div class="chart-wrapper" data-chart-tooltip>
     <script type="application/json" class="chart-tooltip-data">
     {
@@ -204,58 +205,53 @@ scripts: [chart-tooltip]
         {
           "name": "General education teachers",
           "className": "s-neutral",
-          "values": [210.1,215.3,216.4,210.4,222.2,231.4,223.7,209.6,193.5,184.5]
+          "values": [100.0,102.5,103.0,100.1,105.8,110.1,106.5,99.8,92.1,87.8]
         },
         {
           "name": "Special education teachers",
           "className": "s-marblehead",
-          "values": [44.6,43.6,45.5,47.2,31.0,22.9,28.6,41.3,51.8,56.7]
+          "values": [100.0,97.8,102.0,105.8,69.5,51.3,64.1,92.6,116.1,127.1]
         }
       ]
     }
     </script>
-    <svg class="chart" viewBox="0 0 740 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Line chart showing general education teacher FTE declining from 210 to 185 while special education teacher FTE rises from 45 to 57, FY15 to FY24.">
-      <line class="axis-base" x1="70" y1="160" x2="610" y2="160"/>
+    <svg class="chart" viewBox="0 0 740 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Indexed chart, FY15 = 100. General education teacher FTE declines to 87.8. Special education teacher FTE rises to 127.1, after a sharp dip to 51.3 in FY20 that coincides with a corresponding rise in general education FTE.">
+      <line class="axis-base" x1="70" y1="180" x2="610" y2="180"/>
 
-      <!-- Y gridlines -->
-      <line class="grid-minor" x1="70" y1="136" x2="610" y2="136"/>
-      <line class="grid-minor" x1="70" y1="88" x2="610" y2="88"/>
-      <line class="grid-minor" x1="70" y1="40" x2="610" y2="40"/>
+      <!-- 100 reference line + minor gridlines -->
+      <line class="grid-major" x1="70" y1="80" x2="610" y2="80"/>
+      <line class="grid-minor" x1="70" y1="30" x2="610" y2="30"/>
+      <line class="grid-minor" x1="70" y1="130" x2="610" y2="130"/>
 
       <!-- Y tick labels -->
-      <text class="tick-label" x="63" y="164" text-anchor="end">0</text>
-      <text class="tick-label" x="63" y="140" text-anchor="end">50</text>
-      <text class="tick-label" x="63" y="92" text-anchor="end">150</text>
-      <text class="tick-label" x="63" y="44" text-anchor="end">250</text>
+      <text class="tick-label" x="63" y="184" text-anchor="end">50</text>
+      <text class="tick-label" x="63" y="134" text-anchor="end">75</text>
+      <text class="tick-label" x="63" y="84" text-anchor="end">100</text>
+      <text class="tick-label" x="63" y="34" text-anchor="end">125</text>
 
-      <!-- Gen ed teachers: scale 0-250, 160px range, factor=0.64 px per unit -->
-      <!-- y(v) = 160 - v * 0.64 -->
-      <!-- 210.1=25.5 215.3=22.2 216.4=21.5 210.4=25.3 222.2=17.8 231.4=11.9 223.7=16.8 209.6=25.9 193.5=36.2 184.5=41.9 -->
+      <!-- Gen ed teachers (FY15 = 100, scale 50-125 over 100px range, 2 px/unit, y(v) = 280 - 2v) -->
       <polyline class="data-line s-neutral"
-                points="70,26 130,22 190,21 250,25 310,18 370,12 430,17 490,26 550,36 610,42"/>
-      <text class="end-label s-neutral" x="616" y="38">184.5</text>
+                points="70,80 130,75 190,74 250,80 310,68 370,60 430,67 490,80 550,96 610,104"/>
+      <text class="end-label s-neutral" x="616" y="100">87.8</text>
 
       <!-- SPED teachers -->
-      <!-- 44.6=131.5 43.6=132.1 45.5=130.9 47.2=129.8 31.0=140.2 22.9=145.3 28.6=141.7 41.3=133.6 51.8=126.8 56.7=123.7 -->
       <polyline class="data-line s-marblehead"
-                points="70,131 130,132 190,131 250,130 310,140 370,145 430,142 490,134 550,127 610,124"/>
-      <text class="end-label s-marblehead" x="616" y="120">56.7</text>
+                points="70,80 130,84 190,76 250,68 310,141 370,177 430,152 490,95 550,48 610,26"/>
+      <text class="end-label s-marblehead" x="616" y="22">127.1</text>
+
+      <!-- FY15 = 100 annotation -->
+      <text class="annotation annotation--hide-sm" x="55" y="76" text-anchor="end" font-size="10">FY15 = 100</text>
 
       <!-- X labels -->
-      <text class="tick-label tick-label--major" x="70"  y="180" text-anchor="middle">FY15</text>
-      <text class="tick-label tick-label--minor" x="250" y="180" text-anchor="middle">FY18</text>
-      <text class="tick-label tick-label--major" x="430" y="180" text-anchor="middle">FY21</text>
-      <text class="tick-label tick-label--major" x="610" y="180" text-anchor="middle">FY24</text>
+      <text class="tick-label tick-label--major" x="70"  y="200" text-anchor="middle">FY15</text>
+      <text class="tick-label tick-label--minor" x="250" y="200" text-anchor="middle">FY18</text>
+      <text class="tick-label tick-label--major" x="430" y="200" text-anchor="middle">FY21</text>
+      <text class="tick-label tick-label--major" x="610" y="200" text-anchor="middle">FY24</text>
     </svg>
   </div>
 
-  <div class="legend">
-    <span class="legend-item s-neutral"><span class="legend-swatch"></span><span class="legend-text">General education</span></span>
-    <span class="legend-item s-marblehead"><span class="legend-swatch"></span><span class="legend-text">Special education</span></span>
-  </div>
-
   <p class="caption">
-    Teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> by program area, FY15&ndash;FY24, from <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr>. General education teachers fell from 210.1 to 184.5 (&minus;12.2%). Special education teachers rose from 44.6 to 56.7 (+27.1%). The net result is a small total decline (256.8 to 245.7), but the mix shifted substantially toward mandated special education staffing. Raw data in <code>data/dese_teacher_fte_by_program.csv</code>.
+    Teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> by program area, FY15&ndash;FY24, indexed to FY15 = 100, from <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr>. General education teachers fell from 210.1 to 184.5 (&minus;12.2%); special education teachers rose from 44.6 to 56.7 (+27.1%). Total teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> fell only 4% (256.8 to 245.7) but the mix shifted toward mandated special education staffing. The FY19&ndash;FY21 dip in special education coincides with a parallel rise in general education, suggesting <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> reclassification rather than actual cuts. Raw data in <code>data/dese_teacher_fte_by_program.csv</code>.
   </p>
 
   <p class="chart-label">Students per teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr>, four peer towns</p>
@@ -345,12 +341,12 @@ scripts: [chart-tooltip]
   </p>
 
   <div class="notes">
-    <p><strong>Which measure should I use?</strong> It depends on the question. The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> number captures the total cost footprint (every education employee the town pays). The <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> total captures school-side staffing (the people working in school buildings). The <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> teacher count captures classroom instruction specifically. Claims about "staffing going up" or "staffing going down" should specify which measure, because two of the three show a decline.</p>
+    <p><strong>Which measure should I use?</strong> It depends on the question. The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> number captures the total cost footprint (every education employee the town pays, on a broader definition than the state uses). The <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> total captures school-side staffing (people working in school buildings). The <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> teacher count captures classroom instruction specifically. The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> and <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> totals should not be directly compared as if they measure the same thing.</p>
     <p>Enrollment from <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> "Demographic and Economic Statistics" tables. May include or exclude charter school students depending on year.</p>
-    <p><abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> education <abbr class="g" title="Full-Time Equivalent">FTE</abbr> from "Full-time Equivalent Town Employees by Function," education row. <abbr class="g" title="Full-Time Equivalent">FTE</abbr> counts part-time employees as fractions. The FY23 jump from 483 to 537 is a reporting change, not 54 actual new hires: the town's current school finance office and <abbr class="g" title="Chief Financial Officer">CFO</abbr>, asked in 2026, characterized it as a reporting error by the previous administrations. The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> and <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> totals should not be directly compared as if they measure the same thing.</p>
+    <p><abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> education <abbr class="g" title="Full-Time Equivalent">FTE</abbr> from "Full-time Equivalent Town Employees by Function," education row. <abbr class="g" title="Full-Time Equivalent">FTE</abbr> counts part-time employees as fractions.</p>
     <p><abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> total educator <abbr class="g" title="Full-Time Equivalent">FTE</abbr> from the Education Personnel Information Management System (<abbr class="g" title="Education Personnel Information Management System">EPIMS</abbr>), accessed via the E2C Hub Socrata API at <code>educationtocareer.data.mass.gov/resource/j5ue-xkfn.json</code>. Raw data in <code>data/dese_total_educator_fte.csv</code>.</p>
     <p><abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> by program area from <code>educationtocareer.data.mass.gov/resource/vd2f-ib9q.json</code>. Raw data in <code>data/dese_teacher_fte_by_program.csv</code>. Peer-town teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> and enrollment data in <code>data/dese_peer_teachers_enrollment.csv</code>.</p>
-    <p>The declining enrollment / flat staffing pattern is common across Massachusetts and is partly driven by special education mandates (IEP-required staffing), out-of-district placements ($4.6M in FY26 school budget), and federal requirements that do not scale with enrollment.</p>
+    <p>The declining-enrollment / flat-staffing pattern is common across Massachusetts and is partly driven by special education mandates (IEP-required staffing), out-of-district placements ($4.6M in FY26 school budget), and federal requirements that do not scale with enrollment.</p>
   </div>
 
   <div class="read-next">

--- a/charts/enrollment_vs_staffing.html
+++ b/charts/enrollment_vs_staffing.html
@@ -4,10 +4,14 @@ scripts: [chart-tooltip]
 ---
 <style>
 .chart-label {
-    font-size: 12px; font-weight: 700; text-transform: uppercase;
-    letter-spacing: 1px; margin-bottom: 8px; padding-left: 2px;
-    color: var(--text-subtle);
-  }
+  font-size: 12px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 1px; margin: 28px 0 8px; padding-left: 2px;
+  color: var(--text-subtle);
+}
+.page h3 { margin-top: 28px; }
+.page h2 + p { margin-bottom: 18px; }
+.page .caption + .legend { margin-top: 4px; }
+.page .legend + .chart-wrapper { margin-top: 0; }
 #staffing-legend .legend-item { cursor: pointer; }
 #staffing-legend .legend-item--off { opacity: 0.3; }
 </style>
@@ -176,14 +180,13 @@ scripts: [chart-tooltip]
     FY15&ndash;FY24, all series indexed to FY15 = 100. Enrollment fell 19%. Of the three staffing measures, both <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> (state) measures decline (total educator <abbr class="g" title="Full-Time Equivalent">FTE</abbr> &minus;13.9%, classroom teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr> &minus;4.3%). The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> (town) rises 9.6%, but its FY23 jump is a <a href="../inside-school-staffing.html#the-fy23-mystery">reporting error</a> flagged below.
   </p>
 
-  <details>
-    <summary>What each measure counts</summary>
-    <ul>
-      <li><strong><abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> education <abbr class="g" title="Full-Time Equivalent">FTE</abbr></strong> (490 &rarr; 537): From the town's annual financial reports. Counts all staff the town categorizes under "education," a broader definition than what the state tracks.</li>
-      <li><strong><abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> total educator <abbr class="g" title="Full-Time Equivalent">FTE</abbr></strong> (501.8 &rarr; 431.8): From the state. Includes teachers, co-teachers, paraprofessionals, counselors, psychologists, administrators, and office staff reported by the schools.</li>
-      <li><strong><abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr></strong> (256.8 &rarr; 245.7): From the state. Only licensed classroom teachers (general education, special education, and English learner).</li>
-    </ul>
-  </details>
+  <h3>What each measure counts</h3>
+  <ul class="tldr">
+    <li><strong><abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> education <abbr class="g" title="Full-Time Equivalent">FTE</abbr></strong> (town financial report, 490 &rarr; 537): every education employee the town pays, on a broader definition than the state uses. Captures the total cost footprint.</li>
+    <li><strong><abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> total educator <abbr class="g" title="Full-Time Equivalent">FTE</abbr></strong> (state, 501.8 &rarr; 431.8): teachers, paraprofessionals, counselors, psychologists, administrators, and office staff in school buildings.</li>
+    <li><strong><abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> teacher <abbr class="g" title="Full-Time Equivalent">FTE</abbr></strong> (state, 256.8 &rarr; 245.7): only licensed classroom teachers (general education, special education, English learner).</li>
+  </ul>
+  <p>The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> and <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> totals should not be compared as if they measure the same thing. Use whichever fits the question: the <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> for cost footprint, the <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> total for school-side staffing, the <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> teacher count for classroom instruction.</p>
 
   <h3>The FY23 ACFR jump is a reporting error</h3>
   <p>Between FY22 and FY23 the <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>'s education FTE jumped from 483 to 537, then held at exactly 537.0 for two years. Over the same window <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> shows a small <em>decline</em> (450 to 445). Asked about the discrepancy in 2026, the town's school finance office and <abbr class="g" title="Chief Financial Officer">CFO</abbr> attributed it to a reporting error by prior administrations, not 54 new hires. Strip the jump out and all three measures point the same direction. <a href="../inside-school-staffing.html#the-fy23-mystery">More on the discrepancy</a>.</p>
@@ -341,7 +344,6 @@ scripts: [chart-tooltip]
   </p>
 
   <div class="notes">
-    <p><strong>Which measure should I use?</strong> It depends on the question. The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> number captures the total cost footprint (every education employee the town pays, on a broader definition than the state uses). The <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> total captures school-side staffing (people working in school buildings). The <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> teacher count captures classroom instruction specifically. The <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> and <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> totals should not be directly compared as if they measure the same thing.</p>
     <p>Enrollment from <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> "Demographic and Economic Statistics" tables. May include or exclude charter school students depending on year.</p>
     <p><abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> education <abbr class="g" title="Full-Time Equivalent">FTE</abbr> from "Full-time Equivalent Town Employees by Function," education row. <abbr class="g" title="Full-Time Equivalent">FTE</abbr> counts part-time employees as fractions.</p>
     <p><abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> total educator <abbr class="g" title="Full-Time Equivalent">FTE</abbr> from the Education Personnel Information Management System (<abbr class="g" title="Education Personnel Information Management System">EPIMS</abbr>), accessed via the E2C Hub Socrata API at <code>educationtocareer.data.mass.gov/resource/j5ue-xkfn.json</code>. Raw data in <code>data/dese_total_educator_fte.csv</code>.</p>


### PR DESCRIPTION
## Summary
- Fix the 3-vs-4 mismatch on the indexed staffing chart. Heading + intro + caption now consistently describe three staffing measures with enrollment plotted as a reference line.
- Convert the gen ed vs SPED chart from a 0-250 absolute Y-axis to FY15 = 100 indexed. The +27% special education growth was barely visible at 0-250 scale (the SPED line moved ~7 px on screen and read as flat). Indexed, both lines start at 100 and the divergence is what the caption claims.
- Tighten the prose. Drop "data discontinuity," "frozen at a round number," the redundant ACFR-vs-DESE definitional paragraph, and the duplicate FY23 paragraph in the notes. Story now flows: enrollment fell → staffing depends on source → FY23 ACFR is a reporting error → teacher count masks a gen ed / SPED composition shift.
- Caption on the SPED chart also notes that the FY19–FY20 SPED dip is mirrored by a gen ed rise, suggesting DESE reclassification rather than actual cuts.

## Test plan
- [x] `bundle exec jekyll build` clean
- [x] `npm run test:local` passes (57/0)
- [x] Visual check on rendered page: SPED line clearly diverges from gen ed line; +27% is visible as a line going from 100 to 127

🤖 Generated with [Claude Code](https://claude.com/claude-code)