### PR TITLE
what-can-we-do: totals row + plainer section headings + Idea 01 dupe fix

### DIFF
--- a/what-can-we-do.html
+++ b/what-can-we-do.html
@@ -285,6 +285,69 @@ community_pulse: off-sections
     .sb-c-time { grid-area: time; }
   }
 
+  /* Scoreboard totals block, sits below the table */
+  .sb-totals {
+    max-width: 980px;
+    margin: 12px 0 8px;
+    padding: 16px 18px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--c-fog) 25%, var(--surface));
+  }
+  .sb-totals-eye {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.9px;
+    text-transform: uppercase;
+    color: var(--text-subtle);
+    margin: 0 0 10px;
+  }
+  .sb-totals-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+  .sb-totals-list li {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 12px;
+    font-size: 14px;
+    line-height: 1.4;
+    color: var(--text);
+    padding: 6px 0;
+    border-bottom: 1px dashed color-mix(in srgb, var(--border) 50%, transparent);
+  }
+  .sb-totals-list li:last-child { border-bottom: 0; }
+  .sb-totals-list li.is-grand {
+    font-weight: 700;
+    border-bottom: 0;
+    padding-top: 10px;
+    border-top: 2px solid var(--border);
+    margin-top: 4px;
+  }
+  .sb-totals-label { color: var(--text); }
+  .sb-totals-val {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    color: var(--text);
+    white-space: nowrap;
+  }
+  .sb-totals-list li.is-gov .sb-totals-val {
+    font-weight: 500;
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+  .sb-totals-note {
+    margin: 14px 0 0;
+    font-size: 12.5px;
+    line-height: 1.5;
+    color: var(--text-muted);
+  }
+  .sb-totals-note strong { color: var(--text); font-weight: 700; }
+
   /* Idea grid: 1-column at all widths so each card gets full reading width
      and side panels (Rough Guess / Difficulty / Who Pays) sit cleanly.
      Larger gap restores card-as-unit rhythm at desktop widths where
@@ -739,6 +802,29 @@ community_pulse: off-sections
     <a class="sb-row" data-cat="gov" data-money="1000" data-diff="2" data-time="18" href="#idea-17"><span class="sb-c-num">17</span><span class="sb-c-item">Department-level zero-based / scoped review</span><span class="sb-c-money">$500K&ndash;$1.5M/cycle</span><span class="sb-c-diff"><span class="sb-pill sb-pill-med">Medium</span></span><span class="sb-c-time">1&ndash;2 years/cycle</span></a>
     <a class="sb-row" data-cat="gov" data-money="" data-diff="1" data-time="9" href="#idea-18"><span class="sb-c-num">18</span><span class="sb-c-item">Formal performance audit of major cost centers</span><span class="sb-c-money">$30K&ndash;$400K cost</span><span class="sb-c-diff"><span class="sb-pill sb-pill-easy">Easy to commission</span></span><span class="sb-c-time">6&ndash;12 months</span></a>
   </div>
+
+  <div class="sb-totals">
+    <p class="sb-totals-eye">Naive totals &middot; sum of low ends and high ends</p>
+    <ul class="sb-totals-list">
+      <li>
+        <span class="sb-totals-label">Revenue (5 items)</span>
+        <span class="sb-totals-val">$405K to $1.1M / yr</span>
+      </li>
+      <li>
+        <span class="sb-totals-label">Cost reduction (10 items, one cost-neutral)</span>
+        <span class="sb-totals-val">$1.5M to $4.8M / yr</span>
+      </li>
+      <li class="is-gov">
+        <span class="sb-totals-label">Governance and process (3 items)</span>
+        <span class="sb-totals-val">not summed</span>
+      </li>
+      <li class="is-grand">
+        <span class="sb-totals-label">Revenue + cost ceiling</span>
+        <span class="sb-totals-val">$1.9M to $5.9M / yr</span>
+      </li>
+    </ul>
+    <p class="sb-totals-note"><strong>Read this before quoting the number.</strong> These add the low ends together and the high ends together as if each item were independent. Several items overlap and would not all stack at full size: items 06, 11, 12, and 15 all touch the same health-insurance line; item 07 (energy contract) overlaps with line items a zero-based review (17) would also touch; items 13 and 18 could find some of the same overtime dollars. Item 17 is per audit cycle, not annual. Item 18 is a cost, not a saving. The combined number is a ceiling, not an estimate.</p>
+  </div>
 </section>
 
 <!-- ============================================================ -->
@@ -746,7 +832,7 @@ community_pulse: off-sections
 <!-- ============================================================ -->
 <section id="revenue" class="wcwd-stop">
   <p class="wcwd-eye">Revenue <span class="dot">&bull;</span> 5 questions</p>
-  <h2 class="wcwd-section-h2">Could the town raise more money this way?</h2>
+  <h2 class="wcwd-section-h2">How can the town make more money?</h2>
   <p class="wcwd-section-lead">Local-option taxes, fee structures, and existing assets the town might be able to monetize more aggressively. A couple of these have been on a Town Meeting warrant and narrowly lost.</p>
 
   <div class="idea-grid">
@@ -773,7 +859,6 @@ community_pulse: off-sections
         <span class="idea-catch-label">Who pays?</span>
         <p><strong>Visitors pay.</strong> Hotels, inns, and Airbnb hosts collect and remit. The lodging industry argues it suppresses bookings at the margin; data on this is mixed.</p>
         <p>Worth noting: visitors use the harbor, beaches, parking, and emergency services without paying property tax. One argument is that this tax makes their use of town services more equitable. Another is that it makes visiting Marblehead more expensive without obvious benefit. Reasonable people disagree.</p>
-        <p><strong>In real dollars:</strong> a $250-a-night Airbnb stay for a weekend ($500 total) would cost an extra $30 with the 6 percent excise. A 5-night hotel stay at $200 a night ($1,000 total) would cost an extra $60. The state's 5.7 percent excise already applies on top.</p>
         <p><strong>In real dollars:</strong> a $250-a-night Airbnb stay for a weekend ($500 total) would cost an extra $30 with the 6 percent excise. A 5-night hotel stay at $200 a night ($1,000 total) would cost an extra $60. The state's 5.7 percent excise already applies on top.</p>
       </div>
       <details class="idea-research">
@@ -927,7 +1012,7 @@ community_pulse: off-sections
 <!-- ============================================================ -->
 <section id="cost" class="wcwd-stop wcwd-stop--tinted">
   <p class="wcwd-eye">Cost reduction <span class="dot">&bull;</span> 10 questions</p>
-  <h2 class="wcwd-section-h2">Could the town stop spending this way?</h2>
+  <h2 class="wcwd-section-h2">How can the town spend less?</h2>
   <p class="wcwd-section-lead">Structural cost work and procurement moves that might be available within existing board authority. Several can begin without any Town Meeting vote.</p>
 
   <div class="idea-grid">
@@ -1290,7 +1375,7 @@ community_pulse: off-sections
 <!-- ============================================================ -->
 <section id="governance" class="wcwd-stop">
   <p class="wcwd-eye">Governance and process <span class="dot">&bull;</span> 3 questions</p>
-  <h2 class="wcwd-section-h2">Could the town make these decisions differently?</h2>
+  <h2 class="wcwd-section-h2">How can the town make decisions differently?</h2>
   <p class="wcwd-section-lead">These don't generate dollars themselves. They're the structures that decide whether the items above get pursued or shelved.</p>
 
   <div class="idea-grid">
@@ -1504,7 +1589,7 @@ community_pulse: off-sections
   </div>
 
   <p class="wcwd-prov-fine" style="margin-top:32px;">
-    <strong>Updates.</strong> 2026-06-09: At-a-glance scoreboard columns are now sortable; click a column header to re-rank. Added Article 46 and Viewpoint receipts to ideas 18 and 10. 2026-06-02 (afternoon): Added four employee-benefit and personnel items after a reader flagged the gap: active-employee premium-share renegotiation (11, large lever), spousal surcharge or carve-out (12, moderate lever), overtime audit (13, smaller), and schedule fragmentation at benefit thresholds (14, listed but not recommended). Page is now 16 items, not 12. 2026-06-02 (morning): Initial draft, then several rounds of correction in response to readers. Reframed from "inventory of measures" to "list of questions" after a reader pointed out the original framing overstated what one person's research conversation can actually claim. Boat excise card rewritten to reflect that valuations are statutory; the only local lever is compliance. "Who pays?" boxes added to every card so the distributional tradeoff sits at the same visual weight as the dollar number. Idea 8 reframed from "combine" to "share" to respect the legal structure under <abbr class="g" title="Massachusetts General Laws">MGL</abbr> c. 71 &sect; 37, which gives the School Committee independent budget authority. Idea 9 updated to acknowledge the existing joint ambulance contract with Swampscott (2025-07-23). Idea 10 reframed honestly as roughly cost-neutral after a reader pointed out that the software cost was missing from the prior math. Zero-based budgeting card updated to reflect four prior School Committee discussions (2020-06-08, 2022-07-19, 2023-07-06, 2025-10-17), not two.
+    <strong>Updates.</strong> 2026-06-09 (afternoon): Added a totals block under the scoreboard, with the overlap caveats spelled out. Section headings rephrased ("How can the town make more money / spend less / make decisions differently"). 2026-06-09: At-a-glance scoreboard columns are now sortable; click a column header to re-rank. Added Article 46 and Viewpoint receipts to ideas 18 and 10. 2026-06-02 (afternoon): Added four employee-benefit and personnel items after a reader flagged the gap: active-employee premium-share renegotiation (11, large lever), spousal surcharge or carve-out (12, moderate lever), overtime audit (13, smaller), and schedule fragmentation at benefit thresholds (14, listed but not recommended). Page is now 16 items, not 12. 2026-06-02 (morning): Initial draft, then several rounds of correction in response to readers. Reframed from "inventory of measures" to "list of questions" after a reader pointed out the original framing overstated what one person's research conversation can actually claim. Boat excise card rewritten to reflect that valuations are statutory; the only local lever is compliance. "Who pays?" boxes added to every card so the distributional tradeoff sits at the same visual weight as the dollar number. Idea 8 reframed from "combine" to "share" to respect the legal structure under <abbr class="g" title="Massachusetts General Laws">MGL</abbr> c. 71 &sect; 37, which gives the School Committee independent budget authority. Idea 9 updated to acknowledge the existing joint ambulance contract with Swampscott (2025-07-23). Idea 10 reframed honestly as roughly cost-neutral after a reader pointed out that the software cost was missing from the prior math. Zero-based budgeting card updated to reflect four prior School Committee discussions (2020-06-08, 2022-07-19, 2023-07-06, 2025-10-17), not two.
   </p>
 </section>
 


### PR DESCRIPTION
## Summary

Three small fixes:

1. **Totals block under the scoreboard.** Sums of the low ends and the high ends per category, plus a revenue + cost ceiling. Explicit caveats about overlap (06/11/12/15 health insurance, 07 vs 17, 13 vs 18); governance not summed since 17 is per-cycle and 18 is a cost.
2. **Section headings rephrased** from "Could the town X this way?" to "How can the town X?" — "this way" was vague filler.
3. **Removed duplicate "In real dollars" paragraph on Idea 01** that slipped through PR #784.

## Test plan

- [ ] Cloudflare preview renders the totals block under the scoreboard
- [ ] Sortable scoreboard still works (no JS regression)
- [ ] Mobile layout for the totals block looks OK
- [ ] Three section h2s read parallel and natural
- [ ] Only one "In real dollars" paragraph on Idea 01