### PR TITLE
transcripts: hide subscribe CTA until email-capture exists

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,13 @@ baseurl: ""
 # TURNSTILE_SECRET secret on the Pages project). Used by feedback.html.
 turnstile_site_key: "0x4AAAAAADEi6Ymsaf-lEIvW"
 
+# Feature flags. Flip to true once the backing endpoint exists.
+# transcripts_subscribe: shows the "Log in to subscribe" CTA on
+# transcript pages. Disabled until the verification network captures
+# email + a Friday-digest worker is deployed (see the design at
+# docs/superpowers/specs/2026-06-02-meeting-questions-and-subscriptions.md).
+transcripts_subscribe: false
+
 plugins: []
 
 collections:

--- a/_layouts/transcript.html
+++ b/_layouts/transcript.html
@@ -25,6 +25,7 @@ layout: default
     </header>
 
     {%- comment -%} ─── LOGIN TO SUBSCRIBE CTA ─── {%- endcomment -%}
+    {% if site.transcripts_subscribe %}
     <aside class="ms-subscribe" aria-label="Subscribe to meeting summaries">
       <div class="ms-subscribe-copy">
         <p class="ms-subscribe-lead"><strong>Get this in your inbox.</strong></p>
@@ -34,6 +35,7 @@ layout: default
         Log in to subscribe&nbsp;&rarr;
       </a>
     </aside>
+    {% endif %}
 
     {%- comment -%} ─── SEPARATE FEATURED FROM REST ─── {%- endcomment -%}
     {% assign featured = page.topic_segments | where: "featured", true %}

--- a/docs/superpowers/specs/2026-06-02-meeting-questions-and-subscriptions.md
+++ b/docs/superpowers/specs/2026-06-02-meeting-questions-and-subscriptions.md
@@ -15,6 +15,16 @@
 
 Both ride on top of the transcript collection and the existing Neighbor Verification Network. Neither makes sense without verified-resident identity at the entry point: we don't want anonymous spam or non-residents driving the queue. The verification network already handles passkey auth, two-sided invite handshakes, street typeahead, and verified-ballot tally &mdash; **that layer is the foundation; we don't rebuild it.**
 
+### Prerequisite: email capture on the verification network
+
+The current verification flow is passkey-only and does **not** capture an email address. That gap is the blocker for subscriptions. Before either feature ships, the verify flow needs:
+
+1. An optional email field at sign-up, with a clear "this is only used for the meeting digest you opt into; we won't email you otherwise" disclosure.
+2. An email-management surface for the resident to add/change/remove the address later.
+3. Storage in the existing D1 verification database, joined to the resident's verified identity row.
+
+Until that lands, the "Log in to subscribe" CTA on transcript pages is gated behind a `site.transcripts_subscribe` feature flag in `_config.yml` (currently `false`). Flip to `true` once the email-capture flow and the Friday-digest worker both exist.
+
 ## Why now
 
 Three readers' jobs to be done that the current site doesn't serve:


### PR DESCRIPTION
## Summary

Hide the "Log in to subscribe" CTA on transcript pages until the verification network actually captures email and a Friday-digest worker exists. Behind a `transcripts_subscribe` feature flag in `_config.yml`.

## Why

`/verify.html` is passkey-only. There's no email field, no subscription table, and no Friday-digest worker. Clicking "Log in to subscribe" would lead a verified resident to a flow that can't fulfill the promise. Better to hide it than fake it.

## What

- `_config.yml` — new `transcripts_subscribe: false` flag
- `_layouts/transcript.html` — wrap the CTA aside in `{% if site.transcripts_subscribe %}`
- `docs/superpowers/specs/2026-06-02-meeting-questions-and-subscriptions.md` — add "Prerequisite: email capture" subsection naming the three pieces needed to close the gap

## Test plan

- [ ] /meetings/select-board-2026-04-08/ on preview — no subscribe CTA visible
- [ ] /meetings/school-committee-2026-04-09/ on preview — no subscribe CTA visible
- [ ] Spec page renders the new section under "Two features, one substrate"

## To re-enable

Flip `transcripts_subscribe: true` in `_config.yml` once email capture + delivery worker are deployed. No other code change required.