### PR TITLE
Nav: 'Both sides' -> 'Questions'

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,7 +3,7 @@
     <a class="nav-brand" href="{{ '/' | relative_url }}"><img class="nav-logo" src="{{ '/' | relative_url }}favicon.svg" alt="" width="22" height="22"> MHD Data</a>
 
     <a class="nav-link" href="{{ '/' | relative_url }}whats-on-the-ballot.html"{% if page.url == '/whats-on-the-ballot.html' %} aria-current="page"{% endif %}>Ballot</a>
-    <a class="nav-link" href="{{ '/' | relative_url }}explore.html"{% if page.url == '/explore.html' or page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Both sides</a>
+    <a class="nav-link" href="{{ '/' | relative_url }}explore.html"{% if page.url == '/explore.html' or page.url == '/the-debate.html' %} aria-current="page"{% endif %}>Questions</a>
     <a class="nav-link" href="{{ '/' | relative_url }}browse.html"{% if page.url == '/browse.html' %} aria-current="page"{% endif %}>Browse</a>
 
     <button class="search-toggle" aria-label="Search the site" title="Search (Ctrl/Cmd+K)">


### PR DESCRIPTION
## Summary
'Both sides' implied a binary; the destination has three answer cards per question. 'Questions' is the literal match for /explore.html's 15-question structure and dodges the both-sidesism baggage.

## Test plan
- [x] `npm run test:local` &mdash; 55 pass / 0 fail
- [ ] Cloudflare preview: nav reads 'Ballot &middot; Questions &middot; Browse'

🤖 Generated with [Claude Code](https://claude.com/claude-code)