### PR TITLE
Drop undefined 'BCG' acronym from school-buildings page

### DIFF
--- a/school-building-maintenance.html
+++ b/school-building-maintenance.html
@@ -174,7 +174,7 @@ og_url: https://marbleheaddata.org/school-building-maintenance.html
   <article class="sbm-card">
     <h3>Eveleth</h3>
     <p class="sbm-card-meta"><strong>Built</strong> early 20th c. &middot; <strong>Closed</strong> 2021<br><strong>Current:</strong> boiler condemned Nov 2025</p>
-    <p>Closed before BCG, then briefly reopened in 2019&ndash;2020 as swing space for kindergarteners while Bell was being closed down.<sup class="cite" data-href="/meetings/" data-source="School Committee meetings, 2020–2021 (Brown opening &amp; Bell demolition)"></sup> Went dark again when Brown opened.</p>
+    <p>Closed before the Brown project, then briefly reopened in 2019&ndash;2020 as swing space for kindergarteners while Bell was being closed down.<sup class="cite" data-href="/meetings/" data-source="School Committee meetings, 2020–2021 (Brown opening &amp; Bell demolition)"></sup> Went dark again when Brown opened.</p>
     <p>The Facilities Subcommittee has been talking to Park &amp; Recreation about reusing the building for early education and after-school programs.<sup class="cite" data-href="https://resources.finalsite.net/images/v1773772039/marbleheadschoolsorg/mnbn4dk4tvqwsj3bhuzb/SCminutes-2_13_26FacilitiesSubcommittee1.pdf" data-source="Facilities Subcommittee minutes, 2/13/2026"></sup></p>
     <p class="sbm-card-cite">Boiler condemned per facilities subcommittee, Nov 5 2025.<sup class="cite" data-href="https://resources.finalsite.net/images/v1773772163/marbleheadschoolsorg/bxdxwyev0ltqknovdyyz/SCminutes-11_5_25FacilitiesSubcommittee1.pdf" data-source="Facilities Subcommittee minutes, 11/5/2025"></sup></p>
   </article>


### PR DESCRIPTION
## Summary

User flagged `Closed before BCG` in the Eveleth card on the school-buildings page. `BCG` (Bell, Coffin, Gerry) was an internal shorthand I used in commit messages and the brainstorm spec; it shouldn't appear in user-facing copy. Swapped for `Closed before the Brown project`.

One-line change.

## Preview & How to Test

- **Preview URL**: Cloudflare PR preview will appear once the workflow runs.
- **Path**: /school-building-maintenance.html (Eveleth card in the former-buildings grid)
- **Expected**: The Eveleth card reads 'Closed before the Brown project, then briefly reopened in 2019–2020…'

## Proof of Work

`git diff origin/main`:
```
-    <p>Closed before BCG, then briefly reopened in 2019&ndash;2020 as swing space for kindergarteners while Bell was being closed down.
+    <p>Closed before the Brown project, then briefly reopened in 2019&ndash;2020 as swing space for kindergarteners while Bell was being closed down.
```

## Risk

None. No tests reference 'BCG'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)