### PR TITLE
cap-vs-cost: replace SPEED LIMIT framing with factual labels

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -4172,12 +4172,6 @@ svg.chart .speed-limit {
   stroke-dasharray: 6 4;
   fill: none;
 }
-svg.chart .speed-limit-label {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  fill: var(--c-text);
-  letter-spacing: 0.04em;
-}
 svg.chart .row-label {
   font-size: 0.8125rem;
   font-weight: 600;

--- a/cap-vs-cost.html
+++ b/cap-vs-cost.html
@@ -18,9 +18,9 @@ og_url: https://marbleheaddata.org/cap-vs-cost.html
   <div class="key-stat"><div class="key-stat-value">4.6%/yr</div><div class="key-stat-label">Family health premium</div></div>
 </div>
 
-<h2 id="speed-limit">1. The speed limit</h2>
+<h2 id="growth-rates">1. How fast each one grew</h2>
 
-<p>Each bar is one cost, with its annual growth rate. The dashed vertical line is the rate Marblehead's actual tax revenue grew at over the same period. Anything past that line grew faster than the levy could keep up with.</p>
+<p>Each bar is one cost, with its annual growth rate. The dashed vertical line marks Marblehead's actual revenue growth &ndash; the 2.5% cap plus new growth from new construction &ndash; which is the rate the levy actually grew at. Bars past that line grew faster than the levy could keep up with.</p>
 
 <div class="chart-wrap">
 <svg class="chart" viewBox="0 0 820 290" xmlns="http://www.w3.org/2000/svg" role="img"
@@ -56,8 +56,7 @@ og_url: https://marbleheaddata.org/cap-vs-cost.html
   <text class="end-label"      x="682" y="200">4.6%/yr</text>
 
   <line class="speed-limit"    x1="504.4" y1="50" x2="504.4" y2="225"/>
-  <text class="speed-limit-label" x="504.4" y="38" text-anchor="middle">SPEED LIMIT</text>
-  <text class="annotation"     x="504.4" y="20" text-anchor="middle">Marblehead's levy = 2&frac12;% cap + new growth</text>
+  <text class="annotation"     x="504.4" y="38" text-anchor="middle">Marblehead levy</text>
 
   <line class="axis-base"      x1="170" y1="225" x2="720" y2="225"/>
 

--- a/cap-vs-cost.html
+++ b/cap-vs-cost.html
@@ -20,7 +20,7 @@ og_url: https://marbleheaddata.org/cap-vs-cost.html
 
 <h2 id="growth-rates">1. How fast each one grew</h2>
 
-<p>Each bar is one cost, with its annual growth rate. The dashed vertical line marks Marblehead's actual revenue growth &ndash; the 2.5% cap plus new growth from new construction &ndash; which is the rate the levy actually grew at. Bars past that line grew faster than the levy could keep up with.</p>
+<p>Each bar is one cost, with its annual growth rate. The dashed vertical line marks the rate Marblehead's revenue actually grew at (the 2.5% cap plus new growth from new construction). Bars past that line grew faster than the levy could keep up with.</p>
 
 <div class="chart-wrap">
 <svg class="chart" viewBox="0 0 820 290" xmlns="http://www.w3.org/2000/svg" role="img"
@@ -111,13 +111,13 @@ og_url: https://marbleheaddata.org/cap-vs-cost.html
   </tbody>
   <tfoot>
     <tr>
-      <td colspan="4">The rightmost column shows what each value would have been if it grew exactly 2.5% per year for nine years. The gap between that number and the FY24 actual is what the town and households actually paid above the cap. Marblehead's avg single-family tax bill rose faster than the total levy &ndash; from $7,669 to $10,778, +41% &ndash; because residential property values appreciated faster than commercial during this window, shifting more of the levy onto homeowners.<sup class="cite" data-href="data/DOR_AvgSingleFamTaxBill_4towns.xlsx" data-source="Massachusetts DOR, Average Single-Family Tax Bill by municipality, FY1999-FY2026"></sup></td>
+      <td colspan="4">The rightmost column shows what each value would have been if it grew exactly 2.5% per year for nine years. The gap between that number and the FY24 actual is what the town and households actually paid above the cap. Marblehead's avg single-family tax bill rose faster than the total levy (from $7,669 to $10,778, +41%) because residential property values appreciated faster than commercial during this window, shifting more of the levy onto homeowners.<sup class="cite" data-href="data/DOR_AvgSingleFamTaxBill_4towns.xlsx" data-source="Massachusetts DOR, Average Single-Family Tax Bill by municipality, FY1999-FY2026"></sup></td>
     </tr>
   </tfoot>
 </table>
 
 <div class="takeaway takeaway--neutral">
-The same family health plan that cost $17,545 in FY15 cost $25,572 in FY24 &ndash; an increase of $8,027 in nine years. If health insurance had grown at the cap rate, that same plan would have cost $21,898. Multiply that gap by the number of covered families, year after year, and you have most of the budget squeeze.
+The same family health plan that cost $17,545 in FY15 cost $25,572 in FY24, an increase of $8,027 in nine years. If health insurance had grown at the cap rate, that same plan would have cost $21,898. Multiply that gap by the number of covered families, year after year, and you have most of the budget squeeze.
 </div>
 
 <h2 id="year-by-year">3. Year by year</h2>
@@ -214,7 +214,7 @@ The same family health plan that cost $17,545 in FY15 cost $25,572 in FY24 &ndas
 
 <h2 id="what-this-means">What this means</h2>
 
-<p>The cap is fixed at 2.5% by state law. The costs are not. When costs grow faster than the cap allows &ndash; the family health premium has, every year of this window &ndash; the difference has to come from somewhere.</p>
+<p>The cap is fixed at 2.5% by state law. The costs are not. When costs grow faster than the cap allows, the difference has to come from somewhere. The family health premium has grown faster than the cap every year of this window.</p>
 
 <p>For nine years, Marblehead made up the difference with state aid, fees, and free cash. The 2026 Finance Committee Annual Report reported the FY26 budget was balanced only through one-time adjustments and that the three-year forecast had identified projected deficits for FY26, FY27, and FY28.<sup class="cite" data-href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026_FinCom_Report.pdf" data-source="2026 Finance Committee Annual Report (FY26 budget, May 2025 Annual Town Meeting), p. 3"></sup> The FY27 budget shows an $8.47M structural deficit at current service levels.<sup class="cite" data-href="https://github.com/agbaber/marblehead/releases/download/source-archive-v1/2026_State_of_the_Town.pdf" data-source="2026 State of the Town presentation, January 28, 2026"></sup></p>
 


### PR DESCRIPTION
## Summary

Replaces the speed-limit metaphor on `cap-vs-cost.html` with neutral, factual labels.

- Section header: `1. The speed limit` &rarr; `1. How fast each one grew`
- Chart annotation on the dashed reference line: `SPEED LIMIT` + `Marblehead's levy = 2.5% cap + new growth` &rarr; single inline `Marblehead levy`
- Drops the now-unused `.speed-limit-label` CSS rule

## Why

The speed-limit framing was a stretch and slightly editorial. It implied costs growing faster than the cap were *speeding*, which muddles agency: the cap limits what Marblehead can charge, not how fast costs grow. Health insurance isn't speeding; it just costs what it costs.

The dashed line now labels what it is. The prose paragraph above the chart still explains what the line represents and what bars to its right mean.

## Test plan
- [ ] Cloudflare preview shows the bar chart with `Marblehead levy` label above the dashed line, no `SPEED LIMIT` shout
- [ ] Section heading reads `1. How fast each one grew`
- [ ] No layout regressions on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)