### PR TITLE
M101 Ch1: link to /org-chart after the Town Administrator section

### DIFF
--- a/marblehead-101/01-how-the-town-is-run.html
+++ b/marblehead-101/01-how-the-town-is-run.html
@@ -46,6 +46,8 @@ scripts: [citations]
 
 <p>The position is not elected. The Select Board can appoint, supervise, and dismiss the Town Administrator at will. The department staff who report to the administrator (police officers, public works crew, building inspectors, and so on) cannot be fired by the Select Board directly. Their jobs are governed by personnel rules and union contracts.</p>
 
+<p>For the complete map of who reports to whom &ndash; every town department, every school building, and the 18 elected and appointed boards above them &ndash; see <a class="inline" href="{{ '/' | relative_url }}org-chart">Who runs Marblehead?</a></p>
+
 <h2>Why no mayor?</h2>
 
 <p>Massachusetts gives municipalities flexibility in how they organize. The town form predates the city form by centuries. Marblehead was incorporated in 1649 and has used Town Meeting government ever since.</p>


### PR DESCRIPTION
## Summary

Marblehead 101 Chapter 1 explains Town Meeting → Select Board → Town Administrator → department staff at the conceptual level. Readers who want to see the actual reporting map (every dept, every position, every board) had no link to /org-chart. Added a one-paragraph callout after the TA description:

> For the complete map of who reports to whom &ndash; every town department, every school building, and the 18 elected and appointed boards above them &ndash; see [Who runs Marblehead?](/org-chart)

## Preview URL

Preview pending; will edit when sticky comment lands.

## What to check

- `/marblehead-101/01-how-the-town-is-run.html` — after the "How the Town Administrator works" section, there's now a one-paragraph link to /org-chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Happy](https://happy.engineering)