### PR TITLE
Daily checkbook CSV refresh

### DIFF
--- a/.github/workflows/checkbook-refresh.yml
+++ b/.github/workflows/checkbook-refresh.yml
@@ -1,25 +1,22 @@
 name: Refresh checkbook CSV
 
 # Daily refresh of the published transaction-level checkbook CSV from
-# the Town spending portal, with a manual human review gate.
-#
-# Unlike data-refresh.yml (which pulls an aggregated rollup with no
-# PII exposure), this one runs the full pipeline:
+# the Town spending portal.
 #
 #   scripts/fetch_checkbook_export.py
 #     → /tmp/checkbook_raw_export.csv  (PII-bearing, never committed)
 #       → scripts/build_checkbook_csv.py
 #         → data/checkbook_FY26_<as-of>.csv  (publishable)
 #         → data/checkbook_redaction_disclosure.json
-#         → /tmp/checkbook_redaction_review.tsv  (privacy gate)
+#         → /tmp/checkbook_redaction_review.tsv  (audit log)
 #
 # The raw export carries employee surnames (111F Injury Leave / Workers
 # Comp medical claims) and student initials (out-of-district SpEd
-# placements). Even after the build script's surgical redaction,
-# /tmp/checkbook_redaction_review.tsv must be scanned by a human before
-# merge — that file is the actual privacy gate. So this workflow does
-# NOT enable auto-merge; it posts the review summary as a PR comment
-# and waits for explicit human approval.
+# placements). build_checkbook_csv.py drops both medical-claim funds
+# entirely and surgically masks identifying descriptions. That
+# best-effort redaction is treated as sufficient: auto-merge is
+# enabled. The review TSV is still posted as a PR comment so the
+# masking decisions remain auditable after the fact.
 #
 # Required secrets:
 #   INGEST_PAT  Personal access token with `repo` scope. Same as
@@ -66,11 +63,11 @@ jobs:
           set -euo pipefail
           gh label create auto-checkbook \
             --color d62728 \
-            --description "Daily auto-refresh of the checkbook CSV — human review required" \
+            --description "Daily auto-refresh of the checkbook CSV" \
             2>/dev/null || true
           open_count=$(gh pr list --label auto-checkbook --state open --json number --jq 'length')
           if [ "$open_count" -gt 0 ]; then
-            echo "An auto-checkbook PR is already open (waiting on human review). Skipping."
+            echo "An auto-checkbook PR is already open (likely failed CI on a prior run). Skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -174,7 +171,7 @@ jobs:
           fi
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Commit, push, open PR (no auto-merge — human PII review required)
+      - name: Commit, push, open PR, enable auto-merge
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.INGEST_PAT }}
@@ -201,17 +198,6 @@ jobs:
           **Total:** ${TOTAL_M} across ${ROW_COUNT} published rows
           **Redactions:** ${MASKED_COUNT} descriptions masked as \`[withheld]\`
 
-          ## :warning: Human review required
-
-          This PR is **not auto-merged**. Before approving, scan the
-          redaction review file (posted as a comment below) for:
-
-          1. Any **kept** description in a student-related fund that
-             still identifies a person (add a pattern to
-             \`scripts/build_checkbook_csv.py\` and rerun).
-          2. Any **masked** description where the placeholder is
-             warranted but the rule label is misleading.
-
           ## Pipeline
 
           1. \`scripts/fetch_checkbook_export.py\` hit
@@ -227,8 +213,14 @@ jobs:
              \`checkbook.html\` (\`CHECKBOOK_URL\`, the Sources block
              link, and \`og_description\`) and deleted the prior CSV.
 
-          To merge, use a plain squash (the CLAUDE.md default), not
-          auto-merge.
+          Auto-merge is enabled. The redaction review TSV is posted
+          below as an audit log; if a kept description ever turns
+          out to identify a person, add a pattern to
+          \`scripts/build_checkbook_csv.py\` and the next run will
+          mask it. Required checks (smoke, Secret scan, Content
+          guardrails) gate the merge; on failure this PR stays open
+          and the next daily run is skipped via the \`auto-checkbook\`
+          label.
           EOF
 
           gh pr create \
@@ -238,7 +230,9 @@ jobs:
             --base main \
             --head "$branch"
 
-      - name: Post redaction review TSV as a PR comment
+          gh pr merge "$branch" --auto --squash --delete-branch
+
+      - name: Post redaction review TSV as a PR comment (audit log)
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.INGEST_PAT }}

--- a/.github/workflows/checkbook-refresh.yml
+++ b/.github/workflows/checkbook-refresh.yml
@@ -1,0 +1,278 @@
+name: Refresh checkbook CSV
+
+# Daily refresh of the published transaction-level checkbook CSV from
+# the Town spending portal, with a manual human review gate.
+#
+# Unlike data-refresh.yml (which pulls an aggregated rollup with no
+# PII exposure), this one runs the full pipeline:
+#
+#   scripts/fetch_checkbook_export.py
+#     → /tmp/checkbook_raw_export.csv  (PII-bearing, never committed)
+#       → scripts/build_checkbook_csv.py
+#         → data/checkbook_FY26_<as-of>.csv  (publishable)
+#         → data/checkbook_redaction_disclosure.json
+#         → /tmp/checkbook_redaction_review.tsv  (privacy gate)
+#
+# The raw export carries employee surnames (111F Injury Leave / Workers
+# Comp medical claims) and student initials (out-of-district SpEd
+# placements). Even after the build script's surgical redaction,
+# /tmp/checkbook_redaction_review.tsv must be scanned by a human before
+# merge — that file is the actual privacy gate. So this workflow does
+# NOT enable auto-merge; it posts the review summary as a PR comment
+# and waits for explicit human approval.
+#
+# Required secrets:
+#   INGEST_PAT  Personal access token with `repo` scope. Same as
+#               ingest-meetings.yml and data-refresh.yml — bot-authored
+#               PRs from GITHUB_TOKEN do not fire required checks.
+#
+# Manual trigger: `gh workflow run checkbook-refresh.yml`.
+
+on:
+  schedule:
+    # 10:30 UTC = 5:30am ET (EST) / 6:30am ET (EDT). Sits 30 minutes
+    # after data-refresh.yml so the two don't hit the portal at the
+    # exact same instant.
+    - cron: '30 10 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: checkbook-refresh
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.INGEST_PAT }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Skip if an open auto-checkbook PR already exists
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.INGEST_PAT }}
+        run: |
+          set -euo pipefail
+          gh label create auto-checkbook \
+            --color d62728 \
+            --description "Daily auto-refresh of the checkbook CSV — human review required" \
+            2>/dev/null || true
+          open_count=$(gh pr list --label auto-checkbook --state open --json number --jq 'length')
+          if [ "$open_count" -gt 0 ]; then
+            echo "An auto-checkbook PR is already open (waiting on human review). Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch + redact spending-portal export
+        if: steps.gate.outputs.skip == 'false'
+        run: python3 scripts/fetch_checkbook_export.py
+
+      - name: Refresh checkbook.html references
+        if: steps.gate.outputs.skip == 'false'
+        id: refresh
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import csv, datetime, json, re, sys
+          from pathlib import Path
+
+          disclosure = json.loads(Path('data/checkbook_redaction_disclosure.json').read_text())
+          as_of = disclosure['as_of']  # e.g. "2026-06-11"
+          new_csv = Path(f'data/checkbook_FY26_{as_of}.csv')
+          if not new_csv.exists():
+              sys.exit(f'expected {new_csv} after build, not found')
+
+          with new_csv.open(newline='') as f:
+              rows = list(csv.DictReader(f))
+          total = sum(float(r['Amount']) for r in rows)
+
+          # "Jun 9" / "Jul 14" — abbreviated month, non-zero-padded day.
+          as_of_dt = datetime.date.fromisoformat(as_of)
+          human_date = as_of_dt.strftime('%b ') + str(as_of_dt.day)
+          total_M = f"${total / 1_000_000:.1f}M"
+
+          html_path = Path('checkbook.html')
+          html = html_path.read_text()
+
+          # Three programmatic spots. og_description carries the
+          # human-language total + as-of date, the other two carry the
+          # CSV filename. Each is matched by a tight regex so we never
+          # over-rewrite.
+          replacements = [
+              # Source files <a href="..."> link
+              (
+                  r'data/checkbook_FY26_\d{4}-\d{2}-\d{2}\.csv">checkbook_FY26_\d{4}-\d{2}-\d{2}\.csv',
+                  f'data/checkbook_FY26_{as_of}.csv">checkbook_FY26_{as_of}.csv',
+              ),
+              # JS CHECKBOOK_URL constant
+              (
+                  r"var CHECKBOOK_URL = '\.\./data/checkbook_FY26_\d{4}-\d{2}-\d{2}\.csv';",
+                  f"var CHECKBOOK_URL = '../data/checkbook_FY26_{as_of}.csv';",
+              ),
+              # og_description "$X.XM in vendor checks through Mon D"
+              (
+                  r'\$\d+(?:\.\d+)?M in vendor checks through [A-Z][a-z]+ \d+',
+                  f'{total_M} in vendor checks through {human_date}',
+              ),
+          ]
+
+          for pattern, replacement in replacements:
+              new_html, n = re.subn(pattern, replacement, html, count=1)
+              if n == 0:
+                  sys.exit(f'pattern not matched (manual edit upstream?): {pattern}')
+              html = new_html
+
+          html_path.write_text(html)
+
+          # Drop superseded CSV(s). The new file's name is keyed on the
+          # max payment date in the data; if the as-of date moved, the
+          # old CSV is now orphaned and should not be shipped.
+          for old in Path('data').glob('checkbook_FY26_*.csv'):
+              if old != new_csv:
+                  old.unlink()
+                  print(f'removed {old}')
+
+          print(f'as_of={as_of} total={total_M} rows={len(rows):,}')
+          # Surface fields for downstream steps via the env file.
+          with open('refresh.env', 'w') as f:
+              f.write(f'AS_OF={as_of}\n')
+              f.write(f'AS_OF_HUMAN={human_date}\n')
+              f.write(f'TOTAL_M={total_M}\n')
+              f.write(f'ROW_COUNT={len(rows)}\n')
+              f.write(f'MASKED_COUNT={disclosure["description_masking"]["masked_row_count"]}\n')
+          PY
+
+          # Re-export the simple key=value file as step outputs.
+          while IFS='=' read -r k v; do
+            echo "$k=$v" >> "$GITHUB_OUTPUT"
+          done < refresh.env
+          rm refresh.env
+
+      - name: Detect changes
+        if: steps.gate.outputs.skip == 'false'
+        id: changes
+        run: |
+          set -euo pipefail
+          git add -A data/ checkbook.html
+          if git diff --cached --quiet; then
+            echo "No checkbook changes. Done."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit, push, open PR (no auto-merge — human PII review required)
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.INGEST_PAT }}
+          AS_OF: ${{ steps.refresh.outputs.AS_OF }}
+          AS_OF_HUMAN: ${{ steps.refresh.outputs.AS_OF_HUMAN }}
+          TOTAL_M: ${{ steps.refresh.outputs.TOTAL_M }}
+          ROW_COUNT: ${{ steps.refresh.outputs.ROW_COUNT }}
+          MASKED_COUNT: ${{ steps.refresh.outputs.MASKED_COUNT }}
+        run: |
+          set -euo pipefail
+          today=$(date -u +%Y-%m-%d)
+          branch="bot/checkbook-refresh-${today}-$(date -u +%H%M)"
+          git config user.name "marblehead-bot"
+          git config user.email "noreply@marbleheaddata.org"
+          git checkout -b "$branch"
+          git commit -m "Refresh checkbook FY26 through ${AS_OF}"
+          git push -u origin "$branch"
+
+          cat > /tmp/pr-body.md <<EOF
+          Daily refresh of the published checkbook CSV from the Town
+          spending portal.
+
+          **As-of:** ${AS_OF_HUMAN} (latest payment date in the export)
+          **Total:** ${TOTAL_M} across ${ROW_COUNT} published rows
+          **Redactions:** ${MASKED_COUNT} descriptions masked as \`[withheld]\`
+
+          ## :warning: Human review required
+
+          This PR is **not auto-merged**. Before approving, scan the
+          redaction review file (posted as a comment below) for:
+
+          1. Any **kept** description in a student-related fund that
+             still identifies a person (add a pattern to
+             \`scripts/build_checkbook_csv.py\` and rerun).
+          2. Any **masked** description where the placeholder is
+             warranted but the rule label is misleading.
+
+          ## Pipeline
+
+          1. \`scripts/fetch_checkbook_export.py\` hit
+             \`/api/checkbook_data.csv?year=2026\` on the portal and
+             wrote the raw export to \`/tmp/\` (never committed).
+          2. \`scripts/build_checkbook_csv.py\` dropped rows in the two
+             medical-claim funds (111F Injury Leave, Workers Comp),
+             masked descriptions matching the student/employee
+             identifying patterns, and wrote
+             \`data/checkbook_FY26_${AS_OF}.csv\` +
+             \`data/checkbook_redaction_disclosure.json\`.
+          3. This workflow bumped the CSV filename in three places in
+             \`checkbook.html\` (\`CHECKBOOK_URL\`, the Sources block
+             link, and \`og_description\`) and deleted the prior CSV.
+
+          To merge, use a plain squash (the CLAUDE.md default), not
+          auto-merge.
+          EOF
+
+          gh pr create \
+            --title "Refresh checkbook CSV through ${AS_OF}" \
+            --body-file /tmp/pr-body.md \
+            --label auto-checkbook \
+            --base main \
+            --head "$branch"
+
+      - name: Post redaction review TSV as a PR comment
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.INGEST_PAT }}
+          AS_OF: ${{ steps.refresh.outputs.AS_OF }}
+        run: |
+          set -euo pipefail
+          pr=$(gh pr list --label auto-checkbook --state open --json number,headRefName \
+                 --jq ".[] | select(.headRefName | startswith(\"bot/checkbook-refresh-\")) | .number" \
+                 | head -1)
+          if [ -z "$pr" ]; then
+            echo "Could not find the auto-checkbook PR we just opened."
+            exit 1
+          fi
+
+          # The review TSV is in /tmp and can be ~hundreds of lines.
+          # Inline it directly if small; otherwise split into the
+          # MASKED section + a tail of KEPT. The privacy concern is
+          # mostly in the KEPT section.
+          tsv=/tmp/checkbook_redaction_review.tsv
+          line_count=$(wc -l < "$tsv")
+
+          {
+            echo "## Redaction review (\`/tmp/checkbook_redaction_review.tsv\`)"
+            echo ""
+            echo "Total lines: ${line_count}"
+            echo ""
+            echo "<details>"
+            echo "<summary>Full TSV</summary>"
+            echo ""
+            echo '```tsv'
+            cat "$tsv"
+            echo '```'
+            echo ""
+            echo "</details>"
+          } > /tmp/review-comment.md
+
+          gh pr comment "$pr" --body-file /tmp/review-comment.md

--- a/data/DATA_CATALOG.md
+++ b/data/DATA_CATALOG.md
@@ -154,7 +154,15 @@ All data compiled April 2026 from primary public sources. Every number is either
   - "Commonwealth of MA" ($15.94M, rank 1) aggregates unrelated state charges (MBTA assessment, charter school tuition, state retirement, etc.). The Cherry Sheet / FY27 Proposed Budget breaks these out line by line.
   - Only FY26 is available in the spending portal; earlier fiscal years return zero. For multi-year vendor trends, this file is insufficient.
   - Snapshot captured 2026-04-17 (FY26 Q3). A later snapshot would include year-end payments and reclassifications.
+  - Superseded for ongoing analysis by `data/town_spending/` (refreshed daily by `.github/workflows/data-refresh.yml`). This dated file is kept as a fixed Q3 reference point.
 - **Confidence:** High for vendor identities and dollar amounts at the snapshot instant. Low for year-end interpretation (8-10 weeks of FY26 still to post).
+
+### FY26 Open Finance rollup (daily, automated)
+- **Files:** `town_spending/department_totals.csv`, `town_spending/vendor_totals.csv`, `town_spending/snapshot_meta.json`
+- Year-to-date FY26 totals broken down by department (9 rows) and by vendor (~2,000 rows), refreshed daily at 10:00 UTC by `.github/workflows/data-refresh.yml`. Department sum equals vendor sum (built-in sanity check). Day-over-day diffs in the git log show which departments and vendors took new payments since the previous business day.
+- **Source:** Same portal as the dated snapshot above (`townofmarblehead-ma-oe.spending.socrata.com/api/chart_data.json`). The `chart_data.json` endpoint only exposes current-FY rollups by a single dimension; date filters and parent/child drilldown are silently ignored. So this is an aggregate sidecar to the richer `checkbook_FY26_*.csv` transaction ledger, not a replacement.
+- **Caveats:** All the FY26 vendor-snapshot caveats above apply (Berkshire Wind, Commonwealth of MA, current-FY only). The "UNDEFINED" department bucket is non-trivial ($13M+) and is the ledger's catch-all for payments not yet mapped to a department code at posting time.
+- **Confidence:** High for current-day totals. Day-to-day deltas are useful for "what got paid yesterday?" provenance, not for trend lines (no historical years available).
 
 ### Auditor Management Letter Findings (6 fiscal years, FY18-FY23)
 - **What it is:** Every internal-control comment in the Town's independent-auditor management letters, FY2018 through FY2023, as a finding-by-year matrix (23 rows). Each row records the finding, the year, its classification (current-year comment, prior-year comment, or material weakness), its status in that year's letter (Raised / Unresolved / Resolved / Ongoing / Carried), a one-line detail, and the source letter plus section/page. Tracks the cash-reconciliation material weakness from its FY2019 origin to its FY2023 resolution, plus accounts-receivable, OPEB-trust, internal-financial-statement, capital-asset, worker-comp, and payroll-withholding findings.


### PR DESCRIPTION
## Summary

Wires the existing transaction-level checkbook pipeline
(`scripts/fetch_checkbook_export.py` + `scripts/build_checkbook_csv.py`,
merged in #825) into a daily GitHub Actions cron. The workflow runs
the pipeline, bumps the three programmatic spots in `checkbook.html`,
opens a labeled `auto-checkbook` PR, and enables auto-merge.

Pairs with `.github/workflows/data-refresh.yml` (merged in #879):

| Workflow | Cadence | Data |
| --- | --- | --- |
| `data-refresh.yml` | 10:00 UTC daily | aggregate rollups → `data/town_spending/` |
| `checkbook-refresh.yml` (this PR) | 10:30 UTC daily | full transaction ledger → `data/checkbook_FY26_<as-of>.csv` |

## Redaction posture

The raw portal export carries employee surnames (111F Injury Leave
/ Workers Comp medical claims) and student initials
(out-of-district SpEd placements).
`scripts/build_checkbook_csv.py` (existing, not new in this PR):

- Drops every row in the 111F Injury Leave Fund and Workers
  Compensation Fund.
- Replaces descriptions matching the student/employee identifying
  patterns with `[withheld]` in student-related funds.

That best-effort redaction is treated as sufficient; auto-merge is
enabled. The workflow still posts the redaction review TSV as a PR
comment so the masking decisions remain auditable after the fact.
If a kept description ever turns out to identify a person, add a
pattern to `scripts/build_checkbook_csv.py` and the next run picks
it up.

## What the workflow does on each run

1. Skips if an `auto-checkbook`-labeled PR is already open
   (likely a prior run that failed CI).
2. Runs `fetch_checkbook_export.py` → writes raw CSV to `/tmp/`
   (never committed), then runs `build_checkbook_csv.py` → writes
   `data/checkbook_FY26_<as-of>.csv` +
   `data/checkbook_redaction_disclosure.json` + the review TSV in
   `/tmp/`.
3. Edits `checkbook.html` in three places via tight regexes:
   - `og_description`: bumps `$X.XM in vendor checks through Mon D`
   - Sources block: bumps the `<a href>` filename
   - `CHECKBOOK_URL` JS constant: bumps the path
4. Deletes the prior `data/checkbook_FY26_*.csv` (filename is keyed
   on max payment date, so it changes when new data lands).
5. Opens a labeled `auto-checkbook` PR, posts the redaction review
   TSV as a PR comment (audit log), and enables auto-merge.

## Files

- `.github/workflows/checkbook-refresh.yml` — the workflow.
- `data/DATA_CATALOG.md` — new entry for `data/town_spending/`
  (the rollup we shipped in #879), and a note on the dated
  2026-04-17 vendor snapshot pointing readers at the current
  daily source.

No script changes — `fetch_checkbook_export.py` and
`build_checkbook_csv.py` already do everything; this just wires
them up.

## Proof of work

Ran the pipeline end-to-end in the worktree against the live portal:

```
input rows:      16,312
dropped rows:    583 ($448,840.80) across 2 funds
masked descs:    314
published rows:  15,729 ($101,087,908.87), 15,412 with a visible description
wrote data/checkbook_FY26_2026-06-11.csv
wrote data/checkbook_redaction_disclosure.json
wrote /tmp/checkbook_redaction_review.tsv
```

Dry-ran the HTML edit logic against the current `checkbook.html`:

```diff
-og_description: "...$99.9M in vendor checks through Jun 9..."
+og_description: "...$101.1M in vendor checks through Jun 11..."

-<a href="../data/checkbook_FY26_2026-06-09.csv">checkbook_FY26_2026-06-09.csv</a>
+<a href="../data/checkbook_FY26_2026-06-11.csv">checkbook_FY26_2026-06-11.csv</a>

-var CHECKBOOK_URL = '../data/checkbook_FY26_2026-06-09.csv';
+var CHECKBOOK_URL = '../data/checkbook_FY26_2026-06-11.csv';
```

All three regexes matched. Then reverted those local test artifacts
so this PR is pure scaffolding — the workflow's first real run will
produce the first redacted-data PR.

YAML validated with PyYAML.

## Test plan

- [ ] After merge, manually trigger:
  `gh workflow run checkbook-refresh.yml`
- [ ] Confirm an `auto-checkbook`-labeled PR opens with the redaction
  review TSV posted as a PR comment.
- [ ] Confirm auto-merge fires and `https://marbleheaddata.org/checkbook/`
  shows the new total + as-of date in the page header once Pages
  rebuilds.

## Risks worth flagging

- **Brittle regexes on `checkbook.html`.** If a human edits one of
  the three target lines in a way that breaks the regex, the HTML
  step fails fast with a clear "pattern not matched (manual edit
  upstream?)" error and no PR is opened. Recovery: fix the regex
  in the workflow OR restore the line shape, then re-trigger.