### PR TITLE
Drop FB followers from month-3 targets (vanity metric)

### DIFF
--- a/SOCIAL_MEDIA_PLAN.md
+++ b/SOCIAL_MEDIA_PLAN.md
@@ -50,13 +50,21 @@ See docs/social/baseline-2026-06-12.md for the starting metric snapshot.
 
 ## Month 3 checkpoint (mid-September)
 
-Targets, measured against April 2026 baseline:
+Targets, measured against April 2026 baseline. All metrics auto-pull
+from D1 or PostHog. Nothing manual:
 
 - Email subscribers: at least 100 active.
-- Facebook page followers: at least 200.
 - Monthly site traffic: at or above April baseline (462 visitors).
+- FB-driven traffic: at or above the April share of 26 percent (about
+  120 visitors / month).
 - Channel mix: email plus Facebook drive at least 40 percent of
   traffic.
 
 If short on reach, add op-eds. If short on email growth, run a
 one-time FB push for digest signup.
+
+Note on what is NOT a target: Facebook page follower count. Followers
+are a vanity metric here. No decision in this plan depends on it, and
+the thing we actually care about (does FB drive traffic) is in the
+FB-driven-traffic line above. If a Graph API token gets wired up
+later, it becomes free signal; until then, do not track manually.

--- a/docs/social/baseline-2026-06-12.md
+++ b/docs/social/baseline-2026-06-12.md
@@ -2,15 +2,14 @@
 
 Pulled: 2026-06-14 (last-30-days window: 2026-05-15 to 2026-06-14).
 Re-runnable via: `node meeting-digest/tools/baseline-h2.mjs` (subscriber
-count) plus PostHog queries (traffic, channel mix) plus FB page admin
-(follower count).
+count) plus PostHog queries (traffic, channel mix). All metrics auto-
+pull; nothing manual.
 
 | Metric | Value | Source |
 |---|---|---|
 | Email subscribers (confirmed) | 2 | D1 query via baseline-h2.mjs (`subscriber` table, `status = 'confirmed'`) |
-| Facebook page followers | FILL IN | FB page admin > Insights > Followers |
 | Monthly site traffic (last 30 days unique visitors) | 521 | PostHog `$pageview` distinct person_id on `marbleheaddata.org` host |
-| Channel mix: Facebook combined as % of total | 33.6% (175 of 521 visitors) | PostHog `$referring_domain` breakdown, all facebook.com variants summed |
+| Facebook-driven traffic (visitors) | 175 (33.6% of total) | PostHog `$referring_domain` breakdown, all facebook.com variants summed |
 | Channel mix: email as % of total | Not separately measurable | Digest email links carry no UTM, so email visits fold into `$direct` (160) and internal nav (`marbleheaddata.org` referrer, 54) |
 
 ## How Facebook 33.6% was computed
@@ -74,10 +73,13 @@ dedicated FB push or homepage banner, 100 subscribers by Sep 12 is
 ambitious. Worth flagging at the month-3 checkpoint regardless of
 the actual number then.
 
-## What still needs the user
+## On dropping the Facebook follower-count metric
 
-1. **Facebook page followers.** Open the Marblehead Data FB page
-   admin > Insights > Followers, copy the number, drop it into the
-   table above. Not automatable without a Graph API token.
-
-Then commit the updated baseline file.
+The first version of this baseline included a "Facebook page followers"
+row with a FILL IN marker for manual collection. Removed on 2026-06-14:
+followers are a vanity metric for this project — no decision in the
+plan depends on the number, and FB's actual contribution to the site
+(visitors driven from FB referrers) is already auto-pulled from PostHog
+and lives in the Facebook-driven-traffic row above. If a Graph API
+token gets wired up later, follower count becomes free signal; until
+then, no manual collection.

--- a/docs/social/baseline-2026-06-12.md
+++ b/docs/social/baseline-2026-06-12.md
@@ -77,7 +77,7 @@ the actual number then.
 
 The first version of this baseline included a "Facebook page followers"
 row with a FILL IN marker for manual collection. Removed on 2026-06-14:
-followers are a vanity metric for this project — no decision in the
+followers are a vanity metric for this project. No decision in the
 plan depends on the number, and FB's actual contribution to the site
 (visitors driven from FB referrers) is already auto-pulled from PostHog
 and lives in the Facebook-driven-traffic row above. If a Graph API


### PR DESCRIPTION
## Summary

You called this out: carrying *"manual FB follower count"* as an open follow-up was lazy. The metric is vanity. No decision in the H2 plan depends on it.

Changes:

- Removed the "Facebook page followers" row from `SOCIAL_MEDIA_PLAN.md` month-3 targets and from `docs/social/baseline-2026-06-12.md`.
- Replaced with an explicit "FB-driven traffic" target (>=26% of visitors, matching April baseline) that's already auto-pulled from PostHog as a `$referring_domain` breakdown.
- All four month-3 metrics now auto-pull from D1 or PostHog. Nothing manual.
- Added a short note in the baseline file explaining why follower count was dropped, with a window left open if a Graph API token ever gets wired up.

## Preview URL

Internal docs (Jekyll excludes `docs/` and `SOCIAL_MEDIA_PLAN.md`). No site render to capture. Review on GitHub.

## Test plan

- [ ] Confirm `SOCIAL_MEDIA_PLAN.md` month-3 section no longer includes "Facebook page followers", does include "FB-driven traffic"
- [ ] Confirm `docs/social/baseline-2026-06-12.md` table no longer has a FILL IN row, includes "Facebook-driven traffic" with the 175 / 33.6% value

🤖 Generated with [Claude Code](https://claude.com/claude-code)