### PR TITLE
Retry portal fetches on transient 5xx / timeouts

### DIFF
--- a/scripts/fetch_checkbook_export.py
+++ b/scripts/fetch_checkbook_export.py
@@ -42,6 +42,8 @@ import json
 import ssl
 import subprocess
 import sys
+import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -58,13 +60,48 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 BASE = "https://townofmarblehead-ma-oe.spending.socrata.com/api"
 DEFAULT_RAW_PATH = Path("/tmp/checkbook_raw_export.csv")
 
+# Total backoff window 5 + 15 + 45 = 65s across 4 attempts. The portal's
+# observed transient failures are HTTP 503 and TLS read timeouts that
+# clear within seconds, so a short backoff is enough; longer would
+# make a real outage slower to fail without buying additional success
+# rate.
+RETRY_BACKOFFS = (5, 15, 45)
+
+
+def urlopen_with_retry(url: str, *, timeout: int):
+    """urlopen() that retries transient errors with exponential backoff.
+
+    Retries on HTTP 5xx, HTTP 429, and any URLError / TimeoutError /
+    OSError (covers DNS, connect, reset, and socket-level timeouts).
+    Other HTTPErrors (4xx other than 429) are raised immediately —
+    those are caller bugs, not upstream blips.
+    """
+    last_err: BaseException | None = None
+    attempts = len(RETRY_BACKOFFS) + 1
+    for i in range(attempts):
+        try:
+            return urllib.request.urlopen(url, timeout=timeout, context=SSL_CTX)
+        except urllib.error.HTTPError as e:
+            if e.code < 500 and e.code != 429:
+                raise
+            last_err = e
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            last_err = e
+        if i < attempts - 1:
+            wait = RETRY_BACKOFFS[i]
+            print(f"  portal fetch failed ({last_err}); retrying in {wait}s "
+                  f"(attempt {i + 2}/{attempts})", file=sys.stderr, flush=True)
+            time.sleep(wait)
+    assert last_err is not None
+    raise last_err
+
 
 def fetch_meta(year: int) -> dict:
     """Return {'count': N, 'total_amount': X} for the year."""
     url = f"{BASE}/checkbook_data.json?" + urllib.parse.urlencode({
         "year": year, "limit": 1,
     })
-    with urllib.request.urlopen(url, timeout=30, context=SSL_CTX) as r:
+    with urlopen_with_retry(url, timeout=30) as r:
         body = json.loads(r.read())
     return {"count": body["count"], "total_amount": body["total_amount"]}
 
@@ -73,7 +110,7 @@ def fetch_csv(year: int, limit: int, out_path: Path) -> None:
     url = f"{BASE}/checkbook_data.csv?" + urllib.parse.urlencode({
         "year": year, "limit": limit,
     })
-    with urllib.request.urlopen(url, timeout=120, context=SSL_CTX) as r:
+    with urlopen_with_retry(url, timeout=120) as r:
         out_path.write_bytes(r.read())
 
 

--- a/scripts/fetch_town_spending.py
+++ b/scripts/fetch_town_spending.py
@@ -32,6 +32,8 @@ import datetime as dt
 import json
 import os
 import sys
+import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -39,6 +41,41 @@ from pathlib import Path
 PORTAL = "https://townofmarblehead-ma-oe.spending.socrata.com"
 OUT_DIR = Path("data/town_spending")
 USER_AGENT = "marbleheaddata.org daily-refresh (https://marbleheaddata.org)"
+
+# Total backoff window 5 + 15 + 45 = 65s across 4 attempts. The portal's
+# observed transient failures are HTTP 503 and TLS read timeouts that
+# clear within seconds, so a short backoff is enough; longer would
+# make a real outage slower to fail without buying additional success
+# rate.
+RETRY_BACKOFFS = (5, 15, 45)
+
+
+def urlopen_with_retry(req, *, timeout: int):
+    """urlopen() that retries transient errors with exponential backoff.
+
+    Retries on HTTP 5xx, HTTP 429, and any URLError / TimeoutError /
+    OSError (covers DNS, connect, reset, and socket-level timeouts).
+    Other HTTPErrors (4xx other than 429) are raised immediately —
+    those are caller bugs, not upstream blips.
+    """
+    last_err = None
+    attempts = len(RETRY_BACKOFFS) + 1
+    for i in range(attempts):
+        try:
+            return urllib.request.urlopen(req, timeout=timeout)
+        except urllib.error.HTTPError as e:
+            if e.code < 500 and e.code != 429:
+                raise
+            last_err = e
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            last_err = e
+        if i < attempts - 1:
+            wait = RETRY_BACKOFFS[i]
+            print(f"  portal fetch failed ({last_err}); retrying in {wait}s "
+                  f"(attempt {i + 2}/{attempts})", file=sys.stderr, flush=True)
+            time.sleep(wait)
+    assert last_err is not None
+    raise last_err
 
 
 def current_fiscal_year(today: dt.date) -> int:
@@ -54,7 +91,7 @@ def fetch(child_entity: str, year: int, limit: int) -> dict:
     })
     url = f"{PORTAL}/api/chart_data.json?{qs}"
     req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(req, timeout=60) as resp:
+    with urlopen_with_retry(req, timeout=60) as resp:
         return json.loads(resp.read().decode())
 
 


### PR DESCRIPTION
## Summary

Both `scripts/fetch_town_spending.py` (used by `data-refresh.yml`)
and `scripts/fetch_checkbook_export.py` (used by
`checkbook-refresh.yml`) hit the same Town spending-portal host.
That host has produced two transient failures in five days:

| Date | Workflow | Error |
| --- | --- | --- |
| 2026-06-17 11:36 UTC | data-refresh | HTTP 503 Service Unavailable |
| 2026-06-17 12:03 UTC | checkbook-refresh | TLS read timeout |

Each took out a day's data refresh until the next morning's cron.
This PR makes both fetchers ride through that class of blip.

## Change

Add a `urlopen_with_retry` helper to each script (4 attempts,
5 / 15 / 45 second backoffs, 65s total worst case). Both helpers
have identical retry semantics — they're inlined per-script
rather than extracted to a shared module because there are only
two callsites and they have slightly different signatures
(`fetch_checkbook_export.py` threads an `ssl.SSLContext` through
for certifi support, the other doesn't).

**Retries on:**

- HTTP 5xx (server-side flakes — covers the observed 503)
- HTTP 429 (rate limit — cheap to cover, never observed today)
- `URLError`, `TimeoutError`, `OSError` (DNS / connect / reset /
  socket-level timeout — covers the observed TLS read timeout)

**Does not retry on:**

- HTTP 4xx other than 429 (caller bug, not upstream blip)

Backoff total of 65s deliberately picked to outlast every observed
blip without making a real outage slow to fail. The portal's
historical pattern is "503 for a few seconds during EOD batch
processing," not "503 for hours."

## Proof of work

### Live portal happy path

Both scripts ran cleanly against the live portal, returning the
same numbers (cross-check ✓):

```
fetch_town_spending.py:
  FY2026 snapshot 2026-06-19: 9 depts ($101,652,498), 2081 vendors ($101,652,498)

fetch_checkbook_export.py --raw-only:
  rows expected: 16,315
  total expected: $101,652,498.09
  verified: 16,315 rows summing to $101,652,498.09
```

### Retry semantics with mock-patched `urlopen`

```
  portal fetch failed (HTTP Error 503: busy); retrying in 5s (attempt 2/4)
  portal fetch failed (HTTP Error 503: busy); retrying in 15s (attempt 3/4)
  succeeded after 3 attempts; backoff calls: [5, 15]

  404 raised immediately after 1 attempt; backoff calls: 0

  portal fetch failed (read timed out); retrying in 5s (attempt 2/4)
  portal fetch failed (read timed out); retrying in 15s (attempt 3/4)
  portal fetch failed (read timed out); retrying in 45s (attempt 4/4)
  persistent TimeoutError: 4 attempts, 3 backoffs of [5, 15, 45]

all assertions passed
```

## Test plan

- [ ] After merge, the next scheduled cron runs (10:00 + 10:30 UTC
  tomorrow) should both succeed normally — happy path unchanged.
- [ ] If the portal misbehaves again, look for
  `portal fetch failed (...); retrying in Ns` lines in the run log
  to confirm retry kicked in.