### PR TITLE
Org chart: cite cleanup + homepage/data promotion

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -96,6 +96,11 @@ og_url: https://marbleheaddata.org/data/
       <h3>Town Explorer</h3>
       <p>Compare Marblehead against all 351 MA towns on rate, levy, override history, and dozens of fiscal measures.</p>
     </a>
+    <a class="data-featured-tile" href="/org-chart">
+      <div class="tile-eye">STRUCTURE</div>
+      <h3>Who runs Marblehead?</h3>
+      <p>Every town and school department with FY27 staffing and salary lines, plus the elected and appointed boards above them.</p>
+    </a>
   </div>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -183,5 +183,10 @@ og_url: https://marbleheaddata.org/
       <h3>What passed on June 9</h3>
       <p>All four ballot questions passed; the $15M operating tier governs FY27. The full record of the campaign, the candidates, and the result.</p>
     </a>
+    <a class="home-tile" href="/org-chart">
+      <div class="tile-eye">STRUCTURE</div>
+      <h3>Who runs Marblehead?</h3>
+      <p>The two parallel administrations, the 18 elected and appointed boards above them, and the levers residents actually have. Click any department to see FY27 staffing and salary lines.</p>
+    </a>
   </div>
 </section>

--- a/org-chart.html
+++ b/org-chart.html
@@ -46,8 +46,9 @@ og_url: https://marbleheaddata.org/org-chart.html
     <div class="org-column-header">Town</div>
     <div class="org-root">
       <span class="org-root-title">{{ site.data.org_chart.town.head.title }}</span>
-      <span class="org-card-fte"><span class="org-card-num">{{ site.data.org_chart.town.head.fte }}</span><sup class="cite" data-href="{{ site.data.org_chart.town.head.source_url }}" data-source="{{ site.data.org_chart.town.head.source_label }}"></sup></span>
+      <span class="org-card-fte"><span class="org-card-num">{{ site.data.org_chart.town.head.fte }}</span></span>
       {% if site.data.org_chart.town.head.note %}<p class="org-card-note">{{ site.data.org_chart.town.head.note }}</p>{% endif %}
+      <p class="org-card-source">Source<sup class="cite" data-href="{{ site.data.org_chart.town.head.source_url }}" data-source="{{ site.data.org_chart.town.head.source_label }}"></sup></p>
     </div>
 
     {% for cluster_name in site.data.org_chart.town.cluster_order %}
@@ -108,8 +109,9 @@ og_url: https://marbleheaddata.org/org-chart.html
     <div class="org-column-header">Schools</div>
     <div class="org-root">
       <span class="org-root-title">{{ site.data.org_chart.schools.head.title }}</span>
-      <span class="org-card-fte"><span class="org-card-num">{{ site.data.org_chart.schools.head.fte }}</span><sup class="cite" data-href="{{ site.data.org_chart.schools.head.source_url }}" data-source="{{ site.data.org_chart.schools.head.source_label }}"></sup></span>
+      <span class="org-card-fte"><span class="org-card-num">{{ site.data.org_chart.schools.head.fte }}</span></span>
       {% if site.data.org_chart.schools.head.note %}<p class="org-card-note">{{ site.data.org_chart.schools.head.note }}</p>{% endif %}
+      <p class="org-card-source">Source<sup class="cite" data-href="{{ site.data.org_chart.schools.head.source_url }}" data-source="{{ site.data.org_chart.schools.head.source_label }}"></sup></p>
     </div>
 
     {% assign co_total = 0 %}

--- a/tests/smoke-test.mjs
+++ b/tests/smoke-test.mjs
@@ -36,9 +36,9 @@ async function testHomepageLoads(page) {
   }
 
   const tiles = await page.$$('.home-tile');
-  tiles.length === 6
-    ? ok(`6 pillar tiles on homepage (incl. 2026 override archive)`)
-    : fail('Homepage tiles', `expected 6 .home-tile, got ${tiles.length}`);
+  tiles.length === 7
+    ? ok(`7 pillar tiles on homepage (incl. 2026 override archive + Who runs Marblehead)`)
+    : fail('Homepage tiles', `expected 7 .home-tile, got ${tiles.length}`);
 
   const deeper = await page.$('.home-deeper');
   deeper ? ok('Homepage has Checkbook CTA') : fail('Homepage CTA', '.home-deeper missing');


### PR DESCRIPTION
## Summary

Two related changes:

1. **Root-card citations moved from inline to Source footer.** The Town Administrator and Superintendent cards had `<sup class="cite">` glued next to the big "1" FTE number — a tiny superscript dangling off a 2rem digit looked odd. Moved to a "Source ²³" footer line below the note, matching the pattern dept cards use.
2. **Promoted /org-chart from unlinked to two prominent placements.** Was shipped but not surfaced anywhere on the site. Added:
   - Homepage tile grid (7th tile, "STRUCTURE")
   - Data catalog featured tiles (5th tile, "STRUCTURE")

Skipped:
- Footer — utility-only (About/Privacy/Source/Report an error), not a content links spot
- Cross-link from `town-school-admin.html` — that page is now a redirect to inside-school-staffing.html; the original parallel-admin argument was retired

## What changed

- `org-chart.html`: removed `<sup class="cite">` from inside `.org-card-fte` on both root cards; added `<p class="org-card-source">Source<sup class="cite">...</sup></p>` below the note.
- `index.html`: added "Who runs Marblehead?" tile to the home-tiles grid.
- `data/index.html`: added 5th featured tile under the Featured section.

## Preview URL

Preview pending; will edit when sticky comment lands.

## What to check

- `/org-chart` — Town Administrator and Superintendent root cards no longer have a tiny superscript next to the big "1". Each card has a small "Source ²³" line at the bottom instead.
- `/` (homepage) — bottom tile grid now has 7 tiles, with "Who runs Marblehead?" in the STRUCTURE slot.
- `/data/` — Featured row now has 5 tiles, with "Who runs Marblehead?" added.
- Sources `<h2>` at the org-chart page footer still includes both root-card citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Happy](https://happy.engineering)