### PR TITLE
Fix audit-comment race with auto-merge in checkbook-refresh

### DIFF
--- a/.github/workflows/checkbook-refresh.yml
+++ b/.github/workflows/checkbook-refresh.yml
@@ -171,7 +171,7 @@ jobs:
           fi
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Commit, push, open PR, enable auto-merge
+      - name: Commit, push, open PR, post audit comment, enable auto-merge
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.INGEST_PAT }}
@@ -223,37 +223,23 @@ jobs:
           label.
           EOF
 
-          gh pr create \
+          # Capture the PR URL so the audit-log comment can be posted
+          # without re-querying. Re-querying after `gh pr merge --auto`
+          # races against auto-merge actually firing: by the time the
+          # comment step runs, the PR can already be MERGED and a
+          # `--state open` lookup returns nothing.
+          pr_url=$(gh pr create \
             --title "Refresh checkbook CSV through ${AS_OF}" \
             --body-file /tmp/pr-body.md \
             --label auto-checkbook \
             --base main \
-            --head "$branch"
+            --head "$branch")
 
-          gh pr merge "$branch" --auto --squash --delete-branch
-
-      - name: Post redaction review TSV as a PR comment (audit log)
-        if: steps.changes.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.INGEST_PAT }}
-          AS_OF: ${{ steps.refresh.outputs.AS_OF }}
-        run: |
-          set -euo pipefail
-          pr=$(gh pr list --label auto-checkbook --state open --json number,headRefName \
-                 --jq ".[] | select(.headRefName | startswith(\"bot/checkbook-refresh-\")) | .number" \
-                 | head -1)
-          if [ -z "$pr" ]; then
-            echo "Could not find the auto-checkbook PR we just opened."
-            exit 1
-          fi
-
-          # The review TSV is in /tmp and can be ~hundreds of lines.
-          # Inline it directly if small; otherwise split into the
-          # MASKED section + a tail of KEPT. The privacy concern is
-          # mostly in the KEPT section.
+          # Build the audit-log comment. The TSV can run to a few
+          # hundred lines; wrap in <details> so it's collapsed by
+          # default but inspectable.
           tsv=/tmp/checkbook_redaction_review.tsv
           line_count=$(wc -l < "$tsv")
-
           {
             echo "## Redaction review (\`/tmp/checkbook_redaction_review.tsv\`)"
             echo ""
@@ -269,4 +255,9 @@ jobs:
             echo "</details>"
           } > /tmp/review-comment.md
 
-          gh pr comment "$pr" --body-file /tmp/review-comment.md
+          # Post the audit-log comment BEFORE enabling auto-merge so
+          # we're guaranteed to win the race against the PR going
+          # MERGED. gh pr comment accepts a PR URL just like a number.
+          gh pr comment "$pr_url" --body-file /tmp/review-comment.md
+
+          gh pr merge "$pr_url" --auto --squash --delete-branch


### PR DESCRIPTION
## Summary

PR #884 (the first run of `checkbook-refresh.yml`) shipped data
end-to-end successfully — `data/checkbook_FY26_2026-06-11.csv`,
`checkbook.html` updates, and auto-merge all worked. But the
follow-up "Post redaction review TSV as a PR comment" step failed:
the workflow used \`gh pr list --label auto-checkbook --state open\`
to find the PR it had just opened, and by the time the comment step
ran, auto-merge had already closed PR #884. The lookup returned
empty, exited 1, and the workflow finished red.

## Fix

Capture the PR URL from \`gh pr create\` stdout directly. Post the
audit-log comment FIRST. Then enable auto-merge. All in the same
bash step so the URL doesn't need to cross step boundaries.

Net change: -26/+17 lines in the workflow, two steps collapsed into
one.

## Why this didn't block data shipping

The audit comment is metadata, not a gate. The data files were
already committed and pushed before the failing step. So the run
ended red, but \`main\` was already in the right state. A workflow
that ends red still looks broken at a glance, hence this PR.

## Test plan

- [ ] After merge, manually trigger:
  \`gh workflow run checkbook-refresh.yml\`
- [ ] If the data hasn't moved since today's shipped CSV
  (\`checkbook_FY26_2026-06-11.csv\`), the workflow correctly hits
  "No checkbook changes. Done." and exits clean — no PR opened.
- [ ] If it has moved, an auto-checkbook PR opens with the audit-log
  comment posted BEFORE auto-merge fires, and the run finishes green.