### PR TITLE
Stop wrangler deploy from overwriting the Resend secret

### DIFF
--- a/meeting-digest/worker/wrangler.toml
+++ b/meeting-digest/worker/wrangler.toml
@@ -16,7 +16,9 @@ GITHUB_BRANCH = "main"
 MAIL_FROM = "Marblehead Data <digest@meetings.marbleheaddata.org>"
 MAIL_REPLY_TO = "agbaber@gmail.com"
 TURNSTILE_TEST_BYPASS_TOKEN = "TEST-OK"
-MAIL_PROVIDER_API_KEY = "dev-placeholder"
+# MAIL_PROVIDER_API_KEY is a Worker secret set via `wrangler secret put` —
+# do NOT declare it as a var here, or `wrangler deploy` will overwrite the
+# secret with the placeholder string and the Worker will 401 on every send.
 
 # Friday 7:00 AM ET == 11:00 UTC (EST) / 12:00 UTC (EDT).
 # Run at 11:00 and 12:00; the scheduled handler chooses one based on the


### PR DESCRIPTION
## Summary

\`wrangler deploy\` uploads everything declared under \`[vars]\` as plaintext bindings, including names that already exist as Worker *secrets*. When a var shares a name with a secret, the deploy wins and the secret is silently replaced with the placeholder string.

Hit this on the prod Worker today: redeploying after the digest-redesign merge swapped the live \`MAIL_PROVIDER_API_KEY\` Resend key for \`"dev-placeholder"\`, which then 401'd every \`/api/subscribe\` call ("API key is invalid"). Prod \`/subscribe/\` was broken from ~07:11 UTC to ~07:17 UTC until the fix.

## Fix

- Drop \`MAIL_PROVIDER_API_KEY\` from the top-level \`[vars]\` block
- Replace it with a comment warning future contributors not to add it back
- Re-set the secret on prod with \`wrangler secret put\` — done manually, prod verified \`200 {"ok":true}\` after

## Test plan

- [x] Live \`curl POST /api/subscribe\` returns 200 against prod
- [ ] Cloudflare Pages preview deploy green