### PR TITLE
Digest email: simpler design + preview tool

### DIFF
--- a/meeting-digest/tests/render.test.js
+++ b/meeting-digest/tests/render.test.js
@@ -15,10 +15,7 @@ const SB_MATCH = {
       summary: 'The board approved the contract.'
     }
   },
-  matched_segments: [
-    { topic: 'override', start_seconds: 754, headline: 'Board signals support for Tier 2', dek: 'Two members spoke.' },
-    { topic: 'bonding-capital', start_seconds: 2291, headline: 'Mary Allen funding path approved', dek: '$5.43M contract.' }
-  ]
+  matched_segments: []
 };
 const SUB = { manage_token: 'mtok', email: 'hi@example.com' };
 const ENV = { SITE_BASE_URL: 'https://marbleheaddata.org' };
@@ -33,39 +30,42 @@ describe('formatTimecode', () => {
 });
 
 describe('renderSubject', () => {
-  it('uses single-meeting form for 1 match', () => {
-    expect(renderSubject([SB_MATCH])).toBe('[MHD Data] Select Board: Board approves $5.43M Mary Allen contract');
+  it('uses "Board: headline" for a single meeting', () => {
+    expect(renderSubject([SB_MATCH])).toBe('Select Board: Board approves $5.43M Mary Allen contract');
   });
-  it('joins headlines with " · " for 2-3 matches', () => {
-    const two = [SB_MATCH, { ...SB_MATCH, transcript: { ...SB_MATCH.transcript, summary_card: { headline: 'Second meeting' } } }];
-    expect(renderSubject(two)).toBe('[MHD Data] 2 meetings this week: Board approves $5.43M Mary Allen contract · Second meeting');
-  });
-  it('truncates with "..." for 4+ matches', () => {
-    const four = Array.from({ length: 4 }, (_, i) => ({
-      ...SB_MATCH,
-      transcript: { ...SB_MATCH.transcript, summary_card: { headline: `H${i+1}` } }
-    }));
-    expect(renderSubject(four)).toBe('[MHD Data] 4 meetings this week: H1 · H2 · H3...');
+  it('uses "N Marblehead meetings this week" for 2+ matches', () => {
+    expect(renderSubject([SB_MATCH, SB_MATCH])).toBe('2 Marblehead meetings this week');
+    const four = Array.from({ length: 4 }, () => SB_MATCH);
+    expect(renderSubject(four)).toBe('4 Marblehead meetings this week');
   });
 });
 
 describe('renderHtml', () => {
-  it('includes a header, one card per meeting, and a footer with manage/unsubscribe', () => {
+  it('leads with brand + count, then meetings, then footer links', () => {
     const html = renderHtml([SB_MATCH], SUB, ENV, '2026-06-12');
     expect(html).toContain('Marblehead Data');
-    expect(html).toContain('Week ending');
+    expect(html).toContain('1 meeting this week');
     expect(html).toContain('Board approves $5.43M Mary Allen contract');
     expect(html).toContain('Select Board');
-    expect(html).toContain('Matching segments');
-    expect(html).toContain('12:34');
+    expect(html).toContain('Jun 10');
     expect(html).toContain('marbleheaddata.org/me/subscription/?token=mtok');
     expect(html).toContain('marbleheaddata.org/api/unsubscribe?token=mtok');
     expect(html).toContain('AI-generated');
   });
-  it('omits the "Matching segments" block when matched_segments is empty', () => {
-    const noSegs = { ...SB_MATCH, matched_segments: [] };
-    const html = renderHtml([noSegs], SUB, ENV, '2026-06-12');
+  it('pluralises the meeting count correctly', () => {
+    const html = renderHtml([SB_MATCH, SB_MATCH], SUB, ENV, '2026-06-12');
+    expect(html).toContain('2 meetings this week');
+  });
+  it('does not surface matched_segments in the body (simpler design)', () => {
+    const withSegs = {
+      ...SB_MATCH,
+      matched_segments: [
+        { topic: 'override', start_seconds: 754, headline: 'X', dek: 'Y' }
+      ]
+    };
+    const html = renderHtml([withSegs], SUB, ENV, '2026-06-12');
     expect(html).not.toContain('Matching segments');
+    expect(html).not.toContain('12:34');
   });
   it('escapes HTML in user-influenced fields', () => {
     const evil = {
@@ -79,12 +79,13 @@ describe('renderHtml', () => {
 });
 
 describe('renderText', () => {
-  it('produces a plain-text mirror with the same content', () => {
+  it('mirrors the HTML content in plain text', () => {
     const text = renderText([SB_MATCH], SUB, ENV, '2026-06-12');
     expect(text).toContain('Marblehead Data');
+    expect(text).toContain('1 meeting this week');
     expect(text).toContain('Board approves $5.43M Mary Allen contract');
-    expect(text).toContain('SELECT BOARD');
-    expect(text).toContain('12:34');
+    expect(text).toContain('Select Board');
+    expect(text).toContain('Jun 10');
     expect(text).not.toContain('<');
     expect(text).not.toContain('&gt;');
   });

--- a/meeting-digest/tools/send-sample-digest.mjs
+++ b/meeting-digest/tools/send-sample-digest.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Send a sample Friday digest to a single email, using real transcripts from
+// _transcripts/. Bypasses D1, the 7-AM-ET guard, and the 7-day window so you
+// can preview what subscribers will receive without waiting for a real Friday.
+//
+// Usage (from repo root):
+//   RESEND_API_KEY=re_... node meeting-digest/tools/send-sample-digest.mjs you@example.com
+//
+// Optional second arg picks how many of the most recent matching transcripts
+// to include (default: 3).
+
+import { readFile, readdir } from 'node:fs/promises';
+import { parseTranscript, extractDateFromFilename } from '../worker/src/lib/transcripts.js';
+import { matchTranscripts } from '../worker/src/lib/matcher.js';
+import { renderHtml, renderText, renderSubject } from '../worker/src/lib/render.js';
+import { DEFAULT_BOARDS_ON_SIGNUP, TOPICS } from '../worker/src/lib/topics.js';
+
+const [, , toArg, countArg] = process.argv;
+const TO = toArg || 'agbaber@gmail.com';
+const COUNT = Number(countArg) || 3;
+const API_KEY = process.env.RESEND_API_KEY;
+if (!API_KEY) {
+  console.error('Set RESEND_API_KEY in env.');
+  process.exit(1);
+}
+
+const TRANSCRIPT_DIR = new URL('../../_transcripts/', import.meta.url);
+const all = (await readdir(TRANSCRIPT_DIR))
+  .filter(f => f.endsWith('.md'))
+  .map(f => ({ f, date: extractDateFromFilename(f) }))
+  .filter(x => x.date)
+  .sort((a, b) => b.date.localeCompare(a.date))
+  .map(x => x.f);
+
+const subscription = {
+  boards: DEFAULT_BOARDS_ON_SIGNUP,
+  topics: TOPICS.map(t => t.slug)
+};
+
+const matches = [];
+for (const f of all) {
+  const text = await readFile(new URL(f, TRANSCRIPT_DIR), 'utf-8');
+  const t = parseTranscript(f, text);
+  if (!t) continue;
+  const oneMatch = matchTranscripts([t], subscription);
+  if (oneMatch.length > 0) matches.push(oneMatch[0]);
+  if (matches.length >= COUNT) break;
+}
+
+if (matches.length === 0) {
+  console.error('No matching transcripts found.');
+  process.exit(1);
+}
+
+const subscriber = {
+  email: TO,
+  manage_token: 'SAMPLE-PREVIEW-TOKEN'
+};
+const env = { SITE_BASE_URL: 'https://marbleheaddata.org' };
+const weekEnding = new Date().toISOString().slice(0, 10);
+
+const subject = '[PREVIEW] ' + renderSubject(matches);
+const html = renderHtml(matches, subscriber, env, weekEnding);
+const text = renderText(matches, subscriber, env, weekEnding);
+
+const resp = await fetch('https://api.resend.com/emails', {
+  method: 'POST',
+  headers: { 'Authorization': `Bearer ${API_KEY}`, 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    from: 'Marblehead Data <digest@meetings.marbleheaddata.org>',
+    to: [TO],
+    subject,
+    html,
+    text,
+    reply_to: 'agbaber@gmail.com'
+  })
+});
+
+const result = await resp.json();
+if (!resp.ok) {
+  console.error('Resend error:', resp.status, result);
+  process.exit(1);
+}
+console.log(`Sent ${matches.length}-meeting sample digest to ${TO} (resend id: ${result.id})`);
+console.log('Meetings:');
+for (const m of matches) {
+  console.log(`  - ${m.transcript.board_display}: ${m.transcript.summary_card?.headline || m.transcript.title}`);
+}

--- a/meeting-digest/worker/src/lib/render.js
+++ b/meeting-digest/worker/src/lib/render.js
@@ -1,7 +1,4 @@
 // meeting-digest/worker/src/lib/render.js
-import { TOPICS } from './topics.js';
-
-const TOPIC_LABEL = new Map(TOPICS.map(t => [t.slug, t.label]));
 
 function escapeHtml(s) {
   if (s == null) return '';
@@ -22,92 +19,81 @@ export function formatTimecode(seconds) {
   return `${m}:${String(s).padStart(2, '0')}`;
 }
 
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+function formatShortDate(iso) {
+  if (typeof iso !== 'string' || iso.length < 10) return iso || '';
+  const mi = parseInt(iso.slice(5, 7), 10) - 1;
+  const d = parseInt(iso.slice(8, 10), 10);
+  if (Number.isNaN(mi) || Number.isNaN(d) || mi < 0 || mi > 11) return iso;
+  return `${MONTHS[mi]} ${d}`;
+}
+
 export function renderSubject(matches) {
   if (matches.length === 1) {
     const m = matches[0];
-    return `[MHD Data] ${m.transcript.board_display}: ${m.transcript.summary_card?.headline || m.transcript.title}`;
+    return `${m.transcript.board_display}: ${m.transcript.summary_card?.headline || m.transcript.title}`;
   }
-  const heads = matches.slice(0, 3).map(m => m.transcript.summary_card?.headline || m.transcript.title);
-  if (matches.length <= 3) {
-    return `[MHD Data] ${matches.length} meetings this week: ${heads.join(' · ')}`;
-  }
-  return `[MHD Data] ${matches.length} meetings this week: ${heads.join(' · ')}...`;
+  return `${matches.length} Marblehead meetings this week`;
 }
 
-function meetingCardHtml(m, env) {
+function meetingHtml(m, env) {
   const t = m.transcript;
   const meetingUrl = `${env.SITE_BASE_URL}/meetings/${t.slug}/`;
-  const segs = m.matched_segments;
-  const segHtml = segs.length === 0 ? '' : `
-        <p style="margin: 14px 0 6px; font-weight: 600;">Matching segments</p>
-        <ul style="margin: 0 0 14px 0; padding-left: 20px;">
-          ${segs.map(s => `
-            <li><strong>${escapeHtml(TOPIC_LABEL.get(s.topic) || s.topic)}</strong> (${formatTimecode(s.start_seconds)}) — ${escapeHtml(s.headline || '')}${s.dek ? ` <span style="color: #666;">${escapeHtml(s.dek)}</span>` : ''}</li>
-          `).join('')}
-        </ul>`;
   return `
-    <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin: 20px 0; border-top: 1px solid #ddd; border-bottom: 1px solid #ddd;">
-      <tr><td style="padding: 18px 4px;">
-        <p style="margin: 0 0 4px; text-transform: uppercase; letter-spacing: 0.08em; font-size: 12px; color: #666;">${escapeHtml(t.board_display)} · ${escapeHtml(t.date)}</p>
-        <h2 style="margin: 0 0 8px; font-size: 18px;">${escapeHtml(t.summary_card?.headline || t.title)}</h2>
-        <p style="margin: 0 0 10px; color: #333;">${escapeHtml(t.summary_card?.summary || '')}</p>
-        ${segHtml}
-        <p style="margin: 14px 0 0; font-size: 14px;"><a href="${meetingUrl}" style="color: #1a3a5c;">Read on marbleheaddata.org →</a> &nbsp; <a href="${escapeHtml(t.vimeo_url)}" style="color: #1a3a5c;">▶ Watch on MHTV</a></p>
-      </td></tr>
-    </table>`;
+  <div style="margin: 0 0 32px;">
+    <p style="margin: 0 0 6px; font-size: 13px; color: #666;">${escapeHtml(t.board_display)} · ${escapeHtml(formatShortDate(t.date))}</p>
+    <h2 style="margin: 0 0 10px; font-size: 19px; line-height: 1.3; color: #1a1a1a; font-weight: 600;">${escapeHtml(t.summary_card?.headline || t.title)}</h2>
+    <p style="margin: 0 0 12px; color: #333; line-height: 1.55;">${escapeHtml(t.summary_card?.summary || '')}</p>
+    <p style="margin: 0; font-size: 14px;"><a href="${meetingUrl}" style="color: #1B3A57; text-decoration: none; font-weight: 500;">Read &amp; watch on marbleheaddata.org &rarr;</a></p>
+  </div>`;
 }
 
-function meetingCardText(m, env) {
+function meetingText(m, env) {
   const t = m.transcript;
   const meetingUrl = `${env.SITE_BASE_URL}/meetings/${t.slug}/`;
-  const segs = m.matched_segments;
-  let segText = '';
-  if (segs.length > 0) {
-    segText = '\nMatching segments:\n' + segs.map(s =>
-      ` • ${TOPIC_LABEL.get(s.topic) || s.topic} (${formatTimecode(s.start_seconds)}) — ${s.headline || ''}${s.dek ? `. ${s.dek}` : ''}`
-    ).join('\n') + '\n';
-  }
-  return `
-${t.board_display.toUpperCase()} · ${t.date}
+  return `${t.board_display} · ${formatShortDate(t.date)}
 ${t.summary_card?.headline || t.title}
-${'─'.repeat(40)}
+
 ${t.summary_card?.summary || ''}
-${segText}
-Read: ${meetingUrl}
-Watch: ${t.vimeo_url}
-`;
+
+  ${meetingUrl}`;
 }
 
 export function renderHtml(matches, subscriber, env, weekEndingIso) {
   const manageUrl = `${env.SITE_BASE_URL}/me/subscription/?token=${encodeURIComponent(subscriber.manage_token)}`;
   const unsubUrl = `${env.SITE_BASE_URL}/api/unsubscribe?token=${encodeURIComponent(subscriber.manage_token)}`;
+  const count = matches.length;
   return `<!doctype html>
-<html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 640px; margin: 0 auto; padding: 24px; color: #1a1a1a;">
-  <p style="font-size: 12px; color: #666; margin: 0 0 4px; text-transform: uppercase; letter-spacing: 0.06em;">Marblehead Data — Friday digest</p>
-  <p style="margin: 0 0 24px; color: #666;">Week ending ${escapeHtml(weekEndingIso)} · ${matches.length} meeting${matches.length === 1 ? '' : 's'} matched.</p>
+<html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 28px 24px; color: #1a1a1a; line-height: 1.5;">
+  <p style="margin: 0 0 4px; font-size: 13px; color: #666;">Marblehead Data</p>
+  <h1 style="margin: 0 0 28px; font-size: 22px; font-weight: 600; color: #1a1a1a;">${count} ${count === 1 ? 'meeting' : 'meetings'} this week</h1>
 
-  ${matches.map(m => meetingCardHtml(m, env)).join('')}
+  ${matches.map(m => meetingHtml(m, env)).join('')}
 
-  <p style="margin: 32px 0 8px; font-size: 13px; color: #666;">
-    <a href="${manageUrl}" style="color: #1a3a5c;">Manage your subscription</a>
+  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 8px 0 16px;">
+  <p style="margin: 0 0 6px; font-size: 13px; color: #666;">
+    <a href="${manageUrl}" style="color: #1B3A57; text-decoration: none;">Manage subscription</a>
     &nbsp;·&nbsp;
-    <a href="${unsubUrl}" style="color: #1a3a5c;">Unsubscribe (one click)</a>
+    <a href="${unsubUrl}" style="color: #1B3A57; text-decoration: none;">Unsubscribe</a>
   </p>
-  <p style="margin: 4px 0; font-size: 12px; color: #999;">AI-generated summaries · may contain errors · verify with the source video.</p>
+  <p style="margin: 0; font-size: 12px; color: #999;">Summaries are AI-generated. Verify with the source video.</p>
 </body></html>`;
 }
 
 export function renderText(matches, subscriber, env, weekEndingIso) {
   const manageUrl = `${env.SITE_BASE_URL}/me/subscription/?token=${subscriber.manage_token}`;
   const unsubUrl = `${env.SITE_BASE_URL}/api/unsubscribe?token=${subscriber.manage_token}`;
-  return `Marblehead Data — Friday digest
-Week ending ${weekEndingIso} · ${matches.length} meeting${matches.length === 1 ? '' : 's'} matched.
+  const count = matches.length;
+  const body = matches.map(m => meetingText(m, env)).join('\n\n');
+  return `Marblehead Data
+${count} ${count === 1 ? 'meeting' : 'meetings'} this week
 
-${matches.map(m => meetingCardText(m, env)).join('\n')}
+${body}
 
-Manage your subscription: ${manageUrl}
-Unsubscribe (one click): ${unsubUrl}
+---
+Manage subscription: ${manageUrl}
+Unsubscribe: ${unsubUrl}
 
-AI-generated summaries · may contain errors · verify with the source video.
+Summaries are AI-generated. Verify with the source video.
 `;
 }


### PR DESCRIPTION
## Summary

- Simplify the weekly meeting-digest email markup: cut the eyebrow header, card borders, uppercase board labels, and matched-segments block. One link per meeting, friendlier date format, navy accent.
- Add `meeting-digest/tools/send-sample-digest.mjs` so we can preview real-content digests at any time without waiting for Friday's cron.

## What you'll see in the inbox

- Subject (1 meeting): \`Select Board: Board approves \$5.43M Mary Alley contract\`
- Subject (multi):    \`3 Marblehead meetings this week\`
- Header:  "Marblehead Data" + bold "N meetings this week" h1
- Per meeting: muted "Board · Jun 10" line, headline, summary, single link to the meeting page (which embeds the Vimeo player itself)
- Footer:  Manage subscription · Unsubscribe + AI-generated disclaimer

## Test plan

- [x] \`npx vitest run tests/render.test.js\` — 9/9 pass
- [x] Sample digest sent to agbaber@gmail.com from the new tool, manually reviewed
- [ ] Cloudflare Pages preview deploy green
- [ ] After merge: redeploy the Worker so the new render lib is active for next Friday's cron