### PR TITLE
digest: observability + idempotent retry crons

### DIFF
--- a/meeting-digest/tests/worker.test.js
+++ b/meeting-digest/tests/worker.test.js
@@ -258,4 +258,53 @@ describe('runScheduled', () => {
     const log = await env.DB.prepare('SELECT count(*) AS n FROM delivery_log').first();
     expect(log.n).toBe(0);
   });
+
+  it('skips subscribers whose last_sent_at is within the idempotency window', async () => {
+    const row = await confirmedSubscriber('recent@example.com', { boards: ['select-board'], topics: [] });
+    // Mark as just-sent (1 hour ago) — well inside the 5-day window. The
+    // eligible-subscriber query should filter this row out before the
+    // handler ever reaches the GitHub transcript fetch.
+    const oneHourAgoMs = Date.now() - 60 * 60 * 1000;
+    await env.DB.prepare('UPDATE subscriber SET last_sent_at = ? WHERE id = ?').bind(oneHourAgoMs, row.id).run();
+    const out = await runScheduled({}, env, { skipTimeGuard: true });
+    expect(out.ran).toBe(true);
+    expect(out.sent).toBe(0);
+    expect(out.transcripts).toBe(0);
+    const log = await env.DB.prepare('SELECT count(*) AS n FROM delivery_log').first();
+    expect(log.n).toBe(0);
+  });
+
+  it('sends to subscribers whose last_sent_at is older than the idempotency window', async () => {
+    const row = await confirmedSubscriber('stale@example.com', { boards: ['select-board'], topics: [] });
+    // Mark as sent 6 days ago — outside the 5-day window.
+    const sixDaysAgoMs = Date.now() - 6 * 24 * 60 * 60 * 1000;
+    await env.DB.prepare('UPDATE subscriber SET last_sent_at = ? WHERE id = ?').bind(sixDaysAgoMs, row.id).run();
+    // Mock a matching transcript with valid frontmatter so the matcher sees it.
+    const fakeTranscriptMd = `---
+slug: select-board-${new Date().toISOString().slice(0, 10)}
+board: select-board
+board_display: "Select Board"
+date: ${new Date().toISOString().slice(0, 10)}
+title: "Select Board"
+vimeo_url: "https://vimeo.com/0"
+summary_card:
+  headline: "Test headline"
+  summary: "Test summary"
+topic_segments:
+---
+`;
+    fetchMock.get('https://api.github.com')
+      .intercept({ path: /\/repos\/.*\/contents\/_transcripts\?ref=.*/, method: 'GET' })
+      .reply(200, JSON.stringify([
+        { type: 'file', name: `select-board-${new Date().toISOString().slice(0, 10)}.md`, download_url: 'https://example.com/sb.md' }
+      ]));
+    fetchMock.get('https://example.com')
+      .intercept({ path: '/sb.md', method: 'GET' })
+      .reply(200, fakeTranscriptMd);
+    const out = await runScheduled({}, env, { skipTimeGuard: true });
+    expect(out.ran).toBe(true);
+    expect(out.sent).toBe(1);
+    const log = await env.DB.prepare('SELECT count(*) AS n FROM delivery_log').first();
+    expect(log.n).toBe(1);
+  });
 });

--- a/meeting-digest/worker/src/scheduled.js
+++ b/meeting-digest/worker/src/scheduled.js
@@ -5,35 +5,61 @@ import { renderHtml, renderText, renderSubject } from './lib/render.js';
 import { sendMail } from './lib/mail.js';
 import { randomToken } from './lib/email.js';
 
-// Only run on the cron hour that corresponds to 7 AM ET.
-// EST (Nov–Mar): UTC = ET + 5  ⇒  11 UTC == 6 AM ET, 12 UTC == 7 AM ET
-// EDT (Mar–Nov): UTC = ET + 4  ⇒  11 UTC == 7 AM ET, 12 UTC == 8 AM ET
-// We schedule both 11 and 12 UTC, and run when the ET hour equals 7.
-function isSevenAmEasternTime(nowMs = Date.now()) {
+// Backup crons fire 30 minutes after the primary slot, so we never want to
+// re-send within the same morning. Five days is well past that and well
+// short of next Monday's primary fire (7 days), so the next legitimate
+// digest still goes out.
+const IDEMPOTENCY_WINDOW_MS = 5 * 24 * 60 * 60 * 1000;
+
+function getEtHour(nowMs) {
   const fmt = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/New_York', hour12: false, hour: '2-digit'
   });
-  const hour = parseInt(fmt.format(new Date(nowMs)), 10);
-  return hour === 7;
+  return parseInt(fmt.format(new Date(nowMs)), 10);
+}
+
+// Only run on the cron firing whose ET hour equals 7.
+// EST (Nov–Mar): 12 UTC == 7 AM ET (and 12:30 UTC == 7:30 AM ET)
+// EDT (Mar–Nov): 11 UTC == 7 AM ET (and 11:30 UTC == 7:30 AM ET)
+function isSevenAmEasternTime(nowMs = Date.now()) {
+  return getEtHour(nowMs) === 7;
 }
 
 export async function runScheduled(event, env, opts = {}) {
   const now = opts.now ?? Date.now();
+  const scheduledTime = event && event.scheduledTime ? event.scheduledTime : now;
+  const cron = event && event.cron ? event.cron : 'manual';
+  console.log(`[digest] cron fire: cron=${cron} scheduledTime=${new Date(scheduledTime).toISOString()} now=${new Date(now).toISOString()}`);
+
   const skipGuard = opts.skipTimeGuard === true;
   if (!skipGuard && !isSevenAmEasternTime(now)) {
+    console.log(`[digest] skip: not 7am ET (et_hour=${getEtHour(now)})`);
     return { ok: true, ran: false, reason: 'not 7 AM ET' };
   }
 
-  // 1. Fetch recent transcripts (one network read, shared across subscribers).
+  // 1. Pick confirmed subscribers who haven't been emailed in IDEMPOTENCY_WINDOW_MS.
+  //    A backup cron landing 30 min after the primary therefore sees zero rows
+  //    for anyone already sent and the loop is a fast no-op — and we skip the
+  //    GitHub round trip entirely in that case.
+  const idempotencyCutoff = now - IDEMPOTENCY_WINDOW_MS;
+  const { results: subs } = await env.DB.prepare(
+    'SELECT id, email, manage_token, boards, topics FROM subscriber WHERE status = ? AND (last_sent_at IS NULL OR last_sent_at < ?)'
+  ).bind('confirmed', idempotencyCutoff).all();
+  console.log(`[digest] eligible subscribers (confirmed, not sent in last 5d): count=${subs.length}`);
+
+  if (subs.length === 0) {
+    return { ok: true, ran: true, sent: 0, skipped: 0, errored: 0, transcripts: 0 };
+  }
+
+  // 2. Fetch recent transcripts (one network read, shared across subscribers).
   let transcripts;
   try {
     transcripts = await fetchRecentTranscripts(env, now);
   } catch (e) {
+    console.log(`[digest] transcript fetch failed: ${e.message}`);
     return { ok: false, error: `transcript fetch failed: ${e.message}` };
   }
-
-  // 2. For each confirmed subscriber, filter and send.
-  const { results: subs } = await env.DB.prepare('SELECT id, email, manage_token, boards, topics FROM subscriber WHERE status = ?').bind('confirmed').all();
+  console.log(`[digest] fetched transcripts in last 7 days: count=${transcripts.length}`);
 
   const weekEnding = new Date(now).toISOString().slice(0, 10);
   let sent = 0, skipped = 0, errored = 0;
@@ -68,5 +94,6 @@ export async function runScheduled(event, env, opts = {}) {
     }
   }
 
+  console.log(`[digest] done: sent=${sent} skipped=${skipped} errored=${errored} transcripts=${transcripts.length}`);
   return { ok: true, ran: true, sent, skipped, errored, transcripts: transcripts.length };
 }

--- a/meeting-digest/worker/wrangler.toml
+++ b/meeting-digest/worker/wrangler.toml
@@ -2,6 +2,9 @@ name = "marblehead-meeting-digest"
 main = "src/index.js"
 compatibility_date = "2026-06-09"
 
+[observability]
+enabled = true
+
 [[d1_databases]]
 binding = "DB"
 database_name = "meeting-digest"
@@ -21,10 +24,14 @@ TURNSTILE_TEST_BYPASS_TOKEN = "TEST-OK"
 # secret with the placeholder string and the Worker will 401 on every send.
 
 # Monday 7:00 AM ET == 11:00 UTC (EST) / 12:00 UTC (EDT).
-# Run at 11:00 and 12:00; the scheduled handler chooses one based on the
-# current ET hour, the other becomes a no-op. Keeps DST handling simple.
+# We schedule four firings (11:00, 11:30, 12:00, 12:30 UTC). The handler
+# guard accepts any whose ET hour equals 7, so EDT keeps 11:00 + 11:30 and
+# EST keeps 12:00 + 12:30. The :30 fires give us a cheap retry if
+# Cloudflare's best-effort cron misses the :00 slot. Per-subscriber
+# idempotency in scheduled.js skips anyone already sent in the last 5
+# days, so the retry never double-delivers.
 [triggers]
-crons = ["0 11 * * 1", "0 12 * * 1"]
+crons = ["0 11 * * 1", "30 11 * * 1", "0 12 * * 1", "30 12 * * 1"]
 
 [env.staging]
 name = "marblehead-meeting-digest-staging"


### PR DESCRIPTION
## Summary

Three changes to the meeting-digest Worker to make cron misses survivable + visible:

- **Observability on.** `[observability] enabled = true` in `wrangler.toml` so `wrangler tail` shows fires going forward.
- **Idempotent retry crons.** Schedule `:30`-past fallbacks on Monday morning (now `0 11`, `30 11`, `0 12`, `30 12` UTC × Monday). The existing ET-hour-7 guard keeps only the two that map to 7-something AM ET regardless of DST. The fallbacks give us a cheap retry if Cloudflare's best-effort scheduler misses the primary slot.
- **Per-subscriber idempotency.** Eligible-subscriber SQL adds `AND (last_sent_at IS NULL OR last_sent_at < ?)` with a 5-day window, so a fallback fire never re-sends to anyone already emailed. Workflow also short-circuits the GitHub transcript fetch when zero subscribers are eligible. `console.log` lines at every state transition (cron fire, time-guard reject, transcript fetch result, eligible count, final tally) for tail visibility.

53/53 worker tests passing, including two new cases covering recent-vs-stale `last_sent_at`.

## Why now

Two things converged today (Fri 2026-06-12):

1. The deployed **Friday** cron silently missed its 11:00 + 12:00 UTC fires this morning. Cloudflare reports no platform incident, so it's a best-effort cron miss on a single script. The lack of observability meant we only noticed because Andrew didn't get his digest.
2. PR #852 (merged earlier today, post-override-vote H2 operational plan) shifted the cron from Friday to **Monday** in `wrangler.toml`, but the Worker hasn't been re-deployed yet. So even if today's cron HAD fired, next week's Friday cron wouldn't fire anyway, and the new Monday schedule isn't live on Cloudflare until someone runs `wrangler deploy`.

This PR layers retry + visibility on top of the Monday move, so next Monday morning has belt-and-suspenders coverage *and* we can tell from logs whether the cron fired.

## Post-merge

- [ ] Deploy: `cd meeting-digest/worker && npx wrangler deploy` (picks up Monday cron from #852 + retry/idempotency/observability from here)
- [ ] Verify next Monday's digest fires via `npx wrangler tail` ahead of 7am ET — should see `[digest] cron fire: cron=0 11 * * 1 ...`

## Test plan

- [ ] CI vitest run shows 53/53
- [ ] Manual `wrangler deploy --dry-run` (or similar) confirms the four-cron schedule is what gets registered
- [ ] After deploy, `wrangler tail --format=pretty` next Monday shows the `[digest]` log lines

## Proof of work

Local vitest run (this branch):

\`\`\`
✓ |worker| tests/worker.test.js (19 tests) 446ms
 Test Files  6 passed (6)
      Tests  53 passed (53)
\`\`\`

Both new idempotency cases pass:

\`\`\`
✓ runScheduled > skips subscribers whose last_sent_at is within the idempotency window
✓ runScheduled > sends to subscribers whose last_sent_at is older than the idempotency window
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)