### PR TITLE
what-can-we-do.html: section-widget disable + Difficulty/timeline demo on Idea 6

### DIFF
--- a/what-can-we-do.html
+++ b/what-can-we-do.html
@@ -495,12 +495,12 @@ community_pulse: off-sections
   <span class="wcwd-draft">Draft &middot; Working list &middot; Updated 2026-06-02</span>
   <h1>What can we do?</h1>
   <p class="wcwd-hero-sub">
-    Seventeen <strong>questions worth asking the town's finance staff</strong>, drawn from one resident's reading of the public record. Not a feasibility study. The dollar figures below are rough guesses; the "have we tried this" answers came from one research pass and have already missed at least one item.
+    Eighteen <strong>questions worth asking the town's finance staff</strong>, drawn from one resident's reading of the public record. Not a feasibility study. The dollar figures below are rough guesses; the "have we tried this" answers came from one research pass and have already missed at least one item.
   </p>
   <nav class="wcwd-jump" aria-label="Page sections">
     <a href="#revenue" data-cat="rev">5 revenue ideas</a>
     <a href="#cost" data-cat="cost">10 cost reductions</a>
-    <a href="#governance" data-cat="gov">2 governance changes</a>
+    <a href="#governance" data-cat="gov">3 governance changes</a>
     <a href="#cautions">Cautions</a>
     <a href="#paths">How adoption happens</a>
   </nav>
@@ -546,7 +546,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">$200K to $500K</span>
         <span class="idea-guess-cap">per year, at the 6% cap. Range depends on hotel and <abbr class="g" title="Short-Term Rental">STR</abbr> inventory we haven't actually counted.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Medium.</strong> One Town Meeting vote. Failed in 2023 by three votes, so the political case has to be remade.</p>
+        <p><strong>6 to 12 months</strong> to first revenue. One Annual or Special Town Meeting plus the state-quarter activation lag after acceptance.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Visitors pay.</strong> Hotels, inns, and Airbnb hosts collect and remit. The lodging industry argues it suppresses bookings at the margin; data on this is mixed.</p>
         <p>Worth noting: visitors use the harbor, beaches, parking, and emergency services without paying property tax. One argument is that this tax makes their use of town services more equitable. Another is that it makes visiting Marblehead more expensive without obvious benefit. Reasonable people disagree.</p>
@@ -575,7 +580,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">$20K to $75K</span>
         <span class="idea-guess-cap">per year. Small, because it only applies to commercial operators with 2+ units.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Easy if bundled with 01.</strong> Same vote, same statutory family. On its own, similar effort but a narrower constituency to convince.</p>
+        <p><strong>6 to 12 months</strong> if adopted with the room excise. Same activation lag.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Commercial Airbnb operators with 2 or more properties.</strong> Homeowners renting their own place occasionally are unaffected. Small commercial operators sometimes exit at this margin; large operators absorb it. Targeted at investor-class STR operators specifically.</p>
       </div>
@@ -601,7 +611,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">$150K to $400K</span>
         <span class="idea-guess-cap">per year of additional headroom. Heavily dependent on peer-utility comparisons we haven't actually run.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Medium.</strong> Requires Light Commission alignment and a defensible peer-utility comparison. Ratepayer optics are real.</p>
+        <p><strong>12 months.</strong> Negotiated and incorporated in the next annual budget cycle.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Electric ratepayers.</strong> A bigger contribution from <abbr class="g" title="Marblehead Municipal Light Department">MMLD</abbr> means slightly higher electric rates to fund it. Whether that's a con depends on you.</p>
         <p>Big house with central AC, electric heat, and EV charging? Your electric bill is large; a <abbr class="g" title="Payment In Lieu Of Taxes">PILOT</abbr> increase costs you. Senior in an older smaller home with modest electric use but a high property tax bill? You'd come out ahead, because the cost is shifting from your tax bill toward heavier electric consumers. Renters who pay their own electric directly: you'd pay a bit more. Functionally this is a <strong>shift from a property-value tax base to a consumption-based one</strong>, not new money.</p>
@@ -630,7 +645,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">$10K to $30K</span>
         <span class="idea-guess-cap">per year, optimistically. Possibly less. Genuinely uncertain whether the audit pays for itself.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Easy.</strong> Within the Assessor's existing authority; no vote, no bargaining.</p>
+        <p><strong>6 to 12 months.</strong> Cross-reference Harbormaster and commercial-yard rolls against the excise commitment, then bill.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Boat owners whose vessels are kept in Marblehead but somehow not on the rolls here.</strong> Some are non-residents; some are residents who weren't being caught. Every Massachusetts boat owner pays excise to <em>some</em> town anyway, so this isn't new tax, just correctly-allocated tax. The boat-owning community is small but vocal.</p>
       </div>
@@ -657,7 +677,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">$25K to $100K</span>
         <span class="idea-guess-cap">per year, depending entirely on waitlist turnover. Could be way off either direction.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Hard.</strong> Politically charged because of generational waitlist expectations. May require a bylaw amendment.</p>
+        <p><strong>1 to 2 years.</strong> Public process to size the fee, possible Town Meeting vote, then implementation.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Whoever gets to the front of a decades-long waitlist.</strong> Long-time Marblehead families view waitlist position as something to pass to children. Putting a price on the handoff disrupts that social expectation. Progressive in tax incidence (it falls on people receiving a scarce asset) but contentious on cultural grounds, especially with families who've waited two or three generations.</p>
       </div>
@@ -731,7 +756,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">$250K to $500K</span>
         <span class="idea-guess-cap">per year of avoided energy cost, plus $2M to $4M of deferred building maintenance funded from those savings rather than from town capital.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Medium.</strong> No political vote needed. The hard work is the investment-grade audit and selecting an energy company, both slow.</p>
+        <p><strong>12 to 24 months</strong> from RFP to first energy-bill savings. Bigger maintenance benefits show up across the contract life.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>The town, over 10 to 20 years, through the savings stream.</strong> "No upfront cost" is true but slightly misleading: the energy company is financing the upgrades at their margin and capital cost. Over the contract life, the town pays full retail for the upgrades plus the energy company's spread, not the wholesale cost.</p>
         <p>The "guaranteed savings" usually has carve-outs (weather adjustments, utility-rate changes, occupancy variations). It's a real tool with a real track record, but the energy company is a for-profit entity and the contract reflects that. Long-term lock-in is the trade for zero upfront capex.</p>
@@ -762,7 +792,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">$100K to $300K</span>
         <span class="idea-guess-cap">per year over a 24-36 month window, from incremental shared functions, not from a wholesale combine.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Hard.</strong> Requires Select Board and School Committee alignment plus union conversations on any role moves.</p>
+        <p><strong>3 to 5 years</strong> for material savings. Most of the dollar impact happens through retirement timing, not layoffs.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Back-office staff in roles that get reorganized.</strong> Most savings come through attrition: when someone retires, the position is restructured rather than refilled. No one is laid off, but workloads on remaining staff get heavier during transition. Service quality often dips for a year or two while systems consolidate.</p>
         <p>School-side staff sometimes feel the move is a takeover by the town side. The legal structure (school committee budget autonomy) means any shared service has to be a formal agreement, not a merger.</p>
@@ -791,7 +826,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">$50K to $150K</span>
         <span class="idea-guess-cap">per year per shared role. Depends entirely on which role and which neighbor.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Medium.</strong> Needs a willing partner town. The legal mechanism is well-trodden; the hard part is matching workloads and supervisory comfort.</p>
+        <p><strong>1 to 2 years</strong> per shared role, from initial conversation to a functioning shared employee.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>The shared employee, and any Marblehead resident who needs them quickly.</strong> The shared role now has two bosses. Marblehead-specific tasks compete with the neighbor's priorities. Slower response on issues that aren't urgent to both towns. Marblehead also has less unilateral authority over hiring, firing, and discipline of that role.</p>
       </div>
@@ -819,7 +859,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">Roughly cost-neutral</span>
         <span class="idea-guess-cap">Gross savings $50K to $100K per year; software and licensing $30K to $80K per year. Net somewhere between break-even and $40K per year positive after a 1 to 2 year payback. Modest.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Easy</strong> as procurement; harder as a workflow change. Extends an existing OpenGov footprint.</p>
+        <p><strong>12 to 18 months.</strong> Procurement, configuration, training, transition. Resident-side benefits show up first.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>The town up front, in software acquisition, training, and a transition year.</strong> Older residents and people without reliable internet face a learning curve and may need help getting their permits through. Inspectional Services will need to staff a help line at the counter during transition. Net financial win is small and slow; the case for doing it has to rest on service quality, not savings.</p>
       </div>
@@ -847,7 +892,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">$300K to $1.5M</span>
         <span class="idea-guess-cap">per year, net of likely wage offset, over a multi-year bargaining horizon. The full range is wide because the wage-offset assumption dominates the math.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Hard.</strong> Multi-union bargaining. A concession in one contract sets precedent for the others; sequencing matters.</p>
+        <p><strong>3 to 6 years.</strong> Limited by when each union's contract opens. Savings ramp in as each unit moves.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Active employees, through higher premium contributions, partially offset by wage increases over time.</strong> A flat percentage-point change hits lower-paid employees harder than higher-paid ones in absolute terms, since the same percentage of a smaller premium is still a meaningful chunk of a smaller paycheck. The wage offset typically lands on base salary, which then compounds in pensions, so the long-run distributional effects favor higher-tenure employees.</p>
       </div>
@@ -875,7 +925,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">$100K to $400K</span>
         <span class="idea-guess-cap">per year, depending on how many town employees have spouses with their own employer-offered coverage. Highly dependent on the actual demographics, which we haven't seen.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Hard.</strong> Bargained item plus annual attestation infrastructure to administer.</p>
+        <p><strong>2 to 4 years</strong> to negotiate across the bargaining cycles and stand up the administrative process.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Couples where both spouses have full-time jobs with benefits.</strong> Some of those spouses are on Marblehead's plan specifically because it's better than the alternative; for them, the surcharge or carve-out is a real loss. Couples where only one spouse works in benefited employment are unaffected. Bargained with unions; takes a contract cycle.</p>
       </div>
@@ -904,7 +959,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">$50K to $300K</span>
         <span class="idea-guess-cap">per year of net savings, after accounting for non-discretionary overtime. Smaller than several other items on this page. Not a silver bullet, but real money.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Easy to commission.</strong> Within Town Administrator authority and standard procurement.</p>
+        <p><strong>6 to 12 months</strong> for the audit and report. Implementation of any recommendations a further 1 to 2 years, depending on which department.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Public-safety and public-works employees who currently earn meaningful overtime income.</strong> For many of them, overtime is not a windfall, it's a planned portion of household income, often used to compensate for relatively modest base salaries. Cutting it can feel like a pay cut even when the policy is sound. Also: if the audit recommends additional hiring rather than less coverage, the upfront cost shows before the savings.</p>
       </div>
@@ -925,22 +985,25 @@ community_pulse: off-sections
       <h3 class="idea-title">Restructure part-time positions to avoid benefit eligibility</h3>
       <div class="idea-body">
         <p>The mechanism: in Massachusetts, employees become eligible for town-paid health insurance once they work <strong>20 or more hours per week on a regular basis</strong>. Some employers structure part-time jobs at 18 or 19 hours specifically to stay below that threshold and avoid the benefit cost.</p>
-        <p>Included on this page because it came up in conversation and the math, in isolation, sounds attractive. <strong>We do not recommend it.</strong> The reasons:</p>
+        <p>Considerations that limit its use as a primary cost-reduction lever:</p>
         <ul style="font-size:14.5px;line-height:1.6;color:var(--text);margin:0 0 12px 18px;padding:0;">
-          <li>It is widely (and accurately) seen as predatory toward low-wage workers, who tend to be in the positions where it applies (school cafeteria, library aides, council on aging assistants, custodial).</li>
           <li>Federal Affordable Care Act lookback rules require averaging hours over a 6 to 12 month measurement period, which constrains how strictly hours can be capped.</li>
-          <li>The dollar impact in Marblehead is probably small, the town doesn't have many marginal positions at 20 to 25 hours where this could be applied.</li>
-          <li>Increased turnover, recruiting difficulty, and morale costs tend to eat the savings within a year or two.</li>
-          <li>The reputational cost to Marblehead as an employer is real.</li>
+          <li>The dollar impact in Marblehead is probably small; the town doesn't have many marginal positions at 20 to 25 hours where it could be applied.</li>
+          <li>The positions where it would apply (school cafeteria, library aides, Council on Aging assistants, custodial) tend to be the lowest-paid in the town's payroll. Removing benefit access narrows the value of those jobs to workers, with downstream effects on turnover and recruiting.</li>
+          <li>Comparable MA towns generally pursue benefit-cost reduction through the bargained levers above (Medicare Advantage, premium split, spousal surcharge) rather than through schedule restructuring.</li>
         </ul>
-        <p>Listed here as a "considered and rejected" item rather than a live lever. Better mechanisms for managing benefit cost are above (Medicare Advantage, premium split, spousal surcharge).</p>
       </div>
       <div class="idea-guess">
-        <span class="idea-guess-label">Not a lever we'd recommend</span>
+        <span class="idea-guess-label">Rough guess</span>
         <span class="idea-guess-num">$20K to $100K</span>
-        <span class="idea-guess-cap">per year, optimistically. Probably less after turnover and recruiting costs. Listed for honesty, not for adoption.</span>
+        <span class="idea-guess-cap">per year, optimistically, before turnover and recruiting costs. Materially smaller lever than items 06, 11, or 12.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Hard in practice.</strong> ACA lookback rules constrain it; reputational and recruiting costs are real. Few MA towns use it as a primary lever.</p>
+        <p><strong>Not a path most MA towns are taking.</strong> Listed for completeness, not as a recommended pace.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Low-wage workers in part-time roles.</strong> These are often retirees supplementing pensions, students, or second-earners in families with primary jobs elsewhere, populations who specifically rely on these jobs not to be exploitative. The job loses benefit value, the worker loses health coverage or pays more for it, and the town loses recruitment capability. The math may pencil narrowly; the human cost doesn't.</p>
       </div>
@@ -967,7 +1030,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">$180K to $630K</span>
         <span class="idea-guess-cap">per year, sized at 10 to 30 opt-outs (5 to 15 percent of roughly 200 dual-eligible town employees) at $18K to $21K net savings each. Highly sensitive to the actual demographics and the buyout amount chosen. Politically easier than idea 12 because the lever is voluntary and accretive.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Medium.</strong> Still bargained, but the trade is cleaner than the premium-split fight: the lever is voluntary and shared.</p>
+        <p><strong>1 to 3 years.</strong> One or two bargaining cycles to land it; uptake builds over time.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Almost nobody directly &ndash; that's why it works.</strong> Employees who opt out get cash and keep coverage through their spouse. Employees who keep town coverage are unaffected. The town saves real money. The catch is administrative: the ACA's "unconditional opt-out" rules require careful structuring so the cash isn't counted against the affordability calculation, and the buyout amount has to be high enough to drive uptake but low enough to keep the net savings worth it. Bargained with unions, but typically less contentious than the spousal surcharge.</p>
       </div>
@@ -990,7 +1058,7 @@ community_pulse: off-sections
 <!-- GOVERNANCE -->
 <!-- ============================================================ -->
 <section id="governance" class="wcwd-stop">
-  <p class="wcwd-eye">Governance and process <span class="dot">&bull;</span> 2 questions</p>
+  <p class="wcwd-eye">Governance and process <span class="dot">&bull;</span> 3 questions</p>
   <h2 class="wcwd-section-h2">Could the town make these decisions differently?</h2>
   <p class="wcwd-section-lead">These don't generate dollars themselves. They're the structures that decide whether the items above get pursued or shelved.</p>
 
@@ -1009,7 +1077,12 @@ community_pulse: off-sections
         <span class="idea-guess-num">No direct dollars</span>
         <span class="idea-guess-cap">The commission itself produces no revenue. What it produces is recommendations. Peer-town efficiency commissions have surfaced anywhere from nothing to several million per year, depending heavily on composition and authority.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Medium.</strong> The bylaw vote is easy; the commission's quality, composition, and forcing-function are what determine impact.</p>
+        <p><strong>6 months</strong> to adopt the bylaw at the next Town Meeting. <strong>1 to 2 years</strong> for the first set of substantive findings.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Department staff who get audited, and residents who serve on the commission.</strong> Commission seats become contested; the commission's quality depends entirely on membership. Recommendations land on already-busy department heads who can implement them or quietly ignore them. Done well, it produces real savings; done poorly, it produces friction without much else.</p>
       </div>
@@ -1031,22 +1104,62 @@ community_pulse: off-sections
         <p>Most departments build next year's budget by <strong>starting with last year's number and adding inflation</strong>. "Zero-based budgeting" starts from $0 and forces every line to be re-justified from scratch. It's a heavy lift, but done once every few years per department, it resets baselines and uncovers spending that nobody currently remembers approving.</p>
         <p>Schools, Police, and Fire account for about 70% of operating, so they're the natural targets. Zero-based budgeting has come up at School Committee at least four times: a 2020-06-08 commitment to develop a zero-based budget for FY22,<sup class="cite" data-href="/meetings/school-committee-2020-06-08/" data-source="School Committee minutes, 2020-06-08, Public Hearing on the Proposed FY21 School Budget: 'Mr. McAlduff stated the School Committee would need to meet and possibly include the town finance side and write down what definition of a zero based budget we would be using as there are several varying definitions.' (quote_verified=true in catalog)"></sup> a 2022-07-19 overview by the Finance Director proposing an October start with intensive staffing review,<sup class="cite" data-href="/meetings/school-committee-2022-07-19/" data-source="School Committee minutes, 2022-07-19, Zero Based Budget Presentation by Michelle Cresta: 'Assistant Superintendent of Finance and Operations, Michelle Cresta gave an overview of what a zero based budgeting approach would entail. It was explained that the process was created to justify costs based on need in every salary line. Ms. Cresta also provided recommendations for planning for the FY24 budgeting season including beginning the process in October while incorporating an intensive overview of staffing levels, which was last completed some time ago.' (quote_verified=true in catalog)"></sup> a 2023-07-06 proposal to work with an outside consultant on staffing specifically,<sup class="cite" data-href="/meetings/school-committee-2023-07-06/" data-source="School Committee minutes, 2023-07-06, FY24 Budget Discussions: 'Ms. Schaeffner mentioned working with administration to look at a zero-based budgeting for staffing specifically. She also recommended bringing in an outside consultant to complete the process. It was recommended that the discussion be continued at a meeting in August.' (quote_verified=true in catalog)"></sup> and a 2025-10-17 request for a zero-based approach examining staffing against enrollment projections.<sup class="cite" data-href="/meetings/school-committee-2025-10-17/" data-source="School Committee minutes, 2025-10-17, FY27 Budget Planning Discussion and Staffing Analysis: 'Committee requested zero-based budgeting approach examining staffing needs by building based on enrollment projections. Superintendent noted current process already considers contractual obligations and service requirements. Enrollment declined 800 students over eight years, requiring staffing justification. Level funding with contractual increases estimated to require $1.7 million in cuts. Potential elimination of approximately 30 professional staff positions (10% of staff).' (quote_verified flag not yet set in catalog)"></sup> No published board action in the catalog of 331 minute-level entries (FY19&ndash;present) constitutes a formal zero-based exercise. The most recent attempt &ndash; the Oct 17, 2025 request, with methodology development promised for an Oct 28 meeting &ndash; was overtaken at the next School Committee meeting on Oct 30, 2025, where the Budget Subcommittee instead directed all departments to prepare level-service budgets.<sup class="cite" data-href="/meetings/school-committee-2025-10-30/" data-source="School Committee minutes, 2025-10-30, Budget Subcommittee Report: 'Budget subcommittee met twice with finance committee liaison; all departments directed to prepare level service budgets and laid out a timeline (December preliminary information).' The Oct 30 minutes (data/minutes/school_committee/2025-10-30.cleaned.txt) contain no mention of zero-based budgeting, methodology, or the school-by-school staffing breakdowns the Superintendent had committed to on Oct 17."></sup></p>
         <p>A three-year operating forecast for FY26 through FY28 exists, but that's a different exercise from zero-based budgeting on an individual department.</p>
+        <p><strong>Honest read on the label:</strong> strict line-by-line zero-based budgeting is rare in Massachusetts municipal practice. What towns actually run under the "ZBB" label is usually a scoped department review (often staffing-focused), not a full rebuild from $0. Marblehead's own four School Committee discussions are consistent with this; the 2022-07-19 entry explicitly noted "current staffing would not be adequate to fully implement zero-based budgeting." The term does more rhetorical work than methodological work. The lever is real; the label is loose.</p>
       </div>
       <div class="idea-guess">
         <span class="idea-guess-label">Indirect, not direct</span>
         <span class="idea-guess-num">$500K to $1.5M</span>
         <span class="idea-guess-cap">per cycle of potential reallocation, declining over time as baselines reset. Highly speculative until tried locally.</span>
       </div>
-      <div class="idea-catch">
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Medium.</strong> School Committee has discussed it four times without adopting; needs management capacity and a willing department.</p>
+        <p><strong>1 to 2 years per cycle.</strong> What ships under the ZBB label is usually a scoped staffing review on that timeframe, not a full rebuild.</p>
+      </div>
+<div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Department staff.</strong> The exercise is several weeks of line-by-line justification work on top of their regular duties. Demoralizing if framed as "we don't trust your judgment." Some departments learn to game zero-based budgeting by reorganizing line items rather than rethinking spending. Done as a partnership it produces real reallocations; done as an audit it just produces friction.</p>
       </div>
       <details class="idea-research">
         <summary>What we'd need to firm this up</summary>
         <ul>
-          <li>Examples of zero-based budgeting actually run in MA municipal practice</li>
+          <li>What MA municipalities have actually implemented under the zero-based label, and whether any has run line-by-line rather than scoped to staffing review</li>
           <li>Departmental appetite from Schools, Police, Fire</li>
           <li>Resource cost of running it (typically a quarter of one staff person's time per major department)</li>
+        </ul>
+      </details>
+    </div>
+
+    <!-- Idea 18: Performance audit -->
+    <div class="idea" data-cat="gov">
+      <p class="idea-num">18 &middot; Audit</p>
+      <h3 class="idea-title">Commission a formal performance audit of the major cost centers</h3>
+      <div class="idea-body">
+        <p>A <strong>performance audit</strong> is different from the annual financial audit Marblehead already has. A financial audit verifies that the books are accurate and follow accounting standards. A performance audit asks a different question: <strong>is the department achieving its goals efficiently, effectively, and economically?</strong> It's conducted against federal Generally Accepted Government Auditing Standards (the "Yellow Book"). Massachusetts cities and towns can engage the State Auditor's Division of Local Mandates, or outside firms like BerryDunn, Plante Moran, or ICMA Consulting.</p>
+        <p>Marblehead has had narrower, adjacent work. The 2024 CliftonLarsonAllen assessment of the town finance department was an operational review (15 of 23 recommendations implemented by March 2024). The annual Roselli, Clark &amp; Associates engagement is a financial audit, not a performance audit. <strong>The major operating cost centers, schools, police, fire, <abbr class="g" title="Department of Public Works">DPW</abbr>, have not been reviewed under performance-audit standards.</strong></p>
+        <p>What an audit would actually deliver: department-by-department findings on whether services achieve their goals at the lowest cost, with specific recommendations for changes. Cost depends entirely on scope: roughly $30K to $80K for a single-department review, $150K to $400K for a comprehensive town-wide audit. <strong>Honest read:</strong> Marblehead has had several recent assessments and the implementation track record has been uneven. An audit without a serious implementation commitment is a cost without the benefit.</p>
+      </div>
+      <div class="idea-guess">
+        <span class="idea-guess-label">Indirect, not direct</span>
+        <span class="idea-guess-num">$30K to $400K cost</span>
+        <span class="idea-guess-cap">up front, depending on scope. Savings surfaced are indirect and depend on what gets implemented after the report. The CliftonLarsonAllen review surfaced 23 recommendations; about two-thirds went forward.</span>
+      </div>
+            <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Easy to commission, medium to implement.</strong> The audit itself is procurement; the harder work is sustaining attention on the recommendations.</p>
+        <p><strong>6 to 12 months</strong> for a town-wide audit and report. Implementation of accepted recommendations a further 1 to 2 years.</p>
+      </div>
+<div class="idea-catch">
+        <span class="idea-catch-label">Who pays?</span>
+        <p><strong>The town up front in audit fees, and department staff during the engagement.</strong> An audit takes time from the staff being audited; institutional defensiveness is common. A weak follow-through process turns the spend into shelfware. The failure mode is well-known: detailed recommendations land, are partially implemented, and the rest fade. Pairing an audit with a structured implementation commitment (a Town Meeting reporting requirement, a sunset clause, or a follow-up engagement) is what determines whether it matters.</p>
+      </div>
+      <details class="idea-research">
+        <summary>What we'd need to firm this up</summary>
+        <ul>
+          <li>Scope decisions: town-wide vs. targeted to one or two departments</li>
+          <li>Vendor quotes from BerryDunn, Plante Moran, ICMA Consulting, and the State Auditor's office</li>
+          <li>Implementation track record on prior assessments (CliftonLarsonAllen and others)</li>
+          <li>Funding path: existing administrative budget vs. Town Meeting appropriation</li>
         </ul>
       </details>
     </div>
@@ -1088,7 +1201,7 @@ community_pulse: off-sections
 <section id="paths" class="wcwd-stop">
   <p class="wcwd-eye">How adoption happens</p>
   <h2 class="wcwd-section-h2">Most of these don't need a Town Meeting vote.</h2>
-  <p class="wcwd-section-lead">Three procedural paths. Two of the seventeen items need a vote at Town Meeting; the rest can begin at the next board meeting or in the next bargaining cycle.</p>
+  <p class="wcwd-section-lead">Three procedural paths. Two of the eighteen items need a vote at Town Meeting; the rest can begin at the next board meeting or in the next bargaining cycle.</p>
 
   <div class="paths-grid">
 
@@ -1105,6 +1218,7 @@ community_pulse: off-sections
         <li>Spousal surcharge or carve-out (12)</li>
         <li>Overtime audit (13)</li>
         <li>Health-plan opt-out buyout (15)</li>
+        <li>Performance audit of major cost centers (18, may need appropriation if scope is large)</li>
         <li>Boat excise compliance audit (04)</li>
         <li>Further <abbr class="g" title="Marblehead Municipal Light Department">MMLD</abbr> contribution discussion (03)</li>
       </ul>

--- a/what-can-we-do.html
+++ b/what-can-we-do.html
@@ -895,7 +895,7 @@ community_pulse: off-sections
             <div class="idea-odds">
         <span class="idea-odds-label">Difficulty &amp; timeline</span>
         <p><strong>Hard.</strong> Multi-union bargaining. A concession in one contract sets precedent for the others; sequencing matters.</p>
-        <p><strong>3 to 6 years.</strong> Limited by when each union's contract opens. Savings ramp in as each unit moves.</p>
+        <p><strong>3 to 6 years.</strong> Marblehead has separate contracts for police, fire, <abbr class="g" title="Department of Public Works">DPW</abbr>, school custodial, teachers, and town clerical, each running roughly 3 years on its own clock. The premium share is a bargained term that can't be changed unilaterally; you can only move it at contract opening (or by a voluntary mid-contract reopener, which unions rarely grant without offsetting concessions). The first union to accept a new split sets precedent for the rest, so sequencing matters. Savings ramp in as each unit moves, partially counter-flowing with the wage increases unions trade for the concession.</p>
       </div>
 <div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>

--- a/what-can-we-do.html
+++ b/what-can-we-do.html
@@ -5,6 +5,7 @@ og_description: "Twelve questions worth asking the town's finance staff. Assembl
 og_url: https://marbleheaddata.org/what-can-we-do.html
 sitemap: false
 scripts: [citations]
+community_pulse: off-sections
 ---
 <style>
   /* === Scrolling stops, homepage-style === */
@@ -226,6 +227,33 @@ scripts: [citations]
     line-height: 1.5;
     margin: 6px 0 0;
   }
+
+  /* Difficulty + timeline: how hard, how long */
+  .idea-odds {
+    background: color-mix(in srgb, var(--c-brass) 8%, transparent);
+    border: 1px solid color-mix(in srgb, var(--c-brass) 22%, transparent);
+    border-left: 3px solid var(--c-brass);
+    padding: 12px 14px 13px;
+    margin: 0 0 18px;
+    border-radius: 0 8px 8px 0;
+  }
+  .idea-odds-label {
+    display: block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.9px;
+    text-transform: uppercase;
+    color: var(--c-brass);
+    margin: 0 0 6px;
+  }
+  .idea-odds p {
+    font-size: 13.5px;
+    line-height: 1.55;
+    color: var(--text);
+    margin: 0 0 6px;
+  }
+  .idea-odds p:last-child { margin-bottom: 0; }
+  .idea-odds p strong { font-weight: 700; }
 
   /* "Who pays?" block: explicit distributional fact, same weight as the guess */
   .idea-catch {
@@ -667,6 +695,11 @@ scripts: [citations]
         <span class="idea-guess-label">Rough guess</span>
         <span class="idea-guess-num">$300K to $900K</span>
         <span class="idea-guess-cap">per year of town-side savings. Almost certainly the largest dollar item on this page, but needs a real actuarial study before believing it.</span>
+      </div>
+      <div class="idea-odds">
+        <span class="idea-odds-label">Difficulty &amp; timeline</span>
+        <p><strong>Hard.</strong> Requires an actuarial study, retiree consultation, a competitive carrier procurement, and Public Employee Committee bargaining. Politically the most sensitive item on the page.</p>
+        <p><strong>2 to 3 years</strong> from a board decision to start through full transition. Savings begin in year 2 or 3, not immediately.</p>
       </div>
       <div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>

--- a/what-can-we-do.html
+++ b/what-can-we-do.html
@@ -795,7 +795,7 @@ community_pulse: off-sections
             <div class="idea-odds">
         <span class="idea-odds-label">Difficulty &amp; timeline</span>
         <p><strong>Hard.</strong> Requires Select Board and School Committee alignment plus union conversations on any role moves.</p>
-        <p><strong>3 to 5 years</strong> for material savings. Most of the dollar impact happens through retirement timing, not layoffs.</p>
+        <p><strong>3 to 5 years</strong> for material savings. Union contracts and political cost make layoffs slow and expensive; natural attrition (roughly 4 to 8 percent of staff per year through retirement and voluntary departures) is the rate that's available. An early-retirement incentive program can compress the timeline to 18 to 24 months at a cost of roughly $30K to $80K per employee accepting, eating into year-one savings.</p>
       </div>
 <div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
@@ -1001,7 +1001,7 @@ community_pulse: off-sections
             <div class="idea-odds">
         <span class="idea-odds-label">Difficulty &amp; timeline</span>
         <p><strong>Hard in practice.</strong> ACA lookback rules constrain it; reputational and recruiting costs are real. Few MA towns use it as a primary lever.</p>
-        <p><strong>Not a path most MA towns are taking.</strong> Listed for completeness, not as a recommended pace.</p>
+        <p><strong>No comparable timeline.</strong> Few MA municipalities use this as a structured cost-reduction program, so there's no representative implementation pace to cite.</p>
       </div>
 <div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>

--- a/what-can-we-do.html
+++ b/what-can-we-do.html
@@ -724,7 +724,7 @@ community_pulse: off-sections
       <div class="idea-odds">
         <span class="idea-odds-label">Difficulty &amp; timeline</span>
         <p><strong>Hard.</strong> Requires an actuarial study, retiree consultation, a competitive carrier procurement, and Public Employee Committee bargaining. Politically the most sensitive item on the page.</p>
-        <p><strong>2 to 3 years</strong> from a board decision to start through full transition. Savings begin in year 2 or 3, not immediately.</p>
+        <p><strong>2 to 3 years.</strong> The pipeline has four roughly sequential phases: an actuarial feasibility study (3 to 6 months), Public Employee Committee consultation under <abbr class="g" title="Massachusetts General Laws">MGL</abbr> c. 32B &sect; 21 to 23 with retiree associations and active unions (3 to 6 months), a competitive carrier procurement to underwrite a Group Medicare Advantage plan (3 to 6 months), and implementation with retiree communications, enrollment support, and a January 1 plan-year start (6 to 12 months). Savings show in the budget the fiscal year after the transition lands.</p>
       </div>
       <div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
@@ -928,7 +928,7 @@ community_pulse: off-sections
             <div class="idea-odds">
         <span class="idea-odds-label">Difficulty &amp; timeline</span>
         <p><strong>Hard.</strong> Bargained item plus annual attestation infrastructure to administer.</p>
-        <p><strong>2 to 4 years</strong> to negotiate across the bargaining cycles and stand up the administrative process.</p>
+        <p><strong>2 to 4 years.</strong> Same multi-union dynamic as item 11: bargained term, can only move at contract opening, sequencing matters for precedent. Lands faster than the premium-split fight because the concession is narrower (it changes the cost of covering a spouse, not the cost of the employee's own coverage), so the wage-offset demand tends to be smaller. Add 6 to 12 months for <abbr class="g" title="Human Resources">HR</abbr> to stand up the annual attestation, verification, and audit process before the first surcharge collections.</p>
       </div>
 <div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>
@@ -1033,7 +1033,7 @@ community_pulse: off-sections
             <div class="idea-odds">
         <span class="idea-odds-label">Difficulty &amp; timeline</span>
         <p><strong>Medium.</strong> Still bargained, but the trade is cleaner than the premium-split fight: the lever is voluntary and shared.</p>
-        <p><strong>1 to 3 years.</strong> One or two bargaining cycles to land it; uptake builds over time.</p>
+        <p><strong>1 to 3 years.</strong> Bargained the same way as items 11 and 12, but lands faster because the trade is voluntary and accretive: the buyout pays employees to waive coverage they have through a spouse, so no one loses access to anything. Uptake then builds over time: year 1 captures the most eager waivers, year 2 the next tranche as employees who initially declined see colleagues take it, year 3 reaches steady-state. Savings start in year 1 but compound through year 3.</p>
       </div>
 <div class="idea-catch">
         <span class="idea-catch-label">Who pays?</span>


### PR DESCRIPTION
## Summary

Fresh branch off latest main with the two minimum changes to unblock review:

1. **Disable section reaction widgets** (`community_pulse: off-sections` frontmatter). Removes the star/flag/share/note icons next to each `<h2>`.
2. **Demo the Difficulty & timeline box on Idea 6 (Medicare Advantage)** — a brass-bordered side panel sitting between Rough Guess (teal) and Who Pays (red). Two lines: difficulty rating + reason, and timeline range + reason.

Earlier branches (PR #776, #780) got stuck with non-triggering CI. This is the clean version.

## Preview

- **Preview URL**: https://wcwd-fresh-fixes.marbleheaddata-preview.pages.dev/what-can-we-do.html
- Scroll to `#cost` → Idea 6 → should see three stacked panels: Rough guess (teal), **Difficulty & timeline (brass, new)**, Who pays? (red)
- Verify no star/flag icons on any `<h2>`

## What's NOT in this PR (intentional)

The other lost fixes from PR #770 — Idea 14 editorial cleanup, ZBB honest read on the label, new Idea 18 performance audit — are bundled into a separate follow-up PR to keep this one focused on getting the design demo in front of the reader.

## Risk

Very low. Single-file addition on a draft page that's `sitemap: false` and unlinked from nav.