### PR TITLE
welcome primer: add transcript pipeline + named reply path

### DIFF
--- a/_primers/01-welcome.md
+++ b/_primers/01-welcome.md
@@ -4,6 +4,6 @@ title: "What this site is"
 link_url: /
 link_label: "Browse marbleheaddata.org"
 ---
-You just subscribed to a Monday email of summaries from Marblehead board meetings.
+MHTV (Marblehead's public-access TV station) records every board meeting and posts the video online. Each week the site pulls captions for any new recording, runs them through an LLM that extracts the headline action, decisions, and votes, and links each summary back to the source video at the moment it was discussed.
 
-Every number on the site traces back to a primary source. Charts, tools, and explainers cover the override, the budget, debt, staffing, and trash.
+Replies to this email land in my personal inbox (agbaber@gmail.com). Hit reply with corrections, questions, or anything you'd want to see covered.


### PR DESCRIPTION
## Summary

Replaces the welcome primer's generic two-paragraph body with:

1. **The transcript pipeline.** MHTV records every board meeting and posts video online; the site pulls captions weekly, runs them through an LLM to extract headline action, decisions, and votes, and links each summary back to the source video at the timecode discussed.
2. **A named reply path.** Calls out that replies land in ``agbaber@gmail.com`` personally. The permanent footer reply-prompt (PR #914) stays generic; this one introduces the human on the other end.

## Preview URL

Cloudflare Pages preview will appear once the deploy completes. The ``_primers/`` collection is ``output: false``, so there is no visible site change. The Worker reads the file from GitHub at the next Monday cron and the new copy ships then.

## Test plan

- [ ] CI: meeting-digest vitest suite stays green (108 passing).
- [ ] No Worker deploy required (content is fetched live from GitHub at cron time).
- [ ] Next Monday cron (Jun 29): both confirmed subscribers receive the revised welcome primer text alongside their digest.

## Proof of Work

- ``git diff --stat _primers/01-welcome.md``: 1 file changed, 2 insertions, 2 deletions.
- meeting-digest vitest suite still passing: 108 of 108.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)