### PR TITLE
Email redesign: shared shell with hero bar, auth emails refreshed

### DIFF
--- a/meeting-digest/tools/send-sample-auth.mjs
+++ b/meeting-digest/tools/send-sample-auth.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Send sample copies of the subscribe-flow auth emails (confirm + manage) to
+// a single recipient. Uses the same templates the live Worker uses, so what
+// you see in the inbox is exactly what subscribers will see.
+//
+// Usage (from meeting-digest/):
+//   RESEND_API_KEY=re_... node tools/send-sample-auth.mjs [you@example.com]
+//
+// Defaults: agbaber@gmail.com.
+
+import {
+  confirmEmailSubject, renderConfirmEmailHtml, renderConfirmEmailText,
+  manageEmailSubject,  renderManageEmailHtml,  renderManageEmailText
+} from '../worker/src/lib/auth-emails.js';
+
+const TO = process.argv[2] || 'agbaber@gmail.com';
+const API_KEY = process.env.RESEND_API_KEY;
+if (!API_KEY) {
+  console.error('Set RESEND_API_KEY in env.');
+  process.exit(1);
+}
+
+const env = { SITE_BASE_URL: 'https://marbleheaddata.org' };
+const FAKE_CONFIRM_TOKEN = 'SAMPLE-CONFIRM-TOKEN-DO-NOT-USE';
+const FAKE_MANAGE_TOKEN  = 'SAMPLE-MANAGE-TOKEN-DO-NOT-USE';
+
+async function send(label, subject, html, text) {
+  const resp = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${API_KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      from: 'Marblehead Data <digest@meetings.marbleheaddata.org>',
+      to: [TO],
+      subject: `[PREVIEW] ${subject}`,
+      html, text,
+      reply_to: 'agbaber@gmail.com'
+    })
+  });
+  const result = await resp.json();
+  if (!resp.ok) {
+    console.error(`${label} failed:`, resp.status, result);
+    return false;
+  }
+  console.log(`${label}: sent (resend id ${result.id})`);
+  return true;
+}
+
+const ok1 = await send(
+  'confirm',
+  confirmEmailSubject(),
+  renderConfirmEmailHtml(env, FAKE_CONFIRM_TOKEN),
+  renderConfirmEmailText(env, FAKE_CONFIRM_TOKEN)
+);
+const ok2 = await send(
+  'manage',
+  manageEmailSubject(),
+  renderManageEmailHtml(env, FAKE_MANAGE_TOKEN),
+  renderManageEmailText(env, FAKE_MANAGE_TOKEN)
+);
+process.exit(ok1 && ok2 ? 0 : 1);

--- a/meeting-digest/vitest.config.js
+++ b/meeting-digest/vitest.config.js
@@ -19,7 +19,13 @@ export default defineWorkersConfig({
           poolOptions: {
             workers: {
               singleWorker: true,
-              wrangler: { configPath: './worker/wrangler.toml' }
+              wrangler: { configPath: './worker/wrangler.toml' },
+              // MAIL_PROVIDER_API_KEY lives as a Worker secret in prod (not in
+              // wrangler.toml — see PR #807). Tests need a value so mail.js
+              // doesn't throw before stubs intercept the fetch.
+              miniflare: {
+                bindings: { MAIL_PROVIDER_API_KEY: 'test-key' }
+              }
             }
           }
         }

--- a/meeting-digest/worker/src/handlers/subscribe.js
+++ b/meeting-digest/worker/src/handlers/subscribe.js
@@ -1,6 +1,10 @@
 import { normalizeEmail, isValidEmail, randomToken } from '../lib/email.js';
 import { DEFAULT_BOARDS_ON_SIGNUP } from '../lib/topics.js';
 import { sendMail } from '../lib/mail.js';
+import {
+  confirmEmailSubject, renderConfirmEmailHtml, renderConfirmEmailText,
+  manageEmailSubject,  renderManageEmailHtml,  renderManageEmailText
+} from '../lib/auth-emails.js';
 
 const CONFIRMATION_TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -38,7 +42,7 @@ export async function handleSubscribe(request, env, corsHeaders) {
     if (existing.status === 'confirmed') {
       await sendMail(env, {
         to: email,
-        subject: '[MHD Data] Manage your subscription',
+        subject: manageEmailSubject(),
         html: renderManageEmailHtml(env, existing.manage_token),
         text: renderManageEmailText(env, existing.manage_token)
       });
@@ -62,33 +66,11 @@ export async function handleSubscribe(request, env, corsHeaders) {
 
   await sendMail(env, {
     to: email,
-    subject: '[MHD Data] Confirm your subscription',
+    subject: confirmEmailSubject(),
     html: renderConfirmEmailHtml(env, row.confirmation_token),
     text: renderConfirmEmailText(env, row.confirmation_token)
   });
   return jsonResp(200, { ok: true }, corsHeaders);
-}
-
-function renderConfirmEmailHtml(env, token) {
-  const url = `${env.SITE_BASE_URL}/subscribe/confirm/?token=${encodeURIComponent(token)}`;
-  return `<!doctype html><html><body style="font-family: sans-serif; max-width: 560px; margin: 0 auto; padding: 24px;">
-    <p>You asked to subscribe to Marblehead Data's meeting digest.</p>
-    <p><a href="${url}" style="background: #1a3a5c; color: #fff; padding: 10px 18px; text-decoration: none; border-radius: 4px;">Confirm subscription</a></p>
-    <p style="color: #666;">This link expires in 24 hours. If this wasn't you, ignore this email — no account was created.</p>
-  </body></html>`;
-}
-function renderConfirmEmailText(env, token) {
-  return `You asked to subscribe to Marblehead Data's meeting digest.\n\nConfirm: ${env.SITE_BASE_URL}/subscribe/confirm/?token=${token}\n\nThis link expires in 24 hours. If this wasn't you, ignore this email — no account was created.\n`;
-}
-function renderManageEmailHtml(env, manageToken) {
-  const url = `${env.SITE_BASE_URL}/me/subscription/?token=${encodeURIComponent(manageToken)}`;
-  return `<!doctype html><html><body style="font-family: sans-serif; max-width: 560px; margin: 0 auto; padding: 24px;">
-    <p>You're already subscribed to Marblehead Data. Here's your manage link:</p>
-    <p><a href="${url}">${url}</a></p>
-  </body></html>`;
-}
-function renderManageEmailText(env, manageToken) {
-  return `You're already subscribed. Manage: ${env.SITE_BASE_URL}/me/subscription/?token=${manageToken}\n`;
 }
 
 function jsonResp(status, body, corsHeaders) {

--- a/meeting-digest/worker/src/lib/auth-emails.js
+++ b/meeting-digest/worker/src/lib/auth-emails.js
@@ -1,0 +1,87 @@
+// meeting-digest/worker/src/lib/auth-emails.js
+//
+// Templates for the two account-lifecycle emails:
+//   - confirm:  sent on signup or pending-resignup
+//   - manage:   sent when an already-confirmed address tries to subscribe again
+//
+// Both share the chrome from email-shell.js (navy hero bar, light/dark-aware
+// background, lighthouse mark). Keep copy short, no em-dashes, navy buttons.
+
+import { emailShell } from './email-shell.js';
+
+function escapeHtml(s) {
+  if (s == null) return '';
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function button(href, label) {
+  return `<a class="mhd-button" href="${href}" style="display: inline-block; background-color: #1B3A57; color: #ffffff; padding: 12px 22px; text-decoration: none; border-radius: 4px; font-weight: 500; font-size: 15px;">${escapeHtml(label)}</a>`;
+}
+
+export function confirmEmailSubject() {
+  return 'Confirm your Marblehead Data subscription';
+}
+
+export function renderConfirmEmailHtml(env, token) {
+  const url = `${env.SITE_BASE_URL}/subscribe/confirm/?token=${encodeURIComponent(token)}`;
+  return emailShell({ body: `
+  <h1 style="margin: 0 0 14px; font-size: 22px; font-weight: 600; color: #1a1a1a;">Confirm your subscription</h1>
+  <p style="margin: 0 0 18px;">You'll get a short summary of meetings of the Select Board, School Committee, and Finance Committee each Friday morning. You can add Board of Health and Town Meeting after you confirm.</p>
+  <p style="margin: 0 0 28px;">${button(url, 'Confirm subscription')}</p>
+  <p class="mhd-muted" style="margin: 0 0 4px; font-size: 13px; color: #6c757d;">This link expires in 24 hours.</p>
+  <p class="mhd-muted" style="margin: 0; font-size: 13px; color: #6c757d;">If this wasn't you, ignore this email. Nothing happens until you click.</p>
+` });
+}
+
+export function renderConfirmEmailText(env, token) {
+  const url = `${env.SITE_BASE_URL}/subscribe/confirm/?token=${token}`;
+  return `Marblehead Data
+Confirm your subscription
+
+You'll get a short summary of meetings of the Select Board, School
+Committee, and Finance Committee each Friday morning. You can add
+Board of Health and Town Meeting after you confirm.
+
+Confirm: ${url}
+
+This link expires in 24 hours.
+If this wasn't you, ignore this email. Nothing happens until you click.
+
+marbleheaddata.org
+`;
+}
+
+export function manageEmailSubject() {
+  return 'Your Marblehead Data subscription';
+}
+
+export function renderManageEmailHtml(env, manageToken) {
+  const url = `${env.SITE_BASE_URL}/me/subscription/?token=${encodeURIComponent(manageToken)}`;
+  return emailShell({ body: `
+  <h1 style="margin: 0 0 14px; font-size: 22px; font-weight: 600; color: #1a1a1a;">You're already subscribed</h1>
+  <p style="margin: 0 0 28px;">Use the button below to update which boards and topics you hear about, or to unsubscribe.</p>
+  <p style="margin: 0 0 22px;">${button(url, 'Manage subscription')}</p>
+  <p class="mhd-muted" style="margin: 0; font-size: 13px; color: #6c757d;">If you didn't try to subscribe again, you can ignore this email.</p>
+` });
+}
+
+export function renderManageEmailText(env, manageToken) {
+  const url = `${env.SITE_BASE_URL}/me/subscription/?token=${manageToken}`;
+  return `Marblehead Data
+You're already subscribed
+
+Use the link below to update which boards and topics you hear about,
+or to unsubscribe.
+
+Manage: ${url}
+
+If you didn't try to subscribe again, you can ignore this email.
+
+marbleheaddata.org
+`;
+}

--- a/meeting-digest/worker/src/lib/email-shell.js
+++ b/meeting-digest/worker/src/lib/email-shell.js
@@ -1,0 +1,56 @@
+// meeting-digest/worker/src/lib/email-shell.js
+//
+// Shared chrome for every email the Worker sends: light/dark-aware page
+// background, navy hero bar with the Marblehead Data wordmark + lighthouse
+// favicon, a centered 600px content card, and an outer footer line.
+//
+// All callers pass the inner body markup (already styled) and the shell
+// wraps it. Keep inline styles on every element so Gmail/Outlook don't
+// strip them; the <style> block adds prefers-color-scheme overrides for
+// the clients that respect it (Apple Mail, iOS Mail, some Outlook).
+
+const LOGO_URL = 'https://marbleheaddata.org/favicon-192.png';
+
+export function emailShell({ body }) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Marblehead Data</title>
+<style>
+  body, table, td, p, h1, h2, a { -webkit-text-size-adjust: 100%; }
+  @media (prefers-color-scheme: dark) {
+    body { background-color: #0B1620 !important; color: #e7eaee !important; }
+    .mhd-page { background-color: #0B1620 !important; }
+    .mhd-card { background-color: #14222d !important; }
+    .mhd-body, .mhd-body p, .mhd-body h1, .mhd-body h2 { color: #e7eaee !important; }
+    .mhd-muted, .mhd-foot { color: #9aa3ac !important; }
+    .mhd-hr { border-top-color: #2a3946 !important; }
+    a.mhd-button { background-color: #2F7D8E !important; color: #ffffff !important; }
+    a.mhd-link { color: #79c0d4 !important; }
+  }
+</style>
+</head>
+<body class="mhd-page" style="margin: 0; padding: 0; background-color: #F4F7FA; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; color: #1a1a1a;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: #F4F7FA;" class="mhd-page">
+    <tr><td align="center" style="padding: 28px 14px 36px;">
+      <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" class="mhd-card" style="max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 2px rgba(0,0,0,0.04);">
+        <tr><td style="background-color: #1B3A57; padding: 18px 28px;">
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+            <tr>
+              <td valign="middle" style="padding-right: 12px;"><img src="${LOGO_URL}" alt="" width="28" height="28" style="display: block; border: 0; border-radius: 4px;"></td>
+              <td valign="middle"><span style="font-size: 16px; font-weight: 600; color: #ffffff; letter-spacing: 0.01em;">Marblehead Data</span></td>
+            </tr>
+          </table>
+        </td></tr>
+        <tr><td class="mhd-body" style="padding: 32px 28px 28px; color: #1a1a1a; line-height: 1.55;">
+${body}
+        </td></tr>
+      </table>
+      <p class="mhd-foot" style="margin: 14px 0 0; font-size: 12px; color: #8a949c;">marbleheaddata.org &nbsp;·&nbsp; Resident-built, primary-source data</p>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}

--- a/meeting-digest/worker/src/lib/render.js
+++ b/meeting-digest/worker/src/lib/render.js
@@ -1,5 +1,7 @@
 // meeting-digest/worker/src/lib/render.js
 
+import { emailShell } from './email-shell.js';
+
 function escapeHtml(s) {
   if (s == null) return '';
   return String(s)
@@ -40,11 +42,11 @@ function meetingHtml(m, env) {
   const t = m.transcript;
   const meetingUrl = `${env.SITE_BASE_URL}/meetings/${t.slug}/`;
   return `
-  <div style="margin: 0 0 32px;">
-    <p style="margin: 0 0 6px; font-size: 13px; color: #666;">${escapeHtml(t.board_display)} · ${escapeHtml(formatShortDate(t.date))}</p>
+  <div style="margin: 0 0 28px;">
+    <p class="mhd-muted" style="margin: 0 0 6px; font-size: 13px; color: #6c757d;">${escapeHtml(t.board_display)} · ${escapeHtml(formatShortDate(t.date))}</p>
     <h2 style="margin: 0 0 10px; font-size: 19px; line-height: 1.3; color: #1a1a1a; font-weight: 600;">${escapeHtml(t.summary_card?.headline || t.title)}</h2>
-    <p style="margin: 0 0 12px; color: #333; line-height: 1.55;">${escapeHtml(t.summary_card?.summary || '')}</p>
-    <p style="margin: 0; font-size: 14px;"><a href="${meetingUrl}" style="color: #1B3A57; text-decoration: none; font-weight: 500;">Read &amp; watch on marbleheaddata.org &rarr;</a></p>
+    <p class="mhd-body" style="margin: 0 0 12px; color: #2a3036; line-height: 1.55;">${escapeHtml(t.summary_card?.summary || '')}</p>
+    <p style="margin: 0; font-size: 14px;"><a class="mhd-link" href="${meetingUrl}" style="color: #1B3A57; text-decoration: none; font-weight: 500;">Read &amp; watch on marbleheaddata.org &rarr;</a></p>
   </div>`;
 }
 
@@ -63,21 +65,19 @@ export function renderHtml(matches, subscriber, env, weekEndingIso) {
   const manageUrl = `${env.SITE_BASE_URL}/me/subscription/?token=${encodeURIComponent(subscriber.manage_token)}`;
   const unsubUrl = `${env.SITE_BASE_URL}/api/unsubscribe?token=${encodeURIComponent(subscriber.manage_token)}`;
   const count = matches.length;
-  return `<!doctype html>
-<html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 28px 24px; color: #1a1a1a; line-height: 1.5;">
-  <p style="margin: 0 0 4px; font-size: 13px; color: #666;">Marblehead Data</p>
-  <h1 style="margin: 0 0 28px; font-size: 22px; font-weight: 600; color: #1a1a1a;">${count} ${count === 1 ? 'meeting' : 'meetings'} this week</h1>
+  return emailShell({ body: `
+  <h1 style="margin: 0 0 24px; font-size: 22px; font-weight: 600; color: #1a1a1a; line-height: 1.25;">${count} ${count === 1 ? 'meeting' : 'meetings'} this week</h1>
 
   ${matches.map(m => meetingHtml(m, env)).join('')}
 
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 8px 0 16px;">
-  <p style="margin: 0 0 6px; font-size: 13px; color: #666;">
-    <a href="${manageUrl}" style="color: #1B3A57; text-decoration: none;">Manage subscription</a>
+  <hr class="mhd-hr" style="border: none; border-top: 1px solid #e5e5e5; margin: 8px 0 16px;">
+  <p style="margin: 0 0 6px; font-size: 13px; color: #6c757d;">
+    <a class="mhd-link" href="${manageUrl}" style="color: #1B3A57; text-decoration: none;">Manage subscription</a>
     &nbsp;·&nbsp;
-    <a href="${unsubUrl}" style="color: #1B3A57; text-decoration: none;">Unsubscribe</a>
+    <a class="mhd-link" href="${unsubUrl}" style="color: #1B3A57; text-decoration: none;">Unsubscribe</a>
   </p>
-  <p style="margin: 0; font-size: 12px; color: #999;">Summaries are AI-generated. Verify with the source video.</p>
-</body></html>`;
+  <p class="mhd-muted" style="margin: 0; font-size: 12px; color: #8a949c;">Summaries are AI-generated. Verify with the source video.</p>
+` });
 }
 
 export function renderText(matches, subscriber, env, weekEndingIso) {


### PR DESCRIPTION
## Summary

All three Worker-sent emails (subscribe-confirm, already-subscribed, Friday digest) now share a single shell with the navy hero bar + lighthouse mark, a centered card, navy buttons, and a \`prefers-color-scheme: dark\` media query for clients that respect it. Replaces the bare-bones \"sans-serif paragraph\" look the confirm/manage emails had on day 1.

## What you'll see in the inbox

- Confirm email: \"Confirm your Marblehead Data subscription\" (no \`[MHD Data]\` prefix), navy button labeled \"Confirm subscription\", copy says exactly what you're subscribing to (Select Board / School Committee / Finance Committee, with BoH and Town Meeting opt-in after).
- Manage email: same shell, h1 \"You're already subscribed\", navy button \"Manage subscription\".
- Friday digest: same shell wrapping the simpler card layout from PR #806.

## Dark mode

The shared shell ships a \`@media (prefers-color-scheme: dark)\` block. Clients that respect it (Apple Mail, iOS Mail) flip the page background to \`#0B1620\` (style guide's dark token) and the card to \`#14222d\`. Gmail Web and Outlook Web ignore it; they stay on the light default. We considered storing a per-subscriber theme preference and decided against it (too much UX cost at signup for too little win).

## Refactor notes

- Extracted confirm + manage email templates from \`handlers/subscribe.js\` into a new \`lib/auth-emails.js\` so the handler stays a routing/control file and the templates are unit-test- and preview-script-friendly.
- New \`tools/send-sample-auth.mjs\` mirrors \`send-sample-digest.mjs\`: \`RESEND_API_KEY=... node tools/send-sample-auth.mjs you@example.com\` sends both auth emails as \`[PREVIEW]\` to any inbox without touching the Worker or D1.
- \`vitest.config.js\` injects \`MAIL_PROVIDER_API_KEY=test-key\` into the worker pool. PR #807 dropped this from \`wrangler.toml\` vars (so deploy doesn't overwrite the prod secret); tests still need a runtime value.

## Test plan

- [x] \`npx vitest run\` from \`meeting-digest/\` - 51/51 pass
- [x] Confirm + manage previews delivered to agbaber@gmail.com
- [x] Digest preview delivered to agbaber@gmail.com
- [ ] Cloudflare Pages preview deploy green
- [ ] After merge: redeploy the prod Worker (\`wrangler deploy\`) so the new shell is live for the next Friday cron + any new subscribers