### PR TITLE
Fill Jun 12 baseline with PostHog traffic + channel mix

### DIFF
--- a/docs/social/baseline-2026-06-12.md
+++ b/docs/social/baseline-2026-06-12.md
@@ -7,7 +7,7 @@ count) plus PostHog queries (traffic, channel mix) plus FB page admin
 
 | Metric | Value | Source |
 |---|---|---|
-| Email subscribers (confirmed) | FILL IN (CLOUDFLARE_API_TOKEN required) | D1 query via baseline-h2.mjs |
+| Email subscribers (confirmed) | 2 | D1 query via baseline-h2.mjs (`subscriber` table, `status = 'confirmed'`) |
 | Facebook page followers | FILL IN | FB page admin > Insights > Followers |
 | Monthly site traffic (last 30 days unique visitors) | 521 | PostHog `$pageview` distinct person_id on `marbleheaddata.org` host |
 | Channel mix: Facebook combined as % of total | 33.6% (175 of 521 visitors) | PostHog `$referring_domain` breakdown, all facebook.com variants summed |
@@ -64,15 +64,20 @@ small task, not in scope for this baseline-fill PR.
   pageviews-per-visitor is expected as residents stop checking
   obsessively. Visitor breadth is the better post-vote metric.
 
+## On the subscriber count of 2
+
+Far below the month-3 target of 100, as expected. The digest
+subscription was only just re-exposed in the site nav (PR #840,
+"Re-expose meeting digest signups"). The signup CTA on the
+`meetings.html` page is the primary growth surface. Without a
+dedicated FB push or homepage banner, 100 subscribers by Sep 12 is
+ambitious. Worth flagging at the month-3 checkpoint regardless of
+the actual number then.
+
 ## What still needs the user
 
-To complete the month-0 baseline:
-
-1. **Email subscribers.** Set `CLOUDFLARE_API_TOKEN` and run
-   `node meeting-digest/tools/baseline-h2.mjs`, then drop the
-   number into the table above.
-2. **Facebook page followers.** Open the Marblehead Data FB page
-   admin > Insights > Followers, copy the number, drop it into
-   the table above.
+1. **Facebook page followers.** Open the Marblehead Data FB page
+   admin > Insights > Followers, copy the number, drop it into the
+   table above. Not automatable without a Graph API token.
 
 Then commit the updated baseline file.

--- a/docs/social/baseline-2026-06-12.md
+++ b/docs/social/baseline-2026-06-12.md
@@ -1,21 +1,78 @@
-# Baseline snapshot 2026-06-12
+# Baseline snapshot 2026-06-14
 
-Run via: `node meeting-digest/tools/baseline-h2.mjs`
-
-Note: this is a placeholder. To populate the actual values:
-1. Run the script from the repo root (the script uses `cd meeting-digest/worker && npx wrangler d1 execute ...`).
-2. Wrangler must be authenticated. If not: `cd meeting-digest/worker && npx wrangler login`.
-3. Copy the script output over the table below.
-4. Hand-fill the three manual values from FB admin and PostHog.
-5. Commit.
+Pulled: 2026-06-14 (last-30-days window: 2026-05-15 to 2026-06-14).
+Re-runnable via: `node meeting-digest/tools/baseline-h2.mjs` (subscriber
+count) plus PostHog queries (traffic, channel mix) plus FB page admin
+(follower count).
 
 | Metric | Value | Source |
 |---|---|---|
-| Email subscribers (confirmed) | FILL IN (run script) | D1 query, automated |
+| Email subscribers (confirmed) | FILL IN (CLOUDFLARE_API_TOKEN required) | D1 query via baseline-h2.mjs |
 | Facebook page followers | FILL IN | FB page admin > Insights > Followers |
-| Monthly site traffic (last 30 days unique visitors) | FILL IN | PostHog dashboard |
-| Channel mix: FB + email as % of total traffic | FILL IN | PostHog acquisition |
+| Monthly site traffic (last 30 days unique visitors) | 521 | PostHog `$pageview` distinct person_id on `marbleheaddata.org` host |
+| Channel mix: Facebook combined as % of total | 33.6% (175 of 521 visitors) | PostHog `$referring_domain` breakdown, all facebook.com variants summed |
+| Channel mix: email as % of total | Not separately measurable | Digest email links carry no UTM, so email visits fold into `$direct` (160) and internal nav (`marbleheaddata.org` referrer, 54) |
 
-## Notes
+## How Facebook 33.6% was computed
 
-Compare against April 2026 baseline: 462 unique visitors, 26% Facebook.
+PostHog `$referring_domain` breakdown over the last 30 days:
+
+| Referrer | Visitors |
+|---|---|
+| facebook.com | 92 |
+| l.facebook.com | 41 |
+| m.facebook.com | 16 |
+| www.facebook.com | 15 |
+| lm.facebook.com | 11 |
+| **Facebook combined** | **175** |
+| $direct | 160 |
+| marbleheaddata.org (internal nav) | 54 |
+| duckduckgo.com | 47 |
+| marbleheadcurrent.org | 41 |
+| www.google.com | 30 |
+| www.bing.com | 27 |
+| andrewbaber.com | 11 |
+| search.yahoo.com | 10 |
+| Others (each less than 5) | ~9 |
+
+Total: 521 unique visitors.
+
+## Notes on email-as-channel
+
+The plan calls for tracking "email plus Facebook combined drive at
+least 40 percent of traffic". As of this baseline, email visits are
+not separately measurable: the meeting-digest worker's links
+(`SITE_BASE_URL=https://marbleheaddata.org`) include no `?utm_source=`
+query parameter, so when a subscriber clicks through, the visit lands
+in PostHog as either `$direct` (most common, since email clients
+strip referrers) or as a `marbleheaddata.org` internal-nav referrer
+(if the click was from a webmail interface that preserved the
+referrer).
+
+To make email separately measurable at the Sep 12 month-3 checkpoint,
+add `?utm_source=digest&utm_medium=email&utm_campaign=weekly` (or
+similar) to the digest worker's outbound links. That is a separate
+small task, not in scope for this baseline-fill PR.
+
+## Comparison to April 2026 baseline (Apr 12 to Apr 24, 30-day window)
+
+- Unique visitors: 521 (this baseline) vs 462 (April) = +12.8%.
+- Pageviews: 1,719 (this baseline) vs 3,432 (April) = down ~50%.
+- Facebook share: 33.6% (this baseline) vs 26% (April).
+- Total traffic above the April target (>=462). Override-vote week
+  was almost certainly the April pageview peak, so the drop in
+  pageviews-per-visitor is expected as residents stop checking
+  obsessively. Visitor breadth is the better post-vote metric.
+
+## What still needs the user
+
+To complete the month-0 baseline:
+
+1. **Email subscribers.** Set `CLOUDFLARE_API_TOKEN` and run
+   `node meeting-digest/tools/baseline-h2.mjs`, then drop the
+   number into the table above.
+2. **Facebook page followers.** Open the Marblehead Data FB page
+   admin > Insights > Followers, copy the number, drop it into
+   the table above.
+
+Then commit the updated baseline file.

--- a/meeting-digest/tools/baseline-h2.mjs
+++ b/meeting-digest/tools/baseline-h2.mjs
@@ -18,9 +18,11 @@
 import { execSync } from 'node:child_process';
 
 function pullSubscriberCount() {
-  // wrangler d1 execute against the meeting-digest DB. Requires the
-  // user to be logged into wrangler.
-  const cmd = `cd meeting-digest/worker && npx wrangler d1 execute meeting-digest --command "SELECT COUNT(*) as n FROM subscriber WHERE status = 'confirmed'" --json`;
+  // wrangler d1 execute against the production meeting-digest DB.
+  // Requires CLOUDFLARE_API_TOKEN in the environment. --remote is
+  // critical: without it, wrangler queries the local sqlite DB which
+  // has no subscriber table.
+  const cmd = `cd meeting-digest/worker && npx wrangler d1 execute meeting-digest --command "SELECT COUNT(*) as n FROM subscriber WHERE status = 'confirmed'" --remote --json`;
   try {
     const out = execSync(cmd, { encoding: 'utf8' });
     const parsed = JSON.parse(out);


### PR DESCRIPTION
## Summary

Populates `docs/social/baseline-2026-06-12.md` with the two values that are pullable from PostHog. The two values that require external credentials are flagged with what's needed to populate them.

## Numbers (last 30 days, 2026-05-15 to 2026-06-14)

- **Unique visitors:** 521 (vs April baseline 462, +12.8%)
- **Facebook combined share:** 33.6% (175 of 521), summed across facebook.com, l.facebook.com, m.facebook.com, www.facebook.com, lm.facebook.com referrer variants
- **Pageviews:** 1,719 (vs April baseline 3,432, down ~50%; expected as override-week obsessive checking ended)
- **Email-as-channel:** not separately measurable. Digest links carry no UTM, so email visits fold into `$direct` (160) and internal nav (54). Documented in the file as a separate small follow-up: add `?utm_source=digest&utm_medium=email` to the worker's outbound links before the Sep 12 month-3 checkpoint.

## Still needs the user

Documented in the file:

1. **Email subscribers (confirmed)** — requires `CLOUDFLARE_API_TOKEN` to run `node meeting-digest/tools/baseline-h2.mjs` against the production D1 database. I do not have the token in this session.
2. **Facebook page followers** — manual pull from the Marblehead Data FB page admin > Insights > Followers. Not automatable without a Graph API token and additional scaffolding the plan declined to build.

## Preview URL

Internal docs (`docs/` excluded from Jekyll build). No site preview to capture. Review the diff on GitHub.

## Test plan

- [ ] Read `docs/social/baseline-2026-06-12.md` on GitHub
- [ ] Sanity check the 33.6% Facebook share against your sense of which FB groups have been sharing the site
- [ ] Note the email UTM gap as a small follow-up before the Sep 12 checkpoint
- [ ] (Optional now, required before Sep 12) Set `CLOUDFLARE_API_TOKEN` and run the baseline script, then drop the subscriber count in. Same for FB followers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)