### PR TITLE
Add 2025 Town Meeting Article 46 transcript and summary

### DIFF
--- a/data/meetings.json
+++ b/data/meetings.json
@@ -1,6 +1,6 @@
 {
   "last_updated": "2026-04-24T00:06:11.604Z",
-  "video_count": 61,
+  "video_count": 62,
   "meeting_count": 13,
   "community_count": 48,
   "pdf_count": 0,
@@ -11,6 +11,50 @@
     "Finance Committee": 3
   },
   "videos": [
+    {
+      "id": "ootpoCJlG6k",
+      "title": "Marblehead Annual Town Meeting 5-8-25",
+      "board": "Town Meeting",
+      "date": "2025-05-08",
+      "duration_min": 158,
+      "description": "Final session of the 2025 Annual Town Meeting.",
+      "url": "https://www.youtube.com/watch?v=ootpoCJlG6k",
+      "thumbnail": null,
+      "upload_date": "2025-05-09",
+      "plays": 0,
+      "summary": {
+        "summary": "At the May 8, 2025 Annual Town Meeting, Article 46, which proposed appropriating up to $100,000 from free cash to fund an independent town audit, was indefinitely postponed at the request of its own sponsor, Philip A. Mancuso, Jr. The motion to indefinitely postpone carried 405 to 21 with no debate and no speakers recorded. No funds were appropriated and no independent audit was established.",
+        "topics": [
+          {
+            "title": "Article 46: Appropriate Funds for an Independent Audit (Indefinitely Postponed)",
+            "detail": "The article, sponsored by Philip A. Mancuso, Jr. and others, originally proposed appropriating up to $100,000 from free cash to establish an independent audit of town departments. The auditor would have been selected by the Finance Committee, published findings to voters at the 2026 Annual Town Meeting, and the authorization would have been subject to annual reauthorization. The sponsor moved indefinite postponement; there was no debate and no speakers were recorded before the vote.",
+            "vote": "Motion to indefinitely postpone, moved by the sponsor. Passed 405 to 21."
+          }
+        ],
+        "public_comment_themes": [],
+        "key_numbers": [
+          {
+            "label": "Maximum appropriation proposed in Article 46 (not approved)",
+            "value": "$100,000"
+          },
+          {
+            "label": "Vote in favor of indefinite postponement",
+            "value": "405"
+          },
+          {
+            "label": "Votes opposed to indefinite postponement",
+            "value": "21"
+          }
+        ],
+        "action_items": [
+          "No action items. The article was indefinitely postponed; no funds were appropriated and no independent audit was established.",
+          "Confirm final vote tally against Town Clerk's official minutes."
+        ],
+        "override_relevant": false,
+        "override_details": ""
+      },
+      "transcript_file": "data/town_meeting_2025-05-08_transcript.txt"
+    },
     {
       "id": "1185678252",
       "title": "REV250 Marblehead Revolutionary Near Miss by Judy Anderson",

--- a/data/town_meeting_2025-05-08_transcript.txt
+++ b/data/town_meeting_2025-05-08_transcript.txt
@@ -1,0 +1,15 @@
+Source: MHTV recording of the 2025 Annual Town Meeting, final session, May 8, 2025 (YouTube video ootpoCJlG6k), approximately 1:19:00 to 1:20:15. Transcribed from the video's auto-generated caption track and lightly cleaned. Speaker labels are inferred from context; the caption track does not name speakers. Vote tally should be confirmed against the Town Clerk's official minutes.
+
+Excerpt: Article 46 (Appropriate Funds, Independent Audit). Sponsored by Philip A. Mancuso, Jr. and others. The article as printed in the warrant asked Town Meeting to appropriate from free cash a sum not to exceed $100,000 to establish an independent town audit by an independent audit agency or entity, which would publish a report to the voters at the 2026 annual town meeting of any and all departmental budget recommendations or policy changes designed to control town costs and expenses and to balance the town budget against available funding, with the auditor selected by the Finance Committee and the article subject to annual reauthorization.
+
+Moderator: Article 46, appropriate funds for an independent audit. The main motion for this is indefinite postponement, by the sponsor.
+
+Sponsor: Move.
+
+Moderator: Do I have a second? Thank you. Seeing no speakers, we're going to go to a vote on the indefinite postponement of Article 46. If you favor the article, use your green "yes" button; if you oppose, use the red "no" button. Thirty-second voting starts now.
+
+[Vote taken.]
+
+Moderator: Article 46 passes, 405 to 21.
+
+Note: The motion on the floor was indefinite postponement, moved by the sponsor. "Article 46 passes, 405 to 21" means the motion to indefinitely postpone carried. No funds were appropriated and no independent audit was established. There was no debate; the moderator recorded no speakers before the vote. This followed the same pattern as Article 45 (indefinitely postponed 418 to 13) immediately before and Article 47, the sustainability coordinator article (indefinitely postponed 375 to ...), immediately after.


### PR DESCRIPTION
Transcribes the **Article 46 (Appropriate Funds, Independent Audit)** discussion from the final session of the 2025 Annual Town Meeting (May 8, 2025) and adds it to the meeting data.

## What happened
The sponsor, Philip A. Mancuso, Jr., moved **indefinite postponement of his own article**. There was no debate and no speakers were recorded. The motion to indefinitely postpone carried **405 to 21**. No funds were appropriated and no independent audit was established. (Same pattern as Article 45 before it and Article 47 after it, both also IP'd by their sponsors.)

## Changes
- `data/town_meeting_2025-05-08_transcript.txt` — Article 46 excerpt, transcribed from the [MHTV YouTube recording](https://www.youtube.com/watch?v=ootpoCJlG6k) auto-caption track (~1:19:00–1:20:15), lightly cleaned. Speaker labels inferred from context.
- `data/meetings.json` — new entry for the 5-8-25 session plus the `summarize_meeting.mjs` structured summary.

## Caveats
- Source is the video's **auto-generated caption track**, not a stenographic record. The **405–21 tally should be confirmed against the Town Clerk's official minutes** before being cited elsewhere on the site.
- Em/en dashes were stripped from the model-generated summary per the no-dash style rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)