### PR TITLE
profile: consume OAuth #token fragment on /profile.html

### DIFF
--- a/assets/community-pulse/profile.js
+++ b/assets/community-pulse/profile.js
@@ -8,7 +8,24 @@ const VERIFY_API = (location.hostname === 'localhost')
 const JWT_KEY = 'verify_jwt';
 
 function readJwt() { return localStorage.getItem(JWT_KEY); }
+function setJwt(jwt) { localStorage.setItem(JWT_KEY, jwt); }
 function clearJwt() { localStorage.removeItem(JWT_KEY); }
+
+/**
+ * The FB callback redirects returning users straight to
+ * /profile.html#token=<jwt>. Pull the JWT out, stash it in localStorage
+ * so subsequent /api/profile calls can authenticate via Bearer, and
+ * strip the fragment so the token does not linger in the URL bar.
+ */
+function consumeOAuthFragment() {
+  if (!location.hash || !location.hash.includes('token=')) return false;
+  const params = new URLSearchParams(location.hash.slice(1));
+  const token = params.get('token');
+  if (!token) return false;
+  setJwt(token);
+  history.replaceState(null, '', location.pathname + location.search);
+  return true;
+}
 
 function track(event, props) {
   try {
@@ -186,6 +203,9 @@ function renderProfile(root, profile) {
 
 async function init() {
   const root = document.getElementById('profile-root');
+  // Consume any OAuth JWT in the URL fragment first (returning users
+  // land here via the FB callback's redirect to /profile.html#token=...).
+  consumeOAuthFragment();
   const profile = await fetchProfile();
   if (!profile || !profile.identity_hash) {
     renderSignedOut(root);


### PR DESCRIPTION
## Summary

Returning users (already in the residents table by fb_user_id) hit FB OAuth, the callback redirects them to `/profile.html#token=<jwt>`, but `profile.js` only read the JWT from localStorage -- the fragment was ignored, fetchProfile returned null, and the user was shown the signed-out "Sign in" prompt.

The bug bit the user in production today.

claim.js had the same fragment-consumption pattern from the cross-origin fix. profile.js just needs the same.

## Fix

Add `consumeOAuthFragment()` to profile.js and call it as the first step in `init()`. Same shape as claim.js: read `#token=...`, save to localStorage, strip the fragment via `history.replaceState`.

## Test plan

- [ ] Cloudflare preview deploys
- [ ] Visit `/profile.html#token=<some-jwt>` and confirm the URL fragment is cleared on load and the profile renders (or signed-out renders if the JWT is stale)
- [ ] Live OAuth round-trip from `/verify-me.html` lands a returning user on `/profile.html` showing their verified-resident card

🤖 Generated with [Claude Code](https://claude.com/claude-code)