### PR TITLE
copy: Open Town Meeting, not reps (sketch fix)

### DIFF
--- a/data/checkbook_fund_provenance.json
+++ b/data/checkbook_fund_provenance.json
@@ -71,7 +71,7 @@
       "amount_fy26": 43914648,
       "share": 0.439,
       "bucket": "town_meeting",
-      "authorized_by": "Annual Town Meeting representatives",
+      "authorized_by": "Registered voters at Annual Town Meeting (Open Town Meeting; no delegates)",
       "authorized_when": "Annual Town Meeting, May 2025 (FY26 omnibus budget article)",
       "vote_source": "data/2025_FinCom_Report.pdf (transmittal letter); Town Clerk's published warrant and minutes",
       "one_line": "Year-to-year operating budget for every General Fund Town department (DPW, Fire, Police, Library, Council on Aging, Town Clerk, Finance, etc.)",
@@ -92,7 +92,7 @@
       "amount_fy26": 8066631,
       "share": 0.081,
       "bucket": "town_meeting",
-      "authorized_by": "Annual Town Meeting representatives",
+      "authorized_by": "Registered voters at Annual Town Meeting (Open Town Meeting; no delegates)",
       "authorized_when": "Annual Town Meeting, May 2025 (school appropriation article)",
       "vote_source": "data/2025_FinCom_Report.pdf; School Committee FY26 budget book",
       "one_line": "Year-to-year operating budget for Marblehead Public Schools (vendor spend; teacher salaries paid via payroll, not in ledger)."
@@ -132,7 +132,7 @@
       "amount_fy26": 2305312,
       "share": 0.023,
       "bucket": "town_meeting",
-      "authorized_by": "Annual Town Meeting representatives",
+      "authorized_by": "Registered voters at Annual Town Meeting (Open Town Meeting; no delegates)",
       "authorized_when": "ATM capital articles, each year as adopted",
       "vote_source": "Town Clerk's annual warrant and minutes",
       "one_line": "Capital articles funded inside the levy (no debt exclusion); each individual article voted at Town Meeting."

--- a/sketches/checkbook-choices-v1.html
+++ b/sketches/checkbook-choices-v1.html
@@ -258,7 +258,7 @@
       </div>
       <div class="stack-legend">
         <span><i class="sw-ballot"></i> Ballot &mdash; you voted directly</span>
-        <span><i class="sw-tm"></i> Town Meeting &mdash; your reps there</span>
+        <span><i class="sw-tm"></i> Town Meeting &mdash; you, in person, if you went</span>
         <span><i class="sw-enter"></i> Ratepayer &mdash; not your tax bill</span>
         <span><i class="sw-grant"></i> State / federal grants</span>
         <span><i class="sw-rev"></i> Revolving (user fees)</span>
@@ -291,7 +291,7 @@
         <span class="accent tm"></span>
         <h3 class="title">Voted at Town Meeting (this year's annual budget)</h3>
         <div class="amt">~$54M<small>~54% of FY26 spend</small></div>
-        <p class="who"><b>Who chose this:</b> Town Meeting representatives at the May 2025 Annual Town Meeting, line-by-line. Largest single appropriation: <b>General Government &amp; School operating</b>.</p>
+        <p class="who"><b>Who chose this:</b> the voters who showed up to the May 2025 Annual Town Meeting and approved each article. Marblehead runs Open Town Meeting &mdash; any registered voter can attend, no delegates. Largest single appropriation: <b>General Government &amp; School operating</b>.</p>
         <div class="caveat">
           <b>Choice qualifier:</b> roughly $25&ndash;30M of this bucket is contractually fixed before Town Meeting sees it &mdash; GIC health insurance premiums (set by the state's GIC board), PERAC pension assessment (actuarial), and state Cherry Sheet assessments. Town Meeting votes the appropriation but does not set the price.
         </div>

--- a/sketches/checkbook-choices-v1.html
+++ b/sketches/checkbook-choices-v1.html
@@ -244,7 +244,7 @@
   <section>
     <div class="lede" style="margin-top: 36px;">
       <h2>Of the $99.9M paid so far, here's who chose to spend it</h2>
-      <p>Every fund in the ledger was authorized by a specific vote &mdash; or by no vote at all. Same dollars, sorted by who said yes.</p>
+      <p>Every fund in the ledger was authorized by a specific vote &mdash; or by no vote at all.</p>
     </div>
 
     <div class="stack-wrap">
@@ -379,7 +379,7 @@
   <!-- collapsed table -->
   <details class="table-disclosure">
     <summary>Every payment (the raw ledger)</summary>
-    <p>Same 15,364 rows the live page shows today, with filters by vendor, fund, division, and date. Useful if you have a specific vendor or check to look up. Hidden by default so it doesn't compete with the framing above.</p>
+    <p>The full ledger of 15,364 rows, filterable by vendor, fund, division, and date. Useful for looking up a specific vendor or check.</p>
   </details>
 
   <!-- notes (short) -->

--- a/sketches/checkbook-choices-v2.html
+++ b/sketches/checkbook-choices-v2.html
@@ -357,7 +357,7 @@
   <section class="hero">
     <div class="crumb">Home / Checkbook</div>
     <h1 class="h1">What we paid, and the choices we made</h1>
-    <p class="sub">Every fund in the FY26 ledger traces back to a specific vote &mdash; ballot, Town Meeting, contract, or rate-setting board. Same dollars, sorted by who said yes.</p>
+    <p class="sub">Every fund in the FY26 ledger traces back to a specific vote &mdash; ballot, Town Meeting, contract, or rate-setting board.</p>
     <span class="freshness"><span class="dot"></span> Snapshot: Jun 9, 2026 &middot; <em>5 days old</em> &middot; weekly cadence</span>
   </section>
 
@@ -388,7 +388,7 @@
   <section>
     <div class="lede" style="margin-top: 36px;">
       <h2>Of the $99.9M paid so far, here's who chose to spend it</h2>
-      <p>Top-20 funds cover 97.8% of the ledger; the bar below classifies each by its authorizing power.</p>
+      <p>Top-20 funds cover 97.8% of the ledger.</p>
     </div>
 
     <div class="stack-wrap">
@@ -505,7 +505,7 @@
         </details>
         <div class="subbucket" style="background: var(--subbucket-ballot-bg); border-left-color: var(--c-teal);">
           <h4>Caveat: this is a floor, not a ceiling.</h4>
-          <p>FY26 also paid <b>$14.24M to U.S. Bank in bond service</b> across many bond series (Abbot Library 2021, Fort Sewall 2019, Gerry School 2016, Pleasant St 2012, and others). Some of that debt service traces to ballot-approved exclusions and some to in-levy Town Meeting articles; the ledger doesn't split bond-by-bond, so we can't apportion it cleanly here. Sits inside the Town Meeting bucket below.</p>
+          <p>FY26 also paid <b>$14.24M to U.S. Bank in bond service</b> across many bond series (Abbot Library 2021, Fort Sewall 2019, Gerry School 2016, Pleasant St 2012, and others). Some of that debt service traces to ballot-approved exclusions and some to in-levy Town Meeting articles; the ledger doesn't split bond-by-bond, so it can't be apportioned cleanly without an external debt schedule.</p>
         </div>
       </article>
 
@@ -639,14 +639,14 @@
   <!-- collapsed table -->
   <details class="table-disclosure">
     <summary>Every payment (the raw ledger)</summary>
-    <p>Same 15,364 rows the live page shows today, with filters by vendor, fund, division, and date. Useful for looking up a specific vendor or check. Hidden by default so it doesn't compete with the framing above.</p>
+    <p>The full ledger of 15,364 rows, filterable by vendor, fund, division, and date. Useful for looking up a specific vendor or check.</p>
   </details>
 
   <!-- What we can't fully account for -->
   <section class="unaccounted">
     <div class="lede">
       <h3>What we can't fully account for</h3>
-      <p>Of the $99.93M paid through Jun 9, <strong>$97.71M (97.8%)</strong> sits in a top-20 fund that maps to a named authorizing vote. The remaining tail is small but worth naming explicitly so the bucket totals aren't read as more precise than they are.</p>
+      <p>Of the $99.93M paid through Jun 9, <strong>$97.71M (97.8%)</strong> sits in a top-20 fund that maps to a named authorizing vote. The remaining 2.2% is bucketed but with caveats.</p>
     </div>
 
     <div class="unaccounted-grid">
@@ -702,8 +702,7 @@
   <section class="notes">
     <h3>About this sketch</h3>
     <p>All bucket totals are real, computed from the <code>checkbook_FY26_2026-06-09.csv</code> ledger. Fund-to-vote provenance is in <code>data/checkbook_fund_provenance.json</code> (top 20 funds, 97.8% of paid spend). Vote citations cross-reference <code>data/dor_debt_exclusion_all.csv</code> (MA DOR Proposition 2&frac12; Debt Exclusion Votes) for the ballot bucket.</p>
-    <p>The carve-out inside the Town Meeting card is the substantive finding: only <b>14.3% of vendor checks out of General Fund &mdash; Town</b> are actually subject to year-to-year Town Meeting discretion. The other 85.7% (GIC + pension + bond debt + state assessments) is set by outside boards or prior contracts. Payroll, the largest discretionary line, is paid via a separate system and isn't in the ledger &mdash; that's a real limitation of using the ledger alone.</p>
-    <p>Things that change vs. today's live <code>/checkbook/</code>: the 5-toggle &ldquo;Budget vs actual&rdquo; section is gone, replaced by the choice-bucketed stacked bar plus the Snow Removal callout. &ldquo;Top vendors&rdquo; ranked-bar list is gone (it mixes apples and oranges &mdash; Commonwealth of MA is GIC + Cherry Sheet, Berkshire Wind is Light Dept wholesale, neither is &ldquo;a vendor we paid for services&rdquo; in the resident's sense). The 15,364-row data table is demoted to a disclosure below the fold.</p>
+    <p>Only <b>14.3% of vendor checks out of General Fund &mdash; Town</b> are subject to year-to-year Town Meeting discretion. The other 85.7% (GIC + pension + bond debt + state assessments) is set by outside boards or prior contracts. Payroll, the largest discretionary line, is paid via a separate system and isn't in the ledger.</p>
   </section>
 
 </main>

--- a/sketches/checkbook-choices-v2.html
+++ b/sketches/checkbook-choices-v2.html
@@ -402,7 +402,7 @@
       </div>
       <div class="stack-legend">
         <span><i class="sw-ballot"></i> Ballot &mdash; you voted directly</span>
-        <span><i class="sw-tm"></i> Town Meeting &mdash; your reps there</span>
+        <span><i class="sw-tm"></i> Town Meeting &mdash; you, in person, if you went</span>
         <span><i class="sw-enter"></i> Ratepayer &mdash; not your tax bill</span>
         <span><i class="sw-grant"></i> State / federal grants</span>
         <span><i class="sw-rev"></i> Revolving (user fees)</span>
@@ -514,7 +514,7 @@
         <span class="accent tm"></span>
         <h3 class="title">Voted at Town Meeting (this year's annual budget)</h3>
         <div class="amt">$54.29M<small>54.3% of FY26 spend</small></div>
-        <p class="who"><b>Who chose this:</b> Annual Town Meeting representatives at the May 2025 ATM, line by line. Covers <b>General Fund &mdash; Town</b>, <b>General Fund &mdash; School</b>, and <b>General Fund &mdash; Tax Articles</b> (in-levy capital).</p>
+        <p class="who"><b>Who chose this:</b> the voters who showed up to the May 2025 Annual Town Meeting and approved each article. Marblehead runs Open Town Meeting under MGL c.39 &mdash; any registered voter can attend and vote, no delegates. Covers <b>General Fund &mdash; Town</b>, <b>General Fund &mdash; School</b>, and <b>General Fund &mdash; Tax Articles</b> (in-levy capital).</p>
 
         <!-- The honesty box: the carve-out inside this bucket -->
         <div class="subbucket">


### PR DESCRIPTION
## Summary

Marblehead runs **Open Town Meeting** under MGL c.39 — any registered voter can attend and vote, no delegates. The just-merged sketch was framing Town Meeting like a representative body ("your reps there", "Town Meeting representatives at the May 2025 ATM"), which is factually wrong for this town and weakens the page's whole premise that residents' own choices are what's being traced.

This fixes the language in both sketches (`v1` and `v2`) and the three matching entries in the provenance JSON.

## Preview & How to Test

- **Preview URL**: _waiting for the Cloudflare deploy to go green — I'll edit this body once the preview comment appears._
- **Specific paths/screens to check**:
  1. `/sketches/checkbook-choices-v2` — Town Meeting card lede paragraph and the legend chip below the stacked bar should read "you, in person, if you went" and the lede should call out Open Town Meeting under MGL c.39 explicitly.
  2. `/sketches/checkbook-choices-v1` — same chip + lede fix, shorter wording (no MGL cite).
- **Expected behavior**: nothing about a representative body anywhere on the page. Town Meeting framed as the voters who showed up.
- **Edge cases worth poking**:
  - The phrase "no delegates" is the substantive disambiguation — if you find it stilted vs. clarifying, happy to soften.

## Proof of Work

Diff is text-only; no rendered artifacts beyond the existing prod URLs once this deploys. Visual layout unchanged.

## Risk

- Text-only change, no markup, no styles, no scripts touched.
- Affects only the static `/sketches/` artifacts — production `/checkbook/` page is unchanged.