### PR TITLE
primer week 2: tighten org-chart copy (status flags, not salary)

### DIFF
--- a/_primers/02-org-chart.md
+++ b/_primers/02-org-chart.md
@@ -6,4 +6,4 @@ link_label: "See the org chart"
 ---
 Marblehead is actually two parallel administrations, each with its own elected board, each answerable to the town's registered voters. State law keeps them legally separate even though they pull from one tax base.
 
-The chart lays out every department by FTE count, head title, and FY27 salary appropriation, plus the elected boards above them. Worth a look so the boards and departments that show up in meeting digests aren't abstractions.
+Click any department card to see its positions with FY27 status flags: new in FY27, reduced, eliminated. The shape of the budget shows up as concrete roles, not as line items in a spreadsheet.


### PR DESCRIPTION
## Summary

The week-2 primer claimed the org chart shows "FTE count, head title, and FY27 salary appropriation" on every department card. Salary is actually behind a click-to-reveal ``<details>`` disclosure, not on the card face. Worse, salary undersells what the disclosure actually offers: FY27 position-status flags (``new in FY27``, ``reduced``, ``eliminated``).

Replaces the second paragraph with copy that names what is genuinely behind the click and frames it around the FY27 budget conversation.

## Preview URL

Cloudflare Pages preview will appear once the deploy completes. The ``_primers/`` collection is ``output: false``, so there is no visible site change. Worker fetches the primer at the next Monday cron.

## Test plan

- [ ] CI: meeting-digest vitest suite stays green (108 passing).
- [ ] No Worker deploy required.
- [ ] Next Monday cron (Jun 29): subscribers reaching ``drip_week_index = 2`` receive the revised text.

## Proof of Work

- ``git diff --stat _primers/02-org-chart.md``: 1 file changed, 1 insertion, 1 deletion (single paragraph swap).
- meeting-digest vitest suite still passing: 108 of 108.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)