### PR TITLE
verify: instrument PostHog funnel events for claim + profile flows

### DIFF
--- a/assets/community-pulse/claim.js
+++ b/assets/community-pulse/claim.js
@@ -27,6 +27,7 @@ function consumeOAuthFragment() {
   setJwt(token);
   const cleanHash = claim ? '#claim' : '';
   history.replaceState(null, '', location.pathname + location.search + cleanHash);
+  track('verify_oauth_returned', { claim_intent: claim });
   return { token, claim };
 }
 
@@ -60,6 +61,16 @@ async function fetchPreResident() {
     if (!res.ok) return null;
     return res.json();
   } catch (e) { return null; }
+}
+
+// --- PostHog event helper --------------------------------------------
+
+function track(event, props) {
+  try {
+    if (window.posthog && window.posthog.capture) {
+      window.posthog.capture(event, props || {});
+    }
+  } catch (e) { /* analytics never blocks the user */ }
 }
 
 // --- DOM helpers ------------------------------------------------------
@@ -227,6 +238,8 @@ async function onSubmit(e) {
   submit.disabled = true;
   submitText.textContent = 'Checking';
   result.innerHTML = `<p class="vm-loading">Matching against the assessor record</p>`;
+  // Track the submit -- count attempts independently of result.
+  track('verify_claim_submitted');
 
   let res;
   try {
@@ -243,6 +256,7 @@ async function onSubmit(e) {
     submit.disabled = false;
     submitText.textContent = 'Claim this address';
     result.innerHTML = renderGenericError('network');
+    track('verify_claim_result', { status: 'network_error' });
     return;
   }
 
@@ -251,14 +265,20 @@ async function onSubmit(e) {
 
   if (res.status === 429) {
     result.innerHTML = renderRateLimit();
+    track('verify_claim_result', { status: 'rate_limited' });
     return;
   }
   if (!res.ok) {
     result.innerHTML = renderGenericError(res.status);
+    track('verify_claim_result', { status: 'http_error', http_status: res.status });
     return;
   }
 
   const body = await res.json();
+  track('verify_claim_result', {
+    status: body.status,
+    had_alternatives: !!(body.alternatives && body.alternatives.length),
+  });
   switch (body.status) {
     case 'match':
       if (body.session_jwt) setJwt(body.session_jwt);
@@ -284,6 +304,13 @@ async function onSubmit(e) {
 async function init() {
   const oauth = consumeOAuthFragment();
   const isClaimStep = (oauth && oauth.claim) || location.hash === '#claim';
+
+  // Wire FB CTA click tracking on the landing.
+  const fbLink = document.getElementById('fb-start-link');
+  if (fbLink && !fbLink.__verifyTracked) {
+    fbLink.__verifyTracked = true;
+    fbLink.addEventListener('click', () => track('verify_fb_start_clicked'));
+  }
 
   const profile = await fetchSelf();
   if (profile && profile.identity_hash) {

--- a/assets/community-pulse/profile.js
+++ b/assets/community-pulse/profile.js
@@ -10,6 +10,14 @@ const JWT_KEY = 'verify_jwt';
 function readJwt() { return localStorage.getItem(JWT_KEY); }
 function clearJwt() { localStorage.removeItem(JWT_KEY); }
 
+function track(event, props) {
+  try {
+    if (window.posthog && window.posthog.capture) {
+      window.posthog.capture(event, props || {});
+    }
+  } catch (e) { /* analytics never blocks the user */ }
+}
+
 async function fetchProfile() {
   const jwt = readJwt();
   if (!jwt) return null;
@@ -60,8 +68,11 @@ function renderSignedOut(root) {
     <div class="pf-signedout">
       <h1>Profile</h1>
       <p>You are not signed in. Sign in to manage your verified-resident identity, the ideas you've backed, and how you appear on the site.</p>
-      <a class="pf-signin" href="/verify-me.html">Sign in</a>
+      <a class="pf-signin" id="pf-signin-link" href="/verify-me.html">Sign in</a>
     </div>`;
+  track('verify_profile_viewed', { state: 'signed_out' });
+  document.getElementById('pf-signin-link')
+    ?.addEventListener('click', () => track('verify_signin_clicked', { from: 'profile_page' }));
 }
 
 function renderProfile(root, profile) {

--- a/assets/community-pulse/profile.js
+++ b/assets/community-pulse/profile.js
@@ -154,16 +154,33 @@ function renderProfile(root, profile) {
   document.getElementById('pf-save-name').addEventListener('click', async () => {
     const v = nameInput.value.trim();
     const r = await postProfile({ display_name: v });
-    if (r.ok) showSaved();
+    if (r.ok) {
+      showSaved();
+      track('verify_display_name_saved', { is_empty: v.length === 0 });
+    }
   });
   const toggle = document.getElementById('pf-public-toggle');
   toggle.addEventListener('change', async (e) => {
-    await postProfile({ public_identity: e.target.checked ? 1 : 0 });
+    const value = e.target.checked ? 1 : 0;
+    await postProfile({ public_identity: value });
     e.target.parentElement.querySelector('.pf-toggle-label').textContent =
       e.target.checked ? 'On' : 'Off';
+    track('verify_public_identity_changed', { value });
   });
   document.getElementById('pf-release').addEventListener('click', async () => {
-    if (confirm('Release this claim and sign out?')) await releaseClaim();
+    if (confirm('Release this claim and sign out?')) {
+      track('verify_claim_released');
+      await releaseClaim();
+    }
+  });
+
+  track('verify_profile_viewed', {
+    state: 'signed_in',
+    claim_source: profile.claim_source,
+    auth_source: profile.auth_source,
+    has_facebook: !!profile.has_facebook,
+    has_passkey: !!profile.has_passkey,
+    public_identity: profile.public_identity === 1,
   });
 }
 

--- a/community-pulse/README.md
+++ b/community-pulse/README.md
@@ -54,3 +54,35 @@ node scripts/sync_parcel_owners.mjs --db community-pulse-staging --remote
 This truncates and reinserts `parcel_owners` in the named D1. Run it
 any time the assessor CSV is refreshed. Omit `--remote` to sync the
 local D1 instead.
+
+## PostHog events captured for the verify flow
+
+Client-side via `assets/community-pulse/claim.js` + `profile.js`. All
+events use the `verify_` prefix. No PII (no addresses, names, or
+identity hashes) is sent as event properties -- only status enums,
+boolean flags, and HTTP status codes.
+
+### `/verify-me.html` flow
+
+| Event | Fires when | Properties |
+|---|---|---|
+| `verify_fb_start_clicked` | User clicks "Continue with Facebook" | -- |
+| `verify_oauth_returned` | FB callback redirects back with a JWT in the URL fragment | `claim_intent` (bool) |
+| `verify_claim_submitted` | User submits the claim form | -- |
+| `verify_claim_result` | API returns a response | `status` (`match` / `first_initial_mismatch` / `name_mismatch` / `no_match` / `rate_limited` / `http_error` / `network_error`), `had_alternatives` (bool), `http_status` (number, on http_error only) |
+
+### `/profile.html` flow
+
+| Event | Fires when | Properties |
+|---|---|---|
+| `verify_profile_viewed` | Page loads | `state` (`signed_in` / `signed_out`), and when signed in: `claim_source`, `auth_source`, `has_facebook` (bool), `has_passkey` (bool), `public_identity` (bool) |
+| `verify_signin_clicked` | Signed-out user clicks Sign in | `from` (`profile_page`) |
+| `verify_display_name_saved` | User saves their display name | `is_empty` (bool) |
+| `verify_public_identity_changed` | User toggles public/private | `value` (0 / 1) |
+| `verify_claim_released` | User releases their claim | -- |
+
+### Suggested funnels in PostHog
+
+- **Landing -> verified**: `$pageview` (path=/verify-me.html) -> `verify_fb_start_clicked` -> `verify_oauth_returned` -> `verify_claim_submitted` -> `verify_claim_result` (status=match)
+- **Assessor match rate**: `verify_claim_result` breakdown by `status`
+- **Drop-off after OAuth**: `verify_oauth_returned` (claim_intent=true) -> `verify_claim_submitted` (cohort delta)


### PR DESCRIPTION
## Summary

PostHog is loaded site-wide so `$pageview` and `$autocapture` fire for /verify-me.html and /profile.html, but there are zero custom events on the funnel. Result: we can see who lands but not how many make it through, where they drop off, or what the assessor-match rate actually is.

Add 8 semantic `verify_*` events covering the full flow.

## Events

| Event | Where | Properties |
|---|---|---|
| `verify_fb_start_clicked` | landing | -- |
| `verify_oauth_returned` | after FB callback | `claim_intent` |
| `verify_claim_submitted` | form submit | -- |
| `verify_claim_result` | API response | `status` (match / first_initial_mismatch / name_mismatch / no_match / rate_limited / http_error / network_error), `had_alternatives`, `http_status?` |
| `verify_profile_viewed` | profile load | `state`, `claim_source`, `auth_source`, `has_facebook`, `has_passkey`, `public_identity` |
| `verify_signin_clicked` | signed-out profile -> Sign in | `from` |
| `verify_display_name_saved` | save name | `is_empty` |
| `verify_public_identity_changed` | toggle | `value` |
| `verify_claim_released` | release | -- |

## PII

Zero. No addresses, names, identity hashes, or FB user ids ride along as event properties -- only status enums, booleans, HTTP status codes.

## Funnels worth defining in PostHog

1. **Landing → verified**: `$pageview` (path=/verify-me.html) → `verify_fb_start_clicked` → `verify_oauth_returned` → `verify_claim_submitted` → `verify_claim_result` (status=match)
2. **Assessor match rate**: `verify_claim_result` breakdown by `status`
3. **OAuth → claim drop-off**: `verify_oauth_returned` (claim_intent=true) cohort, count who fire `verify_claim_submitted` within session

These are listed in `community-pulse/README.md` next to the event reference.

## Test plan

- [ ] Cloudflare preview deploys
- [ ] In a browser with DevTools Network tab open, click Continue with Facebook on the preview, then watch for a request to `t.marbleheaddata.org/e/?v=...` with `verify_fb_start_clicked` in the payload
- [ ] Same for `verify_claim_submitted` and `verify_claim_result` when submitting the form
- [ ] `verify_profile_viewed` fires on `/profile.html` with state=signed_in if you have a JWT

🤖 Generated with [Claude Code](https://claude.com/claude-code)