### PR TITLE
Sample-ballot picker on where-candidates-stand.html

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -44,6 +44,7 @@
 {% endif %}{% if page.scripts contains "deep-dive" %}<script defer src="{{ '/' | relative_url }}assets/deep-dive.js"></script>
 {% endif %}{% if page.scripts contains "lens" %}<script defer src="{{ '/' | relative_url }}assets/lens.js"></script>
 {% endif %}{% if page.scripts contains "chart-tooltip" %}<script defer src="{{ '/' | relative_url }}assets/chart-tooltip.js"></script>
+{% endif %}{% if page.scripts contains "ballot-picker" %}<script defer src="{{ '/' | relative_url }}assets/ballot-picker.js"></script>
 {% endif %}
 {% unless page.community_pulse == "off-sections" %}
 <link rel="stylesheet" href="{{ '/' | relative_url }}assets/community-pulse/widget.css">

--- a/assets/ballot-picker.js
+++ b/assets/ballot-picker.js
@@ -191,7 +191,7 @@
       var row = document.createElement('div');
       row.className = 'bp-row';
       var pick = arr.length
-        ? '<p class="bp-row__pick">' + escapeHtml(arr.join(', ')) + '</p>'
+        ? arr.map(function (n) { return '<p class="bp-row__pick">' + escapeHtml(n) + '</p>'; }).join('')
         : '<p class="bp-row__pick is-empty">No pick yet</p>';
       row.innerHTML = '<p class="bp-row__race">' + escapeHtml(rd.name) + '</p>' + pick;
       rows.appendChild(row);
@@ -227,7 +227,14 @@
     var any = false;
     raceData.forEach(function (rd) {
       var arr = selected(rd);
-      if (arr.length) { lines.push(rd.name + ': ' + arr.join(', ')); any = true; }
+      if (!arr.length) return;
+      any = true;
+      if (arr.length === 1) {
+        lines.push(rd.name + ': ' + arr[0]);
+      } else {
+        lines.push(rd.name + ':');
+        arr.forEach(function (n) { lines.push('  ' + n); });
+      }
     });
     if (!any) lines.push('(no picks yet)');
     lines.push('');
@@ -332,7 +339,10 @@
       c.font = '600 40px ' + SANS;
       if (arr.length) {
         c.fillStyle = '#0F2A3D';
-        y = wrapText(c, arr.join(', '), PAD, y, W - PAD * 2, 50);
+        arr.forEach(function (n, idx) {
+          if (idx > 0) y += 50;
+          y = wrapText(c, n, PAD, y, W - PAD * 2, 50);
+        });
       } else {
         c.fillStyle = '#A6B3BE';
         c.fillText('No pick yet', PAD, y);

--- a/assets/ballot-picker.js
+++ b/assets/ballot-picker.js
@@ -1,0 +1,396 @@
+/*
+ * ballot-picker.js
+ * Sample-ballot picker for where-candidates-stand.html.
+ *
+ * Progressive enhancement: reads the existing race/candidate DOM, injects
+ * a pick control per candidate, a sticky progress bar, and a summary modal.
+ * Picks are stored in localStorage only. Nothing leaves the browser unless
+ * the reader taps "Share my picks", which renders a PNG client-side.
+ *
+ * No candidate selection state is ever sent anywhere. No backend.
+ */
+(function () {
+  'use strict';
+
+  var STORE_NAME = 'marblehead-ballot-picks';
+  var PAGE_URL = 'marbleheaddata.org/where-candidates-stand.html';
+
+  var races = Array.prototype.slice.call(document.querySelectorAll('.race'));
+  var firstCand = document.querySelector('.cand');
+  if (!races.length || !firstCand) return;
+
+  document.body.classList.add('js-picker');
+
+  // ---- state ----------------------------------------------------------
+  var picks = load();          // { raceName: [candidateName, ...] }
+  var raceData = [];           // [{ el, name, max, cands, counter }]
+  var bar, barText, barFill, overlay, modal, toastEl;
+
+  function load() {
+    try {
+      var raw = window.localStorage.getItem(STORE_NAME);
+      var obj = raw ? JSON.parse(raw) : {};
+      return (obj && typeof obj === 'object') ? obj : {};
+    } catch (e) { return {}; }
+  }
+  function save() {
+    try { window.localStorage.setItem(STORE_NAME, JSON.stringify(picks)); } catch (e) {}
+  }
+
+  // ---- build per-race model + inject controls -------------------------
+  var CHECK_SVG = '<svg viewBox="0 0 12 12" aria-hidden="true"><path d="M2.5 6.2 5 8.6l4.5-5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+
+  races.forEach(function (raceEl) {
+    var h2 = raceEl.querySelector('.race-headings h2');
+    var meta = raceEl.querySelector('.race-meta');
+    if (!h2) return;
+    var name = h2.textContent.trim();
+    var max = 1;
+    if (meta) {
+      var m = meta.textContent.match(/not more than\s+(\d+)/i);
+      if (m) max = parseInt(m[1], 10);
+    }
+
+    var rd = { el: raceEl, name: name, max: max, cands: [], counter: null };
+
+    Array.prototype.forEach.call(raceEl.querySelectorAll('.cand'), function (candEl) {
+      var h3 = candEl.querySelector('.cand-head h3');
+      var head = candEl.querySelector('.cand-head');
+      if (!h3 || !head) return;
+      var cname = h3.textContent.trim();
+
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'pick-btn';
+      btn.setAttribute('aria-pressed', 'false');
+      btn.innerHTML = '<span class="tick">' + CHECK_SVG + '</span><span class="pick-btn__label">Pick</span>';
+      head.appendChild(btn);
+
+      var rec = { el: candEl, name: cname, btn: btn, label: btn.querySelector('.pick-btn__label') };
+      rd.cands.push(rec);
+      btn.addEventListener('click', function () { toggle(rd, rec); });
+    });
+
+    if (max > 1 && meta) {
+      rd.counter = document.createElement('span');
+      rd.counter.className = 'seat-count';
+      meta.appendChild(rd.counter);
+    }
+
+    raceData.push(rd);
+    applyRace(rd);
+    updateCounter(rd);
+  });
+
+  // ---- selection ------------------------------------------------------
+  function selected(rd) { return picks[rd.name] ? picks[rd.name].slice() : []; }
+
+  function toggle(rd, rec) {
+    var arr = selected(rd);
+    var i = arr.indexOf(rec.name);
+    if (i !== -1) {
+      arr.splice(i, 1);
+    } else if (rd.max === 1) {
+      arr = [rec.name];
+    } else {
+      arr.push(rec.name);
+      if (arr.length > rd.max) arr.shift(); // bump earliest pick
+    }
+    if (arr.length) picks[rd.name] = arr; else delete picks[rd.name];
+    save();
+    applyRace(rd);
+    updateCounter(rd);
+    updateBar();
+  }
+
+  function applyRace(rd) {
+    var arr = selected(rd);
+    rd.cands.forEach(function (rec) {
+      var on = arr.indexOf(rec.name) !== -1;
+      rec.el.classList.toggle('is-picked', on);
+      rec.btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+      if (rec.label) rec.label.textContent = on ? 'Picked' : 'Pick';
+    });
+  }
+
+  function updateCounter(rd) {
+    if (!rd.counter) return;
+    var n = selected(rd).length;
+    rd.counter.textContent = n + ' of ' + rd.max + ' selected';
+    rd.counter.classList.toggle('is-full', n >= rd.max);
+  }
+
+  function racesChosen() {
+    var k = 0;
+    raceData.forEach(function (rd) { if (selected(rd).length) k++; });
+    return k;
+  }
+
+  // ---- sticky progress bar -------------------------------------------
+  function buildBar() {
+    bar = document.createElement('div');
+    bar.className = 'bp-bar';
+    bar.setAttribute('role', 'status');
+    bar.innerHTML =
+      '<span class="bp-bar__text"></span>' +
+      '<span class="bp-bar__track"><span class="bp-bar__fill"></span></span>' +
+      '<button type="button" class="bp-bar__btn">View my ballot</button>';
+    document.body.appendChild(bar);
+    barText = bar.querySelector('.bp-bar__text');
+    barFill = bar.querySelector('.bp-bar__fill');
+    bar.querySelector('.bp-bar__btn').addEventListener('click', openSummary);
+  }
+
+  function updateBar() {
+    if (!bar) buildBar();
+    var k = racesChosen();
+    var total = raceData.length;
+    barText.textContent = k + ' of ' + total + ' races chosen';
+    barFill.style.width = (k / total * 100) + '%';
+    bar.classList.toggle('is-active', k >= 1);
+  }
+
+  // ---- summary modal --------------------------------------------------
+  function buildModal() {
+    overlay = document.createElement('div');
+    overlay.className = 'bp-overlay';
+    overlay.innerHTML =
+      '<div class="bp-modal" role="dialog" aria-modal="true" aria-label="My June 9 sample ballot">' +
+        '<div class="bp-card" id="bp-card">' +
+          '<p class="bp-card__kicker">Marblehead &middot; June 9, 2026</p>' +
+          '<h2 class="bp-card__title">My sample ballot</h2>' +
+          '<div class="bp-card__rows" id="bp-rows"></div>' +
+          '<p class="bp-card__foot"><strong>marbleheaddata.org</strong> &middot; my sample ballot, not an endorsement</p>' +
+        '</div>' +
+        '<div class="bp-actions">' +
+          '<button type="button" class="bp-act bp-act--primary" data-act="share">Share my picks</button>' +
+          '<button type="button" class="bp-act" data-act="copy">Copy as text</button>' +
+          '<button type="button" class="bp-act bp-act--ghost" data-act="clear">Clear</button>' +
+          '<button type="button" class="bp-act bp-act--ghost" data-act="close">Done</button>' +
+        '</div>' +
+        '<p class="bp-footnote">Saved on this device only. The four ballot questions are on the <a href="whats-on-the-ballot.html#how-youll-vote">practice ballot</a>.</p>' +
+      '</div>';
+    document.body.appendChild(overlay);
+    modal = overlay.querySelector('.bp-modal');
+
+    overlay.addEventListener('click', function (e) { if (e.target === overlay) closeSummary(); });
+    overlay.querySelector('[data-act="close"]').addEventListener('click', closeSummary);
+    overlay.querySelector('[data-act="copy"]').addEventListener('click', copyText);
+    overlay.querySelector('[data-act="share"]').addEventListener('click', sharePicks);
+    overlay.querySelector('[data-act="clear"]').addEventListener('click', clearAll);
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && overlay.classList.contains('is-open')) closeSummary();
+    });
+  }
+
+  function renderRows() {
+    var rows = overlay.querySelector('#bp-rows');
+    rows.innerHTML = '';
+    raceData.forEach(function (rd) {
+      var arr = selected(rd);
+      var row = document.createElement('div');
+      row.className = 'bp-row';
+      var pick = arr.length
+        ? '<p class="bp-row__pick">' + escapeHtml(arr.join(', ')) + '</p>'
+        : '<p class="bp-row__pick is-empty">No pick yet</p>';
+      row.innerHTML = '<p class="bp-row__race">' + escapeHtml(rd.name) + '</p>' + pick;
+      rows.appendChild(row);
+    });
+  }
+
+  function openSummary() {
+    if (!overlay) buildModal();
+    renderRows();
+    overlay.classList.add('is-open');
+    document.body.style.overflow = 'hidden';
+    var first = overlay.querySelector('.bp-act');
+    if (first) first.focus();
+  }
+  function closeSummary() {
+    if (!overlay) return;
+    overlay.classList.remove('is-open');
+    document.body.style.overflow = '';
+  }
+
+  function clearAll() {
+    picks = {};
+    save();
+    raceData.forEach(function (rd) { applyRace(rd); updateCounter(rd); });
+    updateBar();
+    renderRows();
+    toast('Ballot cleared');
+  }
+
+  // ---- copy / share ---------------------------------------------------
+  function ballotText() {
+    var lines = ['My Marblehead sample ballot, June 9, 2026', ''];
+    var any = false;
+    raceData.forEach(function (rd) {
+      var arr = selected(rd);
+      if (arr.length) { lines.push(rd.name + ': ' + arr.join(', ')); any = true; }
+    });
+    if (!any) lines.push('(no picks yet)');
+    lines.push('');
+    lines.push(PAGE_URL);
+    return lines.join('\n');
+  }
+
+  function copyText() {
+    var text = ballotText();
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () { toast('Copied to clipboard'); },
+        function () { legacyCopy(text); });
+    } else {
+      legacyCopy(text);
+    }
+  }
+  function legacyCopy(text) {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'absolute';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand('copy'); toast('Copied to clipboard'); }
+    catch (e) { toast('Copy failed'); }
+    document.body.removeChild(ta);
+  }
+
+  function sharePicks() {
+    var canvas = drawShareCard();
+    canvas.toBlob(function (blob) {
+      if (!blob) { toast('Could not make image'); return; }
+      var file = new File([blob], 'marblehead-ballot.png', { type: 'image/png' });
+      var shareData = {
+        title: 'My Marblehead sample ballot',
+        text: ballotText()
+      };
+      if (navigator.canShare && navigator.canShare({ files: [file] }) && navigator.share) {
+        shareData.files = [file];
+        navigator.share(shareData).catch(function () {});
+      } else {
+        downloadCanvas(canvas);
+      }
+    }, 'image/png');
+  }
+
+  function downloadCanvas(canvas) {
+    try {
+      var url = canvas.toDataURL('image/png');
+      var a = document.createElement('a');
+      a.href = url;
+      a.download = 'marblehead-ballot.png';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      toast('Image saved');
+    } catch (e) { toast('Could not save image'); }
+  }
+
+  // ---- share card (drawn client-side, light palette) -----------------
+  function drawShareCard() {
+    var W = 1080, H = 1350;
+    var canvas = document.createElement('canvas');
+    canvas.width = W; canvas.height = H;
+    var c = canvas.getContext('2d');
+
+    // background
+    var g = c.createLinearGradient(0, 0, W, H);
+    g.addColorStop(0, '#FFFFFF');
+    g.addColorStop(1, '#EAF1F5');
+    c.fillStyle = g; c.fillRect(0, 0, W, H);
+    // top accent band
+    c.fillStyle = '#1B3A57'; c.fillRect(0, 0, W, 14);
+
+    var PAD = 84;
+    var SANS = 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+    var y = 150;
+
+    c.textBaseline = 'alphabetic';
+    c.fillStyle = '#7A8A98';
+    c.font = '700 26px ' + SANS;
+    c.fillText('MARBLEHEAD  ·  JUNE 9, 2026', PAD, y);
+    y += 64;
+
+    c.fillStyle = '#0F2A3D';
+    c.font = '800 76px ' + SANS;
+    c.fillText('My sample ballot', PAD, y);
+    y += 40;
+
+    c.strokeStyle = '#D8E1E8'; c.lineWidth = 2;
+    c.beginPath(); c.moveTo(PAD, y); c.lineTo(W - PAD, y); c.stroke();
+    y += 30;
+
+    raceData.forEach(function (rd) {
+      var arr = selected(rd);
+      y += 34;
+      c.fillStyle = '#7A8A98';
+      c.font = '700 24px ' + SANS;
+      c.fillText(rd.name.toUpperCase(), PAD, y);
+      y += 46;
+      c.font = '600 40px ' + SANS;
+      if (arr.length) {
+        c.fillStyle = '#0F2A3D';
+        y = wrapText(c, arr.join(', '), PAD, y, W - PAD * 2, 50);
+      } else {
+        c.fillStyle = '#A6B3BE';
+        c.fillText('No pick yet', PAD, y);
+      }
+      y += 18;
+      c.strokeStyle = '#ECF1F5'; c.lineWidth = 1;
+      c.beginPath(); c.moveTo(PAD, y); c.lineTo(W - PAD, y); c.stroke();
+    });
+
+    // footer
+    c.fillStyle = '#1B3A57';
+    c.font = '800 30px ' + SANS;
+    c.fillText('marbleheaddata.org', PAD, H - 90);
+    c.fillStyle = '#7A8A98';
+    c.font = '500 24px ' + SANS;
+    c.fillText('My sample ballot, not an endorsement.', PAD, H - 54);
+
+    return canvas;
+  }
+
+  function wrapText(c, text, x, y, maxWidth, lineHeight) {
+    var words = text.split(' ');
+    var line = '';
+    for (var i = 0; i < words.length; i++) {
+      var test = line ? line + ' ' + words[i] : words[i];
+      if (c.measureText(test).width > maxWidth && line) {
+        c.fillText(line, x, y);
+        line = words[i];
+        y += lineHeight;
+      } else {
+        line = test;
+      }
+    }
+    if (line) { c.fillText(line, x, y); }
+    return y;
+  }
+
+  // ---- toast ----------------------------------------------------------
+  var toastTimer;
+  function toast(msg) {
+    if (!toastEl) {
+      toastEl = document.createElement('div');
+      toastEl.className = 'bp-toast';
+      document.body.appendChild(toastEl);
+    }
+    toastEl.textContent = msg;
+    toastEl.classList.add('is-show');
+    window.clearTimeout(toastTimer);
+    toastTimer = window.setTimeout(function () { toastEl.classList.remove('is-show'); }, 1900);
+  }
+
+  // ---- util -----------------------------------------------------------
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (ch) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch];
+    });
+  }
+
+  // ---- init -----------------------------------------------------------
+  updateBar();
+})();

--- a/assets/ballot-picker.js
+++ b/assets/ballot-picker.js
@@ -116,6 +116,7 @@
   function updateCounter(rd) {
     if (!rd.counter) return;
     var n = selected(rd).length;
+    rd.el.classList.toggle('is-incomplete', n > 0 && n < rd.max);
     rd.counter.classList.remove('is-need', 'is-full');
     if (n === 0) {
       rd.counter.textContent = '';

--- a/assets/ballot-picker.js
+++ b/assets/ballot-picker.js
@@ -116,8 +116,20 @@
   function updateCounter(rd) {
     if (!rd.counter) return;
     var n = selected(rd).length;
-    rd.counter.textContent = n + ' of ' + rd.max + ' selected';
-    rd.counter.classList.toggle('is-full', n >= rd.max);
+    rd.counter.classList.remove('is-need', 'is-full');
+    if (n === 0) {
+      rd.counter.textContent = '';
+      rd.counter.style.display = 'none';
+      return;
+    }
+    rd.counter.style.display = '';
+    if (n < rd.max) {
+      rd.counter.textContent = 'Pick ' + (rd.max - n) + ' more';
+      rd.counter.classList.add('is-need');
+    } else {
+      rd.counter.textContent = rd.max + ' selected';
+      rd.counter.classList.add('is-full');
+    }
   }
 
   function racesChosen() {
@@ -193,7 +205,10 @@
       var pick = arr.length
         ? arr.map(function (n) { return '<p class="bp-row__pick">' + escapeHtml(n) + '</p>'; }).join('')
         : '<p class="bp-row__pick is-empty">No pick yet</p>';
-      row.innerHTML = '<p class="bp-row__race">' + escapeHtml(rd.name) + '</p>' + pick;
+      var hint = (arr.length && arr.length < rd.max)
+        ? '<p class="bp-row__hint">Pick ' + (rd.max - arr.length) + ' more</p>'
+        : '';
+      row.innerHTML = '<p class="bp-row__race">' + escapeHtml(rd.name) + '</p>' + pick + hint;
       rows.appendChild(row);
     });
   }

--- a/docs/superpowers/specs/2026-06-03-ballot-picker-design.md
+++ b/docs/superpowers/specs/2026-06-03-ballot-picker-design.md
@@ -1,0 +1,60 @@
+# Sample-ballot picker for where-candidates-stand.html
+
+Date: 2026-06-03
+Status: approved, ready to build
+
+## Goal
+
+Let a reader pick their candidates in the six contested June 9 races on
+`where-candidates-stand.html`, then keep their choices: a private,
+screenshot-ready "my sample ballot" summary, with an opt-in shareable
+"Wrapped"-style picks card. Fully client-side. No backend, no PII.
+
+Sign-up (email/reminder) is explicitly deferred to a later phase.
+
+## Decisions
+
+- **Scope:** candidates only, the six contested races on this page. The four
+  ballot questions stay on the existing practice ballot in
+  `whats-on-the-ballot.html`; the summary links to it.
+- **Privacy:** picks live in `localStorage` only. Nothing leaves the browser
+  unless the user taps the opt-in share.
+- **Neutrality:** selection uses the navy/teal page accent (not green/red).
+  The generic community-pulse save/share/reaction widgets are turned off on
+  this page (`community_pulse: "off-sections"`) so race sections carry no
+  reaction-count scoreboard.
+- **No calendar reminder** (dropped from scope).
+
+## UX
+
+1. Each candidate row gets a JS-injected select control (progressive
+   enhancement; no-JS readers see the page unchanged). Tap to select/deselect.
+2. Per-race cap = the real ballot rule ("vote for not more than N"): Select
+   Board 2, Recreation & Park 5, the other four races 1. Selecting past the
+   cap bumps the earliest pick. A "N of M selected" counter shows on capped
+   races.
+3. Slim sticky progress bar: "k of 6 races chosen" + thin fill + a
+   "View my ballot" button (always available, partial ballots allowed).
+4. Summary (default, private): "My June 9 sample ballot" card listing each
+   race and the picks. Affordances: Copy as text, Clear, link to the
+   question practice ballot. Screenshot-ready on its own.
+5. Opt-in "Share my picks": generates a Wrapped-style PNG including the
+   picks, shared via the Web Share API (file), with a PNG-download +
+   copy-text fallback. Minimal branding; footer reads
+   "marbleheaddata.org - my sample ballot, not an endorsement".
+
+## Build
+
+- `assets/ballot-picker.js` (new), loaded via a new `ballot-picker` gate in
+  `_includes/head.html` and the page's `scripts:` frontmatter.
+- Picker CSS in the page's `<style>` block (page-specific).
+- Share image rendered dependency-free by hand-drawing to a `<canvas>`
+  (picks are short text; no html2canvas/library).
+- Data hooks: `data-race` + `data-max` on each `.race`, `data-candidate` on
+  each `.cand`. All interactive UI is JS-created and styled to match the
+  recent pages.
+
+## Out of scope (later)
+
+- Email sign-up / vote reminder (separate infra + privacy-policy design).
+- Including the four ballot questions in this tool.

--- a/where-candidates-stand.html
+++ b/where-candidates-stand.html
@@ -289,14 +289,44 @@ og_url: https://marbleheaddata.org/where-candidates-stand.html
 
   /* per-race seat counter, shown only on multi-seat races */
   .seat-count {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
     font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 0.4px;
-    color: var(--text-subtle);
+    font-weight: 800;
+    letter-spacing: 0.5px;
     text-transform: uppercase;
     margin-left: 8px;
+    padding: 3px 9px;
+    border-radius: 999px;
+    vertical-align: middle;
+    color: var(--text-subtle);
+    background: color-mix(in srgb, var(--text-subtle) 12%, var(--surface));
   }
-  .seat-count.is-full { color: var(--accent); }
+  .seat-count.is-need {
+    color: #fff;
+    background: var(--accent);
+    animation: seatNudge 0.4s ease;
+  }
+  .seat-count.is-full {
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 13%, var(--surface));
+  }
+  @keyframes seatNudge {
+    0% { transform: scale(0.9); }
+    60% { transform: scale(1.07); }
+    100% { transform: scale(1); }
+  }
+  @media (prefers-reduced-motion: reduce) { .seat-count.is-need { animation: none; } }
+
+  /* incomplete-race hint inside the summary card */
+  .bp-row__hint {
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+    color: var(--accent);
+    margin: 4px 0 0;
+  }
 
   /* sticky progress bar */
   .bp-bar {

--- a/where-candidates-stand.html
+++ b/where-candidates-stand.html
@@ -328,6 +328,15 @@ og_url: https://marbleheaddata.org/where-candidates-stand.html
     margin: 4px 0 0;
   }
 
+  /* a multi-seat race with an unfilled seat gets an accent ring */
+  .race.is-incomplete {
+    border-color: color-mix(in srgb, var(--race-accent, var(--accent)) 55%, var(--border));
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--race-accent, var(--accent)) 22%, transparent), var(--shadow-sm);
+  }
+  .race.is-incomplete:hover {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--race-accent, var(--accent)) 30%, transparent), var(--shadow-md);
+  }
+
   /* sticky progress bar */
   .bp-bar {
     position: fixed;

--- a/where-candidates-stand.html
+++ b/where-candidates-stand.html
@@ -1,6 +1,7 @@
 ---
 title: "Where the candidates stand"
-scripts: [citations]
+scripts: [citations, ballot-picker]
+community_pulse: "off-sections"
 og_title: "Where the candidates stand"
 og_description: "What every candidate in Marblehead's six contested June 9 races said about the override, the budget, schools and trash, drawn from their own published candidate Q&As in the Marblehead Current and the Marblehead Independent voter guide."
 og_url: https://marbleheaddata.org/where-candidates-stand.html
@@ -235,6 +236,282 @@ og_url: https://marbleheaddata.org/where-candidates-stand.html
       from { opacity: 0; transform: translateY(14px); }
       to   { opacity: 1; transform: translateY(0); }
     }
+  }
+
+  /* ============================================================
+     Sample-ballot picker (progressive enhancement; .js-picker is
+     added to <body> by ballot-picker.js once it wires up)
+     ============================================================ */
+
+  /* pick control injected into each .cand-head */
+  .pick-btn {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+    color: var(--accent);
+    background: var(--surface);
+    border: 1.5px solid color-mix(in srgb, var(--accent) 32%, var(--surface));
+    border-radius: 999px;
+    padding: 5px 12px 5px 9px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.12s ease;
+  }
+  .pick-btn:hover { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, var(--surface)); }
+  .pick-btn:active { transform: scale(0.96); }
+  .pick-btn .tick {
+    width: 15px; height: 15px;
+    border-radius: 50%;
+    border: 1.5px solid color-mix(in srgb, var(--accent) 45%, var(--surface));
+    display: inline-flex; align-items: center; justify-content: center;
+    flex: none;
+  }
+  .pick-btn .tick svg { width: 9px; height: 9px; opacity: 0; transition: opacity 0.15s ease; }
+  .cand.is-picked .pick-btn {
+    color: #fff;
+    background: var(--accent);
+    border-color: var(--accent);
+  }
+  .cand.is-picked .pick-btn .tick { border-color: rgba(255,255,255,0.9); }
+  .cand.is-picked .pick-btn .tick svg { opacity: 1; }
+  .cand.is-picked .avatar {
+    color: #fff;
+    background: var(--accent);
+    border-color: var(--accent);
+  }
+  .cand { transition: background 0.18s ease; border-radius: var(--radius-sm); }
+  .cand.is-picked { background: color-mix(in srgb, var(--accent) 5%, var(--surface)); }
+
+  /* per-race seat counter, shown only on multi-seat races */
+  .seat-count {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.4px;
+    color: var(--text-subtle);
+    text-transform: uppercase;
+    margin-left: 8px;
+  }
+  .seat-count.is-full { color: var(--accent); }
+
+  /* sticky progress bar */
+  .bp-bar {
+    position: fixed;
+    left: 50%;
+    bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+    transform: translate(-50%, 130%);
+    z-index: 60;
+    width: min(560px, calc(100vw - 28px));
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px 10px 16px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    box-shadow: var(--shadow-md);
+    opacity: 0;
+    transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.35s ease;
+  }
+  .bp-bar.is-active { transform: translate(-50%, 0); opacity: 1; }
+  .bp-bar__text {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    white-space: nowrap;
+    flex: none;
+  }
+  .bp-bar__track {
+    flex: 1;
+    height: 6px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--accent) 14%, var(--surface));
+    overflow: hidden;
+    min-width: 40px;
+  }
+  .bp-bar__fill {
+    height: 100%;
+    width: 0;
+    border-radius: 999px;
+    background: var(--accent);
+    transition: width 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .bp-bar__btn {
+    font: inherit;
+    font-size: 13px;
+    font-weight: 700;
+    color: #fff;
+    background: var(--accent);
+    border: 0;
+    border-radius: 999px;
+    padding: 8px 16px;
+    cursor: pointer;
+    white-space: nowrap;
+    flex: none;
+    transition: filter 0.15s ease, transform 0.12s ease;
+  }
+  .bp-bar__btn:hover { filter: brightness(1.08); }
+  .bp-bar__btn:active { transform: scale(0.97); }
+  @media (max-width: 480px) {
+    .bp-bar__text { font-size: 12px; }
+    .bp-bar__btn { padding: 8px 13px; }
+  }
+
+  /* summary overlay */
+  .bp-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 70;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 24px 16px;
+    overflow-y: auto;
+    background: color-mix(in srgb, var(--c-text) 55%, transparent);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+    -webkit-backdrop-filter: blur(3px);
+    backdrop-filter: blur(3px);
+  }
+  .bp-overlay.is-open { opacity: 1; pointer-events: auto; }
+  .bp-modal {
+    width: min(460px, 100%);
+    margin: auto;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+    transform: translateY(16px) scale(0.98);
+    transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .bp-overlay.is-open .bp-modal { transform: translateY(0) scale(1); }
+
+  /* the screenshot-ready ballot card */
+  .bp-card {
+    padding: 22px 22px 20px;
+    background:
+      radial-gradient(120% 80% at 100% 0%, color-mix(in srgb, var(--c-teal) 12%, var(--surface)), transparent 60%),
+      radial-gradient(120% 80% at 0% 100%, color-mix(in srgb, var(--c-navy) 12%, var(--surface)), transparent 55%),
+      var(--surface);
+  }
+  .bp-card__kicker {
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: 1.4px;
+    text-transform: uppercase;
+    color: var(--text-subtle);
+    margin: 0 0 2px;
+  }
+  .bp-card__title {
+    font-size: 21px;
+    font-weight: 800;
+    color: var(--text);
+    margin: 0 0 14px;
+    line-height: 1.15;
+  }
+  .bp-row {
+    display: grid;
+    grid-template-columns: 1fr;
+    padding: 9px 0;
+    border-top: 1px solid var(--divider);
+  }
+  .bp-row:first-child { border-top: 0; }
+  .bp-row__race {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--text-subtle);
+    margin: 0 0 3px;
+  }
+  .bp-row__pick {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text);
+    margin: 0;
+    line-height: 1.35;
+  }
+  .bp-row__pick.is-empty {
+    font-weight: 500;
+    font-style: italic;
+    color: var(--text-faint);
+  }
+  .bp-card__foot {
+    margin: 16px 0 0;
+    font-size: 11px;
+    color: var(--text-subtle);
+    border-top: 1px solid var(--divider);
+    padding-top: 10px;
+  }
+  .bp-card__foot strong { color: var(--text-muted); font-weight: 700; }
+
+  /* actions under the card */
+  .bp-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 14px 18px 8px;
+    border-top: 1px solid var(--divider);
+  }
+  .bp-act {
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    border-radius: var(--radius-sm);
+    padding: 9px 14px;
+    cursor: pointer;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    transition: background 0.15s ease, border-color 0.15s ease, transform 0.12s ease;
+  }
+  .bp-act:hover { background: var(--bg); }
+  .bp-act:active { transform: scale(0.97); }
+  .bp-act--primary {
+    color: #fff;
+    background: var(--accent);
+    border-color: var(--accent);
+    flex: 1;
+    min-width: 150px;
+  }
+  .bp-act--primary:hover { background: var(--accent); filter: brightness(1.08); }
+  .bp-act--ghost { color: var(--text-subtle); border-color: transparent; }
+  .bp-act--ghost:hover { color: var(--text); background: var(--bg); }
+  .bp-footnote {
+    padding: 4px 18px 16px;
+    font-size: 12px;
+    color: var(--text-subtle);
+    line-height: 1.5;
+  }
+  .bp-footnote a { color: var(--link); }
+
+  .bp-toast {
+    position: fixed;
+    left: 50%;
+    bottom: calc(80px + env(safe-area-inset-bottom, 0px));
+    transform: translate(-50%, 12px);
+    z-index: 80;
+    background: var(--c-text);
+    color: var(--c-fog);
+    font-size: 13px;
+    font-weight: 600;
+    padding: 9px 16px;
+    border-radius: 999px;
+    box-shadow: var(--shadow-md);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+  .bp-toast.is-show { opacity: 1; transform: translate(-50%, 0); }
+
+  @media (prefers-reduced-motion: reduce) {
+    .bp-bar, .bp-overlay, .bp-modal, .bp-bar__fill, .pick-btn, .bp-act { transition: none; }
   }
 </style>
 


### PR DESCRIPTION
Adds an interactive "pick your candidates" tool to the candidate-positions page. A reader taps their choices in the six contested June 9 races and gets a keepable summary.

## How it works
- **Fully client-side.** Picks are stored in `localStorage` only. Nothing leaves the browser unless the reader taps **Share my picks**.
- **Progressive enhancement.** `ballot-picker.js` reads the existing DOM (race name from each `h2`, seat cap from the "vote for not more than N" meta, candidate name from each `h3`) and injects the pick controls, a sticky progress bar, and a summary modal. No-JS readers see the page unchanged.
- **Real ballot rules.** Per-race cap enforced (Select Board 2, Rec & Park 5, the rest 1); a tap past the cap bumps the earliest pick. Selection uses the navy/teal page accent, never green/red.

## The finish
- **Private by default:** a screenshot-ready "My sample ballot" card with **Copy as text**, **Clear**, and a link to the existing practice ballot for the four override/trash questions.
- **Opt-in Share my picks:** renders a Wrapped-style PNG client-side (hand-drawn `<canvas>`, no library) for the Web Share API, with a PNG-download / copy-text fallback. Minimal branding, footer reads "marbleheaddata.org · my sample ballot, not an endorsement."

## Neutrality
- Turns off the generic community-pulse save/share/reaction widgets on this contested page (`community_pulse: off-sections`) so race sections carry no reaction-count scoreboard.
- The shareable card is opt-in and clearly framed as the reader's own ballot, not a site endorsement.

Sign-up (email/vote reminder) is intentionally deferred to a later phase.

Spec: `docs/superpowers/specs/2026-06-03-ballot-picker-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)