### PR TITLE
checkbook: catch the hero block in the daily refresh

### DIFF
--- a/.github/workflows/checkbook-refresh.yml
+++ b/.github/workflows/checkbook-refresh.yml
@@ -104,10 +104,13 @@ jobs:
           html_path = Path('checkbook.html')
           html = html_path.read_text()
 
-          # Three programmatic spots. og_description carries the
-          # human-language total + as-of date, the other two carry the
-          # CSV filename. Each is matched by a tight regex so we never
-          # over-rewrite.
+          # Six programmatic spots. The page-header hero block exposes
+          # the same three numbers a second time in a different shape
+          # (totals at the top of the page vs. og_description and
+          # source-files at the bottom). Each pattern is tight enough
+          # that we never over-rewrite, but the head-vs-body redundancy
+          # means every refresh edits both ends of the file.
+          row_count = f"{len(rows):,}"
           replacements = [
               # Source files <a href="..."> link
               (
@@ -123,6 +126,25 @@ jobs:
               (
                   r'\$\d+(?:\.\d+)?M in vendor checks through [A-Z][a-z]+ \d+',
                   f'{total_M} in vendor checks through {human_date}',
+              ),
+              # Hero block: "Vendor payments" value ($X.XM). Anchored on
+              # the preceding hero-label so we don't collide with other
+              # M-suffix dollar values elsewhere on the page.
+              (
+                  r'(<div class="hero-label">Vendor payments</div>\s*<div class="hero-value">)\$\d+(?:\.\d+)?M(</div>)',
+                  rf'\g<1>{total_M}\g<2>',
+              ),
+              # Hero block: "X,XXX checks, payroll excluded" sub.
+              (
+                  r'<div class="hero-sub">\d{1,3}(?:,\d{3})* checks, payroll excluded</div>',
+                  f'<div class="hero-sub">{row_count} checks, payroll excluded</div>',
+              ),
+              # Hero block: "Through" value (Mon D). Anchored on the
+              # preceding "Through" label so we don't catch the
+              # "11 of 12 months" sub or any other Mon D string.
+              (
+                  r'(<div class="hero-label">Through</div>\s*<div class="hero-value">)[A-Z][a-z]+ \d+(</div>)',
+                  rf'\g<1>{human_date}\g<2>',
               ),
           ]
 


### PR DESCRIPTION
## Summary

The choice-bucketed layout sketch (PR #886) added a hero stat block
at the top of `checkbook.html` with three numbers nobody told the
daily refresh workflow about:

```html
<div class="hero-stat">
  <div class="hero-label">Vendor payments</div>
  <div class="hero-value">$99.9M</div>
  <div class="hero-sub">15,364 checks, payroll excluded</div>
</div>
<div class="hero-stat">
  <div class="hero-label">Through</div>
  <div class="hero-value">Jun 9</div>
  <div class="hero-sub">11 of 12 months</div>
</div>
```

`og_description`, the Sources block link, and `CHECKBOOK_URL` have
been getting bumped daily by `.github/workflows/checkbook-refresh.yml`,
so the bottom of the page now reads "Jun 17" — but the hero block
sat at the layout-sketch values because the workflow's regex didn't
know about it.

## Change

Extend the HTML replacement step from 3 patterns to 6. The three
new patterns are anchored on the preceding hero-label so they
don't collide with other dollar values or month-day strings
elsewhere on the page.

## Proof of work

Dry-ran all six regexes against `origin/main:checkbook.html` with
fake future values; all matched:

```
1. matched: data/checkbook_FY26_\d{4}-\d{2}-\d{2}\.csv">checkbook_FY26...
2. matched: var CHECKBOOK_URL = '\.\./data/checkbook_FY26_\d{4}-\d{2}...
3. matched: \$\d+(?:\.\d+)?M in vendor checks through [A-Z][a-z]+ \d+
4. matched: (<div class="hero-label">Vendor payments</div>\s*<div c...
5. matched: <div class="hero-sub">\d{1,3}(?:,\d{3})* checks, payroll...
6. matched: (<div class="hero-label">Through</div>\s*<div class="he...
```

## How the page actually catches up

After merge, manually trigger the workflow. It'll re-read the
on-disk CSV (currently `checkbook_FY26_2026-06-17.csv`), notice
that the hero block doesn't match, edit all 6 spots, and open an
auto-checkbook PR with the catch-up.

## Why the original hand-edit was dropped

The first draft of this PR also patched the hero block by hand to
Jun 11 / $101.1M / 15,729. While that PR sat, PR #895 shipped
Jun 17 data and PR #893 restructured `og_description`. The
hand-edit became stale. Letting the workflow itself catch up on
its next run avoids that race.