### PR TITLE
checkbook: URL-param filters (2/3 of cutover)

### DIFF
--- a/checkbook.html
+++ b/checkbook.html
@@ -1567,6 +1567,83 @@ og_url: https://marbleheaddata.org/checkbook/
     meta.textContent = totalRows + ' rows · ' + fmtMoney(sumBudget, { compact: true }) + ' budgeted · ' + fmtMoney(sumActual, { compact: true }) + ' actual';
   }
 
+  // --- URL parameter parsing for shareable filter links ---
+  //
+  // Reading: on initial load, after the f-fund/f-division dropdowns are
+  // populated from the CSV, copy any `?fund=...&vendor=...&division=...`
+  // values from the URL onto the matching filter input/select. If a
+  // requested value isn't an existing option (typo, stale link), the
+  // select stays on its default empty value and that filter just isn't
+  // applied — the table shows the unfiltered result rather than a
+  // confusing "0 rows" empty.
+  //
+  // Writing: each time a filter changes, syncUrl() replaces the URL's
+  // query string with the active filter values via history.replaceState
+  // so users can share their view by copying the URL. No page reload, no
+  // history-entry spam.
+  var URL_PARAM_TO_FIELD = {
+    'vendor':     'f-vendor',
+    'family':     'f-family',
+    'fund':       'f-fund',
+    'division':   'f-division',
+    'date_min':   'f-date-min',
+    'date_max':   'f-date-max',
+    'amount_min': 'f-amount-min',
+  };
+  var FIELD_TO_URL_PARAM = Object.keys(URL_PARAM_TO_FIELD).reduce(function (m, k) {
+    m[URL_PARAM_TO_FIELD[k]] = k; return m;
+  }, {});
+
+  function applyUrlParams() {
+    var params;
+    try { params = new URLSearchParams(window.location.search); }
+    catch (e) { return; }
+    var anyApplied = false;
+    Object.keys(URL_PARAM_TO_FIELD).forEach(function (param) {
+      if (!params.has(param)) return;
+      var raw = params.get(param);
+      if (raw === null || raw === '') return;
+      var el = document.getElementById(URL_PARAM_TO_FIELD[param]);
+      if (!el) return;
+      if (el.tagName === 'SELECT') {
+        // Only set if the option exists; otherwise leave default
+        var found = false;
+        for (var i = 0; i < el.options.length; i++) {
+          if (el.options[i].value === raw) { found = true; break; }
+        }
+        if (found) { el.value = raw; anyApplied = true; }
+      } else {
+        el.value = raw;
+        anyApplied = true;
+      }
+    });
+    if (anyApplied) {
+      // Bring the filters panel into view so users see they landed in a
+      // pre-filtered state rather than wonder why the table looks small.
+      var filtersPanel = document.querySelector('.ck-filters') || document.getElementById('f-vendor');
+      if (filtersPanel) {
+        setTimeout(function () {
+          filtersPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 100);
+      }
+    }
+  }
+
+  function syncUrl() {
+    var params = new URLSearchParams();
+    Object.keys(FIELD_TO_URL_PARAM).forEach(function (id) {
+      var el = document.getElementById(id);
+      if (!el) return;
+      var v = el.value;
+      if (typeof v === 'string') v = v.trim();
+      if (v) params.set(FIELD_TO_URL_PARAM[id], v);
+    });
+    var qs = params.toString();
+    var newUrl = window.location.pathname + (qs ? '?' + qs : '') + window.location.hash;
+    try { history.replaceState(null, '', newUrl); }
+    catch (e) { /* sandboxed environments may block this; harmless */ }
+  }
+
   // --- Transaction table rendering ---
   function applyFilters() {
     var vendorQ = document.getElementById('f-vendor').value.trim().toUpperCase();
@@ -1671,7 +1748,7 @@ og_url: https://marbleheaddata.org/checkbook/
     });
 
     // Filter inputs
-    var dRender = debounce(function () { page = 0; renderTable(); }, 150);
+    var dRender = debounce(function () { page = 0; renderTable(); syncUrl(); }, 150);
     ['f-vendor', 'f-family', 'f-fund', 'f-division', 'f-date-min', 'f-date-max', 'f-amount-min'].forEach(function (id) {
       var el = document.getElementById(id);
       el.addEventListener('input', dRender);
@@ -1682,7 +1759,7 @@ og_url: https://marbleheaddata.org/checkbook/
       ['f-vendor', 'f-family', 'f-fund', 'f-division', 'f-date-min', 'f-date-max', 'f-amount-min'].forEach(function (id) {
         document.getElementById(id).value = '';
       });
-      page = 0; renderTable();
+      page = 0; renderTable(); syncUrl();
     });
 
     // Sort headers
@@ -2046,6 +2123,7 @@ og_url: https://marbleheaddata.org/checkbook/
         dSel.appendChild(o);
       });
       renderBva();
+      applyUrlParams();
       renderTable();
       renderPerf(perf);
     }).catch(function (err) {


### PR DESCRIPTION
## Summary

Second of three PRs in the path toward unifying the live `/checkbook/` with the choice-bucketed sketch. This one teaches `/checkbook/` to accept its filter state from the URL query string and to update the URL as the user changes filters.

Solves two needs:

1. **Re-enables the deep-link affordances** the sketch (PR #877) wanted but had to strip in a follow-up commit because `/checkbook/` ignored query strings. Once this lands, PR #3's cutover can re-introduce those "see all 84 rows of A11 2022 →" links pointing into the real filter UI.
2. **Shareable filter URLs in general** — copy-paste a URL with filters applied and it reproduces the view.

Supported params (all optional):
- `?vendor=...` — substring search on the free-text vendor input
- `?family=...` — fund-family select (general-fund, enterprise, etc.)
- `?fund=...` — fund select, must match an existing option exactly
- `?division=...` — division select, must match an existing option
- `?date_min=YYYY-MM-DD`, `?date_max=YYYY-MM-DD`
- `?amount_min=N`

**Graceful degradation:** if a `?fund=` or `?division=` value isn't in the populated dropdown (typo, stale link, snapshot doesn't include that fund anymore), the select stays empty and that one filter is silently skipped. The rest of the URL params still take effect. Better than showing "0 rows" because of an unmatched filter.

Two small helpers added near the existing filter code: `applyUrlParams()` called once after dropdowns populate, `syncUrl()` called from the existing debounced render-on-input handler. URL updates via `history.replaceState` so browser history doesn't get spammed.

## Preview & How to Test

- **Preview URL**: https://checkbook-url-params.marbleheaddata-preview.pages.dev
- **Specific paths/screens to check**:
  1. `/checkbook/` — loads exactly as before; no params, no filter applied.
  2. `/checkbook/?vendor=U.S.+BANK` — vendor field pre-filled with "U.S. BANK", table filtered to those 36 rows of bond debt service.
  3. `/checkbook/?fund=A11+2022+CAPITAL+IMPROVEMENT` — fund dropdown selected, table filtered to that project's 84 rows.
  4. `/checkbook/?fund=NONEXISTENT&vendor=Republic` — fund filter silently dropped (no matching option), vendor filter applied.
  5. `/checkbook/?division=GROUP+INSURANCE&date_min=2025-07-01&date_max=2025-09-30` — multiple filters compose correctly.
  6. Open `/checkbook/` with no params, type "Amazon" in the vendor box — URL updates live to `/checkbook/?vendor=Amazon`.
  7. Hit the "Reset filters" button — URL clears back to bare `/checkbook/`.
- **Expected behavior**: filters land already-populated; the page scrolls to bring the filters panel into view so users see why the table is filtered; subsequent edits keep the URL in sync.
- **Edge cases worth poking**:
  - URL params with `+` or `%20` for spaces (`?fund=A11+2022...` vs `?fund=A11%202022...`) — both should work since URLSearchParams handles both.
  - URLs with `#anchor` plus `?params` — the anchor should survive the `history.replaceState` calls.
  - Filter values that contain commas or special chars (`&`, `?`) — should round-trip through `params.toString()` cleanly.

## Proof of Work

- [x] Playwright smoke against `/checkbook.html` with 5 URL variations: vendor, fund (matching), fund (nonexistent), reset-after-set, and live URL-sync as the user types. All five pass; no console errors.
- [x] Counts plausible: `?vendor=U.S.+BANK` returns 37 rendered rows (page size cap), `?fund=A11+2022+CAPITAL+IMPROVEMENT` returns 50 (same cap).
- [x] No existing functionality affected: dropdown population, debouncing, sort, paginator, reset-filters button all unchanged in behavior.

## Risk

- **Scope:** the live `/checkbook/` page. Adds 80 LOC of vanilla JS in the existing `<script>` block; touches no other pages.
- **History pollution:** uses `replaceState`, not `pushState` — back-button behavior is unchanged. If `history.replaceState` is blocked by the sandbox, the wrapped `try/catch` swallows the error and reading still works.
- **No new dependencies; no CSS changes.** Pure JS-on-existing-DOM.
- **Backward-compatible:** any existing bookmarks to `/checkbook/` (no params) behave identically to before.