### PR TITLE
Nav labels: Debate -> Both sides, Data -> Browse

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,8 +3,8 @@
     <a class="nav-brand" href="{{ '/' | relative_url }}"><img class="nav-logo" src="{{ '/' | relative_url }}favicon.svg" alt="" width="22" height="22"> MHD Data</a>
 
     <a class="nav-link" href="{{ '/' | relative_url }}whats-on-the-ballot.html"{% if page.url == '/whats-on-the-ballot.html' %} aria-current="page"{% endif %}>Ballot</a>
-    <a class="nav-link" href="{{ '/' | relative_url }}explore.html"{% if page.url == '/explore.html' or page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Debate</a>
-    <a class="nav-link" href="{{ '/' | relative_url }}browse.html"{% if page.url == '/browse.html' %} aria-current="page"{% endif %}>Data</a>
+    <a class="nav-link" href="{{ '/' | relative_url }}explore.html"{% if page.url == '/explore.html' or page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Both sides</a>
+    <a class="nav-link" href="{{ '/' | relative_url }}browse.html"{% if page.url == '/browse.html' %} aria-current="page"{% endif %}>Browse</a>
 
     <button class="search-toggle" aria-label="Search the site" title="Search (Ctrl/Cmd+K)">
       <svg class="search-icon" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="9" cy="9" r="6"/><path d="m17 17-3.5-3.5"/></svg>


### PR DESCRIPTION
## Summary
- 'Debate' &rarr; **Both sides**. The destination is /explore.html, a 15-question steelmanned scroller. 'Both sides' names what's actually there and matches the site's non-advocacy stance.
- 'Data' &rarr; **Browse**. The destination is /browse.html, an all-pages index. 'Data' implied datasets or interactive tools that don't live there.
- 'Ballot' unchanged &mdash; concrete and accurate.

## Test plan
- [x] `npm run test:local` &mdash; 55 pass / 0 fail
- [ ] Cloudflare preview: confirm nav reads 'Ballot &middot; Both sides &middot; Browse' on desktop and in mobile horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)