### PR TITLE
Auto-ingest meetings (2026-06-11)

### DIFF
--- a/_transcripts/select-board-2026-06-10.md
+++ b/_transcripts/select-board-2026-06-10.md
@@ -1,0 +1,212 @@
+---
+slug: select-board-2026-06-10
+board: select-board
+board_display: "Select Board"
+date: 2026-06-10
+title: "Select Board: June 10, 2026"
+vimeo_id: 1200515418
+vimeo_url: "https://vimeo.com/1200515418"
+duration_seconds: 1772
+ai_generated: true
+status: published
+source: vimeo-auto+llm
+
+summary_card:
+  headline: "Select Board reorganizes after election; override passes; board pledges accountability"
+  summary: "At its first meeting following the annual town election, the Select Board unanimously appointed Moses Grader as vice chair and seated newly elected member Rosanna Ferrante. Board members acknowledged the passage of the Prop 2½ override and committed to quarterly financial updates, a communication strategy, and departmental accountability measures. The board also approved three one-day liquor licenses and routine housekeeping items."
+  decisions:
+    - "Approved appointment of Moses Grader as vice chair"
+    - "Approved three one-day liquor licenses (Corinthian Yacht Club, Our Lady Star of the Sea, Bubble Bar at Abbot Hall)"
+    - "Approved minutes of April 15, May 13, and May 21"
+    - "Approved holiday hours for Abbot Hall and Mary Alley Building for Juneteenth and July 4th"
+    - "Approved motion to prepare proclamation for 60th Marblehead Festival of Arts"
+    - "Approved declaration of two HP printers as surplus equipment"
+    - "Approved letter of appreciation for John Kelly's approximately 40 years of service on the assessment board"
+  votes:
+    - motion: "Appoint Moses Grader as vice chair"
+      result: "in favor (unanimous)"
+    - motion: "Approve three one-day liquor licenses"
+      result: "in favor (unanimous)"
+    - motion: "Approve minutes of April 15, May 13, May 21"
+      result: "in favor (unanimous)"
+    - motion: "Approve holiday hours for Juneteenth and July 4th"
+      result: "in favor (unanimous)"
+    - motion: "Proclamation for 60th Marblehead Festival of Arts"
+      result: "in favor (unanimous)"
+    - motion: "Declare HP printers as surplus"
+      result: "in favor (unanimous)"
+    - motion: "Letter of appreciation for John Kelly"
+      result: "in favor (unanimous)"
+
+topic_segments:
+  - topic: admin-housekeeping
+    topic_confidence: 0.9
+    start_seconds: 1
+    end_seconds: 119
+    headline: "Select Board reorganizes: Grader named vice chair, Ferrante seated as newest member"
+    dek: "The board held its first meeting after the annual town election, appointing officers and seating newly elected members."
+    summary: "The meeting opened with a unanimous vote appointing Moses Grader as vice chair of the Select Board. The town administrator noted the board is the 378th convening of the Select Board in Marblehead's history and shared that 381 individuals have held the office since 1648. Grader was assigned number 375, noted as the third Moses and second Grader to serve. New member Rosanna Ferrante was designated number 381, the most junior member in Marblehead's recorded history."
+    key_speakers: ["Moses Grader (Vice Chair)", "Town Administrator", "Rosanna Ferrante (Board Member)"]
+  - topic: public-comment
+    topic_confidence: 0.97
+    start_seconds: 120
+    end_seconds: 741
+    headline: "Resident Al Jordan raises concerns about override costs, DPW communication, and town services"
+    dek: "Al Jordan of Mossvale Avenue spoke at length about the override vote, trash service, sidewalk conditions, and accessibility to department heads."
+    summary: |
+      Al Jordan praised the town clerk's office staff for managing the recent election with reduced staffing. He expressed mixed feelings about the override not initially passing, noting he canvassed over 350 homes and heard widespread frustration about snow removal, trash service, and department head responsiveness.
+      
+      Jordan raised concerns about the cost impact on fixed-income seniors, referencing a tax relief program at the senior center that he said would allow up to 100 qualifying residents (age 65+, income under $75,000, 10-year residency) to receive up to $2,000 off their taxes, which he argued would be insufficient if assessments rise significantly.
+      
+      He also called for a dedicated highway department director separate from water and sewer, better public communication before road and sidewalk work begins, and greater accessibility to select board members. A brief exchange occurred when a board member clarified that select board members waived their stipends this year.
+    key_speakers: ["Al Jordan (Resident, Mossvale Avenue)"]
+  - topic: override
+    topic_confidence: 0.97
+    start_seconds: 1265
+    end_seconds: 1633
+    featured: true
+    headline: "Board members commit to accountability and quarterly updates following override passage"
+    dek: "Board members discussed the override result, MOU obligations, and plans for financial transparency and communication with residents."
+    summary: |
+      Following passage of the Prop 2½ override, board members acknowledged the significance of the vote and discussed the responsibilities it entails. Members referenced the MOU commitment to quarterly financial updates, with the first anticipated in early October after the close of the first quarter.
+      
+      One member outlined the approved funding allocations:
+      - **$6.5 million** for municipal services
+      - **$8.5 million** for schools
+      - **$2.3 million** for trash collection
+      
+      Members noted that roughly $7.7 million in restorations were understood by voters, with approximately $9.6 million in additional needs still requiring clearer public articulation. The board discussed developing an accountability plan, improving the communication cadence with residents, and pursuing GFOA budget module implementation to link departmental strategy to financial data.
+      
+      Finance Director Alicia Benjamin was recognized for her role in the override effort and her work over three years implementing financial transparency tools. Members also praised the collaboration between the Select Board and School Committee during the override process and expressed interest in expanding that model to other boards.
+    key_speakers: ["Moses Grader (Vice Chair)", "Erin Newby (Board Member)", "Jim Sisson (Board Member)", "Dan Fox (Board Member)", "Rosanna Ferrante (Board Member)", "Town Administrator"]
+  - topic: permits-zoning
+    topic_confidence: 0.95
+    start_seconds: 927
+    end_seconds: 1017
+    headline: "Board approves three one-day liquor licenses for summer events"
+    dek: "Licenses approved for Corinthian Yacht Club, Our Lady Star of the Sea, and Bubble Bar at Abbot Hall, with one date corrected at the meeting."
+    summary: |
+      The board approved one-day liquor licenses for three events:
+      
+      | Applicant | Location | Date | Hours |
+      |---|---|---|---|
+      | Corinthian Yacht Club | 42 Foster Street | July 1, 2026 | 6–10 PM |
+      | Our Lady Star of the Sea | 85 Atlantic Ave | June 27 (corrected from June 25) | 5–7:30 PM |
+      | Bubble Bar | Upper Grounds, Abbot Hall | July 3–4 | 11 AM–4 PM |
+      
+      Approval was subject to standard conditions including proof of authorized alcohol sourcing. Alcohol for the Bubble Bar event is to be purchased from Campus Importing and Distribution, Merrimack Valley Distributing Company, and Martinetti's.
+    key_speakers: ["Town Administrator"]
+  - topic: admin-housekeeping
+    topic_confidence: 0.92
+    start_seconds: 1040
+    end_seconds: 1265
+    headline: "Board approves minutes, holiday hours, Festival of Arts proclamation, and surplus equipment"
+    dek: "Routine items included minutes approval, Juneteenth and July 4th building hours, a proclamation for the 60th Marblehead Festival of Arts, and disposal of two printers."
+    summary: |
+      The board approved minutes from April 15, May 13, and May 21. Holiday hours were set for Abbot Hall and the Mary Alley Building: for Juneteenth (observed June 19), the buildings will be open Thursday June 18 from 8 AM to 12:30 PM and closed all day Friday; for July 4th, open July 2 from 8 AM to 12:30 PM and closed July 3, with Abbot Hall remaining open for Festival of Arts activity.
+      
+      The board approved a motion to prepare a proclamation honoring the 60th Marblehead Festival of Arts (July 1). Two HP printers were declared surplus. The board also approved a letter of appreciation for John Kelly, who served on the town's assessment board for approximately 40 years.
+      
+      A notice was shared that a water and sewer rate hearing will be held June 30 at 100 Tower Way at 7:00 PM.
+    key_speakers: ["Town Administrator", "Moses Grader (Vice Chair)"]
+  - topic: public-safety
+    topic_confidence: 0.75
+    start_seconds: 1744
+    end_seconds: 1760
+    headline: "Firefighter memorial service announced for Sunday at Waterside"
+    dek: "A board member reminded attendees of the firefighter memorial service scheduled for Sunday at 9:00 AM at Waterside."
+    summary: "A board member noted an upcoming firefighter memorial service on Sunday at 9:00 AM at Waterside. The board also noted a Juneteenth celebration on Friday from 4:00 to 6:00 PM at Abbot Hall."
+    key_speakers: ["Board Member"]
+---
+
+> Transcript captured from MHTV's Vimeo auto-captioning. No speaker labels;
+> proper names and dollar figures occasionally misheard. Click any timecode to
+> jump to that moment in the source video.
+
+**[0:01](https://vimeo.com/1200515418#t=1s)** All those in favor? And that is unanimous. Yeah. I will now hand it over to the chair. Thank you. I think actually-- So thank you. Thank you guys all for that trust. Yeah. I would also like to make another motion. I'd like to move to appoint Captain Marc C. "AK" Moses Greater as vice chair of the select board. I'll second that.
+
+**[0:26](https://vimeo.com/1200515418#t=26s)** All in favor? Unanimous. Adjournment. Thank you. Adjourned. And congratulations to everyone. Welcome. Thank you. And congratulations to your reelections. Congratulations to everyone across the town who ran, whether they won or not. Yeah. As we all know, it's a lot to run and put yourself out there. So even for those who didn't win- Yeah ... we thank you for engaging in our volunteerism here in Marblehead. So, as we do every year, we start off with the Town of Marblehead land acknowledgement per our bylaws. We acknowledge the land on which we reside, now known as the Town of Marblehead, is the ancestral homeland of the Naumkeag band of Massachusetts and Patuxet tribes that lived here under the leadership of the great
+
+**[1:14](https://vimeo.com/1200515418#t=74s)** sachem, Naniposhmit. Since time immemorial, the Naumkeag people maintained this land and surrounding water with the utmost respect, preserving it for the future generations and treating it as sacred ground for the burial of their dead. They had an organized and thriving community before the arrival of European settlers. The Naumkeag people suffered great loss of life during King Philip's war and the smallpox plagues, and the surviving members were disposed of the land. Although we are unaware of any Naumkeag descendants living in Marblehead today, we honor the Naumkeag people of the Massachusetts and Patuxet tribes, past and present, as original stewards of this land, and pledge to include their history in the history of our town. And this was done at the 2022 Annual Town
+
+**[2:00](https://vimeo.com/1200515418#t=120s)** Meeting, Article 32. With that, we will open up for public comment. Mr. Jordan. Al Jordan, Mosvale Avenue. The first, welcome all. Good luck in your endeavors. I first want to thank, and I think you people should give them a day off, the two in the town clerk's office. I have never seen any department in Marblehead go through what they went through the last week, and you gave them really, really short notice. And the other thing that was surprising, I believe I've been told that the town clerk's been held for months, and I was told that office couldn't run with two people. To be honest with you, I think it's running better with two people. So I don't understand. I was told we couldn't have a town election
+
+**[2:48](https://vimeo.com/1200515418#t=168s)** without three people in there. So I just really want to give them a pat on the back. That's coming from me, okay? The public really, really appreciates what's going on in there. Okay. The next thing,
+
+**[3:05](https://vimeo.com/1200515418#t=185s)** I'm not disappointed that the override didn't go through. I went around and walked over 350 houses Friday and Saturday. I stood out for 12 hours yesterday. I stood out for six hours the day before. A lot of people stopped. I don't even know who these people are. They're really, really upset at a lot of the department heads in this town. Snow removal, the trash situation. It's really, really, really sad. One guy came up and's been living in a car three years in Marblehead. I never even knew that went on. Just got a place in the homeless yard. I don't even know who the person is. I don't want to probably tell me this stuff. But I really felt bad for a lot of the residents around town. I went to a lot of houses that used to be-- I used to deliver newspapers
+
+**[3:53](https://vimeo.com/1200515418#t=233s)** 25, 30 years ago, and they was one-story little houses, and now they've been expanded three times the size. I do not know why this town doesn't have any money. And the other thing I felt bad for, a few people, I go, "You vote whatever way. I'm giving you this card. It has information on it. You read. You do what you feel is better for you." A couple people told me, "We have kids. I walk up the stairs. I didn't know if I was going to make it because you can't leave the mailboxes down below. The stairs are really dangerous." The guy told me, "I'm sorry, I don't have money to fix the stairs. I don't have money to pay for this override." So I just hope-- I don't know what this is going to cost. It tells me on a million-dollar house on the sign that I was holding, it's going to be $7,500 in three years. Someone else told me that's wrong.
+
+**[4:40](https://vimeo.com/1200515418#t=280s)** Someone else says it's going to be 33%. I'm going to find out in three years. My house, I think, is valued at 849,000. So thank God mine's going to be a little less, unless it's successful later on. But I really, really feel bad because there's a lot of older people in Marblehead, and you're pricing them out. They live on a fixed income. I know this program's a little mislaid. I do my homework. I went out to the senior center, and they're going to allow 100 people. They've got 200,000, I don't know where it's from, and the state came up with a new program. And 100 people will qualify for it, make under $75,000,
+
+**[5:25](https://vimeo.com/1200515418#t=325s)** have to be over 65. I believe they have to own the house for 10 years or live in Marblehead for 10 years. And they can get $2,000 off their taxes. If 200 people apply for it, they'll only get $1,000 off. But what I don't understand about it, it's not really going to do them much good if their assessment goes up $4,000 or $5,000 or $6,000 and they get $2,000 off and the taxes are going up $4,000 or $5,000. So, I really think we need to look into all these services in town. If the school wants more, more, and more, then the people that have the kids have to pay more, not the people that have been here for years that aren't getting these services. I support the schools.
+
+**[6:12](https://vimeo.com/1200515418#t=372s)** I bought a house in 1998. I don't have any children in school. I've been paying my full tax bill since 1998.And so I already supported the schools, so if they want to add more and more, we all know there's 200 less kids. We know the vocational school's over in Middleton, has 30 more openings, so thank... Hopefully, some people will take advantage of that. That's a real great school over there. I know a lot of people that have got out of it. I know a lot of contractors that have hired a lot of people. Not everyone's a college-educated. Better off going into vocational schools. I mean, there's a lot of job need for it around Massachusetts. And they could stay in this area or go any place in the world and do that type of work.
+
+**[6:57](https://vimeo.com/1200515418#t=417s)** I just want the selectmen... I asked to be on the agenda a few weeks ago. I spoke to your executive secretary. I was told I have to email. I don't know how to email. I left a message with someone. I got a text message back. They were very busy. I got news for you, I'm very busy, too, and I'm not getting paid for what I do. Okay, so everyone's busy. And I don't bother people too often. And I resent when I go to a department head in Marblehead, and they walk away from me, or they tell me that they don't have time. I'm a taxpayer in this town, and other people feel the same way. And I just went over about the trash. I've been over to Beverly, Danvers, and Swampscott, and spoke to people over an hour, gave me their card. I told them I don't live in their community.
+
+**[7:43](https://vimeo.com/1200515418#t=463s)** I got all this information. And I just don't understand how I can go out of town and be treated better than the town I'm paying taxes in. And it was really disheartening to hear people. I don't know why anybody would want to come up and tell me their problems. But they've talked to department heads in Marblehead. The highway department, especially if the third tier goes over, it needs its own director up there. Not the water and sewer. They already have nothing against the person at the water and sewer. They already have 20-odd people to deal with, and they've got emergency calls at night for water and sewer. It's too much on one person's plate, and we're spending a lot of money. I read another letter from Booby Road in the
+
+**[8:30](https://vimeo.com/1200515418#t=510s)** local newspaper again today about the sidewalks. I'm really getting irritated that these people can't get the department heads to communicate when something's going to go in their neighborhood. They should know about it before it happens, not after it happens when they come home from work. Okay? Why are they putting curb cuts on Booby Road? I took my 94-and-a-half-year-old mother that passed on to the Catholic church, a pedestrian crossing on Atlantic Avenue, and there's no curb cut and a pedestrian light in Marblehead, and we're putting them on. And she passed on five and a half years. Hundreds of people have to walk over a big curb. I don't understand. They don't have meetings that the public can go to when there's so little money, and let the public--
+
+**[9:18](https://vimeo.com/1200515418#t=558s)** Let's put the money where we get the best bang for the buck. Let's not do all these side streets. Let's put it where the people use the most. If we can't give everyone a sidewalk and a granite... I'd love a granite curb on my street. You want to do it, I've got no objections, but it's really not necessary. I'd rather see it. Okay. I'm going to leave you with there. I just hope you people will answer the phone because I will find out in year one, two, and three what's going on, and if people come to me and- Thank you, Mr. Jordan ... I'm able to do things- Mm-hmm ... I'm going to be calling you, and I hope you call me back, because some people I know in Marblehead- Absolutely. We appreciate your help, Mr. Jordan. Thank you. Yeah. The last thing-- No, I'm not through yet.
+
+**[10:04](https://vimeo.com/1200515418#t=604s)** Okay. I thought you were. The last thing is, Jim Sisson brought up a proposal a few weeks ago. Mm-hmm. Okay. I've mentioned this to you months ago when you first came on this board. I thought you were going to be accessible. I met with you. We met once. Mm-hmm. We might have talked a couple other times. I don't think I bothered you that much. But everything I've talked to you about, nothing has happened yet. The public wants some people to be able to talk to. The selecting used to have subcommittees, and the public's the one paying these bills. And I appreciate a lot of the things he does, but the public isn't happy. I got an earful yesterday, and a few of them went and saw
+
+**[10:49](https://vimeo.com/1200515418#t=649s)** him, too, I was told. So I'm more satisfied with him myself than a lot of the public that came over and talked to me yesterday. I have nothing against him. Very difficult job, but we've had two administrators before him in a short period of time that ran this town into the ground as far as I'm concerned. And he had a full plate when he came in here. But I have to pay as a taxpayer to pick up after all this. So I really hope that you people take to serious consideration, and you say you want to be transparent. I hope the public doesn't feel like they can't talk to the board because I used to talk to them. And if I ask ever to be on the agenda again and I can't
+
+**[11:36](https://vimeo.com/1200515418#t=696s)** email, I will call the Secretary of State's office, and I'll say I'm handicapped, and I'll get someone down here to tell you what the laws are if someone can't do that. Very true, Mr. Jordan. You should have respect. Mr. Jordan- Nothing against you. Mr. Jordan, we understand it. Thank you. Appreciate it. Listen, I appreciate the dedication. I do want to clarify one thing. We're not paid either this year. Okay. So just so you know that. You said that you're not paid for anything. Yeah. We did waive our fee this year. Yeah. Our big pay from last year, but just so you know- Okay ... given our budget crisis. No, but you're representing the town, and if you- Sorry, please sit. Mr. Jordan. Stop. Please sit down. Don't run for office. I didn't say I didn't want to run for office. What I told you is I was clarifying a misstatement that you made about us being paid, and I just wanted you to know we're not being paid.
+
+**[12:21](https://vimeo.com/1200515418#t=741s)** Okay. Okay? That was all I was saying. I think all of us-- Hold on, sir. Stop. Please. I let you talk for a long time. Sure. If I'm speaking, please don't interrupt me. Oh. I show you respect there. Yeah. So thank you. I always do. I think we show you a lot of respect, and we appreciate your input. So do we have anyone else online?Oh. I, because no games or something. Okay. Why don't we move on to town manager update? Thank you, Mr. Chairman. So in the spirit of this being the 378th convening of the Select Board, um, did a little research and some update, uh, to the fact that... Well, let me start. Uh, we're all familiar with sort of the trend now that we identify presidents by their number. Right?
+
+**[13:08](https://vimeo.com/1200515418#t=788s)** So George Washington was number one. Joe Biden was president 46. We have president 47. So I did a little research and updated a list that's been done, where I listed the names of every person who's ever been a selectman- Oh, wow ... a Select Board member in the town of Marblehead since, um, uh, 1648. That's cool. And now the plan- That's cool ... is to assign you all a number. So you can order your hats with the embossed number on it, and sell the mark. Um, so there's been 381 people now who have held the office that you're sitting in- Mm ... since 1648. So it's an incredible legacy.
+
+**[13:53](https://vimeo.com/1200515418#t=833s)** So the senior member currently, Moses Grader, you are number 375. That's a good round number. That is a- That's a great number. I'm jealous ... good number. And by the way, you are the third Moses and the second Grader that's held number. Third Moses. The third Moses. Which one takes it? Moses Maverick. Yeah. Moses Ma- no, Moses Maverick was, too. Yeah, he was very early. Yeah, yeah. So you're clearly- Did you know? ... the third Moses to serve- Yeah ... and the second Grader. We measure it from the 1600s. Right. And we know you're the third Moses. Yes. And the rest of you are unique. So, um, uh, Erin, you are, uh, member 377. Uh, Dan Fox, your number's 379. Jim Sisson is 380. And Rosanna Ferrante, you
+
+**[14:40](https://vimeo.com/1200515418#t=880s)** are the most junior member in the history of Marblehead at 381. So congratulations. Thank you. That's awesome. Um, so yeah, I, I, I point that out one, just so it's about legacy. Uh, Marblehead is one of the oldest continuous running governments in North America, uh, one of the earliest. And to point out that you are part of a legacy, being, um, uh, serving in the role, uh, you're each one of 381 people in the history of Marblehead to serve on this board. So congratulations. Yeah, thanks for doing that. Thanks for that. And with that, I conclude my update and interesting question. You got that update. Yeah. Thorough stretch there, huh?
+
+**[15:27](https://vimeo.com/1200515418#t=927s)** All right. Let's move on to our one-day liquor licenses. Uh, we have three one-day liquor licenses to approve. If I could have a motion to approve the requests for the following one-day liquor licenses from Cleon Yacht Club, 42 Foster Street, July 1, 2026 from 6 to 10 PM. Our Lady Star of the Sea, 85 Atlantic Ave, Saturday, June 25th from 5 to 7:30 PM. And Bubble Bar on the Upper Grounds of Abbot Hall on July 3rd. Correction. Thank you. Change of date. Star of the Sea, uh, says the 27th, so. There you go.
+
+**[16:04](https://vimeo.com/1200515418#t=964s)** So we will amend. Thank you.
+
+**[16:08](https://vimeo.com/1200515418#t=968s)** Glad you showed up. Yeah.
+
+**[16:11](https://vimeo.com/1200515418#t=971s)** Be a lot of leftover liquor then. Um, so we'll amend the Lady of Star of the Sea for June 27th. Same times, 5 to 7:30? Mm-hmm. All right. We'll go with that. And Bubble Bar? Perfect, thank you. July 3rd and 4th, Upper Grounds at Abbot Hall, 11 AM to 4 PM, subject to the following conditions. Delivery of receipt by licensed authorities, a required fee of $50 each. Delivery of receipt by the licensing authority of proof that the alcohol will be purchased from an authorized source. Proof that the applicant can receive proper delivery, provide proper storage and disposal of alcohol beverages purchased all in accordance with requirements of DLC 138. Alcohol will be purchased from Capus Importing and Distribution and Merrimack Valley Distributes- Distributing Company and Martinetti's. So moved. Do I have a second? Second. All right. Roll vote. Uh, Ms. Ferrante?
+
+**[16:57](https://vimeo.com/1200515418#t=1017s)** Yes. Mr. Sisson? In favor. Ms. Newby? In favor. Mr. Grader? In favor. Mr. Foy? In favor. Moving on to approval of minutes. We have, if I get a motion to approve the minutes of April 15th, May 13th and May 21st, that's in your package. So moved. I second. All in favor?
+
+**[17:20](https://vimeo.com/1200515418#t=1040s)** Unanimous. Um, next on there, we have motion to approve the following holiday hours, uh, for the operation at Abbot Hall and Mary A. Alley Building. Juneteenth will be observed on Thursday, June 18th from 8 AM to 12:30 PM. Is that... What am I doing wrong? It's, yeah, that's when they're open. The first one's open, sorry. Yeah. So let's do it again. They're gonna be open. Good start to the year. Um, 8 AM to 12:30 PM, and on Friday they are closed all day. Thank you. This is Abbot Hall. 4th of July, for observance of that, they will be open on July 2nd, 8 AM to 12:30, and on Friday, July 3rd, closed all day. Abbot Hall will remain open for Festival Arts activity.
+
+**[18:08](https://vimeo.com/1200515418#t=1088s)** So let me, let me clarify. So, um, th- those are observed holidays. Um, so, and under the collective bargaining agreements from the IU, they get a full day off, but because Fridays is a shortened day, the seven and a half hour full day rolls backwards into Thursday. Okay. So we're, we open Thursday normal, but we close early on Thursday, closed all day on Friday- Mm-hmm ... for those holidays. Cool. So moved. Second. All in favor? Unanimous. And if I could have a motion, um, we have a request from Brian Weir from the Chair of Performing Arts, um, about having MosesYou have a specific request there, Moses, your proclamation on July 1st-
+
+**[18:54](https://vimeo.com/1200515418#t=1134s)** Yes ... for the 60th Marblehead Festival of Arts. We have a motion to prepare a proclamation in honor of that. So moved. Second. In favor. We have some surplus equipment to declare. We have a motion made and seconded to declare the following items as surplus and no longer needed for municipal purpose, so may be disposed of in accordance with the town policy on surplus equipment. An HP LaserJet 4250TN, HP Color LaserJet Enterprise M553. So moved. Second. All in favor.
+
+**[19:30](https://vimeo.com/1200515418#t=1170s)** And then we do have here, we don't need a vote on it, but just a notice of rate hearing for water and sewer, which will be held on June 30th at 100 Tower Way at 7:00 PM. We are all invited, as well as the public, to attend to hear how they set the rates for water and sewers. Moving on through select board announcements.
+
+**[19:51](https://vimeo.com/1200515418#t=1191s)** Anyone have any? Yeah. I'd like to congratulate John Kelly, who's been serving, basically on the assessment board for close to 40 years- Wow ... so he's seen it all come and go, for sure, and has been part of the latest adjustments. But I'd like to make a motion to write a letter to him, a letter of congratulations and appreciation for his long service.
+
+**[20:19](https://vimeo.com/1200515418#t=1219s)** Second? So moved. Second. All in favor. Thank you. I would just like to-- I think we discussed setting a date for a retreat. We've done a retreat every year off during the week. I don't know if Kyle, you want to send out some-- We can send out some proposed times for that, and then maybe we can discuss even at our next meeting, how we'd like to do this retreat. If we want to do it the same way, three different cohorts, or if you want to set it up in a different way. Yeah. I'd like to maybe see it a little different. I want. We'll just put that on the agenda for next week to discuss what we find appropriate and specific. In advance of that is Kyle's just going to try to find a date. Yeah. So Kyle will send out an email saying he had a date- Yeah. He'll email. Yep. And then at our next- And talk about it. Yeah. Yep. And I would just like to say,
+
+**[21:05](https://vimeo.com/1200515418#t=1265s)** after last night's override, I feel a ton of responsibility for that, that it is a lot of money. I feel a lot of responsibility as the select board, not me personally, but as the select board. And I think I would argue the school committee probably feels the same way. I don't view this as a blank check. I don't think any of us do, and really like to be open and transparent and about following what we said we would do in our MOU. We're going to do a quarterly update. And I think we have responsibility to continue to cut costs and find efficiencies, not just rely on the taxpayer's money. But I think that we do have a responsibility to continue the work that we have been doing. And now that it's not something that is encompassing us, we can really focus on that. I look forward to doing that this year.
+
+**[21:51](https://vimeo.com/1200515418#t=1311s)** I would add, interestingly enough, Lee Flynn, who sent us a email- Mm-hmm ... for our statement on the override. My words were almost exactly what you said. I actually said it's a lot of money, but it's a lot more responsibility. Okay. And, I went on to say, just off the top of my head, there was some defining things that we said we are going to do that we have to follow through. And, with that said, I think, just like you said, I really want to push for efficiencies because I would like that override hopefully to last, maybe 21 years would be a challenge, but we should really try to see how long we can stretch that oxygen tank- Yeah ... as much as we can. And
+
+**[22:37](https://vimeo.com/1200515418#t=1357s)** the other thing, I said in the statement, I implore people, like Jack Adcock does every year, is start going in a few months to different finance committee and budget hearings when you can. It's like, don't wait till town meeting to get involved. And because it's the voters and residents' town and their money. Mm-hmm. So, I agree. I have a comment. So, when do you think we'll be able to set the first meeting? First meeting for- Quarterly ... the quarterly? Well, the quarter ends September. I would think we would have it in the first couple weeks of October. Yeah. So I think we'll set that date, Thatcher and John. Yeah. I think we can set that, but it'll be right after the quarter ends, and give it a
+
+**[23:23](https://vimeo.com/1200515418#t=1403s)** week or so to- Okay ... to put the numbers together. Just I'm very focused on that, so I just want to make sure like the dates don't start slipping because of schedules and whatever. No. So if it's the first week of October- Yeah ... roughly right now, obviously we're way in advance, but I just want to make sure that everybody knows we are taking this very seriously and taking the responsibility of the votes yesterday. So anyway, I'm just focused on that date. And did we land that the meeting would be the full board or just the chairs and- I think it was the chair, but I think just because of the MOU was the chairs of each board is how it was written. But I think without question then that'll be the next meeting will be a full board- Yeah ... or it'll be distributed to everyone. So we can figure that out.
+
+**[24:08](https://vimeo.com/1200515418#t=1448s)** Obviously, it's the first year, first meeting. Yeah. And clearly everyone should have all the information as quickly as possible. Yeah. Yeah. No question. Yeah. Look, the only thing that I would add is, if I could, Mr. Torres, is that yesterday was a victory, and especially in the trust and confidence in the town has really bestowed upon us. I think that's something that we have to, are really going to have to live up to. And I think I just want to say hats off to Alex Goldsby, Molly Tate, and the finance committee for really stepping up in a really substantive way, in a material way that really helped us. But we have been given some big checks, and I can just review very quickly. We've got 6.5 million for municipal service, 8.5 million for the schools, 2.3 for trash collection.
+
+**[24:53](https://vimeo.com/1200515418#t=1493s)** And so we know we're kind of 7.7. I think people in their minds understand where the 7.7 restoration is coming from. But we have another 9.6 that we have to probably do. I know we have to do a better job articulating what that is, but it's a wonderful opportunity in a lot of ways.I think, but in addition to the quarterly meetings, I think we should really try to develop a plan around accountability. In other words, how are we going to show that accountability, and literally think consciously about it. And I think we have the resources now to really lean into that pretty heavily. Not the least of which, getting GFOA module that we can implement. I actually think it's a very important strategic document. However, I think with the transition from
+
+**[25:42](https://vimeo.com/1200515418#t=1542s)** OpenGov to Munis, we didn't have the automated features so much. But I think that's very important, the strategic document at the department level that links to the numbers. So when you roll it all up, and it's a long document, it's 80 pages, but you get a really good sense of where the underlying strategies are getting implemented to drive forward our strategic oversight of the town. Yeah. I know I'm sounding like- No, it's- Sounding like a broken record. No, it's- I think it's a good way to start the year with the GFOA, right? Yeah, that's right. No. You had to get that one in. You had to get that one in. Hold up one second. One a month. I think Anna had something to say. Go ahead.
+
+**[26:27](https://vimeo.com/1200515418#t=1587s)** Yeah, no, I just wanted to just follow up. I agree with Mohak on that. I think, having the plans and the strategy in place, and then I do think we need a communication strategy. Mm-hmm. How are we going to keep the community updated? Kind of what's the cadence? What's the form? Again, I think this is just such a big responsibility we have, and so it's also a great opportunity. And so I think the more clarity we can bring to the community as to what's happening, I think the better for everybody. Yeah, the sooner we get on it, the better. We know that we had the where the $4.3 million goes in year one, right? That was already approved in Article 29 at town meeting. Sure. Yeah. And so we know where we go from there, but it's about lining that up and making sure we're tracking it well for the future years when we stick to what decisions we've said we're going to do as well.
+
+**[27:13](https://vimeo.com/1200515418#t=1633s)** Yeah. Go ahead, I'm sorry. No. Oh, I just wanted to acknowledge the hard work of our finance director, Alicia Benjamin. I mean, she was so instrumental in this and deserves such recognition for working so closely with the finance committee and all the department heads and each one of us. I mean, I personally had a lot of phone calls and a lot of questions and, I just want-- She works really long hours and hard, and she's accomplished quite a bit in her three years that she's been here. So,
+
+**[27:53](https://vimeo.com/1200515418#t=1673s)** it's quite an undertaking and quite a feat as your first contract, first finance director to have the town feel the level of trust in her, over the last three years that she's been here and, just wanted to acknowledge that. I would just add to that, that she really was instrumental in the implementation of the technology- Yeah ... that's enabled our more recent transparency that the finance committee has wanted. Yeah. One more other thing that, we keep saying one more thing, but, is that the collaboration that we had with the schools this year I thought was very impressive. I would like to see that continue with other boards. I think you and I have discussed it, but collaborate closer with other boards because I think that's just going to help to keep us more efficient in
+
+**[28:40](https://vimeo.com/1200515418#t=1720s)** knowing what's going on. That collaboration was huge and hope to continue and expand that. Anybody else have any other comments, announcements? Again, welcome. Thank you. Yeah. Glad to have you. Yes, sir. I have a reminder for an event. Okay. This Sunday, what time is it? 9:00. This Sunday, 9:00, the firefighter memorial service at Waterside.
+
+**[29:04](https://vimeo.com/1200515418#t=1744s)** And also, actually, while you say that, we have Juneteenth this Friday- Yeah ... at 4:00 to 6:00 PM here. Yep. Yep. So 9:00 AM at Waterside. Okay. SE. Firefighters. All right, could we have a motion to adjourn? So moved. Second. All in favor? Just a moment. Just so you know, all of our meetings only go half an hour. Oh, I didn't know that.

--- a/data/vimeo_meetings.json
+++ b/data/vimeo_meetings.json
@@ -1,8 +1,16 @@
 {
-  "last_updated": "2026-06-08T00:34:41.985Z",
+  "last_updated": "2026-06-11T20:53:04.614Z",
   "channel_url": "https://vimeo.com/marbleheadtv",
-  "total_videos": 2784,
+  "total_videos": 2790,
   "meetings": [
+    {
+      "vimeo_id": "1200515418",
+      "title": "Marblehead Select Board Meeting: 6-10-26",
+      "board_slug": "select-board",
+      "board_display": "Select Board",
+      "date": "2026-06-10",
+      "raw_title": "Marblehead Select Board Meeting: 6-10-26"
+    },
     {
       "vimeo_id": "1196731483",
       "title": "Marblehead Select Board Meeting: 5-27-26",


### PR DESCRIPTION
Daily auto-ingest of MHTV meeting transcripts.

**Newly added `_transcripts/` files:**

```
_transcripts/select-board-2026-06-10.md
```

**Pipeline:**
1. `scripts/transcripts/pull_vimeo.mjs` refreshed the Vimeo channel index.
2. `scripts/transcripts/backfill_auto.mjs` downloaded the `en-x-autogen` VTT for each new meeting and wrote the stub markdown.
3. `scripts/transcripts/enrich_one.mjs` added `summary_card` + `topic_segments` to each.

Auto-merge is enabled. The PR will land as soon as the required checks (smoke, Secret scan, Content guardrails) pass. If a check fails, this PR stays open for inspection and the next daily run is skipped (gated on the `auto-meetings` label) so the failure does not get buried.
