### PR TITLE
Reformat Marblehead 101 card and drop section share/flag bar on homepage

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -3697,7 +3697,30 @@ blockquote.quote--mixed p {
   font-size: 0.875rem;
   color: var(--text-subtle);
   line-height: 1.55;
-  margin-bottom: 12px;
+  margin-bottom: 10px;
+}
+.featured-card-meta {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  color: var(--text-muted);
+  margin-bottom: 14px;
+}
+.featured-card-meta .dot {
+  color: var(--c-navy);
+  margin: 0 6px;
+}
+.featured-card-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--c-teal);
+  transition: gap 0.2s;
+}
+.featured-card:hover .featured-card-cta {
+  gap: 7px;
 }
 
 @media (max-width: 600px) {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ---
 title: "Marblehead Budget Data"
+community_pulse: "off-sections"
 scripts: [citations]
 og_title: "Marblehead Budget Data: the override in one page"
 og_description: "Two ballot questions, three override tiers, an $8.47M deficit. What's on the June 9 ballot, what it costs, why there's a gap, and what happens if it fails."
@@ -555,8 +556,9 @@ og_url: https://marbleheaddata.org/
 <a href="marblehead-101/" class="featured-card">
   <div class="featured-card-eyebrow">New here?</div>
   <h2 class="featured-card-title">Marblehead 101</h2>
-  <p class="featured-card-desc">A plain-English primer on how the town works, where the money goes, and how a resident takes part. 8 short chapters, ~25 min total.</p>
-  <span style="font-size: 0.875rem; font-weight: 600; color: var(--c-teal);">Start the primer &rarr;</span>
+  <p class="featured-card-desc">A plain-English primer on how the town works, where the money goes, and how a resident takes part.</p>
+  <p class="featured-card-meta">8 short chapters <span class="dot">&middot;</span> about 25 min total</p>
+  <span class="featured-card-cta">Start the primer &rarr;</span>
 </a>
 
 <section class="home-stop home-stop--tinted" id="deficit">


### PR DESCRIPTION
## What

Two homepage cleanups:

1. **Drop the share/flag bar on the homepage.** The community-pulse widget hydrates every `<h2>` on a page with a bookmark / flag / share / note bar. On the homepage it was injecting that bar after the "Data and tools" heading and, worse, appending it *inside* the clickable Marblehead 101 featured card (the card's `<h2>` has no following h2/h3/footer, so the bar fell through to the end of the anchor). This opts the homepage out via the documented page-level switch `community_pulse: "off-sections"`, which also short-circuits loading `widget.js` entirely on this page.

2. **Better-formatted Marblehead 101 card.** Replaced the inline-styled CTA span (`style="..."`) with a proper `.featured-card-cta` class, and pulled the "8 short chapters, ~25 min" detail out of the description paragraph into its own muted `.featured-card-meta` row. Added a subtle hover nudge on the CTA arrow.

## Verification

- `bundle exec jekyll build` compiles cleanly.
- Confirmed in the rendered `_site/index.html`: the new `.featured-card-meta` / `.featured-card-cta` markup is present, `community-pulse/widget.js` is no longer loaded, and the body carries `data-community-pulse="off-sections"`.
- The Playwright smoke suite could not run in the remote sandbox (the Chromium binary download is blocked by the environment's network policy); CI will run it on this PR.

https://claude.ai/code/session_015qH4FqGtis4NUjnL2LwkAL

---
_Generated by [Claude Code](https://claude.ai/code/session_015qH4FqGtis4NUjnL2LwkAL)_