### PR TITLE
cap-vs-cost: stack levy bar (cap + new growth), fix methodology CSS

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -4182,6 +4182,35 @@ svg.chart .data-dot--halo {
   stroke-width: 1.5;
 }
 
+/* Deep-dive body content (methodology section etc.):
+   the global `* { padding: 0 }` reset zeroes <ul> padding, and the
+   safety-net rule for `.container > details > ul` doesn't reach lists
+   nested inside `.deep-dive-body > ul`. Restore list and heading
+   styling explicitly. */
+.deep-dive .deep-dive-body h3 {
+  margin: 1.25rem 0 0.4rem;
+  font-size: 1rem;
+  color: var(--c-navy);
+}
+.deep-dive .deep-dive-body h3:first-child {
+  margin-top: 0;
+}
+.deep-dive .deep-dive-body p {
+  line-height: 1.6;
+}
+.deep-dive .deep-dive-body ul,
+.deep-dive .deep-dive-body ol {
+  padding-left: 1.5rem;
+  margin: 0 0 0.85rem;
+  list-style: disc;
+}
+.deep-dive .deep-dive-body ol { list-style: decimal; }
+.deep-dive .deep-dive-body li {
+  margin-bottom: 0.25rem;
+  line-height: 1.55;
+  color: var(--text-muted);
+}
+
 /* Cap-vs-cost dollar comparison table */
 .dollar-table {
   width: 100%;

--- a/cap-vs-cost.html
+++ b/cap-vs-cost.html
@@ -20,11 +20,11 @@ og_url: https://marbleheaddata.org/cap-vs-cost.html
 
 <h2 id="growth-rates">1. How fast each one grew</h2>
 
-<p>Each bar is one cost, with its annual growth rate. The dashed vertical line marks the rate Marblehead's revenue actually grew at (the 2.5% cap plus new growth from new construction). Bars past that line grew faster than the levy could keep up with.</p>
+<p>Each bar is one cost, with its annual growth rate. The Marblehead levy bar is itself the 2.5% cap (gray) plus new growth from new construction (navy). The dashed vertical line at the levy's right edge marks the rate the levy actually grew at; bars past that line grew faster than the levy could keep up with.</p>
 
 <div class="chart-wrap">
 <svg class="chart" viewBox="0 0 820 290" xmlns="http://www.w3.org/2000/svg" role="img"
-     aria-label="Horizontal bar chart of annual growth rates: pure 2.5% cap (legal floor), Marblehead levy 3.0% per year, average teacher salary 3.4% per year, family health premium 4.3% per year. Vertical dashed line at 3.0% marks Marblehead's actual revenue speed; teacher salary and family health premium exceed it.">
+     aria-label="Horizontal bar chart of annual growth rates: pure 2.5% cap (legal floor), Marblehead levy 3.0% per year (composed of the 2.5% cap plus 0.5% from new construction), average teacher salary 3.4% per year, family health premium 4.3% per year. Vertical dashed line at 3.0% marks the levy's actual growth rate; teacher salary and family health premium exceed it.">
 
   <line class="grid-minor" x1="170" y1="55" x2="170" y2="225"/>
   <line class="grid-minor" x1="280" y1="55" x2="280" y2="225"/>
@@ -37,8 +37,10 @@ og_url: https://marbleheaddata.org/cap-vs-cost.html
   <text class="row-label"      x="160" y="80"  text-anchor="end">Pure 2&frac12;% cap</text>
   <text class="end-label"      x="455" y="80">2.5%/yr</text>
 
+  <!-- Marblehead levy: stacked. Cap-portion (0->2.5%) styled like the cap bar above; new-growth portion (2.5->3.0%) is solid navy. -->
+  <rect class="bar-solid-cap"  x="170" y="100" width="275"   height="32" rx="2"/>
   <g class="s-marblehead">
-    <rect class="data-bar"     x="170" y="100" width="334.4" height="32" rx="2"/>
+    <rect class="data-bar"     x="445" y="100" width="59.4"  height="32" rx="2"/>
   </g>
   <text class="row-label"      x="160" y="120" text-anchor="end">Marblehead levy</text>
   <text class="end-label"      x="514" y="120">3.0%/yr</text>


### PR DESCRIPTION
## Summary

Two visual polish fixes on `cap-vs-cost.html`:

### 1. Levy bar is now stacked

The Marblehead levy bar shows the composition: 0&ndash;2.5% styled like the cap bar above (gray, dashed outline), 2.5&ndash;3.0% as solid navy for the +0.5%/yr from new construction. Makes the relationship between the cap and the levy literal: *the levy is the cap plus a small slice from new construction*. The prose paragraph above the chart and the aria-label reflect this.

### 2. Methodology deep-dive CSS

The nested `<ul>` rendered bullets outside the box. Root cause: the global `* { padding: 0 }` reset zeroes `<ul>` padding, and the existing safety-net rule for `.container > details > ul` doesn't reach lists inside `.deep-dive-body > ul`.

Fix: add scoped CSS rules for `.deep-dive .deep-dive-body` (h3 margins, p line-height, ul/ol padding-left and list-style, li line-height). Fixes spacing for any future deep-dive section on any page, not just this one.

## Test plan
- [ ] Cloudflare preview: levy bar shows two visually distinct segments at 2.5% boundary
- [ ] Methodology section bullets are inside the box, with consistent spacing between h3/p/ul

🤖 Generated with [Claude Code](https://claude.com/claude-code)