### PR TITLE
FB OAuth: fix cross-origin redirect + drop HttpOnly cookie

### DIFF
--- a/assets/community-pulse/claim.js
+++ b/assets/community-pulse/claim.js
@@ -35,12 +35,34 @@ async function fetchSelf() {
 
 function show(el) { el.hidden = false; }
 
-async function init() {
-  const isClaimStep = location.hash === '#claim';
+/**
+ * The FB callback redirects here with `#token=<jwt>&claim=1`. Consume
+ * the fragment: stash the JWT in localStorage and clear the hash so the
+ * token doesn't linger in the URL bar / history.
+ *
+ * Returns { token, claim } extracted from the fragment, or null if the
+ * fragment didn't carry an OAuth handoff.
+ */
+function consumeOAuthFragment() {
+  if (!location.hash || !location.hash.includes('token=')) return null;
+  const params = new URLSearchParams(location.hash.slice(1));
+  const token = params.get('token');
+  const claim = params.get('claim') === '1';
+  if (!token) return null;
+  setSessionJwt(token);
+  // Clear the fragment without reloading; keep `#claim` as a state hint
+  // for backward compat with bookmarks pointing at /verify-me#claim.
+  const cleanHash = claim ? '#claim' : '';
+  history.replaceState(null, '', location.pathname + location.search + cleanHash);
+  return { token, claim };
+}
 
-  // The FB callback sets verify_jwt as HttpOnly so JS cannot read it.
-  // We re-fetch /api/profile to check whether the session is already a
-  // full resident. If so, redirect to /profile.
+async function init() {
+  const oauth = consumeOAuthFragment();
+  const isClaimStep = (oauth && oauth.claim) || location.hash === '#claim';
+
+  // If we already have a JWT (just consumed, or from a prior session),
+  // check whether it's a full-resident JWT. If so, head to /profile.
   const profile = await fetchSelf();
   if (profile && profile.identity_hash) {
     location.href = '/profile.html';
@@ -65,15 +87,16 @@ async function init() {
     datalist.appendChild(opt);
   }
 
-  // Fetch the FB display name from /api/me/pre. The verify_jwt cookie
-  // is HttpOnly, so we authenticate via credentials:'include' (the cookie
-  // travels automatically on same-origin and cross-origin-with-credentials).
-  const preRes = await fetch(`${VERIFY_API}/api/me/pre`, {
-    credentials: 'include',
-  });
-  if (preRes.ok) {
-    const meta = await preRes.json();
-    document.getElementById('claim-fb-name').textContent = meta.fb_display_name || '';
+  // Fetch the FB display name from /api/me/pre using Authorization: Bearer.
+  const jwt = readSessionJwt();
+  if (jwt) {
+    const preRes = await fetch(`${VERIFY_API}/api/me/pre`, {
+      headers: { Authorization: `Bearer ${jwt}` },
+    });
+    if (preRes.ok) {
+      const meta = await preRes.json();
+      document.getElementById('claim-fb-name').textContent = meta.fb_display_name || '';
+    }
   }
 
   document.getElementById('claim-form').addEventListener('submit', onSubmit);
@@ -87,10 +110,13 @@ async function onSubmit(e) {
   const result = document.getElementById('claim-result');
   result.textContent = 'Checking...';
 
+  const jwt = readSessionJwt();
   const res = await fetch(`${VERIFY_API}/api/claim/address`, {
     method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+    },
     body: JSON.stringify({ claimed_address }),
   });
 

--- a/community-pulse/package-lock.json
+++ b/community-pulse/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "community-pulse",
       "version": "0.1.0",
+      "dependencies": {
+        "@passwordless-id/webauthn": "^2.4.0"
+      },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.12.0",
         "fake-indexeddb": "^5.0.2",
@@ -1233,6 +1236,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@passwordless-id/webauthn": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@passwordless-id/webauthn/-/webauthn-2.4.0.tgz",
+      "integrity": "sha512-xOuI2/7nSgxEt6aFnJYOayoq2SHNplqEsHf1A40rTfmU/7LKs97LiyAumFzqxymHPc/eZNeHpJtqFcr3WFN9JQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/passwordless-id"
       }
     },
     "node_modules/@poppinss/colors": {

--- a/community-pulse/package.json
+++ b/community-pulse/package.json
@@ -10,9 +10,12 @@
     "worker:deploy": "wrangler deploy worker/src/index.js"
   },
   "devDependencies": {
-    "vitest": "^3.2.0",
     "@cloudflare/vitest-pool-workers": "^0.12.0",
     "fake-indexeddb": "^5.0.2",
+    "vitest": "^3.2.0",
     "wrangler": "^3.60.0"
+  },
+  "dependencies": {
+    "@passwordless-id/webauthn": "^2.4.0"
   }
 }

--- a/community-pulse/tests/fb.test.js
+++ b/community-pulse/tests/fb.test.js
@@ -123,4 +123,38 @@ describe('handleFbCallback', () => {
     const res = await handleFbCallback(req, mockEnv());
     expect(res.status).toBe(400);
   });
+
+  it('redirects to SITE_URL with the JWT in the URL fragment', async () => {
+    // Stub FB token exchange + profile fetch.
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'FBT' }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: '777',
+          name: 'Jane Doe',
+          link: 'https://facebook.com/jane',
+          picture: { data: { url: 'https://cdn.fb/j.jpg' } },
+        }),
+      });
+
+    const env = mockEnv({ SITE_URL: 'https://marbleheaddata.org' });
+    const req = new Request(
+      'https://x.example/api/auth/fb/callback?code=C&state=ABC',
+      { headers: { Cookie: 'fb_oauth_state=ABC' } });
+    const res = await handleFbCallback(req, env);
+
+    expect(res.status).toBe(302);
+    const loc = res.headers.get('Location');
+    // New-user path: lands on /verify-me.html with the claim flag and a token.
+    expect(loc.startsWith('https://marbleheaddata.org/verify-me.html#')).toBe(true);
+    expect(loc).toMatch(/token=/);
+    expect(loc).toMatch(/claim=1/);
+    // No session cookie set; only the OAuth state cookie is cleared.
+    const setCookies = res.headers.getSetCookie
+      ? res.headers.getSetCookie()
+      : [res.headers.get('Set-Cookie')];
+    expect(setCookies.some(c => c && c.startsWith('fb_oauth_state=;'))).toBe(true);
+    expect(setCookies.some(c => c && c.startsWith('verify_jwt='))).toBe(false);
+  });
 });

--- a/community-pulse/worker/src/fb.js
+++ b/community-pulse/worker/src/fb.js
@@ -61,7 +61,6 @@ export async function fetchMe(accessToken) {
 import { signJWT } from './jwt.js';
 
 const STATE_COOKIE = 'fb_oauth_state';
-const SESSION_COOKIE = 'verify_jwt';
 
 function randomState() {
   const bytes = crypto.getRandomValues(new Uint8Array(32));
@@ -151,13 +150,20 @@ export async function handleFbCallback(req, env) {
   }
 
   const jwt = await signJWT(payload, env.JWT_SECRET);
-  const redirect = (existing && !existing.revoked_at) ? '/profile' : '/verify-me#claim';
 
-  // Set-Cookie can't be comma-joined into one header; use Headers.append
-  // so each cookie ships as its own Set-Cookie line.
+  // The site lives at a different origin than the Worker. Hand the JWT
+  // to the site via the URL fragment (never sent to any server) so the
+  // browser script can stash it in localStorage and use Authorization:
+  // Bearer for the subsequent API calls. Fragments are cleared by the
+  // client right after they're consumed; see assets/community-pulse/claim.js.
+  const siteUrl = env.SITE_URL || originOf(req);
+  const path = (existing && !existing.revoked_at) ? '/profile.html' : '/verify-me.html';
+  const claimFlag = (existing && !existing.revoked_at) ? '' : '&claim=1';
+  const redirect = `${siteUrl}${path}#token=${encodeURIComponent(jwt)}${claimFlag}`;
+
+  // Clear the OAuth state cookie; no session cookie needed (token rides
+  // in the fragment instead).
   const headers = new Headers({ Location: redirect });
-  headers.append('Set-Cookie',
-    `${SESSION_COOKIE}=${jwt}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=86400`);
   headers.append('Set-Cookie',
     `${STATE_COOKIE}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`);
   return new Response(null, { status: 302, headers });

--- a/community-pulse/worker/wrangler.toml
+++ b/community-pulse/worker/wrangler.toml
@@ -11,6 +11,7 @@ migrations_dir = "schema"
 [vars]
 ALLOWED_ORIGIN = "https://marbleheaddata.org"
 FB_APP_ID = "1024901246889499"
+SITE_URL = "https://marbleheaddata.org"
 
 [dev]
 port = 8787
@@ -30,6 +31,7 @@ migrations_dir = "schema"
 [env.staging.vars]
 ALLOWED_ORIGIN = "*"
 FB_APP_ID = "1024901246889499"
+SITE_URL = "https://marbleheaddata.org"
 # JWT_SECRET is set via `wrangler secret put JWT_SECRET --env staging`.
 # A dev-grade value used to live here; removed once self-serve
 # verification (which signs real session JWTs) shipped to staging.

--- a/tests/smoke-test.mjs
+++ b/tests/smoke-test.mjs
@@ -474,10 +474,12 @@ async function testVerifyMePageLoads(page) {
     ? ok('verify-me h1 is "Verify yourself"')
     : fail('verify-me h1', `expected "Verify yourself", got "${h1Text}"`);
 
-  const fbCta = await page.$('a.btn--primary[href="/api/auth/fb/start"]');
+  // CTA must point at the Worker host (absolute), not the site (relative
+  // would 404 because the site and Worker are at different origins).
+  const fbCta = await page.$('a.btn--primary[href*="/api/auth/fb/start"]');
   fbCta
     ? ok('verify-me FB CTA present')
-    : fail('verify-me FB CTA', 'missing a[href="/api/auth/fb/start"]');
+    : fail('verify-me FB CTA', 'missing a[href*="/api/auth/fb/start"]');
 
   const inviteFallback = await page.$('a.btn--secondary[href="/verify.html"]');
   inviteFallback

--- a/verify-me.html
+++ b/verify-me.html
@@ -22,9 +22,22 @@ permalink: /verify-me.html
       spouse not on the deed), we will route you to a neighbor who can
       confirm.
     </p>
-    <a href="/api/auth/fb/start" class="btn btn--primary">
+    <a id="fb-start-link"
+       href="https://marblehead-community-pulse.agbaber.workers.dev/api/auth/fb/start"
+       class="btn btn--primary">
       Continue with Facebook
     </a>
+    <script>
+      // The community-pulse Worker lives at a different origin than the
+      // Pages-hosted site, so the OAuth start URL must be absolute. Switch
+      // to localhost in local dev.
+      (function(){
+        if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
+          document.getElementById('fb-start-link').href =
+            'http://localhost:8787/api/auth/fb/start';
+        }
+      })();
+    </script>
     <p class="verify-door__note">
       <a href="/privacy.html#facebook-sign-in">What we receive from Facebook</a>
     </p>


### PR DESCRIPTION
## Summary

The FB OAuth flow couldn't complete a round-trip because the site (`marbleheaddata.org`, Pages) and the Worker (`marblehead-community-pulse.agbaber.workers.dev`) are at different origins, and Phase 1 silently assumed same-origin. Two concrete bugs:

1. **`/verify-me.html` line 25** — the "Continue with Facebook" anchor was `<a href="/api/auth/fb/start">`. Relative URL, so on the site it resolved to `marbleheaddata.org/api/auth/fb/start` which 404s on the static Pages site instead of hitting the Worker.

2. **`fb.js` `handleFbCallback`** — after FB auth the Worker 302'd to relative `/profile` or `/verify-me#claim`. Since the callback runs on the Worker, the redirect landed the user on `marblehead-community-pulse.agbaber.workers.dev/profile` — also a 404.

## Fix

- FB CTA href on `/verify-me.html` is now absolute (`https://marblehead-community-pulse.agbaber.workers.dev/api/auth/fb/start`), with a tiny inline script that flips to `http://localhost:8787` in local dev.
- Worker callback now redirects to an absolute URL using a new `SITE_URL` env var (set to `https://marbleheaddata.org` for both prod and staging in `wrangler.toml`).
- Dropped the HttpOnly session cookie. Pass the freshly-minted JWT via the URL fragment (`#token=<jwt>&claim=1`); `claim.js` stashes it in localStorage and strips the fragment via `history.replaceState`. All subsequent API calls use `Authorization: Bearer` — matching the existing invite-handshake convention, and sidestepping the cross-origin cookie problem entirely (no `SameSite=None`, no CORS credentials needed).

## Also in this PR

`@passwordless-id/webauthn` is now a declared dep in `community-pulse/package.json`. It's been a hidden transitive dep all along — `wrangler deploy` was failing on fresh checkouts until I manually installed it. Now `npm install` puts it in place.

## Deploy status

Both workers were redeployed from this branch during testing:
- Staging: `marblehead-community-pulse-staging` version `80e2f181`
- Production: `marblehead-community-pulse` version `bd1bb6b8`

## Test plan

- [ ] 8 vitest cases in `community-pulse/tests/fb.test.js` pass (new test confirms the callback redirects to `$SITE_URL/verify-me.html#token=...&claim=1` and sets no session cookie)
- [ ] Live OAuth round-trip on `marbleheaddata.org/verify-me.html` → Continue with Facebook → land back on `marbleheaddata.org/verify-me.html#claim` signed in, with the FB display name shown above the claim form

🤖 Generated with [Claude Code](https://claude.com/claude-code)