### PR TITLE
Add where-candidates-stand.html: candidate positions for 6 contested races

### DIFF
--- a/where-candidates-stand.html
+++ b/where-candidates-stand.html
@@ -1,0 +1,271 @@
+---
+title: "Where the candidates stand"
+scripts: [citations]
+og_title: "Where the candidates stand"
+og_description: "What every candidate in Marblehead's six contested June 9 races said about the override, the budget, schools and trash, drawn from their own published candidate Q&As in the Marblehead Current and the Marblehead Independent voter guide."
+og_url: https://marbleheaddata.org/where-candidates-stand.html
+---
+<style>
+  /* Page-scoped: per-race candidate position blocks */
+  .race {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: 18px 20px 16px;
+    margin: 0 0 18px;
+  }
+  .race > h2 {
+    font-size: 19px;
+    margin: 0 0 2px;
+    line-height: 1.25;
+    border: 0;
+    padding: 0;
+  }
+  .race-meta {
+    font-size: 12px;
+    color: var(--text-subtle);
+    font-variant-numeric: tabular-nums;
+    margin: 0 0 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    font-weight: 700;
+  }
+  .tier-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+    margin: 0 0 14px;
+    padding: 10px 12px;
+    background: var(--fog);
+    border-radius: var(--radius-sm);
+    font-size: 13px;
+  }
+  .tier-strip .tier-strip-label {
+    width: 100%;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-weight: 700;
+    color: var(--text-subtle);
+    margin-bottom: 2px;
+  }
+  .tier-strip span.t {
+    font-variant-numeric: tabular-nums;
+  }
+  .tier-strip span.t strong { color: var(--text); }
+  .cand {
+    padding: 12px 0;
+    border-top: 1px solid var(--border);
+  }
+  .cand:first-of-type { border-top: 0; padding-top: 2px; }
+  .cand h3 {
+    font-size: 16px;
+    margin: 0 0 6px;
+    line-height: 1.3;
+  }
+  .cand h3 .role {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-subtle);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-left: 6px;
+  }
+  .cand p {
+    font-size: 14px;
+    line-height: 1.6;
+    margin: 0 0 8px;
+    color: var(--text-muted);
+  }
+  .cand p:last-child { margin-bottom: 0; }
+  .cand p strong { color: var(--text); }
+  .cand .no-answer {
+    font-style: italic;
+    color: var(--text-subtle);
+  }
+</style>
+
+<h1>Where the candidates stand</h1>
+
+<p class="page-lead">Six of the offices on the <a href="whats-on-the-ballot.html">June 9 ballot</a> are contested. The positions below come from each candidate's own answers in two published Q&As: the <strong>Marblehead Current</strong>'s individual candidate interviews and the <strong>Marblehead Independent</strong>'s 2026 voter guide. Where a candidate did not answer, that is noted rather than filled in.</p>
+
+<p class="source">These are the candidates' stated positions, quoted from their published interviews. Nothing here is an endorsement, and this site is not affiliated with any candidate or campaign. For the full list of all 24 seats, ballot mechanics and the four override questions, see <a href="whats-on-the-ballot.html">what else is on the June 9 ballot</a>.</p>
+
+<h2 id="select-board">Select Board</h2>
+
+<div class="race">
+  <h2>Three candidates, two seats</h2>
+  <p class="race-meta">Vote for not more than 2 &middot; 3-year terms</p>
+
+  <div class="tier-strip">
+    <span class="tier-strip-label">Stated override position</span>
+    <span class="t"><strong>Noonan:</strong> Tier 3 (Question 3, $15M)</span>
+    <span class="t"><strong>Ferrante:</strong> Tier 2</span>
+    <span class="t"><strong>Schaeffner:</strong> no tier named</span>
+  </div>
+
+  <div class="cand">
+    <h3>Erin Marie Noonan <span class="role">Incumbent</span></h3>
+    <p>Backs all three override questions and will vote <strong>Question 3</strong>, the $15M three-year option, which she says "simply restores the town to 2020 service levels."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/erin-noonan-for-select-board/" data-source="Marblehead Current, candidate Q&A: Erin Noonan for Select Board, May 19, 2026"></sup> She lists what it funds: three police and four firefighter positions, a special education program for 18 to 22 year-olds, a <abbr class="g" title="Department of Public Works">DPW</abbr> foreman, mental health funding, about $1.5M in capital repairs and a grant writer. She calls it "a responsible, measured path back to the service levels Marblehead residents deserve."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    <p>Beyond the override she points to revenue the town adopted in 2024, a 0.75% local meals tax and a 6% room occupancy tax together worth roughly $480,000 a year, plus a smart-growth zoning overlay and returning unused town property such as the Coffin School to the tax base.<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/erin-noonan-for-select-board/" data-source="Marblehead Current, candidate Q&A: Erin Noonan for Select Board, May 19, 2026"></sup> A five-year incumbent and an attorney, she disputes that residents broadly distrust officials, citing Town Meeting's roughly 90% support for the override proposal.</p>
+  </div>
+
+  <div class="cand">
+    <h3>Rossana Ferrante</h3>
+    <p>Says "the town needs an override" after attending the Finance Committee's budget session, but criticizes the process as "hurried." In the Current (May 19) she said she was "leaning towards supporting Tier 1 and/or Tier 2" and suggested keeping a possible underride "on the radar."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/rossana-ferrate-for-select-board/" data-source="Marblehead Current, candidate Q&A: Rossana Ferrante for Select Board, May 19, 2026"></sup> In the Independent's voter guide she states her position more firmly: <strong>"I support Tier 2,"</strong> and says she is open to a fee-based trash structure that gives "people more choice."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    <p>The Recreation and Park Commission chair, a former Planning Board member and an attorney, she calls for a "deep dive into all aspects of how we do business," including insurance, contracts and unused town property, and for better coordination across departments to "find creative solutions to not raise taxes."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/rossana-ferrate-for-select-board/" data-source="Marblehead Current, candidate Q&A: Rossana Ferrante for Select Board, May 19, 2026"></sup></p>
+  </div>
+
+  <div class="cand">
+    <h3>Jennifer Schaeffner</h3>
+    <p>Calls the town's finances "a genuine fiscal crisis" and says that after years of spending down reserves, raising the tax levy may be "an unfortunate but necessary step." She <strong>does not endorse a tier</strong>, citing concerns about transparency and noting that 2025 voters wanted a menu of choices that "deserved to be heard and respected." If the override passes and she is elected, she commits to "fight to ensure that the additional revenue is used to provide meaningful relief."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/jenn-schaeffner-for-select-board/" data-source="Marblehead Current, candidate Q&A: Jenn Schaeffner for Select Board, May 19, 2026"></sup></p>
+    <p>A current School Committee member and Housing Authority chair with a finance and banking background, she would apply "zero-based budgeting across every town department," look for shared services to cut duplication, and grow revenue through tourism and a more business-friendly approach "without adding to the tax burden on our residents."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+  </div>
+</div>
+
+<h2 id="school-committee">School Committee</h2>
+
+<div class="race">
+  <h2>Three candidates, two seats</h2>
+  <p class="race-meta">Vote for not more than 2</p>
+
+  <div class="tier-strip">
+    <span class="tier-strip-label">Stated override position</span>
+    <span class="t"><strong>Clucas:</strong> Tier 3</span>
+    <span class="t"><strong>Jordan:</strong> Tier 3</span>
+    <span class="t"><strong>Fox:</strong> no tier named</span>
+  </div>
+
+  <div class="cand">
+    <h3>Melissa Marie Clucas <span class="role">Incumbent</span></h3>
+    <p>Will vote <strong>Tier 3</strong>: "Tier 3 isn't a wish list. It's the invest-and-improve tier." Appointed in September 2025 and a chief financial officer by profession, she says she has spent six months "inside this budget" through the override working group.<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/melissa-clucas-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Melissa Clucas for School Committee, May 20, 2026"></sup> She warns the FY27 budget is balanced only by a $1.5M one-time special education prepayment, "a structural hole we're papering over," and that without new revenue FY28 could force "another 30 to 50 positions" in cuts.</p>
+    <p>On enrollment, down 24% since 2016-17 with 215 students leaving in 2024-25, she wants the district's exit interviews made "systematic, not anecdotal," and the schools' record told "clearly and early." She frames the override commitments as something to track, "not letting that document sit in a drawer."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/melissa-clucas-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Melissa Clucas for School Committee, May 20, 2026"></sup></p>
+  </div>
+
+  <div class="cand">
+    <h3>Sarah A. Fox</h3>
+    <p>Says the town's "tax levy capacity needs to grow" but <strong>does not commit to a tier</strong>, calling herself "troubled by what appears to have been a rushed process" and saying she is still "digging into" what each tier funds so she can "make an educated decision on June 9."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/sarah-fox-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Sarah Fox for School Committee, May 20, 2026"></sup> In the Independent's guide she notes the current plan "does not return any of the eliminated positions to the schools at any tier," and that a projected $2M surplus might allow full-day kindergarten to be "phased in" without a full override.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    <p>A former two-term member and budget subcommittee chair, she wants the district to "work collaboratively towards a zero-based budget" built on a current analysis of student needs "rather than simply rolling over what may currently exist," and renews her call for exit surveys of departing families.<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/sarah-fox-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Sarah Fox for School Committee, May 20, 2026"></sup></p>
+  </div>
+
+  <div class="cand">
+    <h3>Ann-Marie Jordan</h3>
+    <p>Supports the override and backs <strong>Tier 3</strong>: "I believe that this is a structural deficit that cannot be overcome by just cutting more and more from the budget."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/ann-marie-jordan-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Ann-Marie Jordan for School Committee, May 20, 2026"></sup> A retired educator and integrated preschool director, she says she would look to district leadership for an implementation plan, "timelines, staffing and salary calculations," on the 18 to 22 special education program.</p>
+    <p>She considers the FY27 budget right-sized, saying leaders "worked very hard to make cuts that had minimal impact on front-line work with children," while cautioning that "we need to make sure that we do not end up with insufficient staffing going forward." On enrollment she backs exit surveys but notes "there is very little the school district can do" about birth rates and housing costs.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+  </div>
+</div>
+
+<h2 id="moderator">Moderator</h2>
+
+<div class="race">
+  <h2>Two candidates, one seat</h2>
+  <p class="race-meta">Vote for not more than 1 &middot; 1-year term</p>
+
+  <div class="cand">
+    <h3>John Gregory Attridge <span class="role">Incumbent</span></h3>
+    <p>Seeking another term as Town Meeting moderator, a role he has held for years and once described as "sort of my Netflix and my hobby." He says he prioritizes efficiency "without compromising quorum" and yields "in most cases, to the will of the assembly." He supports free childcare at Town Meeting and says he is exploring additional accommodations for residents with limited mobility.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+  </div>
+
+  <div class="cand">
+    <h3>Peter Jaffe</h3>
+    <p class="no-answer">Did not submit answers to the Independent's voter guide.</p>
+    <p>At the May 27 candidates forum, the lifelong resident and first-time candidate said he would focus on closer review of warrant articles, coordinating with town counsel, more consistent procedure (he questioned the use of hand counts over electronic clickers) and firmer enforcement of meeting decorum.<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/27/overrides-trust-and-towns-path-forward-debated-at-candidates-forum/" data-source="Marblehead Current, 'Overrides, trust and town's path forward debated at candidates forum,' May 27, 2026"></sup></p>
+  </div>
+</div>
+
+<h2 id="rec-park">Recreation &amp; Park Commission</h2>
+
+<div class="race">
+  <h2>Six candidates, five seats</h2>
+  <p class="race-meta">Vote for not more than 5 &middot; 1-year terms</p>
+  <p class="source" style="margin-top:-4px;">Two issues run through this race: the override, and a proposal for artificial turf at Reynolds field, which the commission advanced on a 4-1 vote.</p>
+
+  <div class="cand">
+    <h3>Shelly Curran Bedrossian <span class="role">Incumbent</span></h3>
+    <p>Says she is "begrudgingly voting Yes on 1 and 4" after criticizing the override process as rushed. In her third term, she proposes consolidating facilities upkeep under a new buildings and grounds department, and has made accessibility a signature issue, noting the town does not have "one park in town that is fully ADA compliant." She supported the turf plan.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+  </div>
+
+  <div class="cand">
+    <h3>Larry J. Simpson <span class="role">Incumbent</span></h3>
+    <p>"I would support the Tier 2 override," which he calls the most balanced option, and says trash costs "should be distributed evenly across the socioeconomic spectrum." A horticulturist who taught botany for 20 years, he was the lone dissenter on the 4-1 turf vote, citing microplastics, <abbr class="g" title="per- and polyfluoroalkyl substances, a class of synthetic chemicals">PFAS</abbr> and heat.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+  </div>
+
+  <div class="cand">
+    <h3>Karin Linnea Ernst <span class="role">Incumbent</span></h3>
+    <p>Undecided on the override, saying "I go back and forth" on the tiers and on trash, and that she values "thoughtful, balanced decisions" over a quick answer. She supported the turf plan, citing more playability.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+  </div>
+
+  <div class="cand">
+    <h3>Kenneth S. Klaiman</h3>
+    <p>Says "a moderate override, around 2 to 4 percent" makes sense, and prefers an override to fees for trash, citing fairness and stability, while supporting "abatements/rebates to those where an increased tax/fee would be an unduly financial burden." A first-time candidate, he opposes the turf plan: "Real grass and no chemicals, because that's what parks and kids are about."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+  </div>
+
+  <div class="cand">
+    <h3>Christopher E. Kennedy <span class="role">Incumbent</span></h3>
+    <p class="no-answer">Did not submit answers to the Independent's voter guide.</p>
+    <p>At the May 27 forum he supported the turf proposal, saying the town needs "more turf" and "more playability."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/27/overrides-trust-and-towns-path-forward-debated-at-candidates-forum/" data-source="Marblehead Current, 'Overrides, trust and town's path forward debated at candidates forum,' May 27, 2026"></sup></p>
+  </div>
+
+  <div class="cand">
+    <h3>Michael Ryan McCarthy</h3>
+    <p class="no-answer">Did not submit answers to the Independent's voter guide, and a statement was read on his behalf at the forum because of a medical situation.</p>
+    <p>That statement cited more than 20 years in commercial real estate and coaching Marblehead youth sports, and said he is "the only candidate with children utilizing the fields today."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/27/overrides-trust-and-towns-path-forward-debated-at-candidates-forum/" data-source="Marblehead Current, 'Overrides, trust and town's path forward debated at candidates forum,' May 27, 2026"></sup></p>
+  </div>
+</div>
+
+<h2 id="cemetery">Cemetery Commission</h2>
+
+<div class="race">
+  <h2>Two candidates, one seat</h2>
+  <p class="race-meta">Vote for not more than 1 &middot; 2-year unexpired term</p>
+
+  <div class="cand">
+    <h3>Sally Bull Sands <span class="role">Incumbent</span></h3>
+    <p>Appointed to the seat in early 2026 and seeking a full term, she supports the override and "specifically urges Tier 1" to fund a cemetery laborer position and Memorial Day preparation. She describes cemeteries as "primary sources of historic information" and calls for long-range planning for future cemetery space.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+  </div>
+
+  <div class="cand">
+    <h3>Rose A. McCarthy</h3>
+    <p>Supports Question 1, "because Council on Aging services depend on it." A former commission member with long service on the Recreation Board, she raises the idea that an abandoned pool near Waterside Cemetery "could be used as some grave lots."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+  </div>
+</div>
+
+<h2 id="housing-authority">Housing Authority</h2>
+
+<div class="race">
+  <h2>Two candidates, one seat</h2>
+  <p class="race-meta">Vote for not more than 1</p>
+
+  <div class="cand">
+    <h3>Jeffrey Richard Weeden</h3>
+    <p>Supports "all three tiers" plus the trash question, describing Tier 3 as "additional investment to deferred capital improvements." Director of planning and development at the Lynn Housing Authority for 18 years, he sees the Broughton Road site as an opportunity for "mixed-income residents, community space, and energy efficient" housing, with federal Low-Income Housing Tax Credit safeguards.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+  </div>
+
+  <div class="cand">
+    <h3>Jean R. Eldridge <span class="role">Incumbent</span></h3>
+    <p class="no-answer">Her voter-guide questionnaire response was incomplete in the source as of June 1.</p>
+    <p>On the Housing Authority since 1994, she runs on "a practical understanding of how it works, institutional knowledge, and commitment to the residents we serve," and notes she has attended town meetings "every single Wednesday night, rain, shine or snow."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+  </div>
+</div>
+
+<h2 id="uncontested">The rest of the ballot</h2>
+
+<p>The other elected bodies on June 9 are uncontested this year: Assessors, the regular-term Cemetery Commission seat, Board of Health, Abbot Public Library Trustees, Municipal Light Commissioner, Planning Board, and Water &amp; Sewer Commission. Their candidates, addresses and incumbent status are listed on <a href="whats-on-the-ballot.html#offices">what else is on the June 9 ballot</a>.</p>
+
+<p class="source">Positions are transcribed from the candidates' own answers in the Marblehead Current's individual candidate Q&As (May 19 and 20, 2026) and the Marblehead Independent's 2026 voter guide (last updated June 1, 2026). Forum statements, where used for candidates who did not return a questionnaire, are from the Marblehead Current's May 27, 2026 candidates-forum report. Candidate names follow the Town Clerk's official sample ballot. Where the two papers' answers differ, both are shown with their dates.</p>
+
+<div class="read-next">
+  <div class="read-next-label">Read next</div>
+  <a class="read-next-link" href="whats-on-the-ballot.html">
+    <div class="read-next-title">What else is on the June 9 ballot? &rarr;</div>
+    <div class="read-next-desc">Every office and candidate, the four ballot questions, and a practice ballot.</div>
+  </a>
+  <a class="read-next-link" href="charts/override_calculator.html">
+    <div class="read-next-title">What does the override cost me? &rarr;</div>
+    <div class="read-next-desc">Enter your home value and see the year-by-year cost for each tier.</div>
+  </a>
+  <a class="read-next-link" href="what-is-the-override.html">
+    <div class="read-next-title">What is the override? &rarr;</div>
+    <div class="read-next-desc">The three tiers explained, with line-by-line breakdowns and the phase-in schedule.</div>
+  </a>
+</div>

--- a/where-candidates-stand.html
+++ b/where-candidates-stand.html
@@ -6,245 +6,524 @@ og_description: "What every candidate in Marblehead's six contested June 9 races
 og_url: https://marbleheaddata.org/where-candidates-stand.html
 ---
 <style>
-  /* Page-scoped: per-race candidate position blocks */
-  .race {
+  /* ============================================================
+     Where the candidates stand: editorial election guide
+     Built entirely on the site's existing tokens. Tier colors
+     are the sequential teal --series-tier-* scale (neutral by
+     design); per-race accent rails are decorative wayfinding.
+     ============================================================ */
+
+  .kicker {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.4px;
+    color: var(--text-subtle);
+    margin: 0 0 6px;
+  }
+  .kicker::before {
+    content: "";
+    width: 26px;
+    height: 2px;
+    background: var(--accent);
+    border-radius: 2px;
+  }
+
+  /* ---- one-time tier legend ---- */
+  .tier-legend {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px 16px;
+    margin: 18px 0 26px;
+    padding: 12px 14px;
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius-md);
-    padding: 18px 20px 16px;
-    margin: 0 0 18px;
+    font-size: 12.5px;
+    color: var(--text-muted);
   }
-  .race > h2 {
-    font-size: 19px;
-    margin: 0 0 2px;
-    line-height: 1.25;
-    border: 0;
-    padding: 0;
-  }
-  .race-meta {
-    font-size: 12px;
-    color: var(--text-subtle);
-    font-variant-numeric: tabular-nums;
-    margin: 0 0 12px;
+  .tier-legend .legend-label {
+    font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.6px;
-    font-weight: 700;
-  }
-  .tier-strip {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px 14px;
-    margin: 0 0 14px;
-    padding: 10px 12px;
-    background: var(--fog);
-    border-radius: var(--radius-sm);
-    font-size: 13px;
-  }
-  .tier-strip .tier-strip-label {
-    width: 100%;
     font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    font-weight: 700;
     color: var(--text-subtle);
-    margin-bottom: 2px;
   }
-  .tier-strip span.t {
-    font-variant-numeric: tabular-nums;
-  }
-  .tier-strip span.t strong { color: var(--text); }
-  .cand {
-    padding: 12px 0;
-    border-top: 1px solid var(--border);
-  }
-  .cand:first-of-type { border-top: 0; padding-top: 2px; }
-  .cand h3 {
-    font-size: 16px;
-    margin: 0 0 6px;
-    line-height: 1.3;
-  }
-  .cand h3 .role {
+
+  /* ---- tier chip ---- */
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     font-size: 12px;
     font-weight: 600;
-    color: var(--text-subtle);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-left: 6px;
+    line-height: 1;
+    padding: 5px 10px 5px 8px;
+    border-radius: 999px;
+    white-space: nowrap;
+    border: 1px solid transparent;
   }
-  .cand p {
+  .chip .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex: none;
+  }
+  .chip.t1 { background: color-mix(in srgb, var(--series-tier-1) 16%, var(--surface)); border-color: color-mix(in srgb, var(--series-tier-1) 38%, var(--surface)); color: var(--text); }
+  .chip.t1 .dot { background: var(--series-tier-1); }
+  .chip.t2 { background: color-mix(in srgb, var(--series-tier-2) 15%, var(--surface)); border-color: color-mix(in srgb, var(--series-tier-2) 40%, var(--surface)); color: var(--text); }
+  .chip.t2 .dot { background: var(--series-tier-2); }
+  .chip.t3 { background: color-mix(in srgb, var(--series-tier-3) 16%, var(--surface)); border-color: color-mix(in srgb, var(--series-tier-3) 42%, var(--surface)); color: var(--text); }
+  .chip.t3 .dot { background: var(--series-tier-3); }
+  .chip.tnone { background: color-mix(in srgb, var(--text-subtle) 12%, var(--surface)); border-color: color-mix(in srgb, var(--text-subtle) 28%, var(--surface)); color: var(--text-muted); }
+  .chip.tnone .dot { background: var(--text-subtle); }
+
+  /* ---- race card ---- */
+  .race {
+    position: relative;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 0 20px 8px 22px;
+    margin: 0 0 20px;
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+    transition: box-shadow 0.25s ease, transform 0.25s ease;
+  }
+  .race:hover { box-shadow: var(--shadow-md); transform: translateY(-2px); }
+  .race::before {
+    content: "";
+    position: absolute;
+    left: 0; top: 0; bottom: 0;
+    width: 4px;
+    background: var(--race-accent, var(--accent));
+  }
+  .race[data-accent="navy"]  { --race-accent: var(--c-navy); }
+  .race[data-accent="teal"]  { --race-accent: var(--c-teal); }
+  .race[data-accent="plum"]  { --race-accent: var(--c-plum); }
+  .race[data-accent="sage"]  { --race-accent: var(--c-sage); }
+  .race[data-accent="brass"] { --race-accent: var(--c-brass); }
+
+  .race-head {
+    display: flex;
+    align-items: baseline;
+    gap: 14px;
+    padding: 18px 0 12px;
+    border-bottom: 1px solid var(--divider);
+    margin-bottom: 4px;
+  }
+  .race-num {
+    font-size: 30px;
+    font-weight: 800;
+    line-height: 1;
+    color: var(--race-accent, var(--accent));
+    opacity: 0.9;
+    font-variant-numeric: tabular-nums;
+    flex: none;
+  }
+  .race-headings { flex: 1; min-width: 0; }
+  .race-headings h2 {
+    font-size: 19px;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    line-height: 1.2;
+  }
+  .race-meta {
+    font-size: 11.5px;
+    color: var(--text-subtle);
+    font-variant-numeric: tabular-nums;
+    margin: 5px 0 0;
+    text-transform: uppercase;
+    letter-spacing: 0.7px;
+    font-weight: 700;
+  }
+  .race-note {
+    font-size: 13px;
+    color: var(--text-muted);
+    line-height: 1.55;
+    margin: 12px 0 4px;
+    padding: 10px 12px;
+    background: color-mix(in srgb, var(--race-accent, var(--accent)) 6%, var(--surface));
+    border-radius: var(--radius-sm);
+  }
+
+  /* ---- candidate row ---- */
+  .cand {
+    display: grid;
+    grid-template-columns: 44px 1fr;
+    gap: 4px 14px;
+    padding: 16px 0;
+    border-top: 1px solid var(--divider);
+  }
+  .cand:first-of-type { border-top: 0; }
+  .avatar {
+    grid-row: span 2;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     font-size: 14px;
-    line-height: 1.6;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+    border: 1.5px solid color-mix(in srgb, var(--accent) 28%, var(--surface));
+    flex: none;
+  }
+  .cand-head {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    min-height: 44px;
+  }
+  .cand-head h3 {
+    font-size: 16px;
+    margin: 0;
+    line-height: 1.2;
+  }
+  .badge {
+    font-size: 10.5px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    padding: 3px 8px;
+    border-radius: 999px;
+    color: var(--text-subtle);
+    background: color-mix(in srgb, var(--text-subtle) 12%, var(--surface));
+  }
+  .cand-body { grid-column: 2; }
+  .cand-body p {
+    font-size: 14px;
+    line-height: 1.62;
     margin: 0 0 8px;
     color: var(--text-muted);
   }
-  .cand p:last-child { margin-bottom: 0; }
-  .cand p strong { color: var(--text); }
-  .cand .no-answer {
+  .cand-body p:last-child { margin-bottom: 0; }
+  .cand-body p strong { color: var(--text); }
+  .cand-body .no-answer {
     font-style: italic;
     color: var(--text-subtle);
+    padding-left: 11px;
+    border-left: 2px solid var(--border);
+  }
+
+  @media (max-width: 600px) {
+    .cand { grid-template-columns: 36px 1fr; gap: 4px 11px; }
+    .avatar { width: 36px; height: 36px; font-size: 12px; }
+    .cand-head { min-height: 36px; }
+    .race { padding-left: 18px; padding-right: 16px; }
+  }
+
+  /* ---- staggered load-in ---- */
+  @media (prefers-reduced-motion: no-preference) {
+    .race { opacity: 0; animation: riseIn 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards; }
+    .race:nth-of-type(1) { animation-delay: 0.04s; }
+    .race:nth-of-type(2) { animation-delay: 0.10s; }
+    .race:nth-of-type(3) { animation-delay: 0.16s; }
+    .race:nth-of-type(4) { animation-delay: 0.22s; }
+    .race:nth-of-type(5) { animation-delay: 0.28s; }
+    .race:nth-of-type(6) { animation-delay: 0.34s; }
+    @keyframes riseIn {
+      from { opacity: 0; transform: translateY(14px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
   }
 </style>
 
+<p class="kicker">Marblehead &middot; June 9, 2026 election</p>
 <h1>Where the candidates stand</h1>
 
 <p class="page-lead">Six of the offices on the <a href="whats-on-the-ballot.html">June 9 ballot</a> are contested. The positions below come from each candidate's own answers in two published Q&As: the <strong>Marblehead Current</strong>'s individual candidate interviews and the <strong>Marblehead Independent</strong>'s 2026 voter guide. Where a candidate did not answer, that is noted rather than filled in.</p>
 
 <p class="source">These are the candidates' stated positions, quoted from their published interviews. Nothing here is an endorsement, and this site is not affiliated with any candidate or campaign. For the full list of all 24 seats, ballot mechanics and the four override questions, see <a href="whats-on-the-ballot.html">what else is on the June 9 ballot</a>.</p>
 
-<h2 id="select-board">Select Board</h2>
+<div class="tier-legend">
+  <span class="legend-label">Override tiers</span>
+  <span class="chip t1"><span class="dot"></span>Tier 1 &middot; $9M</span>
+  <span class="chip t2"><span class="dot"></span>Tier 2 &middot; $12M</span>
+  <span class="chip t3"><span class="dot"></span>Tier 3 &middot; $15M</span>
+  <span class="chip tnone"><span class="dot"></span>No tier named</span>
+</div>
 
-<div class="race">
-  <h2>Three candidates, two seats</h2>
-  <p class="race-meta">Vote for not more than 2 &middot; 3-year terms</p>
-
-  <div class="tier-strip">
-    <span class="tier-strip-label">Stated override position</span>
-    <span class="t"><strong>Noonan:</strong> Tier 3 (Question 3, $15M)</span>
-    <span class="t"><strong>Ferrante:</strong> Tier 2</span>
-    <span class="t"><strong>Schaeffner:</strong> no tier named</span>
+<div class="race" data-accent="navy">
+  <div class="race-head">
+    <div class="race-num">01</div>
+    <div class="race-headings">
+      <h2 id="select-board">Select Board</h2>
+      <p class="race-meta">Three candidates, two seats &middot; Vote for not more than 2 &middot; 3-year terms</p>
+    </div>
   </div>
 
   <div class="cand">
-    <h3>Erin Marie Noonan <span class="role">Incumbent</span></h3>
-    <p>Backs all three override questions and will vote <strong>Question 3</strong>, the $15M three-year option, which she says "simply restores the town to 2020 service levels."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/erin-noonan-for-select-board/" data-source="Marblehead Current, candidate Q&A: Erin Noonan for Select Board, May 19, 2026"></sup> She lists what it funds: three police and four firefighter positions, a special education program for 18 to 22 year-olds, a <abbr class="g" title="Department of Public Works">DPW</abbr> foreman, mental health funding, about $1.5M in capital repairs and a grant writer. She calls it "a responsible, measured path back to the service levels Marblehead residents deserve."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
-    <p>Beyond the override she points to revenue the town adopted in 2024, a 0.75% local meals tax and a 6% room occupancy tax together worth roughly $480,000 a year, plus a smart-growth zoning overlay and returning unused town property such as the Coffin School to the tax base.<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/erin-noonan-for-select-board/" data-source="Marblehead Current, candidate Q&A: Erin Noonan for Select Board, May 19, 2026"></sup> A five-year incumbent and an attorney, she disputes that residents broadly distrust officials, citing Town Meeting's roughly 90% support for the override proposal.</p>
+    <div class="avatar" aria-hidden="true">EN</div>
+    <div class="cand-head">
+      <h3>Erin Marie Noonan</h3>
+      <span class="badge">Incumbent</span>
+      <span class="chip t3"><span class="dot"></span>Tier 3</span>
+    </div>
+    <div class="cand-body">
+      <p>Backs all three override questions and will vote <strong>Question 3</strong>, the $15M three-year option, which she says "simply restores the town to 2020 service levels."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/erin-noonan-for-select-board/" data-source="Marblehead Current, candidate Q&A: Erin Noonan for Select Board, May 19, 2026"></sup> She lists what it funds: three police and four firefighter positions, a special education program for 18 to 22 year-olds, a <abbr class="g" title="Department of Public Works">DPW</abbr> foreman, mental health funding, about $1.5M in capital repairs and a grant writer. She calls it "a responsible, measured path back to the service levels Marblehead residents deserve."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+      <p>Beyond the override she points to revenue the town adopted in 2024, a 0.75% local meals tax and a 6% room occupancy tax together worth roughly $480,000 a year, plus a smart-growth zoning overlay and returning unused town property such as the Coffin School to the tax base.<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/erin-noonan-for-select-board/" data-source="Marblehead Current, candidate Q&A: Erin Noonan for Select Board, May 19, 2026"></sup> A five-year incumbent and an attorney, she disputes that residents broadly distrust officials, citing Town Meeting's roughly 90% support for the override proposal.</p>
+    </div>
   </div>
 
   <div class="cand">
-    <h3>Rossana Ferrante</h3>
-    <p>Says "the town needs an override" after attending the Finance Committee's budget session, but criticizes the process as "hurried." In the Current (May 19) she said she was "leaning towards supporting Tier 1 and/or Tier 2" and suggested keeping a possible underride "on the radar."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/rossana-ferrate-for-select-board/" data-source="Marblehead Current, candidate Q&A: Rossana Ferrante for Select Board, May 19, 2026"></sup> In the Independent's voter guide she states her position more firmly: <strong>"I support Tier 2,"</strong> and says she is open to a fee-based trash structure that gives "people more choice."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
-    <p>The Recreation and Park Commission chair, a former Planning Board member and an attorney, she calls for a "deep dive into all aspects of how we do business," including insurance, contracts and unused town property, and for better coordination across departments to "find creative solutions to not raise taxes."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/rossana-ferrate-for-select-board/" data-source="Marblehead Current, candidate Q&A: Rossana Ferrante for Select Board, May 19, 2026"></sup></p>
+    <div class="avatar" aria-hidden="true">RF</div>
+    <div class="cand-head">
+      <h3>Rossana Ferrante</h3>
+      <span class="chip t2"><span class="dot"></span>Tier 2</span>
+    </div>
+    <div class="cand-body">
+      <p>Says "the town needs an override" after attending the Finance Committee's budget session, but criticizes the process as "hurried." In the Current (May 19) she said she was "leaning towards supporting Tier 1 and/or Tier 2" and suggested keeping a possible underride "on the radar."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/rossana-ferrate-for-select-board/" data-source="Marblehead Current, candidate Q&A: Rossana Ferrante for Select Board, May 19, 2026"></sup> In the Independent's voter guide she states her position more firmly: <strong>"I support Tier 2,"</strong> and says she is open to a fee-based trash structure that gives "people more choice."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+      <p>The Recreation and Park Commission chair, a former Planning Board member and an attorney, she calls for a "deep dive into all aspects of how we do business," including insurance, contracts and unused town property, and for better coordination across departments to "find creative solutions to not raise taxes."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/rossana-ferrate-for-select-board/" data-source="Marblehead Current, candidate Q&A: Rossana Ferrante for Select Board, May 19, 2026"></sup></p>
+    </div>
   </div>
 
   <div class="cand">
-    <h3>Jennifer Schaeffner</h3>
-    <p>Calls the town's finances "a genuine fiscal crisis" and says that after years of spending down reserves, raising the tax levy may be "an unfortunate but necessary step." She <strong>does not endorse a tier</strong>, citing concerns about transparency and noting that 2025 voters wanted a menu of choices that "deserved to be heard and respected." If the override passes and she is elected, she commits to "fight to ensure that the additional revenue is used to provide meaningful relief."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/jenn-schaeffner-for-select-board/" data-source="Marblehead Current, candidate Q&A: Jenn Schaeffner for Select Board, May 19, 2026"></sup></p>
-    <p>A current School Committee member and Housing Authority chair with a finance and banking background, she would apply "zero-based budgeting across every town department," look for shared services to cut duplication, and grow revenue through tourism and a more business-friendly approach "without adding to the tax burden on our residents."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    <div class="avatar" aria-hidden="true">JS</div>
+    <div class="cand-head">
+      <h3>Jennifer Schaeffner</h3>
+      <span class="chip tnone"><span class="dot"></span>No tier named</span>
+    </div>
+    <div class="cand-body">
+      <p>Calls the town's finances "a genuine fiscal crisis" and says that after years of spending down reserves, raising the tax levy may be "an unfortunate but necessary step." She <strong>does not endorse a tier</strong>, citing concerns about transparency and noting that 2025 voters wanted a menu of choices that "deserved to be heard and respected." If the override passes and she is elected, she commits to "fight to ensure that the additional revenue is used to provide meaningful relief."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/19/jenn-schaeffner-for-select-board/" data-source="Marblehead Current, candidate Q&A: Jenn Schaeffner for Select Board, May 19, 2026"></sup></p>
+      <p>A current School Committee member and Housing Authority chair with a finance and banking background, she would apply "zero-based budgeting across every town department," look for shared services to cut duplication, and grow revenue through tourism and a more business-friendly approach "without adding to the tax burden on our residents."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    </div>
   </div>
 </div>
 
-<h2 id="school-committee">School Committee</h2>
-
-<div class="race">
-  <h2>Three candidates, two seats</h2>
-  <p class="race-meta">Vote for not more than 2</p>
-
-  <div class="tier-strip">
-    <span class="tier-strip-label">Stated override position</span>
-    <span class="t"><strong>Clucas:</strong> Tier 3</span>
-    <span class="t"><strong>Jordan:</strong> Tier 3</span>
-    <span class="t"><strong>Fox:</strong> no tier named</span>
+<div class="race" data-accent="teal">
+  <div class="race-head">
+    <div class="race-num">02</div>
+    <div class="race-headings">
+      <h2 id="school-committee">School Committee</h2>
+      <p class="race-meta">Three candidates, two seats &middot; Vote for not more than 2</p>
+    </div>
   </div>
 
   <div class="cand">
-    <h3>Melissa Marie Clucas <span class="role">Incumbent</span></h3>
-    <p>Will vote <strong>Tier 3</strong>: "Tier 3 isn't a wish list. It's the invest-and-improve tier." Appointed in September 2025 and a chief financial officer by profession, she says she has spent six months "inside this budget" through the override working group.<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/melissa-clucas-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Melissa Clucas for School Committee, May 20, 2026"></sup> She warns the FY27 budget is balanced only by a $1.5M one-time special education prepayment, "a structural hole we're papering over," and that without new revenue FY28 could force "another 30 to 50 positions" in cuts.</p>
-    <p>On enrollment, down 24% since 2016-17 with 215 students leaving in 2024-25, she wants the district's exit interviews made "systematic, not anecdotal," and the schools' record told "clearly and early." She frames the override commitments as something to track, "not letting that document sit in a drawer."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/melissa-clucas-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Melissa Clucas for School Committee, May 20, 2026"></sup></p>
+    <div class="avatar" aria-hidden="true">MC</div>
+    <div class="cand-head">
+      <h3>Melissa Marie Clucas</h3>
+      <span class="badge">Incumbent</span>
+      <span class="chip t3"><span class="dot"></span>Tier 3</span>
+    </div>
+    <div class="cand-body">
+      <p>Will vote <strong>Tier 3</strong>: "Tier 3 isn't a wish list. It's the invest-and-improve tier." Appointed in September 2025 and a chief financial officer by profession, she says she has spent six months "inside this budget" through the override working group.<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/melissa-clucas-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Melissa Clucas for School Committee, May 20, 2026"></sup> She warns the FY27 budget is balanced only by a $1.5M one-time special education prepayment, "a structural hole we're papering over," and that without new revenue FY28 could force "another 30 to 50 positions" in cuts.</p>
+      <p>On enrollment, down 24% since 2016-17 with 215 students leaving in 2024-25, she wants the district's exit interviews made "systematic, not anecdotal," and the schools' record told "clearly and early." She frames the override commitments as something to track, "not letting that document sit in a drawer."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/melissa-clucas-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Melissa Clucas for School Committee, May 20, 2026"></sup></p>
+    </div>
   </div>
 
   <div class="cand">
-    <h3>Sarah A. Fox</h3>
-    <p>Says the town's "tax levy capacity needs to grow" but <strong>does not commit to a tier</strong>, calling herself "troubled by what appears to have been a rushed process" and saying she is still "digging into" what each tier funds so she can "make an educated decision on June 9."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/sarah-fox-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Sarah Fox for School Committee, May 20, 2026"></sup> In the Independent's guide she notes the current plan "does not return any of the eliminated positions to the schools at any tier," and that a projected $2M surplus might allow full-day kindergarten to be "phased in" without a full override.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
-    <p>A former two-term member and budget subcommittee chair, she wants the district to "work collaboratively towards a zero-based budget" built on a current analysis of student needs "rather than simply rolling over what may currently exist," and renews her call for exit surveys of departing families.<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/sarah-fox-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Sarah Fox for School Committee, May 20, 2026"></sup></p>
+    <div class="avatar" aria-hidden="true">SF</div>
+    <div class="cand-head">
+      <h3>Sarah A. Fox</h3>
+      <span class="chip tnone"><span class="dot"></span>No tier named</span>
+    </div>
+    <div class="cand-body">
+      <p>Says the town's "tax levy capacity needs to grow" but <strong>does not commit to a tier</strong>, calling herself "troubled by what appears to have been a rushed process" and saying she is still "digging into" what each tier funds so she can "make an educated decision on June 9."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/sarah-fox-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Sarah Fox for School Committee, May 20, 2026"></sup> In the Independent's guide she notes the current plan "does not return any of the eliminated positions to the schools at any tier," and that a projected $2M surplus might allow full-day kindergarten to be "phased in" without a full override.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+      <p>A former two-term member and budget subcommittee chair, she wants the district to "work collaboratively towards a zero-based budget" built on a current analysis of student needs "rather than simply rolling over what may currently exist," and renews her call for exit surveys of departing families.<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/sarah-fox-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Sarah Fox for School Committee, May 20, 2026"></sup></p>
+    </div>
   </div>
 
   <div class="cand">
-    <h3>Ann-Marie Jordan</h3>
-    <p>Supports the override and backs <strong>Tier 3</strong>: "I believe that this is a structural deficit that cannot be overcome by just cutting more and more from the budget."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/ann-marie-jordan-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Ann-Marie Jordan for School Committee, May 20, 2026"></sup> A retired educator and integrated preschool director, she says she would look to district leadership for an implementation plan, "timelines, staffing and salary calculations," on the 18 to 22 special education program.</p>
-    <p>She considers the FY27 budget right-sized, saying leaders "worked very hard to make cuts that had minimal impact on front-line work with children," while cautioning that "we need to make sure that we do not end up with insufficient staffing going forward." On enrollment she backs exit surveys but notes "there is very little the school district can do" about birth rates and housing costs.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
-  </div>
-</div>
-
-<h2 id="moderator">Moderator</h2>
-
-<div class="race">
-  <h2>Two candidates, one seat</h2>
-  <p class="race-meta">Vote for not more than 1 &middot; 1-year term</p>
-
-  <div class="cand">
-    <h3>John Gregory Attridge <span class="role">Incumbent</span></h3>
-    <p>Seeking another term as Town Meeting moderator, a role he has held for years and once described as "sort of my Netflix and my hobby." He says he prioritizes efficiency "without compromising quorum" and yields "in most cases, to the will of the assembly." He supports free childcare at Town Meeting and says he is exploring additional accommodations for residents with limited mobility.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
-  </div>
-
-  <div class="cand">
-    <h3>Peter Jaffe</h3>
-    <p class="no-answer">Did not submit answers to the Independent's voter guide.</p>
-    <p>At the May 27 candidates forum, the lifelong resident and first-time candidate said he would focus on closer review of warrant articles, coordinating with town counsel, more consistent procedure (he questioned the use of hand counts over electronic clickers) and firmer enforcement of meeting decorum.<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/27/overrides-trust-and-towns-path-forward-debated-at-candidates-forum/" data-source="Marblehead Current, 'Overrides, trust and town's path forward debated at candidates forum,' May 27, 2026"></sup></p>
+    <div class="avatar" aria-hidden="true">AJ</div>
+    <div class="cand-head">
+      <h3>Ann-Marie Jordan</h3>
+      <span class="chip t3"><span class="dot"></span>Tier 3</span>
+    </div>
+    <div class="cand-body">
+      <p>Supports the override and backs <strong>Tier 3</strong>: "I believe that this is a structural deficit that cannot be overcome by just cutting more and more from the budget."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/20/ann-marie-jordan-for-school-committee/" data-source="Marblehead Current, candidate Q&A: Ann-Marie Jordan for School Committee, May 20, 2026"></sup> A retired educator and integrated preschool director, she says she would look to district leadership for an implementation plan, "timelines, staffing and salary calculations," on the 18 to 22 special education program.</p>
+      <p>She considers the FY27 budget right-sized, saying leaders "worked very hard to make cuts that had minimal impact on front-line work with children," while cautioning that "we need to make sure that we do not end up with insufficient staffing going forward." On enrollment she backs exit surveys but notes "there is very little the school district can do" about birth rates and housing costs.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    </div>
   </div>
 </div>
 
-<h2 id="rec-park">Recreation &amp; Park Commission</h2>
-
-<div class="race">
-  <h2>Six candidates, five seats</h2>
-  <p class="race-meta">Vote for not more than 5 &middot; 1-year terms</p>
-  <p class="source" style="margin-top:-4px;">Two issues run through this race: the override, and a proposal for artificial turf at Reynolds field, which the commission advanced on a 4-1 vote.</p>
-
-  <div class="cand">
-    <h3>Shelly Curran Bedrossian <span class="role">Incumbent</span></h3>
-    <p>Says she is "begrudgingly voting Yes on 1 and 4" after criticizing the override process as rushed. In her third term, she proposes consolidating facilities upkeep under a new buildings and grounds department, and has made accessibility a signature issue, noting the town does not have "one park in town that is fully ADA compliant." She supported the turf plan.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+<div class="race" data-accent="plum">
+  <div class="race-head">
+    <div class="race-num">03</div>
+    <div class="race-headings">
+      <h2 id="moderator">Moderator</h2>
+      <p class="race-meta">Two candidates, one seat &middot; Vote for not more than 1 &middot; 1-year term</p>
+    </div>
   </div>
 
   <div class="cand">
-    <h3>Larry J. Simpson <span class="role">Incumbent</span></h3>
-    <p>"I would support the Tier 2 override," which he calls the most balanced option, and says trash costs "should be distributed evenly across the socioeconomic spectrum." A horticulturist who taught botany for 20 years, he was the lone dissenter on the 4-1 turf vote, citing microplastics, <abbr class="g" title="per- and polyfluoroalkyl substances, a class of synthetic chemicals">PFAS</abbr> and heat.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    <div class="avatar" aria-hidden="true">JA</div>
+    <div class="cand-head">
+      <h3>John Gregory Attridge</h3>
+      <span class="badge">Incumbent</span>
+    </div>
+    <div class="cand-body">
+      <p>Seeking another term as Town Meeting moderator, a role he has held for years and once described as "sort of my Netflix and my hobby." He says he prioritizes efficiency "without compromising quorum" and yields "in most cases, to the will of the assembly." He supports free childcare at Town Meeting and says he is exploring additional accommodations for residents with limited mobility.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    </div>
   </div>
 
   <div class="cand">
-    <h3>Karin Linnea Ernst <span class="role">Incumbent</span></h3>
-    <p>Undecided on the override, saying "I go back and forth" on the tiers and on trash, and that she values "thoughtful, balanced decisions" over a quick answer. She supported the turf plan, citing more playability.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
-  </div>
-
-  <div class="cand">
-    <h3>Kenneth S. Klaiman</h3>
-    <p>Says "a moderate override, around 2 to 4 percent" makes sense, and prefers an override to fees for trash, citing fairness and stability, while supporting "abatements/rebates to those where an increased tax/fee would be an unduly financial burden." A first-time candidate, he opposes the turf plan: "Real grass and no chemicals, because that's what parks and kids are about."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
-  </div>
-
-  <div class="cand">
-    <h3>Christopher E. Kennedy <span class="role">Incumbent</span></h3>
-    <p class="no-answer">Did not submit answers to the Independent's voter guide.</p>
-    <p>At the May 27 forum he supported the turf proposal, saying the town needs "more turf" and "more playability."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/27/overrides-trust-and-towns-path-forward-debated-at-candidates-forum/" data-source="Marblehead Current, 'Overrides, trust and town's path forward debated at candidates forum,' May 27, 2026"></sup></p>
-  </div>
-
-  <div class="cand">
-    <h3>Michael Ryan McCarthy</h3>
-    <p class="no-answer">Did not submit answers to the Independent's voter guide, and a statement was read on his behalf at the forum because of a medical situation.</p>
-    <p>That statement cited more than 20 years in commercial real estate and coaching Marblehead youth sports, and said he is "the only candidate with children utilizing the fields today."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/27/overrides-trust-and-towns-path-forward-debated-at-candidates-forum/" data-source="Marblehead Current, 'Overrides, trust and town's path forward debated at candidates forum,' May 27, 2026"></sup></p>
+    <div class="avatar" aria-hidden="true">PJ</div>
+    <div class="cand-head">
+      <h3>Peter Jaffe</h3>
+    </div>
+    <div class="cand-body">
+      <p class="no-answer">Did not submit answers to the Independent's voter guide.</p>
+      <p>At the May 27 candidates forum, the lifelong resident and first-time candidate said he would focus on closer review of warrant articles, coordinating with town counsel, more consistent procedure (he questioned the use of hand counts over electronic clickers) and firmer enforcement of meeting decorum.<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/27/overrides-trust-and-towns-path-forward-debated-at-candidates-forum/" data-source="Marblehead Current, 'Overrides, trust and town's path forward debated at candidates forum,' May 27, 2026"></sup></p>
+    </div>
   </div>
 </div>
 
-<h2 id="cemetery">Cemetery Commission</h2>
+<div class="race" data-accent="sage">
+  <div class="race-head">
+    <div class="race-num">04</div>
+    <div class="race-headings">
+      <h2 id="rec-park">Recreation &amp; Park Commission</h2>
+      <p class="race-meta">Six candidates, five seats &middot; Vote for not more than 5 &middot; 1-year terms</p>
+    </div>
+  </div>
 
-<div class="race">
-  <h2>Two candidates, one seat</h2>
-  <p class="race-meta">Vote for not more than 1 &middot; 2-year unexpired term</p>
+  <p class="race-note">Two issues run through this race: the override, and a proposal for artificial turf at Reynolds field, which the commission advanced on a 4-1 vote.</p>
 
   <div class="cand">
-    <h3>Sally Bull Sands <span class="role">Incumbent</span></h3>
-    <p>Appointed to the seat in early 2026 and seeking a full term, she supports the override and "specifically urges Tier 1" to fund a cemetery laborer position and Memorial Day preparation. She describes cemeteries as "primary sources of historic information" and calls for long-range planning for future cemetery space.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    <div class="avatar" aria-hidden="true">SB</div>
+    <div class="cand-head">
+      <h3>Shelly Curran Bedrossian</h3>
+      <span class="badge">Incumbent</span>
+      <span class="chip t1"><span class="dot"></span>Yes on Q1 &amp; Q4</span>
+    </div>
+    <div class="cand-body">
+      <p>Says she is "begrudgingly voting Yes on 1 and 4" after criticizing the override process as rushed. In her third term, she proposes consolidating facilities upkeep under a new buildings and grounds department, and has made accessibility a signature issue, noting the town does not have "one park in town that is fully ADA compliant." She supported the turf plan.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    </div>
   </div>
 
   <div class="cand">
-    <h3>Rose A. McCarthy</h3>
-    <p>Supports Question 1, "because Council on Aging services depend on it." A former commission member with long service on the Recreation Board, she raises the idea that an abandoned pool near Waterside Cemetery "could be used as some grave lots."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    <div class="avatar" aria-hidden="true">LS</div>
+    <div class="cand-head">
+      <h3>Larry J. Simpson</h3>
+      <span class="badge">Incumbent</span>
+      <span class="chip t2"><span class="dot"></span>Tier 2</span>
+    </div>
+    <div class="cand-body">
+      <p>"I would support the Tier 2 override," which he calls the most balanced option, and says trash costs "should be distributed evenly across the socioeconomic spectrum." A horticulturist who taught botany for 20 years, he was the lone dissenter on the 4-1 turf vote, citing microplastics, <abbr class="g" title="per- and polyfluoroalkyl substances, a class of synthetic chemicals">PFAS</abbr> and heat.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    </div>
+  </div>
+
+  <div class="cand">
+    <div class="avatar" aria-hidden="true">KE</div>
+    <div class="cand-head">
+      <h3>Karin Linnea Ernst</h3>
+      <span class="badge">Incumbent</span>
+      <span class="chip tnone"><span class="dot"></span>Undecided</span>
+    </div>
+    <div class="cand-body">
+      <p>Undecided on the override, saying "I go back and forth" on the tiers and on trash, and that she values "thoughtful, balanced decisions" over a quick answer. She supported the turf plan, citing more playability.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    </div>
+  </div>
+
+  <div class="cand">
+    <div class="avatar" aria-hidden="true">KK</div>
+    <div class="cand-head">
+      <h3>Kenneth S. Klaiman</h3>
+      <span class="chip t1"><span class="dot"></span>Moderate (2-4%)</span>
+    </div>
+    <div class="cand-body">
+      <p>Says "a moderate override, around 2 to 4 percent" makes sense, and prefers an override to fees for trash, citing fairness and stability, while supporting "abatements/rebates to those where an increased tax/fee would be an unduly financial burden." A first-time candidate, he opposes the turf plan: "Real grass and no chemicals, because that's what parks and kids are about."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    </div>
+  </div>
+
+  <div class="cand">
+    <div class="avatar" aria-hidden="true">CK</div>
+    <div class="cand-head">
+      <h3>Christopher E. Kennedy</h3>
+      <span class="badge">Incumbent</span>
+    </div>
+    <div class="cand-body">
+      <p class="no-answer">Did not submit answers to the Independent's voter guide.</p>
+      <p>At the May 27 forum he supported the turf proposal, saying the town needs "more turf" and "more playability."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/27/overrides-trust-and-towns-path-forward-debated-at-candidates-forum/" data-source="Marblehead Current, 'Overrides, trust and town's path forward debated at candidates forum,' May 27, 2026"></sup></p>
+    </div>
+  </div>
+
+  <div class="cand">
+    <div class="avatar" aria-hidden="true">MM</div>
+    <div class="cand-head">
+      <h3>Michael Ryan McCarthy</h3>
+    </div>
+    <div class="cand-body">
+      <p class="no-answer">Did not submit answers to the Independent's voter guide, and a statement was read on his behalf at the forum because of a medical situation.</p>
+      <p>That statement cited more than 20 years in commercial real estate and coaching Marblehead youth sports, and said he is "the only candidate with children utilizing the fields today."<sup class="cite" data-href="https://marbleheadcurrent.org/2026/05/27/overrides-trust-and-towns-path-forward-debated-at-candidates-forum/" data-source="Marblehead Current, 'Overrides, trust and town's path forward debated at candidates forum,' May 27, 2026"></sup></p>
+    </div>
   </div>
 </div>
 
-<h2 id="housing-authority">Housing Authority</h2>
-
-<div class="race">
-  <h2>Two candidates, one seat</h2>
-  <p class="race-meta">Vote for not more than 1</p>
-
-  <div class="cand">
-    <h3>Jeffrey Richard Weeden</h3>
-    <p>Supports "all three tiers" plus the trash question, describing Tier 3 as "additional investment to deferred capital improvements." Director of planning and development at the Lynn Housing Authority for 18 years, he sees the Broughton Road site as an opportunity for "mixed-income residents, community space, and energy efficient" housing, with federal Low-Income Housing Tax Credit safeguards.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+<div class="race" data-accent="brass">
+  <div class="race-head">
+    <div class="race-num">05</div>
+    <div class="race-headings">
+      <h2 id="cemetery">Cemetery Commission</h2>
+      <p class="race-meta">Two candidates, one seat &middot; Vote for not more than 1 &middot; 2-year unexpired term</p>
+    </div>
   </div>
 
   <div class="cand">
-    <h3>Jean R. Eldridge <span class="role">Incumbent</span></h3>
-    <p class="no-answer">Her voter-guide questionnaire response was incomplete in the source as of June 1.</p>
-    <p>On the Housing Authority since 1994, she runs on "a practical understanding of how it works, institutional knowledge, and commitment to the residents we serve," and notes she has attended town meetings "every single Wednesday night, rain, shine or snow."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    <div class="avatar" aria-hidden="true">SS</div>
+    <div class="cand-head">
+      <h3>Sally Bull Sands</h3>
+      <span class="badge">Incumbent</span>
+      <span class="chip t1"><span class="dot"></span>Backs Tier 1</span>
+    </div>
+    <div class="cand-body">
+      <p>Appointed to the seat in early 2026 and seeking a full term, she supports the override and "specifically urges Tier 1" to fund a cemetery laborer position and Memorial Day preparation. She describes cemeteries as "primary sources of historic information" and calls for long-range planning for future cemetery space.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    </div>
+  </div>
+
+  <div class="cand">
+    <div class="avatar" aria-hidden="true">RM</div>
+    <div class="cand-head">
+      <h3>Rose A. McCarthy</h3>
+      <span class="chip t1"><span class="dot"></span>Backs Question 1</span>
+    </div>
+    <div class="cand-body">
+      <p>Supports Question 1, "because Council on Aging services depend on it." A former commission member with long service on the Recreation Board, she raises the idea that an abandoned pool near Waterside Cemetery "could be used as some grave lots."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    </div>
+  </div>
+</div>
+
+<div class="race" data-accent="navy">
+  <div class="race-head">
+    <div class="race-num">06</div>
+    <div class="race-headings">
+      <h2 id="housing-authority">Housing Authority</h2>
+      <p class="race-meta">Two candidates, one seat &middot; Vote for not more than 1</p>
+    </div>
+  </div>
+
+  <div class="cand">
+    <div class="avatar" aria-hidden="true">JW</div>
+    <div class="cand-head">
+      <h3>Jeffrey Richard Weeden</h3>
+      <span class="chip t3"><span class="dot"></span>Tier 3</span>
+    </div>
+    <div class="cand-body">
+      <p>Supports "all three tiers" plus the trash question, describing Tier 3 as "additional investment to deferred capital improvements." Director of planning and development at the Lynn Housing Authority for 18 years, he sees the Broughton Road site as an opportunity for "mixed-income residents, community space, and energy efficient" housing, with federal Low-Income Housing Tax Credit safeguards.<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    </div>
+  </div>
+
+  <div class="cand">
+    <div class="avatar" aria-hidden="true">JE</div>
+    <div class="cand-head">
+      <h3>Jean R. Eldridge</h3>
+      <span class="badge">Incumbent</span>
+    </div>
+    <div class="cand-body">
+      <p class="no-answer">Her voter-guide questionnaire response was incomplete in the source as of June 1.</p>
+      <p>On the Housing Authority since 1994, she runs on "a practical understanding of how it works, institutional knowledge, and commitment to the residents we serve," and notes she has attended town meetings "every single Wednesday night, rain, shine or snow."<sup class="cite" data-href="https://wdowd-arch.github.io/marblehead-voter-guide-2026/" data-source="Marblehead Independent 2026 Voter Guide, candidate questionnaire responses (last updated June 1, 2026)"></sup></p>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
A companion to `whats-on-the-ballot.html`, which lists every office and candidate but no positions. This page summarizes what each candidate said in the six **contested** June 9 races, drawn from their own published Q&As.

## Sources
- **Marblehead Current** individual candidate interviews (May 19 and 20, 2026) for Select Board and School Committee
- **Marblehead Independent** 2026 voter guide questionnaire (last updated June 1, 2026) for all six races
- Marblehead Current candidates-forum report (May 27) only for candidates who returned no questionnaire

Every position is footnoted to the specific paper and date via the citations runtime.

## What's covered
Select Board, School Committee, Moderator, Recreation & Park Commission, Cemetery Commission (2-year term), Housing Authority. A closing section notes the uncontested seats and links back to the full ballot page.

## Format & neutrality
- Hybrid: prose blurb per candidate, plus an override-tier strip for Select Board and School Committee
- Where a candidate did not answer (Jaffe, Kennedy, M. McCarthy, Eldridge), that is stated, not filled in
- Where the two papers diverge (e.g. Ferrante "leaning Tier 1/2" in the Current vs. "I support Tier 2" in the Independent guide), both are shown with dates
- Neutral, non-advocacy framing; explicit note that nothing here is an endorsement

🤖 Generated with [Claude Code](https://claude.com/claude-code)