### PR TITLE
town-debt: clarify the 50/51 vs 28/29 count discrepancy

### DIFF
--- a/town-debt.html
+++ b/town-debt.html
@@ -147,7 +147,7 @@ og_url: https://marbleheaddata.org/town-debt.html
     </tbody>
     <tfoot><tr><td colspan="2"><strong>Total</strong></td><td class="count"><strong>51</strong></td></tr></tfoot>
   </table>
-  <p class="caption">Source: MA DOR debt-exclusion file, filtered to Marblehead.</p>
+  <p class="caption">Source: MA DOR debt-exclusion file, filtered to Marblehead. These are individual ballot questions; <a href="marblehead-voting-record.html">the voting record page</a> groups multiple debt-exclusion questions on the same trip to the polls into one "attempt" and tallies 28 of 29 since 1982. Same vote history, counted differently.</p>
 </details>
 
 <h2 id="how-exclusion-works" data-stance-section="how-exclusion-works">How a borrowing vote works, start to finish</h2>


### PR DESCRIPTION
## What this is

While adding the cross-links in [#808](https://github.com/agbaber/marblehead/pull/808), I noticed `town-debt.html` and `what-is-the-override.html` / `marblehead-voting-record.html` report different counts of the same vote history:

- `town-debt.html`: **50 of 51** since 1988 (individual ballot questions from the MA DOR debt-exclusion file)
- `what-is-the-override.html`, `marblehead-voting-record.html`: **28 of 29** since 1982 (ballot trips, where a ballot with multiple debt-exclusion questions counts as one attempt)

Both correct, but a reader hopping between the two could be momentarily confused.

This PR adds a one-sentence clarification to the caption under the "All 51 votes, grouped" expander on `town-debt.html` so the explanation lives right where the 51 count appears.

## What landed

One sentence appended to the caption. No other changes.