### PR TITLE
Backing and reps (Part A): engagement widget on what-can-we-do.html

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -223,3 +223,36 @@ Rationale: internal links help readers explore the site; external links take the
   rule is against rhetorical "beat inflation" framings that imply waste without
   analytical support, not against honest disclosure that a number is
   inflation-adjusted.
+- No sort-by-backing, "trending," "most backed," "popular," or "featured"
+  treatment of ideas. Ideas stay in editorial order; backing is a layer on top,
+  never a re-ranking signal.
+- No advocacy verbs on engagement copy ("support," "vote for," "champions,"
+  "leads"). Backing is residents endorsing in their own name, not the site
+  endorsing. See "Backing and reps wording rules" below.
+
+## Backing and reps wording rules
+
+The "Who's behind this" panel on `what-can-we-do.html` lets verified residents
+back ideas in their own name. The line we hold: *verified residents endorse
+ideas in their own name; the site itself never endorses an idea.* Word the
+engagement UI accordingly.
+
+| Use | Avoid |
+|-----|-------|
+| "Backed by N verified residents" | "N residents support this" / "N votes for this" |
+| "X says they'll talk to others about this" | "X is leading this" / "X champions this" |
+| "Who's behind this" (panel header) | "Endorsements" / "Supporters" / "Trending" |
+| "Be the first to back this" | "Be the first to support this idea" |
+
+Counts read as "N verified residents," never "N Marbleheaders" or "N voters,"
+because the verified network is a self-selected sample, not a town poll.
+
+### Engagement panel (page component)
+
+The backing panel (`.idea-engage`, `assets/community-pulse/engagement.css`)
+sits *below* the editorial content of an idea card, with lighter typography and
+only a subtle `data-cat` border accent. Reading a card top to bottom, the
+editorial substance (rough guess, difficulty, who pays, research) always lands
+before the backing data. The panel is gated by the `engagement_widget` flag in
+`_config.yml` (`on` by default; set to `off` to hide site-wide without removing
+the underlying data).

--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,11 @@ transcripts_subscribe: true
 # dashboard.
 mapbox_token: "pk.eyJ1IjoiYWdiYWJlciIsImEiOiJjbXFkNzNtcTUweGIwMnBvZ3ByanN3N2oxIn0.mkfdAEIhSUxXH-TeblpX5w"
 
+# Backing and reps widget on what-can-we-do.html. Set to "off" to hide the
+# "Who's behind this" panels site-wide without removing the data. Quoted so
+# YAML keeps it a string (bare on/off parse as booleans).
+engagement_widget: "on"
+
 plugins: []
 
 collections:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -46,6 +46,8 @@
 {% endif %}{% if page.scripts contains "chart-tooltip" %}<script defer src="{{ '/' | relative_url }}assets/chart-tooltip.js"></script>
 {% endif %}{% if page.scripts contains "ballot-picker" %}<script defer src="{{ '/' | relative_url }}assets/ballot-picker.js"></script>
 {% endif %}{% if page.scripts contains "scrollytelling-map" %}<script defer src="{{ '/' | relative_url }}assets/scrollytelling-map.js"></script>
+{% endif %}{% if page.scripts contains "engagement" and site.engagement_widget != "off" %}<link rel="stylesheet" href="{{ '/' | relative_url }}assets/community-pulse/engagement.css">
+<script defer src="{{ '/' | relative_url }}assets/community-pulse/engagement.js"></script>
 {% endif %}
 {% assign _og_title = page.og_title | default: page.title | default: site.title %}
 {% assign _og_desc  = page.og_description | default: site.description %}

--- a/assets/community-pulse/engagement.css
+++ b/assets/community-pulse/engagement.css
@@ -1,0 +1,170 @@
+/* Backing and reps widget for what-can-we-do.html.
+   Sits below the editorial content of each idea card. Lighter typography than
+   the editorial blocks; data-cat color is a subtle accent, never a hero color. */
+
+/* Top inline strip, appended to the .idea-num line. */
+.idea-engage-strip {
+  font: inherit;
+  color: var(--c-ink-3, #6b7785);
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  letter-spacing: inherit;
+}
+.idea-engage-strip:hover { text-decoration: underline; }
+
+/* Bottom panel. */
+.idea-engage {
+  margin-top: 1.25rem;
+  padding: 0.9rem 1rem;
+  border-left: 3px solid var(--c-fog, #e6ebf0);
+  background: var(--c-fog, #f4f7fa);
+  border-radius: 0 6px 6px 0;
+}
+.idea[data-cat="rev"] .idea-engage { border-left-color: var(--c-teal); }
+.idea[data-cat="cost"] .idea-engage { border-left-color: var(--c-navy); }
+.idea[data-cat="gov"]  .idea-engage { border-left-color: var(--c-brass); }
+
+.idea-engage-h {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--c-ink-3, #6b7785);
+  margin: 0 0 0.5rem;
+}
+.idea-engage-summary,
+.idea-engage-empty,
+.idea-engage-anononly {
+  font-size: 0.86rem;
+  line-height: 1.45;
+  color: var(--c-ink-2, #3c4754);
+  margin: 0.35rem 0;
+}
+.idea-engage-empty { color: var(--c-ink-3, #6b7785); }
+
+.idea-engage-names {
+  list-style: none;
+  margin: 0.35rem 0 0.6rem;
+  padding: 0;
+  font-size: 0.86rem;
+  line-height: 1.5;
+  color: var(--c-ink-2, #3c4754);
+}
+.idea-engage-anon { color: var(--c-ink-3, #6b7785); }
+
+.idea-engage-btn {
+  display: inline-block;
+  margin-top: 0.6rem;
+  padding: 0.45rem 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--c-surface, #fff);
+  background: var(--c-navy, #1b3a57);
+  border: 1px solid var(--c-navy, #1b3a57);
+  border-radius: 5px;
+  cursor: pointer;
+  text-decoration: none;
+}
+.idea-engage-btn:hover { opacity: 0.92; }
+.idea-engage-btn--ghost {
+  color: var(--c-navy, #1b3a57);
+  background: transparent;
+}
+
+/* Modal. */
+.idea-engage-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(20, 32, 44, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+.idea-engage-modal {
+  background: var(--c-surface, #fff);
+  border-radius: 10px;
+  max-width: 440px;
+  width: 100%;
+  padding: 1.4rem 1.4rem 1.2rem;
+  box-shadow: 0 12px 40px rgba(20, 32, 44, 0.25);
+  max-height: 90vh;
+  overflow-y: auto;
+}
+.idea-engage-modal-eye {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--c-ink-3, #6b7785);
+  margin: 0 0 0.25rem;
+}
+.idea-engage-modal-title {
+  font-size: 1.02rem;
+  line-height: 1.3;
+  margin: 0 0 1rem;
+  color: var(--c-ink, #1a2530);
+}
+.idea-engage-check {
+  display: flex;
+  gap: 0.55rem;
+  align-items: flex-start;
+  font-size: 0.88rem;
+  line-height: 1.4;
+  margin: 0.55rem 0;
+  color: var(--c-ink-2, #3c4754);
+  cursor: pointer;
+}
+.idea-engage-check input { margin-top: 0.2rem; flex: none; }
+.idea-engage-field {
+  display: block;
+  margin: 0.7rem 0 0.2rem;
+  font-size: 0.82rem;
+  color: var(--c-ink-3, #6b7785);
+}
+.idea-engage-name {
+  display: block;
+  width: 100%;
+  margin-top: 0.3rem;
+  padding: 0.5rem 0.6rem;
+  font-size: 0.92rem;
+  border: 1px solid var(--c-line, #d3dbe3);
+  border-radius: 5px;
+  box-sizing: border-box;
+}
+.idea-engage-modal-note {
+  font-size: 0.78rem;
+  color: var(--c-ink-3, #6b7785);
+  line-height: 1.4;
+  margin: 0.9rem 0 0.4rem;
+}
+.idea-engage-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+.idea-engage-error {
+  color: var(--c-buoy, #c8553d);
+  font-size: 0.82rem;
+  margin: 0.5rem 0 0;
+  min-height: 1em;
+}
+
+/* Editorial note at the top of the idea list. */
+.wcwd-engage-note {
+  font-size: 0.86rem;
+  line-height: 1.5;
+  color: var(--c-ink-3, #6b7785);
+  max-width: 60ch;
+  margin: 1rem auto 0;
+}
+
+@media (max-width: 560px) {
+  .idea-engage-overlay { align-items: flex-end; padding: 0; }
+  .idea-engage-modal { max-width: 100%; border-radius: 12px 12px 0 0; }
+}

--- a/assets/community-pulse/engagement.js
+++ b/assets/community-pulse/engagement.js
@@ -1,0 +1,265 @@
+// Backing and reps widget for what-can-we-do.html.
+// Verified residents endorse ideas in their own name; the site never endorses.
+// Talks to the community-pulse Worker (/api/engagement, /api/verify/me).
+// Fails silent: if the API is unreachable, the page reads exactly as before.
+
+(function () {
+  'use strict';
+
+  var API = (location.hostname === 'localhost' || location.hostname === '127.0.0.1')
+    ? 'http://localhost:8787'
+    : 'https://marblehead-community-pulse.agbaber.workers.dev';
+
+  var state = { jwt: null, me: null };
+
+  function headers() {
+    var h = { 'Content-Type': 'application/json' };
+    if (state.jwt) h['Authorization'] = 'Bearer ' + state.jwt;
+    return h;
+  }
+
+  function api(method, path, body) {
+    var opts = { method: method, headers: headers() };
+    if (body) opts.body = JSON.stringify(body);
+    return fetch(API + path, opts).then(function (r) {
+      if (!r.ok && r.status === 401) { return null; }
+      return r.json();
+    });
+  }
+
+  function emptyEntry() {
+    return { back_count: 0, rep_count: 0, anon_count: 0, named_backers: [], reps: [], my_state: null };
+  }
+
+  function el(tag, cls, text) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (text != null) e.textContent = text;
+    return e;
+  }
+
+  // A verified resident's name with optional branch, e.g. "Jane Smith (Necking Branch)".
+  function nameLine(entry) {
+    var line = entry.name;
+    if (entry.branch) line += ' (' + entry.branch + ')';
+    return line;
+  }
+
+  // ── Render one card ──────────────────────────────────────────────
+
+  function renderCard(card, e) {
+    // Top inline strip, appended to the .idea-num line. Hidden when nothing backed.
+    var num = card.querySelector('.idea-num');
+    var existingStrip = card.querySelector('.idea-engage-strip');
+    if (existingStrip) existingStrip.remove();
+    if (num && e.back_count > 0) {
+      var strip = el('button', 'idea-engage-strip');
+      strip.type = 'button';
+      var parts = [e.back_count + ' backed'];
+      if (e.rep_count > 0) parts.push(e.rep_count + (e.rep_count === 1 ? ' rep' : ' reps'));
+      strip.textContent = parts.join(' · ');
+      strip.addEventListener('click', function () {
+        var panel = card.querySelector('.idea-engage');
+        if (panel) panel.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      });
+      num.appendChild(document.createTextNode('  '));
+      num.appendChild(strip);
+    }
+
+    // Bottom panel, rebuilt each render.
+    var old = card.querySelector('.idea-engage');
+    if (old) old.remove();
+    var panel = el('div', 'idea-engage');
+
+    panel.appendChild(el('p', 'idea-engage-h', "Who's behind this"));
+
+    if (e.back_count === 0) {
+      panel.appendChild(el('p', 'idea-engage-empty',
+        'No verified residents have backed this yet.'));
+    } else {
+      var summary = el('p', 'idea-engage-summary',
+        e.back_count + (e.back_count === 1 ? ' verified resident has' : ' verified residents have') + ' backed this.');
+      panel.appendChild(summary);
+
+      if (e.named_backers.length) {
+        var ul = el('ul', 'idea-engage-names');
+        e.named_backers.forEach(function (b) { ul.appendChild(el('li', null, nameLine(b))); });
+        var anon = e.anon_count;
+        if (anon > 0) ul.appendChild(el('li', 'idea-engage-anon', '+ ' + anon + ' anonymous'));
+        panel.appendChild(ul);
+      } else {
+        panel.appendChild(el('p', 'idea-engage-anononly',
+          e.back_count === 1 ? 'Backed anonymously.' : 'All backed anonymously.'));
+      }
+
+      if (e.rep_count > 0) {
+        panel.appendChild(el('p', 'idea-engage-summary',
+          e.rep_count + (e.rep_count === 1 ? ' rep says' : ' reps say') + ' they’ll talk to others about this:'));
+        var rul = el('ul', 'idea-engage-names');
+        e.reps.forEach(function (r) { rul.appendChild(el('li', null, nameLine(r))); });
+        panel.appendChild(rul);
+      }
+    }
+
+    panel.appendChild(buildButton(card, e));
+    card.appendChild(panel);
+  }
+
+  function buildButton(card, e) {
+    if (!state.me) {
+      var a = el('a', 'idea-engage-btn', 'Verify to back this idea');
+      a.href = '/verify-me.html';
+      return a;
+    }
+    var label = 'Back this idea';
+    if (e.my_state === 'rep') label = 'Manage (you’re a rep)';
+    else if (e.my_state === 'back_named' || e.my_state === 'back_anon') label = 'Manage your backing';
+    var btn = el('button', 'idea-engage-btn');
+    btn.type = 'button';
+    btn.textContent = label;
+    btn.addEventListener('click', function () { openModal(card, e); });
+    return btn;
+  }
+
+  // ── Modal ────────────────────────────────────────────────────────
+
+  function openModal(card, e) {
+    var title = card.querySelector('.idea-title');
+    var overlay = el('div', 'idea-engage-overlay');
+    var modal = el('div', 'idea-engage-modal');
+    overlay.appendChild(modal);
+
+    modal.appendChild(el('p', 'idea-engage-modal-eye', 'Back this idea'));
+    modal.appendChild(el('h3', 'idea-engage-modal-title', title ? title.textContent : card.id));
+
+    // Name field, shown when backing publicly or as a rep.
+    var nameWrap = el('label', 'idea-engage-field');
+    nameWrap.appendChild(el('span', null, 'Your name (shown publicly)'));
+    var nameInput = el('input', 'idea-engage-name');
+    nameInput.type = 'text';
+    nameInput.maxLength = 80;
+    nameInput.placeholder = 'e.g. Jane Smith';
+    if (state.me.display_name) nameInput.value = state.me.display_name;
+    nameWrap.appendChild(nameInput);
+
+    var showName = checkbox('Show my name on this idea publicly');
+    var rep = checkbox('I’ll talk to others about this (become a rep; this shows your name publicly)');
+
+    // Pre-fill from current state.
+    if (e.my_state === 'rep') { rep.input.checked = true; showName.input.checked = true; }
+    else if (e.my_state === 'back_named') { showName.input.checked = true; }
+
+    function syncNameField() {
+      var needName = showName.input.checked || rep.input.checked;
+      nameWrap.style.display = needName ? '' : 'none';
+      // Rep implies name shown.
+      if (rep.input.checked) { showName.input.checked = true; showName.input.disabled = true; }
+      else { showName.input.disabled = false; }
+    }
+    showName.input.addEventListener('change', syncNameField);
+    rep.input.addEventListener('change', syncNameField);
+
+    modal.appendChild(showName.label);
+    modal.appendChild(rep.label);
+    modal.appendChild(nameWrap);
+    syncNameField();
+
+    modal.appendChild(el('p', 'idea-engage-modal-note',
+      'Backing this idea is you endorsing it, not the site.'));
+
+    var actions = el('div', 'idea-engage-actions');
+    var save = el('button', 'idea-engage-btn');
+    save.type = 'button';
+    save.textContent = 'Save';
+    var cancel = el('button', 'idea-engage-btn idea-engage-btn--ghost');
+    cancel.type = 'button';
+    cancel.textContent = 'Cancel';
+    actions.appendChild(save);
+    actions.appendChild(cancel);
+    if (e.my_state) {
+      var remove = el('button', 'idea-engage-btn idea-engage-btn--ghost');
+      remove.type = 'button';
+      remove.textContent = 'Remove';
+      remove.addEventListener('click', function () { submit(card, e, 'none', null, overlay, save); });
+      actions.appendChild(remove);
+    }
+    modal.appendChild(actions);
+
+    var err = el('p', 'idea-engage-error');
+    modal.appendChild(err);
+
+    function close() { overlay.remove(); document.removeEventListener('keydown', onKey); }
+    function onKey(ev) { if (ev.key === 'Escape') close(); }
+    cancel.addEventListener('click', close);
+    overlay.addEventListener('click', function (ev) { if (ev.target === overlay) close(); });
+    document.addEventListener('keydown', onKey);
+
+    save.addEventListener('click', function () {
+      var newState = rep.input.checked ? 'rep' : (showName.input.checked ? 'back_named' : 'back_anon');
+      var name = null;
+      if (newState === 'back_named' || newState === 'rep') {
+        name = nameInput.value.trim();
+        if (!name) { err.textContent = 'Enter your name, or uncheck the name options to back anonymously.'; return; }
+      }
+      submit(card, e, newState, name, overlay, save);
+    });
+
+    document.body.appendChild(overlay);
+    nameInput.focus();
+  }
+
+  function checkbox(text) {
+    var label = el('label', 'idea-engage-check');
+    var input = el('input');
+    input.type = 'checkbox';
+    label.appendChild(input);
+    label.appendChild(el('span', null, text));
+    return { label: label, input: input };
+  }
+
+  function submit(card, e, newState, name, overlay, saveBtn) {
+    saveBtn.disabled = true;
+    var body = { target_type: 'idea', target_id: card.id, state: newState };
+    if (name) body.display_name = name;
+    api('POST', '/api/engagement', body).then(function (res) {
+      if (!res || res.error) {
+        saveBtn.disabled = false;
+        var err = overlay.querySelector('.idea-engage-error');
+        if (err) err.textContent = (res && res.error) ? res.error : 'Something went wrong. Try again.';
+        return;
+      }
+      if (name) state.me.display_name = name;
+      overlay.remove();
+      // Re-fetch this card to refresh names + counts.
+      api('GET', '/api/engagement?target_type=idea&target_ids=' + encodeURIComponent(card.id))
+        .then(function (data) { renderCard(card, (data && data[card.id]) || emptyEntry()); });
+    });
+  }
+
+  // ── Init ─────────────────────────────────────────────────────────
+
+  function init() {
+    var cards = Array.prototype.slice.call(document.querySelectorAll('.idea[id^="idea-"]'));
+    if (!cards.length) return;
+    var ids = cards.map(function (c) { return c.id; });
+
+    state.jwt = localStorage.getItem('verify_jwt');
+    var auth = Promise.resolve();
+    if (state.jwt) {
+      auth = api('GET', '/api/verify/me').then(function (me) {
+        if (me && me.identity_hash) state.me = me;
+        else { state.jwt = null; localStorage.removeItem('verify_jwt'); }
+      }).catch(function () { state.jwt = null; });
+    }
+
+    auth.then(function () {
+      return api('GET', '/api/engagement?target_type=idea&target_ids=' + ids.map(encodeURIComponent).join(','));
+    }).then(function (data) {
+      if (!data) return;
+      cards.forEach(function (card) { renderCard(card, data[card.id] || emptyEntry()); });
+    }).catch(function () { /* fail silent */ });
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();

--- a/community-pulse/tests/engagement.test.js
+++ b/community-pulse/tests/engagement.test.js
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
+import { handleRequest } from '../worker/src/index.js';
+import { signJWT } from '../worker/src/jwt.js';
+
+const SECRET = env.JWT_SECRET || 'dev-secret-not-for-production';
+
+// Seed two residents; return a signed JWT for the first.
+async function seedResident(hash, branchRoot, displayName = null) {
+  const now = Date.now();
+  await env.DB.prepare(
+    'INSERT OR REPLACE INTO residents (identity_hash, invited_by, branch_root, invites_remaining, created_at, display_name) VALUES (?, NULL, ?, 3, ?, ?)'
+  ).bind(hash, branchRoot, now, displayName).run();
+  return signJWT({ sub: hash, branch: branchRoot }, SECRET);
+}
+
+function authHeaders(jwt) {
+  return { 'Content-Type': 'application/json', Authorization: `Bearer ${jwt}` };
+}
+
+async function postEngagement(jwt, body) {
+  const req = new Request('https://pulse.example.com/api/engagement', {
+    method: 'POST',
+    headers: authHeaders(jwt),
+    body: JSON.stringify(body),
+  });
+  return handleRequest(req, env);
+}
+
+async function getEngagement(targetIds, jwt) {
+  const headers = jwt ? { Authorization: `Bearer ${jwt}` } : {};
+  const req = new Request(
+    `https://pulse.example.com/api/engagement?target_type=idea&target_ids=${targetIds.join(',')}`,
+    { headers }
+  );
+  return handleRequest(req, env);
+}
+
+beforeEach(async () => {
+  await env.DB.prepare(`
+    CREATE TABLE IF NOT EXISTS residents (
+      identity_hash TEXT PRIMARY KEY,
+      invited_by TEXT,
+      branch_root TEXT,
+      invites_remaining INTEGER NOT NULL DEFAULT 3,
+      created_at INTEGER NOT NULL,
+      revoked_at INTEGER,
+      display_name TEXT
+    )
+  `).run();
+  await env.DB.prepare(`
+    CREATE TABLE IF NOT EXISTS engagement (
+      identity_hash TEXT NOT NULL,
+      target_type   TEXT NOT NULL CHECK (target_type IN ('idea','warrant','poll')),
+      target_id     TEXT NOT NULL,
+      state         TEXT NOT NULL CHECK (state IN ('back_anon','back_named','rep')),
+      created_at    INTEGER NOT NULL,
+      updated_at    INTEGER NOT NULL,
+      PRIMARY KEY (identity_hash, target_type, target_id)
+    )
+  `).run();
+  // resolveBranchName() joins these; create them so branch labels resolve to null
+  // (no proposed names) rather than throwing.
+  await env.DB.prepare(`
+    CREATE TABLE IF NOT EXISTS branch_names (
+      branch_root TEXT NOT NULL,
+      proposed_name TEXT NOT NULL,
+      proposed_by TEXT NOT NULL,
+      proposed_at INTEGER NOT NULL,
+      PRIMARY KEY (branch_root, proposed_name)
+    )
+  `).run();
+  await env.DB.prepare(`
+    CREATE TABLE IF NOT EXISTS branch_name_votes (
+      identity_hash TEXT NOT NULL,
+      branch_root TEXT NOT NULL,
+      voted_name TEXT NOT NULL,
+      voted_at INTEGER NOT NULL,
+      PRIMARY KEY (identity_hash, branch_root)
+    )
+  `).run();
+  await env.DB.prepare('DELETE FROM engagement').run();
+  await env.DB.prepare('DELETE FROM residents').run();
+});
+
+describe('GET /api/engagement', () => {
+  it('returns zeroed entries for ideas with no engagement', async () => {
+    const res = await getEngagement(['idea-01', 'idea-02']);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body['idea-01']).toEqual({ back_count: 0, rep_count: 0, anon_count: 0, named_backers: [], reps: [] });
+    expect(body['idea-02'].back_count).toBe(0);
+  });
+
+  it('counts anonymous backers without exposing names', async () => {
+    const jwt = await seedResident('h1', 'b1');
+    await postEngagement(jwt, { target_type: 'idea', target_id: 'idea-01', state: 'back_anon' });
+
+    const res = await getEngagement(['idea-01']);
+    const body = await res.json();
+    expect(body['idea-01'].back_count).toBe(1);
+    expect(body['idea-01'].anon_count).toBe(1);
+    expect(body['idea-01'].named_backers).toEqual([]);
+    expect(body['idea-01'].rep_count).toBe(0);
+  });
+
+  it('exposes names for named backers and reps; reps count toward backing', async () => {
+    const jwt1 = await seedResident('h1', 'b1', 'Andrew Baber');
+    const jwt2 = await seedResident('h2', 'b2', 'Jane Smith');
+    const jwt3 = await seedResident('h3', 'b1');
+    await postEngagement(jwt1, { target_type: 'idea', target_id: 'idea-06', state: 'rep' });
+    await postEngagement(jwt2, { target_type: 'idea', target_id: 'idea-06', state: 'back_named' });
+    await postEngagement(jwt3, { target_type: 'idea', target_id: 'idea-06', state: 'back_anon' });
+
+    const res = await getEngagement(['idea-06']);
+    const body = await res.json();
+    const e = body['idea-06'];
+    expect(e.back_count).toBe(3);
+    expect(e.rep_count).toBe(1);
+    expect(e.anon_count).toBe(1);
+    expect(e.named_backers.map(b => b.name).sort()).toEqual(['Andrew Baber', 'Jane Smith']);
+    expect(e.reps.map(r => r.name)).toEqual(['Andrew Baber']);
+  });
+
+  it('excludes backing from revoked residents', async () => {
+    const jwt = await seedResident('h1', 'b1', 'Andrew Baber');
+    await postEngagement(jwt, { target_type: 'idea', target_id: 'idea-01', state: 'back_named' });
+    await env.DB.prepare('UPDATE residents SET revoked_at = ? WHERE identity_hash = ?')
+      .bind(Date.now(), 'h1').run();
+
+    const res = await getEngagement(['idea-01']);
+    const body = await res.json();
+    expect(body['idea-01'].back_count).toBe(0);
+    expect(body['idea-01'].named_backers).toEqual([]);
+  });
+
+  it('includes my_state for an authenticated caller', async () => {
+    const jwt = await seedResident('h1', 'b1', 'Andrew Baber');
+    await postEngagement(jwt, { target_type: 'idea', target_id: 'idea-01', state: 'rep' });
+    const res = await getEngagement(['idea-01'], jwt);
+    const body = await res.json();
+    expect(body['idea-01'].my_state).toBe('rep');
+  });
+});
+
+describe('POST /api/engagement', () => {
+  it('rejects unauthenticated writes', async () => {
+    const req = new Request('https://pulse.example.com/api/engagement', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ target_type: 'idea', target_id: 'idea-01', state: 'back_anon' }),
+    });
+    const res = await handleRequest(req, env);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects an invalid state', async () => {
+    const jwt = await seedResident('h1', 'b1');
+    const res = await postEngagement(jwt, { target_type: 'idea', target_id: 'idea-01', state: 'love' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects back_named/rep when the resident has no display_name and none is provided', async () => {
+    const jwt = await seedResident('h1', 'b1');
+    const res = await postEngagement(jwt, { target_type: 'idea', target_id: 'idea-01', state: 'rep' });
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts a display_name in the body and persists it on the resident', async () => {
+    const jwt = await seedResident('h1', 'b1');
+    const res = await postEngagement(jwt, { target_type: 'idea', target_id: 'idea-01', state: 'back_named', display_name: 'Bob Jones' });
+    expect(res.status).toBe(200);
+    const row = await env.DB.prepare('SELECT display_name FROM residents WHERE identity_hash = ?').bind('h1').first();
+    expect(row.display_name).toBe('Bob Jones');
+  });
+
+  it('overwrites state (back -> rep -> remove)', async () => {
+    const jwt = await seedResident('h1', 'b1', 'Andrew Baber');
+    await postEngagement(jwt, { target_type: 'idea', target_id: 'idea-01', state: 'back_anon' });
+    await postEngagement(jwt, { target_type: 'idea', target_id: 'idea-01', state: 'rep' });
+
+    let body = await (await getEngagement(['idea-01'])).json();
+    expect(body['idea-01'].rep_count).toBe(1);
+    expect(body['idea-01'].back_count).toBe(1);
+
+    const res = await postEngagement(jwt, { target_type: 'idea', target_id: 'idea-01', state: 'none' });
+    expect(res.status).toBe(200);
+    body = await (await getEngagement(['idea-01'])).json();
+    expect(body['idea-01'].back_count).toBe(0);
+  });
+
+  it('returns the updated counts for the target', async () => {
+    const jwt = await seedResident('h1', 'b1', 'Andrew Baber');
+    const res = await postEngagement(jwt, { target_type: 'idea', target_id: 'idea-01', state: 'rep' });
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.engagement.back_count).toBe(1);
+    expect(body.engagement.rep_count).toBe(1);
+    expect(body.engagement.my_state).toBe('rep');
+  });
+});

--- a/community-pulse/vitest.config.js
+++ b/community-pulse/vitest.config.js
@@ -16,7 +16,7 @@ export default defineWorkersConfig({
         extends: true,
         test: {
           name: 'worker',
-          include: ['tests/worker.test.js'],
+          include: ['tests/worker.test.js', 'tests/engagement.test.js'],
           poolOptions: {
             workers: {
               singleWorker: true,

--- a/community-pulse/worker/schema/0007_engagement.sql
+++ b/community-pulse/worker/schema/0007_engagement.sql
@@ -1,0 +1,19 @@
+-- Backing and reps: residents publicly back ideas on what-can-we-do.html.
+-- See docs/superpowers/specs/2026-06-09-backing-and-reps-design.md (Part A).
+--
+-- residents.display_name already exists (0006_self_serve_verification.sql), so
+-- named backing/rep reuses it; this migration only adds the engagement table.
+
+-- Per-target engagement. v1 only writes target_type='idea'; the column exists
+-- so v2 (warrant articles) and v3 (curated polls) reuse this table without
+-- a migration. State is overwriting (like-button semantics), not append-only.
+CREATE TABLE IF NOT EXISTS engagement (
+  identity_hash TEXT NOT NULL,
+  target_type   TEXT NOT NULL CHECK (target_type IN ('idea','warrant','poll')),
+  target_id     TEXT NOT NULL,           -- e.g. 'idea-06', 'atm-2027-article-17'
+  state         TEXT NOT NULL CHECK (state IN ('back_anon','back_named','rep')),
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL,
+  PRIMARY KEY (identity_hash, target_type, target_id)
+);
+CREATE INDEX IF NOT EXISTS idx_engagement_target ON engagement(target_type, target_id, state);

--- a/community-pulse/worker/src/engagement.js
+++ b/community-pulse/worker/src/engagement.js
@@ -1,0 +1,172 @@
+// Backing and reps: verified residents publicly back ideas on
+// what-can-we-do.html. v1 (Part A) of the backing-and-reps spec.
+//
+//   GET  /api/engagement?target_type=idea&target_ids=idea-01,idea-02
+//        -> per-target counts + opted-in names. my_state added if the
+//           caller sends a valid JWT.
+//   POST /api/engagement   { target_type, target_id, state, display_name? }
+//        -> set the caller's state. state 'none' removes the row.
+//
+// Reuses the verification layer's identity hashes and JWT auth.
+
+import {
+  authenticate,
+  parseBody,
+  getActiveResident,
+  resolveBranchName,
+  json,
+} from './verify.js';
+import { extractJWT, verifyJWT } from './jwt.js';
+
+const VALID_TARGET_TYPES = ['idea', 'warrant', 'poll'];
+// Writable states. 'none' removes the row; reads never see it.
+const VALID_WRITE_STATES = ['back_anon', 'back_named', 'rep', 'none'];
+const MAX_DISPLAY_NAME = 80;
+
+export async function handleEngagement(request, env, url) {
+  if (url.pathname !== '/api/engagement') return null;
+  const secret = env.JWT_SECRET || 'dev-secret-not-for-production';
+
+  if (request.method === 'GET') return handleGetEngagement(request, env, url, secret);
+  if (request.method === 'POST') return handlePostEngagement(request, env, secret);
+  return null;
+}
+
+async function handleGetEngagement(request, env, url, secret) {
+  const targetType = url.searchParams.get('target_type') || 'idea';
+  if (!VALID_TARGET_TYPES.includes(targetType)) {
+    return json({ error: 'invalid target_type' }, env, 400);
+  }
+
+  const targetIds = (url.searchParams.get('target_ids') || '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  if (targetIds.length === 0) return json({}, env);
+
+  // Caller identity is optional on reads; only used to fill my_state.
+  let callerHash = null;
+  const token = extractJWT(request);
+  if (token) {
+    const payload = await verifyJWT(token, secret);
+    if (payload) callerHash = payload.sub;
+  }
+
+  const placeholders = targetIds.map(() => '?').join(',');
+  // INNER JOIN + revoked filter: a revoked resident (e.g. confirmed
+  // impersonation) drops out of counts and named lists without a backfill.
+  const { results } = await env.DB.prepare(
+    `SELECT e.target_id, e.state, e.identity_hash, r.display_name, r.branch_root
+       FROM engagement e
+       JOIN residents r ON r.identity_hash = e.identity_hash
+      WHERE e.target_type = ? AND e.target_id IN (${placeholders})
+        AND r.revoked_at IS NULL`
+  ).bind(targetType, ...targetIds).all();
+
+  // Resolve each branch name at most once.
+  const branchCache = new Map();
+  const branchLabel = async (root) => {
+    if (!root) return null;
+    if (!branchCache.has(root)) branchCache.set(root, await resolveBranchName(env, root));
+    return branchCache.get(root);
+  };
+
+  const out = {};
+  for (const id of targetIds) {
+    out[id] = { back_count: 0, rep_count: 0, anon_count: 0, named_backers: [], reps: [] };
+    if (callerHash) out[id].my_state = null;
+  }
+
+  for (const row of results) {
+    const e = out[row.target_id];
+    if (!e) continue;
+    e.back_count += 1;
+    if (row.state === 'rep') e.rep_count += 1;
+    if (row.state === 'back_anon') e.anon_count += 1;
+    if (row.state === 'back_named' || row.state === 'rep') {
+      const entry = {
+        name: row.display_name || 'Verified resident',
+        branch: await branchLabel(row.branch_root),
+      };
+      e.named_backers.push(entry);
+      if (row.state === 'rep') e.reps.push(entry);
+    }
+    if (callerHash && row.identity_hash === callerHash) e.my_state = row.state;
+  }
+
+  return json(out, env);
+}
+
+async function handlePostEngagement(request, env, secret) {
+  const payload = await authenticate(request, env, secret);
+  if (payload instanceof Response) return payload;
+
+  const body = await parseBody(request, env);
+  if (body instanceof Response) return body;
+
+  const targetType = body.target_type || 'idea';
+  const targetId = body.target_id;
+  const state = body.state;
+
+  if (!VALID_TARGET_TYPES.includes(targetType)) {
+    return json({ error: 'invalid target_type' }, env, 400);
+  }
+  if (!targetId) return json({ error: 'missing target_id' }, env, 400);
+  if (!VALID_WRITE_STATES.includes(state)) {
+    return json({ error: 'invalid state' }, env, 400);
+  }
+
+  const resident = await getActiveResident(env, payload.sub);
+  if (!resident) return json({ error: 'resident not found or revoked' }, env, 403);
+
+  const now = Date.now();
+
+  if (state === 'none') {
+    await env.DB.prepare(
+      'DELETE FROM engagement WHERE identity_hash = ? AND target_type = ? AND target_id = ?'
+    ).bind(payload.sub, targetType, targetId).run();
+    return json({ ok: true, engagement: await targetSummary(env, targetType, targetId, payload.sub) }, env);
+  }
+
+  // Named backing and rep both surface the resident's name publicly, so a
+  // display_name must be on file. Accept one inline the first time.
+  if (state === 'back_named' || state === 'rep') {
+    let name = resident.display_name;
+    const provided = (body.display_name || '').trim();
+    if (provided) {
+      name = provided.slice(0, MAX_DISPLAY_NAME);
+      await env.DB.prepare('UPDATE residents SET display_name = ? WHERE identity_hash = ?')
+        .bind(name, payload.sub).run();
+    }
+    if (!name) return json({ error: 'display_name required for named backing or rep' }, env, 400);
+  }
+
+  // Overwriting upsert -- one row per (resident, target), no history.
+  await env.DB.prepare(
+    `INSERT INTO engagement (identity_hash, target_type, target_id, state, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(identity_hash, target_type, target_id)
+     DO UPDATE SET state = excluded.state, updated_at = excluded.updated_at`
+  ).bind(payload.sub, targetType, targetId, state, now, now).run();
+
+  return json({ ok: true, engagement: await targetSummary(env, targetType, targetId, payload.sub) }, env);
+}
+
+/** Aggregate counts for a single target, plus the caller's own state. */
+async function targetSummary(env, targetType, targetId, callerHash) {
+  const { results } = await env.DB.prepare(
+    `SELECT e.state, e.identity_hash
+       FROM engagement e
+       JOIN residents r ON r.identity_hash = e.identity_hash
+      WHERE e.target_type = ? AND e.target_id = ? AND r.revoked_at IS NULL`
+  ).bind(targetType, targetId).all();
+
+  let back_count = 0, rep_count = 0, anon_count = 0, my_state = null;
+  for (const r of results) {
+    back_count += 1;
+    if (r.state === 'rep') rep_count += 1;
+    if (r.state === 'back_anon') anon_count += 1;
+    if (callerHash && r.identity_hash === callerHash) my_state = r.state;
+  }
+  return { back_count, rep_count, anon_count, my_state };
+}

--- a/community-pulse/worker/src/index.js
+++ b/community-pulse/worker/src/index.js
@@ -7,6 +7,7 @@
 // Backed by a D1 database. No auth, no sessions.
 
 import { handleVerify } from './verify.js';
+import { handleEngagement } from './engagement.js';
 import { serveVerifyPage, serveBranchesPage } from './pages.js';
 import { STREETS } from './streets.js';
 import { handleFbStart, handleFbCallback } from './fb.js';
@@ -74,6 +75,12 @@ export async function handleRequest(request, env) {
 
   if (url.pathname === '/api/me/pre' && request.method === 'GET') {
     return handleMePre(request, env);
+  }
+
+  // Backing and reps: residents endorse ideas on what-can-we-do.html.
+  if (url.pathname === '/api/engagement') {
+    const engagementResponse = await handleEngagement(request, env, url);
+    if (engagementResponse) return engagementResponse;
   }
 
   // Street list for address typeahead.

--- a/community-pulse/worker/src/verify.js
+++ b/community-pulse/worker/src/verify.js
@@ -520,6 +520,7 @@ async function handleMe(request, env, secret) {
     branch_name: branchName,
     branch_size: sizeRow?.size || 0,
     invites_remaining: resident.invites_remaining,
+    display_name: resident.display_name || null,
     invites,
   }, env);
 }
@@ -887,7 +888,7 @@ async function handleRecoveryRedeem(request, env, secret, webauthnOrigin) {
 // ═══════════════════════════════════════════════════════════════
 
 /** Parse JSON body, returning a Response on failure. */
-async function parseBody(request, env) {
+export async function parseBody(request, env) {
   try {
     return await request.json();
   } catch {
@@ -896,7 +897,7 @@ async function parseBody(request, env) {
 }
 
 /** Authenticate via JWT. Returns the payload or a 401 Response. */
-async function authenticate(request, env, secret) {
+export async function authenticate(request, env, secret) {
   const token = extractJWT(request);
   if (!token) return json({ error: 'missing authorization' }, env, 401);
 
@@ -911,9 +912,9 @@ async function authenticate(request, env, secret) {
 }
 
 /** Get an active (non-revoked) resident row. */
-async function getActiveResident(env, identity_hash) {
+export async function getActiveResident(env, identity_hash) {
   return env.DB.prepare(
-    'SELECT identity_hash, branch_root, invited_by, invites_remaining, created_at FROM residents WHERE identity_hash = ? AND revoked_at IS NULL'
+    'SELECT identity_hash, branch_root, invited_by, invites_remaining, created_at, display_name FROM residents WHERE identity_hash = ? AND revoked_at IS NULL'
   ).bind(identity_hash).first();
 }
 
@@ -1006,7 +1007,7 @@ async function getVerifiedTally(env, topic) {
 }
 
 /** Resolve the winning branch name (most votes, ties broken by earliest proposal). */
-async function resolveBranchName(env, branchRoot) {
+export async function resolveBranchName(env, branchRoot) {
   if (!branchRoot) return null;
 
   const row = await env.DB.prepare(
@@ -1050,7 +1051,7 @@ function getWebAuthnOrigin(request, env) {
 }
 
 /** JSON response with CORS headers. */
-function json(data, env, status = 200) {
+export function json(data, env, status = 200) {
   return new Response(JSON.stringify(data), {
     status,
     headers: {

--- a/what-can-we-do.html
+++ b/what-can-we-do.html
@@ -4,7 +4,7 @@ og_title: "What can Marblehead do? A working list of questions worth asking."
 og_description: "Twelve questions worth asking the town's finance staff. Assembled by one resident, not by a feasibility study. Dollar figures are rough guesses."
 og_url: https://marbleheaddata.org/what-can-we-do.html
 sitemap: false
-scripts: [citations]
+scripts: [citations, engagement]
 ---
 <style>
   /* === Scrolling stops, homepage-style === */
@@ -735,6 +735,7 @@ scripts: [citations]
   <p class="wcwd-hero-sub">
     Eighteen <strong>questions worth asking the town's finance staff</strong>, drawn from one resident's reading of the public record. Not a feasibility study. The dollar figures below are rough guesses; the "have we tried this" answers came from one research pass and have already missed at least one item.
   </p>
+  {% if site.engagement_widget != "off" %}<p class="wcwd-engage-note">Each card ends with a "Who's behind this" panel: counts and names of verified residents who personally endorse the idea or volunteer to advocate for it. The site doesn't endorse any of these ideas. The editorial content (rough guess, difficulty, who pays, research notes) is the site speaking; the backing data is residents speaking for themselves.</p>{% endif %}
   <nav class="wcwd-jump" aria-label="Page sections">
     <a href="#revenue" data-cat="rev">5 revenue ideas</a>
     <a href="#cost" data-cat="cost">10 cost reductions</a>


### PR DESCRIPTION
Implements **Part A** of the backing-and-reps spec (`docs/superpowers/specs/2026-06-09-backing-and-reps-design.md`, PR #845): verified residents back ideas on `what-can-we-do.html` and self-declare as reps. The open-onramp half (FB Login / assessor match / profile) already shipped via #866/#876; this builds the engagement layer on top of it.

## What it does
- Each idea card gets a **"Who's behind this"** panel below its editorial content: count of verified residents backing it, opted-in names, and reps who say they'll talk to others. A subdued inline strip (`N backed · M reps`) appears on the `.idea-num` line.
- Back anonymously, back with your name shown, or become a rep (name required). One click, overwriting state, manage/remove anytime.
- The site never endorses; residents endorse in their own name. Editorial copy (rough guess, who pays, research) always reads before the backing data. No sort-by-backing, no trending, no leaderboards.

## Backend (community-pulse worker)
- `schema/0007_engagement.sql`: new `engagement` table (reuses the existing `residents.display_name` from #866; `target_type` is forward-compat for v2 warrants / v3 polls).
- `GET /api/engagement?target_type=idea&target_ids=…` (batched counts + opted-in names, `my_state` if authed) and `POST /api/engagement` (set/clear state). Revoked residents are excluded from all counts.
- `/api/verify/me` now returns `display_name` so the widget can pre-fill the name field.

## Frontend
- `assets/community-pulse/engagement.{js,css}`, loaded via `scripts: [citations, engagement]` and gated by the `engagement_widget` kill switch in `_config.yml` (quoted `"on"`; set `"off"` to hide site-wide without deleting data). Fails silent if the API is unreachable.
- STYLE_GUIDE: backing/rep wording rules + "What Not To Do" additions.

## Tests
- 11 new worker tests (`tests/engagement.test.js`); full worker project green (23/23). The 2 failing `store.test.js` cases are pre-existing on `main` (widget stance logic), unrelated to this change.

## Deploy note (needs you)
The worker isn't auto-deployed by the Pages preview. To make the widget live, deploy the worker and apply migration `0007` to D1 (staging + prod):
```
cd community-pulse
npx wrangler d1 migrations apply community-pulse --env staging   # then prod
npx wrangler deploy            # and --env staging
```
Until then the panels render "no one has backed this yet" / the widget fails silent on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)