### PR TITLE
town-history: 'override fights' → 'vigorous debates'

### DIFF
--- a/town-history.html
+++ b/town-history.html
@@ -3,7 +3,7 @@ layout: default
 title: "The town that argued itself into existence"
 body_class: feature-article
 og_title: "The town that argued itself into existence"
-og_description: "Marblehead's civic story has a single through-line from a rocky 17th-century fishing village to the override fights in Abbot Hall today: a town that has never much liked being told what to do."
+og_description: "Marblehead's civic story has a single through-line from a rocky 17th-century fishing village to the vigorous debates in Abbot Hall today: a town that has never much liked being told what to do."
 og_type: article
 ---
 
@@ -269,7 +269,7 @@ og_type: article
 <!-- ============ ARTICLE ============ -->
 <article>
 
-  <p class="lede"><span class="drop">M</span>arblehead doesn't like being told what to do. That was true in the 1600s, when it was a rocky fishing village under Salem, and it's still true today at the override fights at Abbot Hall. The friction was there at the founding. It produced one of the more destructive riots of the colonial era. Four hundred years later, it's still loud at open town meeting.</p>
+  <p class="lede"><span class="drop">M</span>arblehead doesn't like being told what to do. That was true in the 1600s, when it was a rocky fishing village under Salem, and it's still true today in the vigorous debates at Abbot Hall. The friction was there at the founding. It produced one of the more destructive riots of the colonial era. Four hundred years later, it's still loud at open town meeting.</p>
 
   <!-- 1 -->
   <section class="chapter reveal">


### PR DESCRIPTION
## Summary
Two-word copy change in the lede and og_description: "the override fights at Abbot Hall" → "the vigorous debates at Abbot Hall." Softer framing, same meaning. No other instances of "fights" remain on the page.

## Proof of Work
Copy-only change; diff is the proof. No layout or behavior touched.

## Test plan
- [ ] Read the lede on /town-history.html in the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)