### PR TITLE
digest: fix cron firing Sunday (use MON alias)

### DIFF
--- a/meeting-digest/worker/wrangler.toml
+++ b/meeting-digest/worker/wrangler.toml
@@ -31,8 +31,14 @@ TURNSTILE_TEST_BYPASS_TOKEN = "TEST-OK"
 # Cloudflare's best-effort cron misses the :00 slot. Per-subscriber
 # idempotency in scheduled.js skips anyone already sent in the last 5
 # days, so the retry never double-delivers.
+#
+# Always use the day-name alias (MON), not the numeric form. Cloudflare's
+# cron parser interprets numeric day-of-week differently than POSIX cron:
+# `* * * * 1` fired on Sundays in our prod deployment from Jun 14 onward
+# (verified via workersInvocationsAdaptive). Names are unambiguous across
+# whichever convention Cloudflare uses.
 [triggers]
-crons = ["0 11 * * 1", "30 11 * * 1", "0 12 * * 1", "30 12 * * 1"]
+crons = ["0 11 * * MON", "30 11 * * MON", "0 12 * * MON", "30 12 * * MON"]
 
 [env.staging]
 name = "marblehead-meeting-digest-staging"


### PR DESCRIPTION
## Summary

Cloudflare's cron parser interprets `* * * * 1` as Sunday, not Monday as POSIX cron does. Every cron firing since deploy on Jun 14 has landed on a Sunday, not the intended Monday. Verified via the workersInvocationsAdaptive GraphQL endpoint.

Switching the four cron expressions to use the day-name alias `MON` instead of the numeric `1`. Aliases are unambiguous regardless of which numeric convention Cloudflare uses internally.

## Preview URL

Cloudflare Pages preview will appear once the deploy completes, though there is no UI to preview because this is a Worker config change only.

## Test plan

- [ ] CI: meeting-digest vitest suite stays green (108 passing).
- [ ] After merge: ``npm run worker:deploy`` for the Worker.
- [ ] After deploy: ``curl Cloudflare API /schedules`` to confirm the new cron strings are bound.
- [ ] Next Monday (Jun 29): confirm the cron fires Monday morning, not Sunday Jun 28.

## Proof of Work

- ``workersInvocationsAdaptive`` GraphQL query showed all cron firings on Jun 14 and Jun 21 (both Sundays). Friday/Thursday entries are deploy events, not cron triggers.
- Meeting-digest test suite continues to pass: 108 of 108.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)