### PR TITLE
Copy cleanup: meta-narration, stale checkbook framing, bare acronyms

### DIFF
--- a/2026-override/index.html
+++ b/2026-override/index.html
@@ -201,7 +201,7 @@ og_url: https://marbleheaddata.org/2026-override/
 
 <h1>The 2026 Marblehead override: archive</h1>
 
-<p class="page-lead">Marblehead voters considered four ballot questions on June 9, 2026: three operating override tiers and a curbside trash funding question. This page is the cycle's record. The ballot, the candidates, both sides of the debate, the result, and what followed, all in one URL.</p>
+<p class="page-lead">Marblehead voters considered four ballot questions on June 9, 2026: three operating override tiers and a curbside trash funding question. The ballot, the candidates, both sides of the debate, the result, and what followed, all in one URL.</p>
 
 <div class="archive-toc">
   <h2>On this page</h2>
@@ -267,7 +267,7 @@ og_url: https://marbleheaddata.org/2026-override/
     <h3>School Committee</h3>
     <p class="race-meta">Three candidates, two seats</p>
     <ul>
-      <li><strong>Melissa Marie Clucas</strong> (incumbent, CFO) backed Tier 3, warning FY27 was balanced only by a one-time $1.5M special-education prepayment.</li>
+      <li><strong>Melissa Marie Clucas</strong> (incumbent, <abbr class="g" title="Chief Financial Officer">CFO</abbr>) backed Tier 3, warning FY27 was balanced only by a one-time $1.5M special-education prepayment.</li>
       <li><strong>Ann-Marie Jordan</strong> (former educator) backed Tier 3 as a structural deficit fix.</li>
       <li><strong>Sarah A. Fox</strong> (former two-term member) said the levy "needs to grow" but did not commit to a tier.</li>
     </ul>
@@ -331,7 +331,7 @@ og_url: https://marbleheaddata.org/2026-override/
       </div>
       <div class="dl-side">
         <p class="dl-side-label">Against the override</p>
-        <p>Marblehead pays 83% of health premiums (top of an 8-town peer set); benefits extend to 20-hour part-time staff (a policy floor, not a state mandate); ACFR education FTE rose 9.6% even as enrollment fell 19%. These are policy choices, not external forces.</p>
+        <p>Marblehead pays 83% of health premiums (top of an 8-town peer set); benefits extend to 20-hour part-time staff (a policy floor, not a state mandate); <abbr class="g" title="Annual Comprehensive Financial Report">ACFR</abbr> education <abbr class="g" title="Full-Time Equivalent">FTE</abbr> rose 9.6% even as enrollment fell 19%. These are policy choices, not external forces.</p>
       </div>
     </div>
   </div>
@@ -342,7 +342,7 @@ og_url: https://marbleheaddata.org/2026-override/
     <div class="dl-pair">
       <div class="dl-side">
         <p class="dl-side-label">For the override</p>
-        <p>22 town positions removed, 14 school positions, library reduced 43%, OPEB trust contribution zeroed out. Once cut, programs require rehiring and rebuilding trust. Melrose and Stoneham both needed larger overrides after failed votes.</p>
+        <p>22 town positions removed, 14 school positions, library reduced 43%, <abbr class="g" title="Other Post-Employment Benefits">OPEB</abbr> trust contribution zeroed out. Once cut, programs require rehiring and rebuilding trust. Melrose and Stoneham both needed larger overrides after failed votes.</p>
       </div>
       <div class="dl-side">
         <p class="dl-side-label">Against the override</p>
@@ -357,7 +357,7 @@ og_url: https://marbleheaddata.org/2026-override/
     <div class="dl-pair">
       <div class="dl-side">
         <p class="dl-side-label">For the override</p>
-        <p>The three tiers were designed as a multi-year correction. The FinCom three-year forecast named FY26, FY27, FY28 as the projected deficit years; the override was scoped to resolve that window.</p>
+        <p>The three tiers were designed as a multi-year correction. The <abbr class="g" title="Finance Committee">FinCom</abbr> three-year forecast named FY26, FY27, FY28 as the projected deficit years; the override was scoped to resolve that window.</p>
       </div>
       <div class="dl-side">
         <p class="dl-side-label">Against the override</p>
@@ -372,7 +372,7 @@ og_url: https://marbleheaddata.org/2026-override/
     <div class="dl-pair">
       <div class="dl-side">
         <p class="dl-side-label">For the override</p>
-        <p>Marblehead is at the extremes of every structural metric: 95.5% residential levy share, 0.54% five-year new growth. CIP shifts, commercial development, state aid, gateway-city status either do not exist here or do not scale within the FY27 fiscal year.</p>
+        <p>Marblehead is at the extremes of every structural metric: 95.5% residential levy share, 0.54% five-year new growth. <abbr class="g" title="Capital Improvement Program">CIP</abbr> shifts, commercial development, state aid, gateway-city status either do not exist here or do not scale within the FY27 fiscal year.</p>
       </div>
       <div class="dl-side">
         <p class="dl-side-label">Against the override</p>
@@ -402,7 +402,7 @@ og_url: https://marbleheaddata.org/2026-override/
     <div class="dl-pair">
       <div class="dl-side">
         <p class="dl-side-label">For the override</p>
-        <p>DESE classroom teacher FTE fell roughly 4% from FY15 to FY24 while enrollment fell 19%. Non-teaching growth tracked mandates: IDEA special education, out-of-district placements ($4.6M in FY26), English-learner and mental-health caseloads.</p>
+        <p><abbr class="g" title="Department of Elementary and Secondary Education">DESE</abbr> classroom teacher FTE fell roughly 4% from FY15 to FY24 while enrollment fell 19%. Non-teaching growth tracked mandates: <abbr class="g" title="Individuals with Disabilities Education Act">IDEA</abbr> special education, out-of-district placements ($4.6M in FY26), English-learner and mental-health caseloads.</p>
       </div>
       <div class="dl-side">
         <p class="dl-side-label">Against the override</p>
@@ -461,4 +461,4 @@ og_url: https://marbleheaddata.org/2026-override/
   </div>
 </section>
 
-<p class="source" style="margin-top:32px;">Sources: Marblehead Town Clerk's official June 9, 2026 sample ballot; the Marblehead Current and Marblehead Independent candidate Q&amp;As; Town of Marblehead FY27 Proposed Balanced Budget With No Override; Finance Committee Annual Reports 2016-2025; MA DOR debt exclusion and override vote records; PERAC and GIC documents cited throughout.</p>
+<p class="source" style="margin-top:32px;">Sources: Marblehead Town Clerk's official June 9, 2026 sample ballot; the Marblehead Current and Marblehead Independent candidate Q&amp;As; Town of Marblehead FY27 Proposed Balanced Budget With No Override; Finance Committee Annual Reports 2016-2025; MA <abbr class="g" title="Department of Revenue">DOR</abbr> debt exclusion and override vote records; PERAC and GIC documents cited throughout.</p>

--- a/checkbook.html
+++ b/checkbook.html
@@ -570,7 +570,7 @@ og_url: https://marbleheaddata.org/checkbook/
 </div>
 
 <div class="perf-card perf-card--over">
-  <h3>Already over the full year's budget</h3>
+  <h3>Over the full-year budget</h3>
   <div id="perf-over-list" class="ck-loading">Loading&hellip;</div>
 </div>
 
@@ -1344,7 +1344,7 @@ og_url: https://marbleheaddata.org/checkbook/
       .filter(function (r) { return r.pct !== null && r.pct >= 100 && r.delta > 25000; })
       .slice(0, 5);
     var overHost = document.getElementById('perf-over-list');
-    overHost.innerHTML = over.length === 0 ? '<p style="font-size:12.5px;color:var(--text-muted);margin:0;">No department has exceeded its full-year budget yet.</p>'
+    overHost.innerHTML = over.length === 0 ? '<p style="font-size:12.5px;color:var(--text-muted);margin:0;">No department has exceeded its full-year budget.</p>'
       : over.map(function (r) {
         var pctLabel = Math.round(r.pct) + '%';
         return '<div class="perf-row">' +

--- a/marblehead-101/08-how-to-take-part.html
+++ b/marblehead-101/08-how-to-take-part.html
@@ -9,7 +9,7 @@ body_class: m101-chapter
 scripts: [citations]
 ---
 
-<p>The site has its own <a class="inline" href="{{ '/' | relative_url }}what-you-can-do.html">what you can do</a> page listing concrete actions. This chapter zooms out to the structural answer: where in the year is the resident's voice heard, and how to plug in.</p>
+<p>A resident's voice carries at fixed points in the town's year: Town Meeting in May, the town election in June, Finance Committee hearings in winter, and public comment at board meetings year-round. Each works differently, and most have deadlines. For specific budget questions worth raising once you are in the room, <a class="inline" href="{{ '/' | relative_url }}what-can-we-do.html">what can we do</a> keeps a working list.</p>
 
 <h2>Town Meeting (the main event)</h2>
 

--- a/marblehead-101/index.html
+++ b/marblehead-101/index.html
@@ -13,7 +13,7 @@ og_url: https://marbleheaddata.org/marblehead-101/
   <div class="m101-hero-inner">
     <p class="eyebrow">A primer</p>
     <h1>Marblehead 101</h1>
-    <p class="lede">How the town works, where the money goes, and how a resident takes part, in 8 short chapters.</p>
+    <p class="lede">How the town works, where the money goes, and how a resident takes part.</p>
     <div class="meta">
       <span><span class="num">8</span> chapters</span>
       <span><span class="num">~25</span> min total</span>


### PR DESCRIPTION
Post-redesign copy audit fixes. Six small items across four files; no structural changes.

## Changes

**`marblehead-101/index.html`** &ndash; the lede ended with ", in 8 short chapters." That's meta-narration (CLAUDE.md's blank-page test) and duplicates the "8 chapters &middot; ~25 min" meta chips two lines below. The `og_description` keeps the format info since a social card has no chips.

**`marblehead-101/08-how-to-take-part.html`** &ndash; the opener claimed the site has a "what you can do page listing concrete actions," but #820 turned `what-you-can-do.html` into a redirect to `what-can-we-do.html`, which is twelve questions with self-described rough-guess dollar figures, not concrete actions. The second sentence ("This chapter zooms out to...") was meta-narration. Rewritten to lead with the structural claim and describe the linked page accurately, linking it directly rather than through the redirect.

**`checkbook.html`** &ndash; "Already over the full year's budget" read oddly at 92% of the fiscal year and becomes meaningless after June 30. Now "Over the full-year budget", which works at any point in the cycle. The JS empty state drops its matching "yet".

**`2026-override/index.html`** &ndash; removed "This page is the cycle's record." from the lede (meta-narration), and wrapped first-use ACFR, FTE, OPEB, FinCom, CIP, DESE, IDEA, DOR, and CFO in `<abbr class="g" title="...">` per STYLE_GUIDE. The page already did this for GIC, PERAC, and MGL; the rest had been missed.

Verified with a clean `bundle exec jekyll build`; rendered output spot-checked for each change.

https://claude.ai/code/session_01X5PBH6zHze842X1gGPu8PZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5PBH6zHze842X1gGPu8PZ)_