### PR TITLE
Promote tools on browse; add read-next to deficit_model and town_explorer

### DIFF
--- a/browse.html
+++ b/browse.html
@@ -7,9 +7,94 @@ og_description: Every page on marbleheaddata.org, grouped by topic. The 15 voter
 og_type: website
 og_url: https://marbleheaddata.org/browse.html
 ---
+<style>
+  /* Compact tool tiles for the top-of-page calculators & tools strip. */
+  .tool-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 10px;
+    margin: 0 0 28px;
+  }
+  @media (min-width: 600px) {
+    .tool-grid { grid-template-columns: 1fr 1fr; }
+  }
+  @media (min-width: 900px) {
+    .tool-grid { grid-template-columns: repeat(3, 1fr); }
+  }
+  .tool-tile {
+    display: block;
+    padding: 14px 16px 13px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: var(--text);
+    transition: border-color 0.15s, transform 0.15s;
+  }
+  .tool-tile:hover {
+    border-color: var(--c-teal);
+    transform: translateY(-1px);
+  }
+  .tool-tile-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+    margin: 0 0 4px;
+  }
+  .tool-tile-name {
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--c-teal);
+    line-height: 1.2;
+  }
+  .tool-tile-kind {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+    color: var(--text-subtle);
+    white-space: nowrap;
+  }
+  .tool-tile-desc {
+    font-size: 13px;
+    color: var(--text-muted);
+    line-height: 1.45;
+    margin: 0;
+  }
+</style>
+
 <div class="hero">
     <h1>All pages</h1>
     <p>Every page on marbleheaddata.org, grouped by topic. For the 15 steelmanned voter questions, start at <a href="/explore.html">Questions</a>; for the streamlined overview, the <a href="/">home page</a>. Every claim cites a primary source &ndash; <a href="#data-sources">see all sources</a>.</p>
+  </div>
+
+  <p class="section-label">Calculators &amp; tools</p>
+  <div class="tool-grid">
+    <a class="tool-tile" href="charts/override_calculator.html">
+      <div class="tool-tile-head"><span class="tool-tile-name">Override calculator</span><span class="tool-tile-kind">Calculator</span></div>
+      <p class="tool-tile-desc">Enter your home value, see the monthly and annual cost for each tier.</p>
+    </a>
+    <a class="tool-tile" href="charts/deficit_model.html">
+      <div class="tool-tile-head"><span class="tool-tile-name">Deficit model</span><span class="tool-tile-kind">Interactive</span></div>
+      <p class="tool-tile-desc">Adjust revenue and expense growth, toggle tiers, see when the next gap opens.</p>
+    </a>
+    <a class="tool-tile" href="charts/town_explorer.html">
+      <div class="tool-tile-head"><span class="tool-tile-name">Town explorer</span><span class="tool-tile-kind">Interactive</span></div>
+      <p class="tool-tile-desc">Compare Marblehead against all 351 Massachusetts towns on rate, levy, and burden.</p>
+    </a>
+    <a class="tool-tile" href="charts/budget_flow.html">
+      <div class="tool-tile-head"><span class="tool-tile-name">Budget flow</span><span class="tool-tile-kind">Interactive</span></div>
+      <p class="tool-tile-desc">Sankey-style flow from FY27 revenue sources to expense categories.</p>
+    </a>
+    <a class="tool-tile" href="senior-tax-relief.html">
+      <div class="tool-tile-head"><span class="tool-tile-name">Senior tax relief</span><span class="tool-tile-kind">Calculator</span></div>
+      <p class="tool-tile-desc">Circuit Breaker credit by income and home value, plus override impact after relief.</p>
+    </a>
+    <a class="tool-tile" href="charts/your_tax_bill.html">
+      <div class="tool-tile-head"><span class="tool-tile-name">Tax bill split</span><span class="tool-tile-kind">Chart</span></div>
+      <p class="tool-tile-desc">Where your tax dollars go: 8-category breakdown with override tier toggle.</p>
+    </a>
   </div>
 
   <p class="section-label">The ballot</p>

--- a/charts/deficit_model.html
+++ b/charts/deficit_model.html
@@ -916,6 +916,26 @@ An override on its own buys time. It does not change the slope of either line.
   See the lines that grew most: <a href="/town-budget.html?dirfilter=increased&amp;pct_min=10">budget lines up 10%+ in FY27</a>.
 </p>
 
+<div class="read-next">
+  <div class="read-next-label">Read next</div>
+  <a class="read-next-link" href="../charts/override_calculator.html">
+    <div class="read-next-title">What does the override cost me? &rarr;</div>
+    <div class="read-next-desc">Enter your home value and see the year-by-year cost for each tier, plus share of household income.</div>
+  </a>
+  <a class="read-next-link" href="../charts/sustainability.html">
+    <div class="read-next-title">Is this a one-time reset? &rarr;</div>
+    <div class="read-next-desc">Ten years of revenue and expenses behind the model, and how each tier compares to projected expenses through FY30.</div>
+  </a>
+  <a class="read-next-link" href="../charts/town_explorer.html">
+    <div class="read-next-title">Compare Marblehead to 351 MA towns &rarr;</div>
+    <div class="read-next-desc">Filter and sort every Massachusetts municipality by population, income, property wealth, and tax burden.</div>
+  </a>
+  <a class="read-next-link" href="../no-override-budget.html">
+    <div class="read-next-title">What's in the no-override budget? &rarr;</div>
+    <div class="read-next-desc">22 town positions, 18.25 school <abbr class="g" title="Full-Time Equivalents">FTEs</abbr>, library reduced 43%; the alternative the model is projecting against.</div>
+  </a>
+</div>
+
 <details class="notes">
   <summary>Notes and methodology</summary>
   <p>Historical revenue and expenditure figures (FY15 to FY24) are from the General Fund Budgetary Comparison schedules in each year's <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr>. These are budgetary-basis numbers, not GAAP. The data file is <a href="../data/general_fund_budgetary_FY15-24.csv">general_fund_budgetary_FY15-24.csv</a>.<sup class="cite" data-href="../data/general_fund_budgetary_FY15-24.csv" data-source="ACFRs FY15 through FY24, General Fund Budgetary Comparison schedules"></sup></p>

--- a/charts/town_explorer.html
+++ b/charts/town_explorer.html
@@ -445,6 +445,26 @@ scripts: [citations]
   </table>
 </div>
 
+<div class="read-next">
+  <div class="read-next-label">Read next</div>
+  <a class="read-next-link" href="../charts/deficit_model.html">
+    <div class="read-next-title">Project the gap forward &rarr;</div>
+    <div class="read-next-desc">Adjust revenue and expense growth assumptions, toggle tiers, see when the next override hits.</div>
+  </a>
+  <a class="read-next-link" href="../why-not-elsewhere.html">
+    <div class="read-next-title">Why do some MA towns run overrides and others don't? &rarr;</div>
+    <div class="read-next-desc">Residential share of levy, new growth, and override history grouped into four structural archetypes across 21 peer towns.</div>
+  </a>
+  <a class="read-next-link" href="../charts/four_town_rates.html">
+    <div class="read-next-title">Four North Shore towns &rarr;</div>
+    <div class="read-next-desc">Focused comparison of Marblehead, Swampscott, Melrose, and Stoneham on tax rate and average bill.</div>
+  </a>
+  <a class="read-next-link" href="../charts/override_calculator.html">
+    <div class="read-next-title">What does the override cost me? &rarr;</div>
+    <div class="read-next-desc">Year-by-year monthly and annual cost for each tier at your home value, plus share of household income.</div>
+  </a>
+</div>
+
 <details class="notes" style="margin-top: 20px;">
   <summary>Sources and methodology</summary>
   <p><strong>Sources.</strong> Population, <abbr class="g" title="Department of Revenue">DOR</abbr> Income, and <abbr class="g" title="Equalized Valuation">EQV</abbr>: <a href="https://dls-gw.dor.state.ma.us/reports/rdpage.aspx?rdreport=dor_income_eqv_per_capita">MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr>, DOR Income and EQV Per Capita FY2027</a> (pulled April 15, 2026). Tax levies, rates, new growth, and levy capacity: <a href="https://dls-gw.dor.state.ma.us/reports/rdPage.aspx?rdReport=Community_Comparison_Report">MA <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr> Community Comparison Report FY2026</a>. Average single-family tax bill: <abbr class="g" title="Department of Revenue">DOR</abbr> <abbr class="g" title="Division of Local Services">DLS</abbr> FY2026.</p>


### PR DESCRIPTION
## Summary

Two changes from one user note (\"browse still feels overwhelming and my favorite tools are hard to get to; both tools need links out at the bottom\"):

- **browse.html**: new 'Calculators & tools' strip right after the hero. Compact card grid (2-3 columns by viewport) for the six interactive pages: override calculator, deficit model, town explorer, budget flow, senior tax relief, tax-bill split. Sits above the topic sections so the most-used pages aren't buried mid-page.
- **charts/deficit_model.html**: read-next block at the bottom (above 'Notes and methodology') linking to override_calculator, sustainability, town_explorer, and no-override-budget.
- **charts/town_explorer.html**: read-next block at the bottom (above 'Sources and methodology') linking to deficit_model, why-not-elsewhere, four_town_rates, and override_calculator.

## Test plan
- [x] \`npm run test:local\` &mdash; 55 pass / 0 fail
- [x] Local lint check: no unwrapped acronyms, no em-dashes
- [ ] Cloudflare preview: tool grid renders 2 cols on tablet / 3 on desktop; tiles show name + kind badge + description; deficit_model and town_explorer pages each show 4 read-next cards above the methodology section

🤖 Generated with [Claude Code](https://claude.com/claude-code)