### PR TITLE
Refresh browse.html: current page list, homepage-aligned sections

### DIFF
--- a/browse.html
+++ b/browse.html
@@ -2,24 +2,23 @@
 layout: home
 title: "Browse all pages"
 community_pulse: off-sections
-og_title: Marblehead Budget Data
-og_description: Open data and charts about Marblehead, MA municipal finances. Every number is traceable to a primary source.
+og_title: "Marblehead Budget Data - browse all pages"
+og_description: Every page on marbleheaddata.org, grouped by topic. The 15 voter questions live in /explore.html; charts, calculators, and source documents below.
 og_type: website
 og_url: https://marbleheaddata.org/browse.html
 ---
 <div class="hero">
     <h1>All pages</h1>
-    <p>Every page on marbleheaddata.org, grouped by topic. For the interactive question flow, start at <a href="/explore.html">Where do you stand?</a>. Every claim cites a primary source &ndash; <a href="#data-sources">see all sources</a>.</p>
+    <p>Every page on marbleheaddata.org, grouped by topic. For the 15 steelmanned voter questions, start at <a href="/explore.html">Questions</a>; for the streamlined overview, the <a href="/">home page</a>. Every claim cites a primary source &ndash; <a href="#data-sources">see all sources</a>.</p>
   </div>
 
-  <a class="featured-card" href="super-summary.html">
-    <div class="featured-card-eyebrow">New to this?</div>
-    <div class="featured-card-title">The whole override in 60 seconds</div>
-    <div class="featured-card-desc">The deficit, the three ballot tiers, what it costs at your home value, and when you vote. One short page.</div>
-  </a>
-
-  <p class="section-label">The vote</p>
+  <p class="section-label">The ballot</p>
   <div class="question-list">
+    <a class="question" href="whats-on-the-ballot.html">
+      <h2>What's on the June 9 ballot?</h2>
+      <p>The three override tiers (Q1A $15M, Q1B $12M, Q1C $9M), the curbside trash question (Q2 $2.3M), and the 24 other seats up at the Annual Town Election.</p>
+    </a>
+
     <a class="question" href="what-is-the-override.html">
       <h2>What is the override?</h2>
       <p>The three-tier structure, what each tier funds, key terms, and history.</p>
@@ -30,22 +29,50 @@ og_url: https://marbleheaddata.org/browse.html
       <p>The second ballot question. A $2.3M override for curbside trash, or a ~$281/household fee if it fails. What has already been decided, what each option costs by home value, and how other MA towns fund curbside.</p>
     </a>
 
-    <a class="question" href="how-we-got-here.html">
-      <h2>How did we get here?</h2>
-      <p>Seven years of Finance Committee warnings, in their own words. From "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025.</p>
-    </a>
-
-    <a class="question" href="marblehead-voting-record.html">
-      <h2>Has Marblehead voted yes before?</h2>
-      <p>Every Prop 2&frac12; vote since 1988: what passed, what failed, and how much.</p>
+    <a class="question" href="two-votes.html">
+      <h2>Spending vote first, limit vote second</h2>
+      <p>Town Meeting approved the spending side May 4. The June 9 ballot decides whether the levy cap moves up to fund it. Two votes, two different decisions.</p>
     </a>
   </div>
 
-  <p class="section-label">The stakes</p>
+  <p class="section-label">What it costs you</p>
   <div class="question-list">
-    <a class="question" href="no-override-budget.html">
-      <h2>What's in the no-override budget?</h2>
-      <p>22 town positions removed, 18.25 school FTEs, library reduced 43%, and what other MA towns did after similar votes.</p>
+    <a class="question" href="charts/override_calculator.html">
+      <h2>What does the override cost me?</h2>
+      <p>Monthly and annual cost by home value for each tier, at full phase-in. Plus share of household income by tier.</p>
+      <span class="tag tag-charts">Calculator</span>
+    </a>
+
+    <a class="question" href="charts/your_tax_bill.html">
+      <h2>Where your tax dollars go</h2>
+      <p>How an average Marblehead property tax bill splits across schools, public safety, healthcare, and five other categories, with override tier toggle.</p>
+      <span class="tag tag-charts">Chart</span>
+    </a>
+
+    <a class="question" href="charts/levy_vs_bill.html">
+      <svg class="spark-bg" viewBox="60 70 570 240" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
+        <path class="spark-area sf-cost" d="M70,300 116,292 162,277 208,259 254,242 299,222 345,205 391,193 437,179 483,158 528,129 574,108 620,80 L620,310 70,310 Z"/>
+        <polyline class="spark-line sf-neutral" points="70,300 116,294 162,288 208,287 254,282 299,273 345,263 391,255 437,249 483,228 528,190 574,169 620,153"/>
+        <polyline class="spark-line sf-revenue" points="70,300 116,292 162,277 208,260 254,243 299,223 345,206 391,194 437,180 483,162 528,131 574,110 620,87"/>
+        <polyline class="spark-line sf-cost" points="70,300 116,292 162,277 208,259 254,242 299,222 345,205 391,193 437,179 483,158 528,129 574,108 620,80"/>
+      </svg>
+      <h2>Tax levy, median bill, and inflation</h2>
+      <p>Three indexed growth rates over twelve years. The levy and median bill tracked each other closely, both growing faster than <abbr class="g" title="Consumer Price Index">CPI</abbr>.</p>
+      <span class="tag tag-charts">Chart</span>
+    </a>
+
+    <a class="question" href="senior-tax-relief.html">
+      <span class="tag tag-charts">Calculator</span>
+      <h2>What relief can seniors claim?</h2>
+      <p>Enter your home value and income to see your Circuit Breaker credit and how each override tier affects you after relief. Only 418 of an estimated 1,158 eligible seniors claimed the credit in 2022.</p>
+    </a>
+  </div>
+
+  <p class="section-label">Why there's a deficit</p>
+  <div class="question-list">
+    <a class="question" href="where-has-the-money-gone.html">
+      <h2>Where has Marblehead's money gone?</h2>
+      <p>A ten-year walkthrough of how the town has actually spent the tax levy, who has been checking the books, and where the biggest line-item changes landed.</p>
     </a>
 
     <a class="question" href="charts/sustainability.html">
@@ -88,18 +115,57 @@ og_url: https://marbleheaddata.org/browse.html
       <p>Set your own revenue and expense growth rates, toggle override tiers on and off, and see when the gap reopens. Interactive deficit projection model.</p>
       <span class="tag tag-charts">Interactive</span>
     </a>
-  </div>
 
-  <p class="section-label">The budget</p>
-  <div class="question-list">
-    <a class="question" href="where-has-the-money-gone.html">
-      <h2>Where has Marblehead's money gone?</h2>
-      <p>A ten-year walkthrough of how the town has actually spent the tax levy, who has been checking the books, and where the biggest line-item changes landed.</p>
+    <a class="question" href="charts/budget_flow.html">
+      <h2>Where the money goes (Sankey)</h2>
+      <p>Sankey-style flow chart from FY27 revenue sources to expense categories. Adjust tier and watch the flow change.</p>
+      <span class="tag tag-charts">Interactive</span>
     </a>
 
-    <a class="question" href="data/changelog.html">
-      <h2>Changelog</h2>
-      <p>How budget and override numbers have shifted over time, with before/after detail and attribution. Covers meetings, rating actions, and other primary-source releases.</p>
+    <a class="question" href="how-we-got-here.html">
+      <h2>How did we get here?</h2>
+      <p>Seven years of <abbr class="g" title="Finance Committee">FinCom</abbr> warnings, in their own words. From "pleased to report no override needed" in 2016 to "significant budgetary challenges ahead" in 2025.</p>
+    </a>
+
+    <a class="question" href="what-has-the-town-done.html">
+      <h2>What has the town already done to save?</h2>
+      <p>A factual inventory of cost-control measures Marblehead has taken before asking voters for an override, compiled from <abbr class="g" title="Finance Committee">FinCom</abbr> reports and budget documents.</p>
+    </a>
+
+    <a class="question" href="fiscal-goals.html">
+      <h2>Fiscal goals tracker</h2>
+      <p>Three measurable milestones for Marblehead's structural budget gap: identify savings, shift the crossover, get to parallel.</p>
+    </a>
+  </div>
+
+  <p class="section-label">If the override fails</p>
+  <div class="question-list">
+    <a class="question" href="no-override-budget.html">
+      <h2>What's in the no-override budget?</h2>
+      <p>22 town positions removed, 18.25 school <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>, library reduced 43%, and what other MA towns did after similar votes.</p>
+    </a>
+
+    <a class="question" href="after-the-no-vote.html">
+      <h2>After the no-vote: did Marblehead find the money?</h2>
+      <p>What happened after Marblehead's two recent failed overrides (2022 and 2023). The pre-vote threats, what actually got cut, where the money came from, and why the same play cannot run a third time.</p>
+    </a>
+
+    <a class="question" href="info-guides.html">
+      <h2>What each department says is at stake</h2>
+      <p>The town's six department information guides summarized: Council on Aging, Fire, <abbr class="g" title="Department of Public Works">DPW</abbr>, Community Development, Roads, and reserves.</p>
+    </a>
+  </div>
+
+  <p class="section-label">The questions</p>
+  <div class="question-list">
+    <a class="question" href="explore.html">
+      <h2>Where do you stand?</h2>
+      <p>Fifteen voter questions with three steelmanned answers each. Pick the answer that fits and get a position you can review or share.</p>
+    </a>
+
+    <a class="question" href="the-debate.html">
+      <h2>Both sides of the override debate</h2>
+      <p>The six dividing lines in the FY27 override debate, presented as the strongest version of each side's case.</p>
     </a>
   </div>
 
@@ -121,9 +187,14 @@ og_url: https://marbleheaddata.org/browse.html
       <h2>What are all those school positions?</h2>
       <p>430 school staff broken down by role: which are legally mandated, how Marblehead compares to peer towns by category, and what options exist.</p>
     </a>
+
+    <a class="question" href="town-school-admin.html">
+      <h2>Why two sets of departments?</h2>
+      <p>Marblehead runs parallel town and school admin operations. Why they exist, what the overlap actually is, what consolidation has looked like elsewhere, and the realistic savings ceiling.</p>
+    </a>
   </div>
 
-  <p class="section-label">Insurance</p>
+  <p class="section-label">Insurance &amp; compensation</p>
   <div class="question-list">
     <a class="question" href="charts/healthcare_costs.html">
       <svg class="spark-bg" viewBox="50 80 500 175" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
@@ -133,7 +204,7 @@ og_url: https://marbleheaddata.org/browse.html
         <polyline class="spark-line sf-cost" points="60,246 87,234 113,216 140,187 167,201 193,191 220,164 247,184 273,168 300,156 327,145 353,136 380,135 407,127 460,120 487,105 513,89 540,117"/>
       </svg>
       <h2>Why is health insurance outpacing the levy?</h2>
-      <p>Three charts and one loss ratio. Tax levy vs health insurance, spending vs headcount, and the actual annual price of one <abbr class="g" title="Group Insurance Commission">GIC</abbr> family plan: $24K to $39K in 7 years per plan. Town-total health insurance grew slower because headcount fell over the same period.</p>
+      <p>Three charts and one loss ratio. Tax levy vs health insurance, spending vs headcount, and the actual annual price of one <abbr class="g" title="Group Insurance Commission">GIC</abbr> family plan: $24K to $39K in 7 years per plan.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
 
@@ -154,43 +225,17 @@ og_url: https://marbleheaddata.org/browse.html
     </a>
   </div>
 
-  <p class="section-label">Your tax bill</p>
-  <div class="question-list">
-    <a class="question" href="charts/override_calculator.html">
-      <h2>What does it cost me?</h2>
-      <p>Monthly cost by home value for each tier, at full phase-in.</p>
-      <span class="tag tag-charts">Calculator</span>
-    </a>
-
-    <a class="question" href="charts/levy_vs_bill.html">
-      <svg class="spark-bg" viewBox="60 70 570 240" preserveAspectRatio="xMaxYMax slice" aria-hidden="true">
-        <path class="spark-area sf-cost" d="M70,300 116,292 162,277 208,259 254,242 299,222 345,205 391,193 437,179 483,158 528,129 574,108 620,80 L620,310 70,310 Z"/>
-        <polyline class="spark-line sf-neutral" points="70,300 116,294 162,288 208,287 254,282 299,273 345,263 391,255 437,249 483,228 528,190 574,169 620,153"/>
-        <polyline class="spark-line sf-revenue" points="70,300 116,292 162,277 208,260 254,243 299,223 345,206 391,194 437,180 483,162 528,131 574,110 620,87"/>
-        <polyline class="spark-line sf-cost" points="70,300 116,292 162,277 208,259 254,242 299,222 345,205 391,193 437,179 483,158 528,129 574,108 620,80"/>
-      </svg>
-      <h2>Tax levy, median bill, and inflation</h2>
-      <p>Three indexed growth rates over twelve years. The levy and median bill tracked each other closely, both growing faster than <abbr class="g" title="Consumer Price Index">CPI</abbr>.</p>
-      <span class="tag tag-charts">Chart</span>
-    </a>
-
-    <a class="question" href="senior-tax-relief.html">
-      <span class="tag tag-charts">Calculator</span>
-      <h2>What relief can seniors claim?</h2>
-      <p>Enter your home value and income to see your Circuit Breaker credit and how each override tier affects you after relief. Only 418 of an estimated 1,158 eligible seniors claimed the credit in 2022.</p>
-    </a>
-  </div>
-
   <p class="section-label">Peer towns</p>
   <div class="question-list">
-    <a class="question" href="town-budget.html">
-      <h3>Town budget explorer</h3>
-      <p>Every line in the FY27 budget - sortable, filterable, drillable.</p>
-    </a>
-
     <a class="question" href="charts/town_explorer.html">
       <h2>How does Marblehead compare to all 351 MA communities?</h2>
       <p>Sortable, filterable table of every Massachusetts municipality by population, income, property wealth, and tax burden. Define your own peer group instead of relying on a curated set.</p>
+      <span class="tag tag-charts">Interactive</span>
+    </a>
+
+    <a class="question" href="why-not-elsewhere.html">
+      <h2>Why do some MA towns run overrides and others don't?</h2>
+      <p>Residential share of tax levy, new growth rates, and override history for 21 Massachusetts peer towns, grouped into four structural archetypes.</p>
     </a>
 
     <a class="question" href="charts/four_town_rates.html">
@@ -201,8 +246,8 @@ og_url: https://marbleheaddata.org/browse.html
         <path class="spark-area sf-navy" d="M55,262 83,260 111,265 138,261 166,275 194,263 222,250 250,239 277,226 305,220 333,213 361,208 389,208 416,208 444,210 472,210 500,215 528,222 555,222 583,220 611,230 639,251 667,249 694,259 L694,280 55,280 Z"/>
         <polyline class="spark-line sf-navy" points="55,262 83,260 111,265 138,261 166,275 194,263 222,250 250,239 277,226 305,220 333,213 361,208 389,208 416,208 444,210 472,210 500,215 528,222 555,222 583,220 611,230 639,251 667,249 694,259"/>
       </svg>
-      <h2>How does Marblehead compare?</h2>
-      <p>Both the tax rate (lowest in the group) and the average bill (second-highest) for four North Shore towns, with override projections.</p>
+      <h2>Four North Shore towns: rate vs. bill</h2>
+      <p>Both the tax rate (Marblehead's is lowest in the group) and the average bill (second-highest) for four North Shore towns, with override projections.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
 
@@ -234,20 +279,52 @@ og_url: https://marbleheaddata.org/browse.html
       <span class="tag tag-charts">Chart</span>
     </a>
 
-    <a class="question" href="why-not-elsewhere.html">
-      <h2>Why do some MA towns run overrides and others don't?</h2>
-      <p>Residential share of tax levy, new growth rates, and override history for 21 Massachusetts peer towns, grouped into four structural archetypes.</p>
-    </a>
-
     <a class="question" href="charts/statewide_overrides.html">
       <h2>Overrides over time in Massachusetts</h2>
       <p>Every Prop 2&frac12; operating override ballot question across 305 municipalities since 1990: volume, pass rates, and median amounts by year.</p>
       <span class="tag tag-charts">Chart</span>
     </a>
 
-    <a class="question" href="data/case_studies">
+    <a class="question" href="charts/statewide_tax_burden.html">
+      <h2>Tax bill as share of income, all 351 MA communities</h2>
+      <p>Where Marblehead's effective property tax burden sits against every Massachusetts municipality.</p>
+      <span class="tag tag-charts">Chart</span>
+    </a>
+
+    <a class="question" href="charts/override_history.html">
+      <h2>Override vote history</h2>
+      <p>Marblehead's Prop 2&frac12; override votes with the ask, the result, and the margin.</p>
+      <span class="tag tag-charts">Chart</span>
+    </a>
+
+    <a class="question" href="charts/override_landscape.html">
+      <h2>Where does Marblehead's override land?</h2>
+      <p>Large override asks across Massachusetts since FY2020. Sizes Marblehead's FY27 ask against the recent statewide landscape.</p>
+      <span class="tag tag-charts">Chart</span>
+    </a>
+
+    <a class="question" href="charts/general_government_over_time.html">
+      <h2>General government spending over time</h2>
+      <p>Marblehead's general government spending grew 92% over 22 years, slightly slower than the rest of the town budget and roughly in line with inflation. In FY24 it was 3.3% of the budget, the lowest share among nine wealthy MA suburbs.</p>
+      <span class="tag tag-charts">Chart</span>
+    </a>
+
+    <a class="question" href="data/case_studies.html">
       <h2>What happened in towns that voted no?</h2>
       <p>What happened in four Massachusetts towns after override votes failed: two came back with larger asks, two absorbed years of cuts without returning.</p>
+    </a>
+  </div>
+
+  <p class="section-label">History &amp; background</p>
+  <div class="question-list">
+    <a class="question" href="prop25-story.html">
+      <h2>Prop 2&frac12; in Marblehead: a short history</h2>
+      <p>Forty-five years of Proposition 2&frac12; in Marblehead, from the 1980 campaign run by a Marblehead resident through every override the town has voted on since 1990.</p>
+    </a>
+
+    <a class="question" href="marblehead-voting-record.html">
+      <h2>Has Marblehead voted yes before?</h2>
+      <p>Every Prop 2&frac12; vote since 1988: what passed, what failed, and how much.</p>
     </a>
   </div>
 
@@ -257,36 +334,71 @@ og_url: https://marbleheaddata.org/browse.html
       <h2>What can you do?</h2>
       <p>Beyond voting yes or no on the override: who decides what, when residents can input, and how to push for better oversight of the town budget.</p>
     </a>
+
+    <a class="question" href="verify.html">
+      <h2>Join the verification network</h2>
+      <p>Verified Marblehead residents can cast deduplicated votes on ballot questions and sign correction requests. Two-sided invite handshake via existing neighbor.</p>
+    </a>
+
+    <a class="question" href="branches.html">
+      <h2>Verification branches</h2>
+      <p>How verified Marblehead residents are organized into neighborhood branches for the trust-graph neighbor-verification feature.</p>
+    </a>
+  </div>
+
+  <p class="section-label">About this project</p>
+  <div class="question-list">
+    <a class="question" href="about.html">
+      <h2>Who made this?</h2>
+      <p>Who builds marbleheaddata.org, why, the editorial stance, and how to contribute.</p>
+    </a>
+
+    <a class="question" href="super-summary.html">
+      <h2>The 60-second version</h2>
+      <p>The Marblehead FY27 override in under a minute. Three tiers, one trash question, what it costs, and when you vote.</p>
+    </a>
+
+    <a class="question" href="bias-audit.html">
+      <h2>Bias audit</h2>
+      <p>An independent AI audit of marbleheaddata.org for bias, selective framing, and editorial tilt. Run on April 11, 2026 against the full codebase.</p>
+    </a>
   </div>
 
   <div class="data-section" id="data-sources">
     <h2>Data &amp; Sources</h2>
     <div class="data-links">
-      <a class="data-link" href="data/master-data">
+      <a class="data-link" href="data/master-data.html">
         <div>
           <div class="data-link-title">Annual Rollup (FY01&ndash;FY27)</div>
           <div class="data-link-desc">Tax levy, revenue, staffing, benefits, enrollment, year by year</div>
         </div>
         <span class="data-link-badge">TABLE</span>
       </a>
-      <a class="data-link" href="data/DATA_CATALOG">
+      <a class="data-link" href="data/DATA_CATALOG.html">
         <div>
           <div class="data-link-title">Data Catalog</div>
           <div class="data-link-desc">What every field means and where it came from</div>
         </div>
         <span class="data-link-badge">MD</span>
       </a>
-      <a class="data-link" href="data/SOURCE_LOOKUP">
+      <a class="data-link" href="data/SOURCE_LOOKUP.html">
         <div>
           <div class="data-link-title">Source Lookup</div>
           <div class="data-link-desc">Trace any number to its specific document and page</div>
         </div>
         <span class="data-link-badge">MD</span>
       </a>
-      <a class="data-link" href="data/case_studies">
+      <a class="data-link" href="data/changelog.html">
+        <div>
+          <div class="data-link-title">Changelog</div>
+          <div class="data-link-desc">How budget and override numbers have shifted over time</div>
+        </div>
+        <span class="data-link-badge">PAGE</span>
+      </a>
+      <a class="data-link" href="data/case_studies.html">
         <div>
           <div class="data-link-title">Case Studies</div>
-          <div class="data-link-desc">What happened after four towns voted no</div>
+          <div class="data-link-desc">What happened after four MA towns voted no</div>
         </div>
         <span class="data-link-badge">MD</span>
       </a>


### PR DESCRIPTION
## Summary

The Browse page was stale on three axes:

1. **Stale copy.** Hero pointed at '/' for the question flow; that's now /explore.html. Featured 'Override in 60 seconds' card was redundant now that the home page IS that summary.
2. **Missing 16 pages**, including the literal ballot page (\`whats-on-the-ballot.html\`), \`/explore.html\`, \`/the-debate.html\`, \`after-the-no-vote.html\`, plus six chart pages and several background pages.
3. **Broken links** (\`data/case_studies\` etc. missing \`.html\` extensions).

## What changed

- New hero copy points at /explore.html and / for the two main entry points.
- Featured card dropped; super-summary.html now lives in the About section.
- 16 missing pages added across sections.
- Sections reordered to mirror the home page scroll flow: ballot &rarr; cost &rarr; deficit &rarr; if-fails &rarr; questions &rarr; schools &rarr; insurance &rarr; peer towns &rarr; history &rarr; involved &rarr; about.
- Sparkline thumbnails preserved on the cards that already had them; not backfilled on new cards (mixed treatment is fine if every card looks intentional).
- All \`data/\` links now use explicit \`.html\` extension.

## Test plan
- [x] \`npm run test:local\` &mdash; 55 pass / 0 fail
- [x] Local lint check: no unwrapped acronyms, no em-dashes, every internal link resolves to a file on disk
- [ ] Cloudflare preview: scan each section for accurate descriptions and working links

🤖 Generated with [Claude Code](https://claude.com/claude-code)