### PR TITLE
Add .claude/settings.json with blanket Bash + Web allow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(*)",
+      "WebFetch",
+      "WebSearch",
+      "mcp__happy__change_title"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.claude/settings.json` at repo root so Claude Code sessions in this repo don't prompt for read-write Bash, WebFetch, or WebSearch tool calls.

```json
{
  "permissions": {
    "allow": [
      "Bash(*)",
      "WebFetch",
      "WebSearch",
      "mcp__happy__change_title"
    ]
  }
}
```

## Why this is OK here

This is a Hetzner-box-only repo. Sessions run under a tightly scoped systemd-managed Claude Code instance with no extra infrastructure to reach. Granting blanket Bash/Web access to agents in this repo just removes friction (prompts) without expanding real blast radius — the agent already cannot leave the worktree, escalate beyond the unit, or touch anything the user hasn't already entrusted to the box.

## Gotcha

`.claude/` is in the project `.gitignore` by default. This single file is force-added so the allow rules propagate to every worktree on the box once merged.

## Test plan
- [ ] After merge, pull on the main worktree and confirm `.claude/settings.json` exists at repo root
- [ ] Start a new session in any worktree; routine Bash + Web tool calls no longer prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)