### PR TITLE
cap-vs-cost: match health extrapolation to teacher methodology (+4.3%/yr)

### DIFF
--- a/cap-vs-cost.html
+++ b/cap-vs-cost.html
@@ -220,4 +220,36 @@ The same family health plan that cost $17,545 in FY15 cost $25,572 in FY24, an i
 
 <p>The override question on the June 2026 ballot is whether to raise the cap. The data does not say which way to vote. It says what the cap has and has not been able to keep up with.</p>
 
+<details class="deep-dive">
+  <summary>
+    <h2>Methodology</h2>
+    <p class="deep-dive-teaser">How the four lines were constructed, why FY15, and how the FY25&ndash;FY27 estimates work.</p>
+  </summary>
+  <div class="deep-dive-body">
+    <h3>Index baseline (FY15 = 100)</h3>
+    <p>FY15 was chosen as the index baseline because it is the earliest year with audited or directly published data for all four series (the statutory cap, the <abbr class="g" title="Department of Revenue">DOR</abbr> levy limit, the <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> teacher salary, and the <abbr class="g" title="Kaiser Family Foundation">KFF</abbr> national family premium). FY24 is the last year with audited data for all four. An indexed value of 143 means "43% above FY15."</p>
+
+    <h3>Forward projection (FY25&ndash;FY27)</h3>
+    <p>Each line is extrapolated past FY24 at its own FY15&ndash;FY24 compound annual growth rate (<abbr class="g" title="Compound Annual Growth Rate">CAGR</abbr>), shown as dotted line segments past the audited/estimated boundary. This is "trend continues" extrapolation, not a forecast tied to any specific budget cycle:</p>
+    <ul>
+      <li>Pure 2.5% cap: 2.5%/yr (statutory)</li>
+      <li>Marblehead levy: 3.0%/yr (the cap plus the average rate of new construction added to the rolls FY15&ndash;FY24)</li>
+      <li>Avg teacher salary: 3.4%/yr (FY15&ndash;FY24 trend)</li>
+      <li>Family health premium: 4.3%/yr (FY15&ndash;FY24 trend)</li>
+    </ul>
+
+    <h3>The "if 2.5% cap had been the only growth" column</h3>
+    <p>Each FY15 value compounded forward at exactly 2.5% per year for nine years, ignoring new construction. Per Massachusetts General Laws c. 59 &sect; 21C, the levy itself is allowed to grow 2.5% plus the value of new construction. The counterfactual column shows the pure 2.5% rule alone, so the gap to the FY24 actual is the cumulative effect of new growth (for the levy line) or of cost growth above the cap (for teacher salary, health premium, and the avg single-family tax bill).</p>
+
+    <h3>Wage line scope</h3>
+    <p>Teacher salary is the largest single wage component but not the only one. School employees (teachers, paraprofessionals, school administration) are negotiated by the School Committee. Town employees (police, fire, <abbr class="g" title="Department of Public Works">DPW</abbr>, library, town hall) are negotiated by the Town Administrator and Select Board, each with their own union. DESE publishes teacher salary annually with multi-year transparency for every district; the other municipal contracts are public but not aggregated into a single time series. Aggregate state-and-local government employee compensation nationally has tracked similar rates over the same window per the <abbr class="g" title="Bureau of Labor Statistics">BLS</abbr> Employment Cost Index.</p>
+
+    <h3>Family health premium scope</h3>
+    <p>The KFF Employer Health Benefits Annual Survey national family premium is used as a conservative reference. Marblehead's specific Group Insurance Commission (<abbr class="g" title="Group Insurance Commission">GIC</abbr>) family premium has run above the national KFF average over the FY19&ndash;FY26 window for which both are available, so the national line is conservative for Marblehead specifically. <abbr class="g" title="Group Insurance Commission">GIC</abbr>-specific FY06&ndash;FY27 data is on the site's <a href="charts/healthcare_costs.html">healthcare costs</a> page.</p>
+
+    <h3>Avg single-family tax bill (in the dollar table)</h3>
+    <p>The avg single-family tax bill ($7,669 in FY15, $10,778 in FY24, +41%) grew faster than the total levy (+32%) because residential property values appreciated faster than commercial during the window, shifting more of the levy onto homeowners. That is a separate phenomenon from cost growth versus the cap and is included in the table only to give voters a recognizable dollar figure.</p>
+  </div>
+</details>
+
 <p style="font-size: 0.9rem; color: var(--text-muted); margin-top: 2rem;">More: <a href="what-is-the-override.html">What is the override?</a> &middot; <a href="how-we-got-here.html">How did we get here?</a> &middot; <a href="charts/healthcare_costs.html">Why health insurance is outpacing the tax levy</a> &middot; <a href="where-has-the-money-gone.html">Where has the money gone?</a></p>

--- a/cap-vs-cost.html
+++ b/cap-vs-cost.html
@@ -15,7 +15,7 @@ og_url: https://marbleheaddata.org/cap-vs-cost.html
   <div class="key-stat"><div class="key-stat-value">2.5%/yr</div><div class="key-stat-label">Pure 2&frac12;% cap</div></div>
   <div class="key-stat"><div class="key-stat-value">3.0%/yr</div><div class="key-stat-label">Marblehead levy</div></div>
   <div class="key-stat"><div class="key-stat-value">3.4%/yr</div><div class="key-stat-label">Avg teacher salary</div></div>
-  <div class="key-stat"><div class="key-stat-value">4.6%/yr</div><div class="key-stat-label">Family health premium</div></div>
+  <div class="key-stat"><div class="key-stat-value">4.3%/yr</div><div class="key-stat-label">Family health premium</div></div>
 </div>
 
 <h2 id="growth-rates">1. How fast each one grew</h2>
@@ -24,7 +24,7 @@ og_url: https://marbleheaddata.org/cap-vs-cost.html
 
 <div class="chart-wrap">
 <svg class="chart" viewBox="0 0 820 290" xmlns="http://www.w3.org/2000/svg" role="img"
-     aria-label="Horizontal bar chart of annual growth rates: pure 2.5% cap (legal floor), Marblehead levy 3.0% per year, average teacher salary 3.4% per year, family health premium 4.6% per year. Vertical dashed line at 3.0% marks Marblehead's actual revenue speed; teacher salary and family health premium exceed it.">
+     aria-label="Horizontal bar chart of annual growth rates: pure 2.5% cap (legal floor), Marblehead levy 3.0% per year, average teacher salary 3.4% per year, family health premium 4.3% per year. Vertical dashed line at 3.0% marks Marblehead's actual revenue speed; teacher salary and family health premium exceed it.">
 
   <line class="grid-minor" x1="170" y1="55" x2="170" y2="225"/>
   <line class="grid-minor" x1="280" y1="55" x2="280" y2="225"/>
@@ -50,10 +50,10 @@ og_url: https://marbleheaddata.org/cap-vs-cost.html
   <text class="end-label"      x="552" y="160">3.4%/yr</text>
 
   <g class="s-cost">
-    <rect class="data-bar"     x="170" y="180" width="502.7" height="32" rx="2"/>
+    <rect class="data-bar"     x="170" y="180" width="469.7" height="32" rx="2"/>
   </g>
   <text class="row-label"      x="160" y="200" text-anchor="end">Family health premium</text>
-  <text class="end-label"      x="682" y="200">4.6%/yr</text>
+  <text class="end-label"      x="649" y="200">4.3%/yr</text>
 
   <line class="speed-limit"    x1="504.4" y1="50" x2="504.4" y2="225"/>
   <text class="annotation"     x="504.4" y="38" text-anchor="middle">Marblehead levy</text>
@@ -71,7 +71,7 @@ og_url: https://marbleheaddata.org/cap-vs-cost.html
 </svg>
 </div>
 
-<p class="caption">Compound annual growth rate (<abbr class="g" title="Compound Annual Growth Rate">CAGR</abbr>) over each line's data window. Cap is the statutory ceiling on levy growth.<sup class="cite" data-href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter59/Section21C" data-source="Massachusetts General Laws, Chapter 59, Section 21C (Proposition 2&frac12;)"></sup> Levy is FY15&ndash;FY27 from <abbr class="g" title="Department of Revenue">DOR</abbr> Tax Recap.<sup class="cite" data-href="data/marblehead_levy.csv" data-source="Massachusetts Department of Revenue, Tax Recap reports compiled in data/marblehead_levy.csv"></sup> Teacher salary is FY15&ndash;FY24 from <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> School and District Profiles, Marblehead district 01680000.<sup class="cite" data-href="data/dese_marblehead_avg_teacher_salary.csv" data-source="DESE School and District Profiles, Teacher Salaries Report (Marblehead, district 01680000); compiled annually FY15-FY24"></sup> Family health premium is FY15&ndash;FY24 actual plus FY25&ndash;FY27 estimated at the long-run <abbr class="g" title="Kaiser Family Foundation">KFF</abbr> trend, from KFF Employer Health Benefits Survey national family premium.<sup class="cite" data-href="data/health_premiums.csv" data-source="Kaiser Family Foundation Employer Health Benefits Annual Survey, Average Annual Premiums for Family Coverage; compiled in data/health_premiums.csv"></sup></p>
+<p class="caption">Compound annual growth rate (<abbr class="g" title="Compound Annual Growth Rate">CAGR</abbr>) over each line's data window. Cap is the statutory ceiling on levy growth.<sup class="cite" data-href="https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter59/Section21C" data-source="Massachusetts General Laws, Chapter 59, Section 21C (Proposition 2&frac12;)"></sup> Levy is FY15&ndash;FY27 from <abbr class="g" title="Department of Revenue">DOR</abbr> Tax Recap.<sup class="cite" data-href="data/marblehead_levy.csv" data-source="Massachusetts Department of Revenue, Tax Recap reports compiled in data/marblehead_levy.csv"></sup> Teacher salary is FY15&ndash;FY24 from <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> School and District Profiles, Marblehead district 01680000.<sup class="cite" data-href="data/dese_marblehead_avg_teacher_salary.csv" data-source="DESE School and District Profiles, Teacher Salaries Report (Marblehead, district 01680000); compiled annually FY15-FY24"></sup> Family health premium is FY15&ndash;FY24 actual plus FY25&ndash;FY27 extrapolated at the FY15&ndash;FY24 trend (4.3%/yr), from <abbr class="g" title="Kaiser Family Foundation">KFF</abbr> Employer Health Benefits Survey national family premium.<sup class="cite" data-href="data/health_premiums.csv" data-source="Kaiser Family Foundation Employer Health Benefits Annual Survey, Average Annual Premiums for Family Coverage; compiled in data/health_premiums.csv"></sup></p>
 
 <p class="caption"><em>Why teacher salary as the wage line:</em> Marblehead's payroll has two halves with separate contracts. School employees (teachers, paraprofessionals, school administration) are negotiated by the School Committee. Town employees (police, fire, <abbr class="g" title="Department of Public Works">DPW</abbr>, library, town hall) are negotiated by the Town Administrator and Select Board, each with their own union. Teacher salary is shown because <abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> publishes it annually with multi-year transparency for every district; the other municipal contracts are public but not aggregated into a single time series. Aggregate state-and-local government employee compensation nationally tracked similar rates over the same window per the <abbr class="g" title="Bureau of Labor Statistics">BLS</abbr> Employment Cost Index.<sup class="cite" data-href="https://www.bls.gov/eci/" data-source="U.S. Bureau of Labor Statistics, Employment Cost Index, state and local government employee compensation series (CIU2020000000000I)"></sup></p>
 
@@ -125,7 +125,7 @@ The same family health plan that cost $17,545 in FY15 cost $25,572 in FY24, an i
 <p>The bar chart compresses each line to a single number. The full picture, indexed to FY15 = 100:</p>
 
 <div class="legend">
-  <div class="legend-item s-cost"><span class="legend-swatch"></span><span class="legend-text">Family health premium &middot; +4.6%/yr</span></div>
+  <div class="legend-item s-cost"><span class="legend-swatch"></span><span class="legend-text">Family health premium &middot; +4.3%/yr</span></div>
   <div class="legend-item s-marblehead"><span class="legend-swatch"></span><span class="legend-text">Marblehead levy limit &middot; +3.0%/yr</span></div>
   <div class="legend-item s-teacher"><span class="legend-swatch"></span><span class="legend-text">Avg teacher salary &middot; +3.4%/yr</span></div>
   <div class="legend-item s-cap"><span class="legend-swatch"></span><span class="legend-text">Pure 2&frac12;% cap &middot; +2.5%/yr</span></div>
@@ -133,7 +133,7 @@ The same family health plan that cost $17,545 in FY15 cost $25,572 in FY24, an i
 
 <div class="chart-wrap">
 <svg class="chart" viewBox="0 0 820 360" xmlns="http://www.w3.org/2000/svg" role="img"
-     aria-label="Indexed line chart from FY15 to FY27 with FY15 set to 100. Family health premium reaches 171, Marblehead levy 143, teacher salary 149 (extrapolated), pure 2.5% cap 134.">
+     aria-label="Indexed line chart from FY15 to FY27 with FY15 set to 100. Family health premium reaches 165 (extrapolated), Marblehead levy 143, teacher salary 149 (extrapolated), pure 2.5% cap 134.">
 
   <line class="grid-minor" x1="70" y1="300" x2="690" y2="300"/>
   <line class="grid-minor" x1="70" y1="248" x2="690" y2="248"/>
@@ -202,15 +202,15 @@ The same family health plan that cost $17,545 in FY15 cost $25,572 in FY24, an i
     <path class="data-line"
           d="M70,300 L121.67,291.15 L173.33,281.94 L225,269.31 L276.67,270.01 L328.33,243.73 L380,230.71 L431.67,227.12 L483.33,204.82 L535,181.05"/>
     <path class="data-line data-line--dotted"
-          d="M535,181.05 L586.67,160.21 L638.33,138.22 L690,115.01"/>
-    <circle class="data-dot data-dot--halo" cx="690" cy="115.01" r="3.5"/>
-    <text class="end-label" x="700" y="119">Health</text>
+          d="M535,181.05 L586.67,164.85 L638.33,147.96 L690,130.34"/>
+    <circle class="data-dot data-dot--halo" cx="690" cy="130.34" r="3.5"/>
+    <text class="end-label" x="700" y="134">Health</text>
   </g>
 
 </svg>
 </div>
 
-<p class="caption">Each line indexed so FY15 = 100; an indexed value of 143 means "43% above FY15." Solid lines are audited or directly published values; dotted segments past FY24 are trend extrapolations at each line's CAGR (cap and levy are forward-projected at 2.5%/yr and the levy limit's expected new-growth pace; teacher salary at +3.4%/yr; family health premium at +5.5%/yr long-run KFF average).</p>
+<p class="caption">Each line indexed so FY15 = 100; an indexed value of 143 means "43% above FY15." Solid lines are audited or directly published values; dotted segments past FY24 are trend extrapolations at each line's FY15&ndash;FY24 compound annual growth rate (cap at 2.5%/yr and levy at the cap plus expected new growth; teacher salary at 3.4%/yr; family health premium at 4.3%/yr).</p>
 
 <h2 id="what-this-means">What this means</h2>
 


### PR DESCRIPTION
## Summary

The page had two different growth-rate numbers for the family health premium: +4.6%/yr (bar chart label, key-stat, legend) vs. +5.5%/yr (line-chart caption, attributed to "long-run KFF average").

Root cause: the displayed +4.6%/yr was the FY15-FY27 blended CAGR, while +5.5%/yr was the assumed forward extrapolation rate. They were different things, both shown on the page, with no explanation. The +5.5%/yr was also misattributed: KFF's actual long-run is ~5.9%/yr.

## Fix

Extrapolate FY25-FY27 at the FY15-FY24 trend rate (+4.27%/yr), matching the methodology already used for the teacher salary line. Health now consistently shows **+4.3%/yr** in:

- Key-stat (was 4.6%)
- Bar chart bar width and rate label (was 4.6%, 502.7px wide -> 4.3%, 469.7px wide)
- Line chart legend (was +4.6%/yr)
- Line chart endpoint at FY27 (idx 165 vs idx 171; y=130.34 vs y=115.01)
- Bar chart caption (was "long-run KFF trend")
- Line chart caption (was "+5.5%/yr long-run KFF average")
- Aria-label

## Editorial story unchanged

Health still grows ~50% faster than the levy (+4.3% vs +3.0%) and ~70% faster than the cap (+4.3% vs +2.5%). The "twice as fast as the cap" framing in the social post is no longer technically true (it's now ~1.7x); the page itself doesn't make that exact claim.

## Test plan
- [ ] Cloudflare preview shows +4.3%/yr in all four places (key-stat, bar chart, legend, captions)
- [ ] Line chart Health endpoint at FY27 sits ~15px below where it was, matching the lower CAGR
- [ ] Captions read coherently with new methodology phrasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)