### PR TITLE
Social media plan H2 2026: post-vote operational setup

### DIFF
--- a/SOCIAL_MEDIA_PLAN.md
+++ b/SOCIAL_MEDIA_PLAN.md
@@ -1,130 +1,62 @@
 # Social Media Plan
 
-Marblehead Data Facebook page, created April 24, 2026.
-47 days to the June 9 override vote.
+Marblehead Data, post-vote operational plan.
+Six months: Jun 12 to Dec 12, 2026.
+Spec: docs/superpowers/specs/2026-06-12-social-media-plan-h2-design.md
 
-## Page setup
+## Why this plan exists
 
-- **Name:** Marblehead Data
-- **Category:** Reference Website + Community Organization
-- **Action button:** Learn More -> marbleheaddata.org
-- **Profile pic:** Lighthouse favicon on navy `#1B3A57`, 512x512
-- **Cover photo:** Sustainability chart (revenue vs expenses, FY18 lines-cross)
+The pre-vote plan (April 24 to June 9, 2026) ended its mission when
+all four override ballot questions passed. This is the post-vote
+plan: watchdog spine, tools as discovery layer, civic literacy as
+durable fallback.
 
-## Why Facebook
+## Channels and cadence
 
-- 26% of site traffic (122/462 visitors in first 30 days) comes from Facebook
-- The override debate is happening in Marblehead Facebook groups
-- Instagram is a poor fit (3 visitors, data-heavy content, no in-post links)
-- WhatsApp is group-chat based, not public discovery
-- No paid ads -- organic sharing in FB groups is the growth lever
+- Facebook page "Marblehead Data": 2x/week, Mon and Thu mornings.
+- Meeting Digest email: weekly Monday during active season
+  (Sep through Jun), biweekly during summer (Jul to Aug).
+- Marblehead Current op-eds: held in reserve. Revisited mid-Sep.
 
-## Traffic baseline (first 30 days, Apr 12-24)
+The Monday email and the Monday FB post anchor the same morning. The
+email goes to subscribers; the FB post highlights the email's lead
+finding and links to it / to the digest signup.
 
-| Metric | Value |
-|---|---|
-| Unique visitors | 462 |
-| Pageviews | 3,432 |
-| Bounce rate | 20.8% |
-| Avg session duration | 9m 49s |
-| Mobile / Desktop | 57% / 40% |
-| Peak day | Monday |
-| Top source after direct | Facebook (26%) |
+## Three post types
 
-## Posting cadence
+Pick what has substance that week. No fixed ratio.
 
-3x/week: Monday, Wednesday, Friday mornings. Monday is peak traffic day.
+1. Watchdog. What the town did. Default for email and Monday FB.
+2. Tool feature. Screenshot plus a paragraph from one site tool.
+   Default for Thursday FB.
+3. Civic literacy. One durable concept. Fallback when the first two
+   are thin.
 
-## Content calendar
+## Templates
 
-The order is deliberate: tools first to build trust, then how the site
-works, then substantive override-adjacent content last.
-
-### Weeks 1-2: Data tools (Apr 24 - May 9)
-
-| Date | Page | Status |
-|---|---|---|
-| Thu Apr 24 | Town Explorer (launch post) | Posted |
-| Thu Apr 24 | Marblehead Current article (shared on page) | Posted |
-| Wed Apr 30 | Deficit model (interactive sliders) | |
-| Fri May 2 | Four-town tax rate comparison | |
-| Mon May 5 | Enrollment vs staffing | |
-| Wed May 7 | Revenue vs expenses (sustainability) | |
-| Fri May 9 | About / sources / methodology | |
-
-### Week 3: How the site works (May 12-16)
-
-Reinforce sourcing and neutrality. Show the data catalog, explain
-primary vs secondary sources. Build credibility before touching
-anything opinion-adjacent.
-
-### Weeks 4-5: Substantive pages (May 19 - May 30)
-
-- Prop 2&frac12; history (storybook: 1980 to 2026)
-- Where has the money gone
-- How we got here (<abbr class="g" title="Finance Committee">FinCom</abbr> warning arc)
-- The debate (both sides steelmanned)
-- Senior tax relief
-- What is the override
-- Inside school staffing
-
-### Weeks 6-7: Pre-vote (Jun 2-6)
-
-- Re-share top performers (check PostHog for which posts drove clicks)
-- Share any new pages built in the interim
-- Final post Fri Jun 6: roundup linking the homepage
-
-## Post format
-
-- Post from personal account (Andrew Baber) in groups; from the page on the page
-- One link per post (to the site, not to the FB page)
-- Attach a screenshot image -- more feed real estate than link preview cards
-- Branded screenshot template: navy `#1B3A57` frame, lighthouse, URL (Canva)
-- Mention the page with @ tag at the end for discoverability
-
-## Group posting order
-
-1. General Marblehead community group (neutral ground)
-2. Pro-override or town services groups (friendly, builds followers)
-3. Anti-override group last (after page has traction)
-
-For anti-override groups, lead with the Town Explorer tool specifically --
-it lets people make comparisons that support their arguments. Frame it as
-"here's a data tool," not "here's a site about the override."
-
-## Key decisions
-
-- Lead with tools first, override content last
-- No Facebook link on the site until 50+ followers
-- No email collection before June 9
-- No Instagram, no WhatsApp, no paid ads
-- Screenshots should use neutral default views (no pre-sorted conclusions)
-- Every post links to a specific page, not just the homepage
-  (exception: group introduction posts link to homepage)
+- Facebook post: docs/social/fb-post-template.md
+- Email digest: docs/social/email-digest-template.md
+- Tentpole calendar: docs/social/tentpole-calendar.md
 
 ## Tone rules
 
-- No opinion on how people should vote
-- No editorial language or loaded adjectives
-- Match the site voice: factual, sourced, neutral
-- Third-party coverage (Marblehead Current) does the credibility work
+Same as pre-vote: neutral, sourced, plain text, no markdown bold on
+Facebook, no em-dashes anywhere, no editorial language. Acronyms
+expanded on first use. Screenshots default to unfiltered views.
 
-## Drafts
+## Baseline (Jun 12, 2026)
 
-### Prop 2&frac12; history (target slot: weeks 4-5, ideally lead-off Mon May 19)
+See docs/social/baseline-2026-06-12.md for the starting metric snapshot.
 
-- **Page:** [prop25-story.html](prop25-story.html)
-- **Screenshot:** top key-stats strip (1980 / 2005 / 4 of 13 / 28 of 29). Crop to include the page title and lead paragraph if it fits.
-- **Hook:** the 1980-to-2026 arc. Marblehead is voting again on whether to exceed a cap that a Marblehead resident helped create.
+## Month 3 checkpoint (mid-September)
 
-**Post text:**
+Targets, measured against April 2026 baseline:
 
-> 1980: Massachusetts voters pass Proposition 2&frac12;, the law that caps how fast a town's property tax can grow. The statewide campaign is led by Barbara Anderson, a Marblehead resident.
->
-> 2026: Marblehead is again voting on whether to exceed that cap.
->
-> A short walkthrough of how the town has voted on its own overrides since 1990. Six no's in the 1990s. A yes era from 2001 to 2005. A sixteen-year stretch when the Finance Committee didn't ask. The most recent operating override failed in 2023 by about 400 votes.
->
-> Across the full record: voters approved 28 of 29 debt exclusions for buildings, but only 4 of 13 operating overrides.
->
-> https://marbleheaddata.org/prop25-story.html
+- Email subscribers: at least 100 active.
+- Facebook page followers: at least 200.
+- Monthly site traffic: at or above April baseline (462 visitors).
+- Channel mix: email plus Facebook drive at least 40 percent of
+  traffic.
+
+If short on reach, add op-eds. If short on email growth, run a
+one-time FB push for digest signup.

--- a/docs/social/baseline-2026-06-12.md
+++ b/docs/social/baseline-2026-06-12.md
@@ -1,0 +1,21 @@
+# Baseline snapshot 2026-06-12
+
+Run via: `node meeting-digest/tools/baseline-h2.mjs`
+
+Note: this is a placeholder. To populate the actual values:
+1. Run the script from the repo root (the script uses `cd meeting-digest/worker && npx wrangler d1 execute ...`).
+2. Wrangler must be authenticated. If not: `cd meeting-digest/worker && npx wrangler login`.
+3. Copy the script output over the table below.
+4. Hand-fill the three manual values from FB admin and PostHog.
+5. Commit.
+
+| Metric | Value | Source |
+|---|---|---|
+| Email subscribers (confirmed) | FILL IN (run script) | D1 query, automated |
+| Facebook page followers | FILL IN | FB page admin > Insights > Followers |
+| Monthly site traffic (last 30 days unique visitors) | FILL IN | PostHog dashboard |
+| Channel mix: FB + email as % of total traffic | FILL IN | PostHog acquisition |
+
+## Notes
+
+Compare against April 2026 baseline: 462 unique visitors, 26% Facebook.

--- a/docs/social/email-digest-template.md
+++ b/docs/social/email-digest-template.md
@@ -1,0 +1,48 @@
+# Meeting Digest email template
+
+The digest worker (meeting-digest/worker/src/scheduled.js) builds the
+body from recent MHTV transcripts matched to each subscriber's
+boards and topics. This template covers the editorial shape that
+wraps those matches.
+
+## Structure
+
+1. Subject. One line, lead with the most concrete finding from the
+   week. "Select Board: Q1 FY27 spending is tracking 3% under budget"
+   not "Marblehead Data weekly digest". Subject is what gets opened.
+2. Lead finding (one short paragraph). The watchdog headline of the
+   week. Specific number or decision, not "things happened".
+3. Per-board sections (auto-generated). One sub-section per board
+   the subscriber follows, with transcript-matched bullets.
+4. Sidebar (optional, one item). Tool feature or civic literacy
+   piece. Two sentences. Link to the page.
+5. Footer (unchanged from existing worker output): unsubscribe,
+   manage preferences, source attribution.
+
+## Editorial rules
+
+- Lead finding has a number in it whenever possible.
+- Acronyms expanded on first use: "Annual Comprehensive Financial
+  Report (ACFR)" not "ACFR".
+- No editorial language. Say "the budget is X dollars over the FY26
+  baseline", not "the budget jumped to X" or "budget surges to X".
+- Source attribution inline. "From the FY27 adopted budget" or
+  "From the June 3 Select Board meeting".
+- Plain language, but full sentences. Email tolerates a longer
+  attention span than a Facebook post.
+
+## Summer mode
+
+July and August: send every other Monday, not weekly. Skip the
+intermediate Mondays. Human discretion: if there is nothing
+substantive to report that week, skip; if there is, send.
+
+There is no code-level summer toggle. The user decides per send.
+
+## When the lead finding is thin
+
+Late summer or holiday weeks may not have a watchdog lead. In that
+case, lead with a civic literacy piece or a tool feature, and label
+the email accordingly ("Marblehead Data: how free cash works" not
+"weekly digest"). Subscribers tolerate fewer "nothing happened this
+week" emails than they tolerate substantive non-watchdog ones.

--- a/docs/social/fb-post-template.md
+++ b/docs/social/fb-post-template.md
@@ -1,0 +1,59 @@
+# Facebook post template
+
+Plain text only. No markdown bold or italic (renders as literal
+asterisks). No em-dashes. No emojis unless integral to the data.
+
+## Structure
+
+1. Hook (1 to 2 sentences): the specific finding or question. Lead
+   with the number or the verb. No "this post is about" framing.
+2. Two to four lines: what the data shows, in plain language. Cite
+   the source inline ("from the FY27 adopted budget", "from the
+   May 18 Select Board meeting").
+3. One link to a specific page on marbleheaddata.org. Not the
+   homepage unless the post is intentionally a homepage push.
+4. Page tag at end: @MarbleheadData (only if posting from a personal
+   account in a group).
+
+## Screenshot
+
+Always attach one. Specs:
+
+- Source: a specific tool view on the site (Checkbook drill, Town
+  Explorer filter, a chart, a card from a longread).
+- Defaults: unfiltered view. Do not pre-sort or pre-filter to make
+  a point.
+- Format: PNG. Aspect ratio 16:9 or 4:3, not full-page strips.
+- Frame: navy #1B3A57 border, lighthouse mark top-left, URL bottom.
+  Canva template lives at [link to Canva when created].
+
+## Anti-patterns
+
+- "Check this out" with no lead finding.
+- Markdown bold (literal asterisks around a word) appearing as
+  asterisks in the rendered post.
+- Em-dashes (use periods or commas).
+- Editorial framing: "shocking", "concerning", "outrageous", etc.
+- Pre-filtered screenshots that load a conclusion.
+- More than one link per post.
+- Tagging "@MarbleheadData" on the page itself (only useful when
+  posting from a personal account into a group).
+
+## By post type
+
+### Watchdog
+
+Lead with the finding. "The Select Board voted 4-1 on Tuesday to
+spend X on Y." Link to the meeting page or the relevant tool.
+
+### Tool feature
+
+Lead with the question the tool answers. "Want to see which line
+items grew most between FY26 and FY27? The Checkbook drill now
+shows..." Screenshot is the tool itself.
+
+### Civic literacy
+
+Lead with the concept name and a one-line definition. "Free cash is
+the money the town has at end of year that was not spent. Here is
+how it gets used." Link to the page that explains it in full.

--- a/docs/social/tentpole-calendar.md
+++ b/docs/social/tentpole-calendar.md
@@ -1,0 +1,64 @@
+# Tentpole calendar, H2 2026
+
+Three date-anchored posts for the six-month H2 plan. Each is a
+short-notice draft so the live writing is not from scratch.
+
+## Jul 1, 2026 (Wed): "FY27 starts today"
+
+Channels: Facebook (Monday post on Jun 30 cannot mention this; do
+Tue Jun 30 evening FB queued for Wed Jul 1 7 AM, OR shift Thursday
+post to Wed Jul 1).
+
+Draft hook:
+"Today, July 1, is the first day of FY27. The override that passed
+last month adds $15M to the operating budget this year. We will be
+tracking where it lands, line item by line item, on the Checkbook.
+[Link to Checkbook FY27 view as soon as it exists, or to the
+budget-flow page in the meantime.]"
+
+Sub-mentions to include:
+- The trash question also passed; trash funding is now in its own
+  carve-out (link to the trash page).
+- First MOU quarterly review expected in Sep or Oct.
+
+Email send: tie the Jun 29 or Jun 30 Monday digest to this marker.
+Lead: "FY27 starts Wednesday. Here is what changes."
+
+## Sep 12, 2026 (Sat): Month 3 checkpoint
+
+Not a public post; an internal task.
+
+1. Re-run `node meeting-digest/tools/baseline-h2.mjs` and capture as
+   `docs/social/checkpoint-2026-09-12.md`.
+2. Fill in the three manual values.
+3. Compare against the four month-3 targets in `SOCIAL_MEDIA_PLAN.md`.
+4. Decide:
+   - If all four met: stay the course.
+   - If reach short: draft first op-ed for the Marblehead Current.
+   - If email growth short: queue a FB push for digest signup
+     (screenshot a recent digest, lead with the one finding people
+     would have learned by subscribing).
+5. Record the decision in `docs/social/checkpoint-2026-09-12.md`.
+
+## Dec 12, 2026 (Sat): Six-month roundup
+
+Public post and email.
+
+Draft hook:
+"Six months ago, Marblehead voted yes on a $15M override and a
+$2.3M trash carve-out. Here is what the data shows about the first
+six months of FY27 spending. [Link to a half-year spending breakdown
+page, or to the existing Checkbook with a fiscal-year filter set to
+H1 FY27.]"
+
+Components to assemble before the post:
+- H1 FY27 spending pull from the Checkbook (likely needs a
+  pre-loaded query or page).
+- Comparison against the override's promised spending mix (the four
+  Tier 3 line items: schools, public safety, DPW, facilities).
+- Any divergence: where the money landed differently than promised.
+- One civic literacy piece in the email sidebar: how the next
+  budget cycle starts in Jan.
+
+This is also the moment to re-evaluate cadence and channel mix for
+H1 2027.

--- a/docs/superpowers/plans/2026-06-12-social-media-plan-h2.md
+++ b/docs/superpowers/plans/2026-06-12-social-media-plan-h2.md
@@ -1,0 +1,613 @@
+# Social Media Plan H2 2026 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the post-vote H2 2026 social media plan: replace the pre-vote operational doc, build post templates, shift the existing meeting-digest cron from Friday to Monday, capture a baseline, and queue the three tentpole posts (Jul 1, Sep 12 checkpoint, Dec 12 roundup).
+
+**Architecture:** The plan is mostly documentation and one cron change. The committed operational doc replaces `SOCIAL_MEDIA_PLAN.md`. The digest cron in `meeting-digest/worker/wrangler.toml` shifts from Friday 7 AM ET to Monday 7 AM ET. Two templates (FB post, email digest structure) land as committed markdown so future drafts have an anchor. Baseline metrics get a one-shot capture script. The summer biweekly toggle is human discretion, not code.
+
+**Tech Stack:** Markdown (plan + templates), `meeting-digest/worker/wrangler.toml` (cron config), `meeting-digest/worker/src/scheduled.js` (comment update), Node script under `meeting-digest/tools/` for baseline metric capture.
+
+**Spec reference:** `docs/superpowers/specs/2026-06-12-social-media-plan-h2-design.md`
+
+---
+
+## File map
+
+- Modify: `SOCIAL_MEDIA_PLAN.md` (full rewrite, post-vote operational doc)
+- Create: `docs/social/fb-post-template.md` (Facebook post template + Canva guidance)
+- Create: `docs/social/email-digest-template.md` (Monday digest structure: lead + sub-items + sidebar)
+- Create: `docs/social/tentpole-calendar.md` (date-anchored posts: Jul 1, Sep 12, Dec 12, plus any first MOU quarterly review date once announced)
+- Modify: `meeting-digest/worker/wrangler.toml` (cron Fri to Mon)
+- Modify: `meeting-digest/worker/src/scheduled.js` (header comment to match Monday)
+- Modify: `meeting-digest/worker/test/scheduled.test.js` (if it pins Friday)
+- Create: `meeting-digest/tools/baseline-h2.mjs` (one-shot metric snapshot script)
+- Create: `docs/social/baseline-2026-06-12.md` (output of the baseline snapshot, hand-edited if needed)
+
+---
+
+## Task 1: Archive the pre-vote social plan and write the H2 operational doc
+
+The pre-vote `SOCIAL_MEDIA_PLAN.md` describes a campaign that ended June 9. Keep it in git history (no separate archive file) and replace the in-repo file with the H2 operational version.
+
+**Files:**
+- Modify: `SOCIAL_MEDIA_PLAN.md`
+
+- [ ] **Step 1: Replace `SOCIAL_MEDIA_PLAN.md` with the H2 version**
+
+Write the file with this structure (fill in real numbers where bracketed):
+
+```markdown
+# Social Media Plan
+
+Marblehead Data, post-vote operational plan.
+Six months: Jun 12 to Dec 12, 2026.
+Spec: docs/superpowers/specs/2026-06-12-social-media-plan-h2-design.md
+
+## Why this plan exists
+
+The pre-vote plan (April 24 to June 9, 2026) ended its mission when
+all four override ballot questions passed. This is the post-vote
+plan: watchdog spine, tools as discovery layer, civic literacy as
+durable fallback.
+
+## Channels and cadence
+
+- Facebook page "Marblehead Data": 2x/week, Mon and Thu mornings.
+- Meeting Digest email: weekly Monday during active season
+  (Sep through Jun), biweekly during summer (Jul to Aug).
+- Marblehead Current op-eds: held in reserve. Revisited mid-Sep.
+
+The Monday email and the Monday FB post anchor the same morning. The
+email goes to subscribers; the FB post highlights the email's lead
+finding and links to it / to the digest signup.
+
+## Three post types
+
+Pick what has substance that week. No fixed ratio.
+
+1. Watchdog. What the town did. Default for email and Monday FB.
+2. Tool feature. Screenshot plus a paragraph from one site tool.
+   Default for Thursday FB.
+3. Civic literacy. One durable concept. Fallback when the first two
+   are thin.
+
+## Templates
+
+- Facebook post: docs/social/fb-post-template.md
+- Email digest: docs/social/email-digest-template.md
+- Tentpole calendar: docs/social/tentpole-calendar.md
+
+## Tone rules
+
+Same as pre-vote: neutral, sourced, plain text, no markdown bold on
+Facebook, no em-dashes anywhere, no editorial language. Acronyms
+expanded on first use. Screenshots default to unfiltered views.
+
+## Baseline (Jun 12, 2026)
+
+See docs/social/baseline-2026-06-12.md for the starting metric snapshot.
+
+## Month 3 checkpoint (mid-September)
+
+Targets, measured against April 2026 baseline:
+
+- Email subscribers: at least 100 active.
+- Facebook page followers: at least 200.
+- Monthly site traffic: at or above April baseline (462 visitors).
+- Channel mix: email plus Facebook drive at least 40 percent of
+  traffic.
+
+If short on reach, add op-eds. If short on email growth, run a
+one-time FB push for digest signup.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add SOCIAL_MEDIA_PLAN.md
+git commit -m "Replace pre-vote social plan with H2 operational doc"
+```
+
+---
+
+## Task 2: Create the Facebook post template
+
+A reusable scaffold so each Monday or Thursday post has a known shape and the user does not redesign the post each week.
+
+**Files:**
+- Create: `docs/social/fb-post-template.md`
+
+- [ ] **Step 1: Write the template file**
+
+```markdown
+# Facebook post template
+
+Plain text only. No markdown bold or italic (renders as literal
+asterisks). No em-dashes. No emojis unless integral to the data.
+
+## Structure
+
+1. Hook (1 to 2 sentences): the specific finding or question. Lead
+   with the number or the verb. No "this post is about" framing.
+2. Two to four lines: what the data shows, in plain language. Cite
+   the source inline ("from the FY27 adopted budget", "from the
+   May 18 Select Board meeting").
+3. One link to a specific page on marbleheaddata.org. Not the
+   homepage unless the post is intentionally a homepage push.
+4. Page tag at end: @MarbleheadData (only if posting from a personal
+   account in a group).
+
+## Screenshot
+
+Always attach one. Specs:
+
+- Source: a specific tool view on the site (Checkbook drill, Town
+  Explorer filter, a chart, a card from a longread).
+- Defaults: unfiltered view. Do not pre-sort or pre-filter to make
+  a point.
+- Format: PNG. Aspect ratio 16:9 or 4:3, not full-page strips.
+- Frame: navy #1B3A57 border, lighthouse mark top-left, URL bottom.
+  Canva template lives at [link to Canva when created].
+
+## Anti-patterns
+
+- "Check this out" with no lead finding.
+- Markdown bold (\*\*word\*\*) appearing as literal asterisks.
+- Em-dashes (use periods or commas).
+- Editorial framing: "shocking", "concerning", "outrageous", etc.
+- Pre-filtered screenshots that load a conclusion.
+- More than one link per post.
+- Tagging "@MarbleheadData" on the page itself (only useful when
+  posting from a personal account into a group).
+
+## By post type
+
+Watchdog: lead with the finding. "The Select Board voted 4-1 on
+Tuesday to spend X on Y." Link to the meeting page or the relevant
+tool.
+
+Tool feature: lead with the question the tool answers. "Want to see
+which line items grew most between FY26 and FY27? The Checkbook
+drill now shows..." Screenshot is the tool itself.
+
+Civic literacy: lead with the concept name and a one-line definition.
+"Free cash is the money the town has at end of year that was not
+spent. Here is how it gets used." Link to the page that explains it
+in full.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/social/fb-post-template.md
+git commit -m "Add Facebook post template for H2 social plan"
+```
+
+---
+
+## Task 3: Create the email digest template
+
+The existing meeting-digest worker renders subject and body from
+recent transcripts. The template below describes the editorial shape
+for the human-curated lead and sidebar that wrap the auto-generated
+transcript matches.
+
+**Files:**
+- Create: `docs/social/email-digest-template.md`
+
+- [ ] **Step 1: Write the template file**
+
+```markdown
+# Meeting Digest email template
+
+The digest worker (meeting-digest/worker/src/scheduled.js) builds the
+body from recent MHTV transcripts matched to each subscriber's
+boards and topics. This template covers the editorial shape that
+wraps those matches.
+
+## Structure
+
+1. Subject. One line, lead with the most concrete finding from the
+   week. "Select Board: Q1 FY27 spending is tracking 3% under budget"
+   not "Marblehead Data weekly digest". Subject is what gets opened.
+2. Lead finding (one short paragraph). The watchdog headline of the
+   week. Specific number or decision, not "things happened".
+3. Per-board sections (auto-generated). One sub-section per board
+   the subscriber follows, with transcript-matched bullets.
+4. Sidebar (optional, one item). Tool feature or civic literacy
+   piece. Two sentences. Link to the page.
+5. Footer (unchanged from existing worker output): unsubscribe,
+   manage preferences, source attribution.
+
+## Editorial rules
+
+- Lead finding has a number in it whenever possible.
+- Acronyms expanded on first use: "Annual Comprehensive Financial
+  Report (ACFR)" not "ACFR".
+- No editorial language. Say "the budget is X dollars over the FY26
+  baseline", not "the budget jumped to X" or "budget surges to X".
+- Source attribution inline. "From the FY27 adopted budget" or
+  "From the June 3 Select Board meeting".
+- Plain language, but full sentences. Email tolerates a longer
+  attention span than a Facebook post.
+
+## Summer mode
+
+July and August: send every other Monday, not weekly. Skip the
+intermediate Mondays. Human discretion: if there is nothing
+substantive to report that week, skip; if there is, send.
+
+There is no code-level summer toggle. The user decides per send.
+
+## When the lead finding is thin
+
+Late summer or holiday weeks may not have a watchdog lead. In that
+case, lead with a civic literacy piece or a tool feature, and label
+the email accordingly ("Marblehead Data: how free cash works" not
+"weekly digest"). Subscribers tolerate fewer "nothing happened
+this week" emails than they tolerate substantive non-watchdog ones.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/social/email-digest-template.md
+git commit -m "Add email digest editorial template"
+```
+
+---
+
+## Task 4: Move the digest cron from Friday to Monday
+
+The existing cron fires Friday 7 AM ET. The H2 plan anchors on
+Monday. Update the wrangler config and the comments.
+
+**Files:**
+- Modify: `meeting-digest/worker/wrangler.toml`
+- Modify: `meeting-digest/worker/src/scheduled.js` (header comment only)
+
+- [ ] **Step 1: Update wrangler.toml cron**
+
+Replace the existing cron block:
+
+```toml
+# Friday 7:00 AM ET == 11:00 UTC (EST) / 12:00 UTC (EDT).
+# Run at 11:00 and 12:00; the scheduled handler chooses one based on the
+# current ET hour, the other becomes a no-op. Keeps DST handling simple.
+[triggers]
+crons = ["0 11 * * 5", "0 12 * * 5"]
+```
+
+with:
+
+```toml
+# Monday 7:00 AM ET == 11:00 UTC (EST) / 12:00 UTC (EDT).
+# Run at 11:00 and 12:00; the scheduled handler chooses one based on the
+# current ET hour, the other becomes a no-op. Keeps DST handling simple.
+[triggers]
+crons = ["0 11 * * 1", "0 12 * * 1"]
+```
+
+- [ ] **Step 2: Update the comment header in scheduled.js**
+
+Open `meeting-digest/worker/src/scheduled.js` and locate the comment that says:
+
+```
+// Only run on the cron hour that corresponds to 7 AM ET.
+// EST (Nov–Mar): UTC = ET + 5  ⇒  11 UTC == 6 AM ET, 12 UTC == 7 AM ET
+// EDT (Mar–Nov): UTC = ET + 4  ⇒  11 UTC == 7 AM ET, 12 UTC == 8 AM ET
+// We schedule both 11 and 12 UTC, and run when the ET hour equals 7.
+```
+
+No change required to the function logic itself (it still runs when the ET hour equals 7, regardless of day). Update the file's top-level docstring (if any) to refer to "Monday" rather than "Friday" if it currently does. Search for any "Friday" mention in the file and update.
+
+- [ ] **Step 3: Check for any test that pins Friday**
+
+```bash
+grep -rE "(friday|Friday|day.*5)" meeting-digest/worker/test/ meeting-digest/worker/src/
+```
+
+If any test asserts the run-day is Friday, update it to Monday.
+
+- [ ] **Step 4: Run the worker test suite**
+
+```bash
+cd meeting-digest/worker
+npm test
+```
+
+Expected: PASS for all tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add meeting-digest/worker/wrangler.toml meeting-digest/worker/src/scheduled.js
+# include any updated tests
+git commit -m "Shift digest cron from Friday to Monday for H2 social plan"
+```
+
+- [ ] **Step 6: Deploy the worker (not automated)**
+
+The cron change does not take effect until the worker is deployed.
+Note in the commit message or PR body that a manual deploy is
+required:
+
+```
+cd meeting-digest/worker
+npx wrangler deploy
+```
+
+Do not deploy from the agent. The user will deploy when they review
+the PR.
+
+---
+
+## Task 5: Build the baseline-metric snapshot script
+
+A one-shot script that pulls current values for the four month-3
+checkpoint metrics, so we have a Jun 12 baseline to compare to in
+mid-September.
+
+**Files:**
+- Create: `meeting-digest/tools/baseline-h2.mjs`
+- Create: `docs/social/baseline-2026-06-12.md`
+
+- [ ] **Step 1: Write `meeting-digest/tools/baseline-h2.mjs`**
+
+```javascript
+#!/usr/bin/env node
+// Pulls a one-shot snapshot of the four month-3 checkpoint metrics
+// and prints them to stdout in markdown. Intended to be run once on
+// Jun 12, 2026 and once on Sep 12, 2026 (and again on Dec 12, 2026).
+//
+// Outputs:
+//   - Email subscribers count (from the meeting-digest D1 database)
+//   - Facebook page follower count (NOT automated, prompts user to
+//     fill in manually)
+//   - Monthly site traffic (NOT automated, prompts user to read off
+//     PostHog dashboard manually)
+//   - Channel mix percentage (NOT automated, prompts manually)
+//
+// Why partial automation: only the D1 subscriber count is reachable
+// without OAuth scaffolding we do not have. Everything else is a
+// two-minute human pull from PostHog and the FB page admin view.
+
+import { execSync } from 'node:child_process';
+
+function pullSubscriberCount() {
+  // wrangler d1 execute against the meeting-digest DB. Requires the
+  // user to be logged into wrangler.
+  const cmd = `cd meeting-digest/worker && npx wrangler d1 execute meeting-digest --command "SELECT COUNT(*) as n FROM subscriber WHERE status = 'confirmed'" --json`;
+  try {
+    const out = execSync(cmd, { encoding: 'utf8' });
+    const parsed = JSON.parse(out);
+    return parsed?.[0]?.results?.[0]?.n ?? 'unknown';
+  } catch (e) {
+    return `error: ${e.message}`;
+  }
+}
+
+const today = new Date().toISOString().slice(0, 10);
+const subs = pullSubscriberCount();
+
+const out = `# Baseline snapshot ${today}
+
+Run via: \`node meeting-digest/tools/baseline-h2.mjs\`
+
+| Metric | Value | Source |
+|---|---|---|
+| Email subscribers (confirmed) | ${subs} | D1 query, automated |
+| Facebook page followers | FILL IN | FB page admin > Insights > Followers |
+| Monthly site traffic (last 30 days unique visitors) | FILL IN | PostHog dashboard |
+| Channel mix: FB + email as % of total traffic | FILL IN | PostHog acquisition |
+
+## Notes
+
+Compare against April 2026 baseline: 462 unique visitors, 26% Facebook.
+Hand-edit this file with the manual numbers, then commit.
+`;
+
+console.log(out);
+```
+
+- [ ] **Step 2: Make the script executable**
+
+```bash
+chmod +x meeting-digest/tools/baseline-h2.mjs
+```
+
+- [ ] **Step 3: Run it and capture output**
+
+```bash
+node meeting-digest/tools/baseline-h2.mjs > docs/social/baseline-2026-06-12.md
+```
+
+Expected: The subscriber count is populated. The other three fields say "FILL IN".
+
+- [ ] **Step 4: Fill in the three manual values**
+
+Open `docs/social/baseline-2026-06-12.md` in an editor. Replace
+each "FILL IN" with the actual current number from PostHog and the
+FB admin view.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add meeting-digest/tools/baseline-h2.mjs docs/social/baseline-2026-06-12.md
+git commit -m "Capture Jun 12 baseline metrics for H2 social plan"
+```
+
+---
+
+## Task 6: Write the tentpole calendar
+
+Three date-anchored posts the user should not forget. Each has a draft
+hook so the live writing is not from scratch.
+
+**Files:**
+- Create: `docs/social/tentpole-calendar.md`
+
+- [ ] **Step 1: Write the file**
+
+```markdown
+# Tentpole calendar, H2 2026
+
+Three date-anchored posts for the six-month H2 plan. Each is a
+short-notice draft so the live writing is not from scratch.
+
+## Jul 1, 2026 (Wed): "FY27 starts today"
+
+Channels: Facebook (Monday post on Jun 30 cannot mention this; do
+Tue Jun 30 evening FB queued for Wed Jul 1 7 AM, OR shift Thursday
+post to Wed Jul 1).
+
+Draft hook:
+"Today, July 1, is the first day of FY27. The override that passed
+last month adds $15M to the operating budget this year. We will be
+tracking where it lands, line item by line item, on the Checkbook.
+[Link to Checkbook FY27 view as soon as it exists, or to the
+budget-flow page in the meantime.]"
+
+Sub-mentions to include:
+- The trash question also passed; trash funding is now in its own
+  carve-out (link to the trash page).
+- First MOU quarterly review expected in Sep or Oct.
+
+Email send: tie the Jun 29 or Jun 30 Monday digest to this marker.
+Lead: "FY27 starts Wednesday. Here is what changes."
+
+## Sep 12, 2026 (Sat): Month 3 checkpoint
+
+Not a public post; an internal task.
+
+1. Re-run `node meeting-digest/tools/baseline-h2.mjs` and capture as
+   `docs/social/checkpoint-2026-09-12.md`.
+2. Fill in the three manual values.
+3. Compare against the four month-3 targets in `SOCIAL_MEDIA_PLAN.md`.
+4. Decide:
+   - If all four met: stay the course.
+   - If reach short: draft first op-ed for the Marblehead Current.
+   - If email growth short: queue a FB push for digest signup
+     (screenshot a recent digest, lead with the one finding people
+     would have learned by subscribing).
+5. Record the decision in `docs/social/checkpoint-2026-09-12.md`.
+
+## Dec 12, 2026 (Sat): Six-month roundup
+
+Public post and email.
+
+Draft hook:
+"Six months ago, Marblehead voted yes on a $15M override and a
+$2.3M trash carve-out. Here is what the data shows about the first
+six months of FY27 spending. [Link to a half-year spending breakdown
+page, or to the existing Checkbook with a fiscal-year filter set to
+H1 FY27.]"
+
+Components to assemble before the post:
+- H1 FY27 spending pull from the Checkbook (likely needs a
+  pre-loaded query or page).
+- Comparison against the override's promised spending mix (the four
+  Tier 3 line items: schools, public safety, DPW, facilities).
+- Any divergence: where the money landed differently than promised.
+- One civic literacy piece in the email sidebar: how the next
+  budget cycle starts in Jan.
+
+This is also the moment to re-evaluate cadence and channel mix for
+H1 2027.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/social/tentpole-calendar.md
+git commit -m "Add tentpole calendar for H2 social plan (Jul 1, Sep 12, Dec 12)"
+```
+
+---
+
+## Task 7: Open a pull request
+
+Per the project's "always open a PR after pushing" rule (CLAUDE.md).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin social-plan-h2
+```
+
+- [ ] **Step 2: Open the PR**
+
+Use `gh pr create` (works fine from inside the worktree). Title:
+
+"Social media plan H2 2026: post-vote operational setup"
+
+Body sections (paste preview URL when CI populates it):
+
+```markdown
+## Summary
+
+Stands up the post-vote H2 social media plan. Two channels (Facebook
+2x/week Mon/Thu, email digest weekly Mon). Op-eds in the Marblehead
+Current held in reserve, revisited mid-September.
+
+- Replaces pre-vote `SOCIAL_MEDIA_PLAN.md` with H2 operational doc
+- Adds FB post template and email digest editorial template
+- Shifts meeting-digest cron from Friday to Monday (requires manual
+  worker deploy after merge)
+- Captures Jun 12 baseline metrics (subscribers automated, traffic
+  and FB followers hand-filled)
+- Adds tentpole calendar with three date-anchored posts (Jul 1 FY27
+  start, Sep 12 month-3 checkpoint, Dec 12 six-month roundup)
+
+## Preview URL
+
+[fill in once Cloudflare preview deploys]
+
+## Test plan
+
+- [ ] Read `SOCIAL_MEDIA_PLAN.md` in the preview, verify the H2
+      content renders.
+- [ ] Read `docs/social/fb-post-template.md` in the preview.
+- [ ] Read `docs/social/email-digest-template.md` in the preview.
+- [ ] Read `docs/social/baseline-2026-06-12.md` and confirm the
+      three hand-filled values are populated.
+- [ ] Read `docs/social/tentpole-calendar.md` and confirm the three
+      drafts read as usable.
+
+## Post-merge
+
+- [ ] Deploy meeting-digest worker:
+      `cd meeting-digest/worker && npx wrangler deploy`
+- [ ] Verify next Monday's digest fires (Jun 15 if merged before
+      then; otherwise the next Monday after deploy).
+```
+
+---
+
+## Self-review checklist
+
+Run before declaring done.
+
+1. **Spec coverage:** Every spec section maps to a task.
+   - Strategic anchor: Task 1 (the in-repo plan doc).
+   - Channels: Task 1 plus Task 4 (cron) plus Task 7 (PR description).
+   - Cadence: Task 4 (Monday cron); summer biweekly is human
+     discretion per Task 3 template.
+   - Three post types: Task 1 plus Task 2 (FB) plus Task 3 (email).
+   - Tone: Task 1, Task 2, Task 3.
+   - Tentpole calendar: Task 6.
+   - Success metric at month 3: Task 5 (baseline) plus Task 6 (Sep
+     12 checkpoint task in the tentpole calendar).
+   - What this plan does not do / out of scope: covered by absence
+     of tasks; no Instagram, no Substack, etc.
+
+2. **Placeholder scan:** the only "fill in" markers are deliberate
+   (manual metric pulls, preview URL).
+
+3. **Type consistency:** the script in Task 5 names match between
+   creation, executable bit, and run commands.
+
+4. **File-path consistency:** `docs/social/` is used consistently
+   across Tasks 2, 3, 5, 6, 7. Template files are referenced from
+   `SOCIAL_MEDIA_PLAN.md` in Task 1 by the same paths.

--- a/docs/superpowers/specs/2026-06-12-social-media-plan-h2-design.md
+++ b/docs/superpowers/specs/2026-06-12-social-media-plan-h2-design.md
@@ -1,0 +1,187 @@
+# Social media plan, H2 2026 (Jun 12 to Dec 12)
+
+The pre-vote 7-week plan (`SOCIAL_MEDIA_PLAN.md`, April 2026) ended its
+mission on June 9, 2026 when all four override ballot questions passed.
+This is the next six months: post-vote, off-cycle, with new tools and
+new infrastructure available.
+
+## Context at start of plan
+
+- Override passed at the highest tier (`$15M` "Invest", plus the trash
+  question). FY27 starts July 1, 2026.
+- Site has been rewritten in post-vote tense across charts and prose.
+- New infrastructure since the April plan: Checkbook (FY26 transaction
+  explorer), Town History (4-chapter feature), Town Debt page, Town
+  Explorer projections, in-progress Finance Story scrollytelling, Data
+  Lab (browser-side SQL over a bundled SQLite database), and the
+  Meeting Digest email subscription system (Worker + Pages, with daily
+  auto-ingest of MHTV transcripts and a sample-digest preview tool).
+- April 2026 PostHog baseline: 462 unique visitors, 3,432 pageviews,
+  bounce 20.8%, avg session 9m49s, 26% of traffic from Facebook,
+  Monday peak.
+- Facebook page "Marblehead Data" has been live since April 24.
+
+## Strategic anchor
+
+Hybrid. Watchdog is the spine; tool features and civic literacy fill
+in around it.
+
+- Watchdog: did the town spend the `$15M` the way it said it would,
+  and how do residents see that for themselves.
+- Tool features: surface the new tools (Checkbook, Town History, Town
+  Debt, Town Explorer, Data Lab, Finance Story) to off-cycle visitors
+  who never saw the override-era content.
+- Civic literacy: durable explainers (how Prop 2.5 works, what free
+  cash measures, how the MOU's stabilization target works) that pay
+  off whenever the next budget moment comes.
+
+## Channels
+
+Two channels are in play. A third is held in reserve.
+
+1. **Facebook page "Marblehead Data".** Discovery layer.
+2. **Meeting Digest email.** Watchdog spine, sent to subscribers.
+3. **Marblehead Current op-eds (held in reserve).** Not in use at
+   start of plan. Revisited at month 3 (mid-September) based on the
+   success metric below. If used, the lane is factual /
+   accountability op-eds only, signed as "Andrew Baber, who runs
+   marbleheaddata.org." Opinion op-eds are out of scope: they would
+   cost the site's neutrality asset and that asset does not grow back.
+
+Instagram, WhatsApp, Substack, and paid ads remain out of scope, same
+as in the April plan.
+
+## Cadence
+
+| Channel | Active season (Sep to Jun) | Summer (Jul to Aug) |
+|---|---|---|
+| Facebook | 2x/week, Monday and Thursday mornings | 2x/week, Monday and Thursday mornings |
+| Email digest | Weekly, Monday morning | Biweekly, Monday morning |
+
+Monday is the peak traffic day per the April PostHog baseline, which
+is why both channels anchor there. The Monday email goes out to
+subscribers; the Monday Facebook post highlights the email's lead
+finding and links to it (and the digest signup) for non-subscribers.
+They reinforce. They do not compete.
+
+The Thursday FB slot is the discovery slot: a tool feature when news
+is thin, a watchdog follow-up when there is more to say from Monday.
+
+## Three post types
+
+No fixed ratio. Pick whichever has substance that week.
+
+1. **Watchdog.** What the town actually did. Meetings, spending
+   decisions, audit findings, FY27 implementation milestones,
+   quarterly review results. Default for the email; default for
+   Monday Facebook.
+2. **Tool feature.** One screenshot plus one paragraph, drawn from a
+   site tool: Checkbook, Town Explorer, Town History, Town Debt, Data
+   Lab, Finance Story. Default for Thursday Facebook.
+3. **Civic literacy.** One durable concept explained: how Prop 2.5
+   works, what free cash measures, how the MOU's 5% stabilization
+   target is calculated, how a quarterly review is supposed to work,
+   how the FY28 budget gets built. Fallback when watchdog and tool
+   feature are both thin.
+
+## Tone
+
+Same neutrality rules as the April plan. The override passed; the
+firewall stays.
+
+- No editorial language, no loaded adjectives, no "shocking",
+  "crisis", "skyrocketing", "outrageous".
+- State what the data shows. Do not characterize it as "good news",
+  "bad news", "concerning", or as "confirming" anything.
+- Concede where opponents to the override were right (and where
+  supporters were wrong) when relevant. The site's role is informed
+  citizen, not advocate.
+- Plain text on Facebook (no markdown bold or italics, no
+  emoji-driven structure). Em-dashes stay out of all copy.
+- Acronyms expanded on first use, or replaced ("independent annual
+  audit" not "ACFR", "full-time positions" not "FTE", "state pension
+  regulator" not "PERAC").
+- Screenshots default to unfiltered views. No pre-sorted conclusions.
+
+## Tentpole calendar
+
+Known anchors over the six months. Each becomes a natural week of
+programming.
+
+| Window | Anchor | Lead lane |
+|---|---|---|
+| Jun 12 to Jun 30 | Post-vote wrap, "what passed" framing, FY26 closeout | Watchdog |
+| Jul 1 | FY27 begins, the `$15M` starts flowing (one-off marker post) | Watchdog |
+| Jul to Aug | Summer recess, no meetings. Biweekly email mode | Tool feature plus civic literacy |
+| Early Sep | School year resumes, SB and SC ramp back up | Watchdog returns |
+| Sep to Oct | First MOU quarterly review (5% stabilization target check) | Watchdog |
+| Oct to Nov | FY26 audit lands, FY28 budget development opens at FinCom | Watchdog plus civic literacy ("how a budget gets built") |
+| Nov to Dec | Possible fall or special Town Meeting, mid-year FY27 spending data | Watchdog |
+| Mid-Dec | Six-month checkpoint, "Where did the override money actually go in H1" | Watchdog roundup across Facebook plus email |
+
+Calendar is a starting frame. If the town shifts dates, the lane
+mapping shifts with it. The cadence (2x/week FB, weekly or biweekly
+email) does not change with town calendar shifts.
+
+## Success metric at month 3 (mid-September)
+
+Measured against the April 2026 PostHog baseline (462 unique visitors,
+3,432 pageviews, 26% from Facebook).
+
+- **Email subscribers:** at least 100 active. (Fill in the actual
+  current count when this plan starts.)
+- **Facebook page followers:** at least 200.
+- **Monthly site traffic:** at or above the April baseline. Ideally
+  up 25 to 50 percent as off-cycle audience compounds.
+- **Channel mix:** email plus Facebook combined drive at least 40
+  percent of traffic, versus 26 percent Facebook-only in April.
+
+If all four are met at month 3, continue through December.
+
+If short on traffic / discovery, add op-eds in the Marblehead Current
+(the channel held in reserve), starting with one factual /
+accountability piece tied to the next data moment.
+
+If short on email growth specifically, run a one-time Facebook push
+for digest signup, with a screenshot of a recent sample digest.
+
+## What this plan does not do
+
+YAGNI checks against the April plan and the hybrid-strategy
+conversation:
+
+- No content-mix percentages. The 60/20/20 or 40/30/30 schemes are
+  fake precision when post selection is driven by what is actually
+  substantive that week.
+- No prescribed monthly themes. The tentpoles above are real anchors,
+  not invented ones, and the lane mapping is a suggestion, not a
+  contract.
+- No Instagram, WhatsApp, Substack, paid ads, or new platforms.
+- No email collection forms or signup widgets on the site beyond what
+  already exists (the meetings page CTA and nav link, re-exposed in
+  PR #840).
+- No revisiting the "should we add a Facebook link on the site" debate
+  until the page is above 200 followers (currently the new threshold
+  for this plan, up from the 50-follower threshold in the April plan).
+
+## Out of scope, may be added later
+
+- Cross-posting to a town-relevant subreddit (no such community at
+  sufficient scale today).
+- A YouTube or short-form video channel built from MHTV clip content.
+  The transcripts pipeline gives raw material, but the editing
+  workflow does not exist and is outside the six-month horizon.
+- Outreach to peer-town civic data sites (Swampscott, Melrose,
+  Hingham). Useful eventually for shared audience, but not a Q3 / Q4
+  task.
+
+## Open questions to revisit at month 3
+
+- Are op-eds in the Current called for?
+- Has any tool reached "viral within Marblehead" status that warrants
+  a dedicated cross-promotion push?
+- Has any FY27 spending decision diverged enough from the override
+  promises to warrant a standalone deep-dive post rather than a
+  digest-line mention?
+- Are weekly emails sustaining quality, or is biweekly a better
+  steady-state cadence (decoupled from summer)?

--- a/meeting-digest/DEPLOY.md
+++ b/meeting-digest/DEPLOY.md
@@ -137,11 +137,11 @@ Worker URL (instead of staging), commit, push, merge the PR.
 In the Resend dashboard → Webhooks: add the production Worker's
 `/api/mail-event` endpoint. Subscribe to `email.bounced` and
 `email.complained` events. This drives the subscriber-status updates on
-bounce/spam complaint so the Friday cron stops sending to bad addresses.
+bounce/spam complaint so the Monday cron stops sending to bad addresses.
 
-### 10. Trigger the first Friday digest manually
+### 10. Trigger the first Monday digest manually
 
-To test the cron without waiting for Friday morning, use the Cloudflare
+To test the cron without waiting for Monday morning, use the Cloudflare
 dashboard → Workers & Pages → marblehead-meeting-digest → Triggers →
 "Send Test" on the scheduled trigger.
 

--- a/meeting-digest/tools/baseline-h2.mjs
+++ b/meeting-digest/tools/baseline-h2.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// Pulls a one-shot snapshot of the four month-3 checkpoint metrics
+// and prints them to stdout in markdown. Intended to be run once on
+// Jun 12, 2026 and again on Sep 12, 2026 and Dec 12, 2026.
+//
+// Outputs:
+//   - Email subscribers count (from the meeting-digest D1 database)
+//   - Facebook page follower count (NOT automated, prompts user to
+//     fill in manually)
+//   - Monthly site traffic (NOT automated, prompts user to read off
+//     PostHog dashboard manually)
+//   - Channel mix percentage (NOT automated, prompts manually)
+//
+// Why partial automation: only the D1 subscriber count is reachable
+// without OAuth scaffolding we do not have. Everything else is a
+// two-minute human pull from PostHog and the FB page admin view.
+
+import { execSync } from 'node:child_process';
+
+function pullSubscriberCount() {
+  // wrangler d1 execute against the meeting-digest DB. Requires the
+  // user to be logged into wrangler.
+  const cmd = `cd meeting-digest/worker && npx wrangler d1 execute meeting-digest --command "SELECT COUNT(*) as n FROM subscriber WHERE status = 'confirmed'" --json`;
+  try {
+    const out = execSync(cmd, { encoding: 'utf8' });
+    const parsed = JSON.parse(out);
+    return parsed?.[0]?.results?.[0]?.n ?? 'unknown';
+  } catch (e) {
+    return `error: ${e.message}`;
+  }
+}
+
+const today = new Date().toISOString().slice(0, 10);
+const subs = pullSubscriberCount();
+
+const out = `# Baseline snapshot ${today}
+
+Run via: \`node meeting-digest/tools/baseline-h2.mjs\`
+
+| Metric | Value | Source |
+|---|---|---|
+| Email subscribers (confirmed) | ${subs} | D1 query, automated |
+| Facebook page followers | FILL IN | FB page admin > Insights > Followers |
+| Monthly site traffic (last 30 days unique visitors) | FILL IN | PostHog dashboard |
+| Channel mix: FB + email as % of total traffic | FILL IN | PostHog acquisition |
+
+## Notes
+
+Compare against April 2026 baseline: 462 unique visitors, 26% Facebook.
+Hand-edit this file with the manual numbers, then commit.
+`;
+
+console.log(out);

--- a/meeting-digest/tools/send-sample-digest.mjs
+++ b/meeting-digest/tools/send-sample-digest.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// Send a sample Friday digest to a single email, using real transcripts from
+// Send a sample Monday digest to a single email, using real transcripts from
 // _transcripts/. Bypasses D1, the 7-AM-ET guard, and the 7-day window so you
-// can preview what subscribers will receive without waiting for a real Friday.
+// can preview what subscribers will receive without waiting for a real Monday.
 //
 // Usage (from repo root):
 //   RESEND_API_KEY=re_... node meeting-digest/tools/send-sample-digest.mjs you@example.com

--- a/meeting-digest/tools/subscribe-stats.sh
+++ b/meeting-digest/tools/subscribe-stats.sh
@@ -38,7 +38,7 @@ run "Pending-confirmation older than 24h" \
    WHERE status='pending_confirmation'
      AND created_at < strftime('%s','now','-1 day');"
 
-run "Friday digest sends (last 8 weeks)" \
+run "Monday digest sends (last 8 weeks)" \
   "SELECT date(sent_at,'unixepoch') AS day,
           COUNT(*) AS sends,
           SUM(n_meetings) AS total_meetings,

--- a/meeting-digest/worker/src/lib/auth-emails.js
+++ b/meeting-digest/worker/src/lib/auth-emails.js
@@ -31,7 +31,7 @@ export function renderConfirmEmailHtml(env, token) {
   const url = `${env.SITE_BASE_URL}/subscribe/confirm/?token=${encodeURIComponent(token)}`;
   return emailShell({ body: `
   <h1 style="margin: 0 0 14px; font-size: 22px; font-weight: 600; color: #1a1a1a;">Confirm your subscription</h1>
-  <p style="margin: 0 0 18px;">You'll get a short summary of meetings of the Select Board, School Committee, and Finance Committee each Friday morning. You can add Board of Health and Town Meeting after you confirm.</p>
+  <p style="margin: 0 0 18px;">You'll get a short summary of meetings of the Select Board, School Committee, and Finance Committee each Monday morning. You can add Board of Health and Town Meeting after you confirm.</p>
   <p style="margin: 0 0 28px;">${button(url, 'Confirm subscription')}</p>
   <p class="mhd-muted" style="margin: 0 0 4px; font-size: 13px; color: #6c757d;">This link expires in 24 hours.</p>
   <p class="mhd-muted" style="margin: 0; font-size: 13px; color: #6c757d;">If this wasn't you, ignore this email. Nothing happens until you click.</p>
@@ -44,7 +44,7 @@ export function renderConfirmEmailText(env, token) {
 Confirm your subscription
 
 You'll get a short summary of meetings of the Select Board, School
-Committee, and Finance Committee each Friday morning. You can add
+Committee, and Finance Committee each Monday morning. You can add
 Board of Health and Town Meeting after you confirm.
 
 Confirm: ${url}

--- a/meeting-digest/worker/wrangler.toml
+++ b/meeting-digest/worker/wrangler.toml
@@ -20,11 +20,11 @@ TURNSTILE_TEST_BYPASS_TOKEN = "TEST-OK"
 # do NOT declare it as a var here, or `wrangler deploy` will overwrite the
 # secret with the placeholder string and the Worker will 401 on every send.
 
-# Friday 7:00 AM ET == 11:00 UTC (EST) / 12:00 UTC (EDT).
+# Monday 7:00 AM ET == 11:00 UTC (EST) / 12:00 UTC (EDT).
 # Run at 11:00 and 12:00; the scheduled handler chooses one based on the
 # current ET hour, the other becomes a no-op. Keeps DST handling simple.
 [triggers]
-crons = ["0 11 * * 5", "0 12 * * 5"]
+crons = ["0 11 * * 1", "0 12 * * 1"]
 
 [env.staging]
 name = "marblehead-meeting-digest-staging"


### PR DESCRIPTION
## Summary

Stands up the post-vote H2 2026 social media plan. Two channels (Facebook 2x/week Mon/Thu, email digest weekly Mon during active season, biweekly during summer). Op-eds in the Marblehead Current held in reserve, revisited at the mid-September month-3 checkpoint.

- Replaces pre-vote `SOCIAL_MEDIA_PLAN.md` with the H2 operational doc
- Adds FB post template and email digest editorial template under `docs/social/`
- Shifts meeting-digest cron from Friday to Monday (and updates the subscriber confirmation email + DEPLOY.md + dev tools to match)
- Adds `meeting-digest/tools/baseline-h2.mjs` to capture Jun 12 baseline subscriber count, with a `docs/social/baseline-2026-06-12.md` placeholder for the user to populate
- Adds `docs/social/tentpole-calendar.md` with three date-anchored posts (Jul 1 FY27 start, Sep 12 month-3 checkpoint, Dec 12 six-month roundup)

Spec: `docs/superpowers/specs/2026-06-12-social-media-plan-h2-design.md`
Plan: `docs/superpowers/plans/2026-06-12-social-media-plan-h2.md`

## Preview URL

These changes are all internal repo docs and worker config; the Jekyll build excludes `docs/` and `SOCIAL_MEDIA_PLAN.md`, so there is nothing to preview on the site. Review the files via GitHub diff or by checking out the branch locally.

## Test plan

- [ ] Read `SOCIAL_MEDIA_PLAN.md` on GitHub, verify it's the H2 version (not the pre-vote one)
- [ ] Read `docs/social/fb-post-template.md` and confirm tone matches the existing pre-vote social style
- [ ] Read `docs/social/email-digest-template.md` and confirm summer-mode guidance is workable
- [ ] Read `docs/social/tentpole-calendar.md` and confirm the three drafts are usable starting points
- [ ] Confirm `meeting-digest/worker/wrangler.toml` cron is `["0 11 * * 1", "0 12 * * 1"]` (Monday)
- [ ] Confirm `meeting-digest/worker/src/lib/auth-emails.js` says "each Monday morning" in both the HTML and text confirm-email bodies
- [ ] Run `node meeting-digest/tools/baseline-h2.mjs` from the repo root (with wrangler authenticated) and verify it prints the subscriber count
- [ ] Hand-fill the three manual values in `docs/social/baseline-2026-06-12.md` (FB followers, monthly traffic, channel mix), then commit before merging

## Post-merge

- [ ] Deploy meeting-digest worker: `cd meeting-digest/worker && npx wrangler deploy`
- [ ] Verify next Monday's digest fires (the next Monday after deploy, at 7 AM ET)

🤖 Generated with [Claude Code](https://claude.com/claude-code)