### PR TITLE
digest: strip trailing slash from primer link_url (404 fix)

### DIFF
--- a/docs/superpowers/specs/2026-06-15-meeting-digest-drip-primer-design.md
+++ b/docs/superpowers/specs/2026-06-15-meeting-digest-drip-primer-design.md
@@ -61,7 +61,7 @@ Each primer file: `_primers/NN-slug.md`. Example `_primers/01-welcome.md`:
 ---
 week_index: 1
 title: "What this site is"
-link_url: /about/
+link_url: /about
 link_label: "About marbleheaddata.org"
 ---
 Plain-text body, 2 to 4 sentences. Renders as the primer card's dek
@@ -75,7 +75,7 @@ it for HTML output, and drops it into the card.
 |---|---|---|
 | `week_index` | int | Position in the drip. Worker matches `week_index === drip_week_index + 1`. |
 | `title` | string | Primer card headline. |
-| `link_url` | string | Path or full URL the CTA links to. UTM appended at render time. |
+| `link_url` | string | Path or full URL the CTA links to. UTM appended at render time. Plain pages take no trailing slash (a trailing slash 404s on the live site); the renderer drops one if present. |
 | `link_label` | string | CTA link text, with `→` appended at render. |
 
 Body: plain text, no markdown formatting. The Worker preserves paragraph breaks (`\n\n`) and escapes for HTML, then emits one `<p>` per paragraph.

--- a/meeting-digest/tests/render.test.js
+++ b/meeting-digest/tests/render.test.js
@@ -104,6 +104,9 @@ describe('renderText', () => {
   });
 });
 
+// link_url intentionally carries a trailing slash. Plain Jekyll pages on the
+// site serve at /about (no slash) and 404 on /about/, so the renderer is
+// expected to drop it before emitting the link.
 const PRIMER_1 = {
   filename: '01-welcome.md',
   week_index: 1,
@@ -130,7 +133,7 @@ describe('renderHtml with primer', () => {
 
   it('UTM-tags the primer link with per-week campaign', () => {
     const html = renderHtml([SB_MATCH], SUB, ENV, '2026-06-15', PRIMER_1, 4);
-    expect(html).toMatch(/href="https:\/\/marbleheaddata\.org\/about\/\?utm_source=digest&utm_medium=email&utm_campaign=primer-week-1"/);
+    expect(html).toMatch(/href="https:\/\/marbleheaddata\.org\/about\?utm_source=digest&utm_medium=email&utm_campaign=primer-week-1"/);
   });
 
   it('HTML-escapes primer body content', () => {
@@ -158,7 +161,21 @@ describe('renderText with primer', () => {
     expect(text).toContain('What this site is');
     expect(text).toContain('First para.');
     expect(text).toContain('Second para.');
-    expect(text).toMatch(/About marbleheaddata\.org: https:\/\/marbleheaddata\.org\/about\/\?utm_source=digest&utm_medium=email&utm_campaign=primer-week-1/);
+    expect(text).toMatch(/About marbleheaddata\.org: https:\/\/marbleheaddata\.org\/about\?utm_source=digest&utm_medium=email&utm_campaign=primer-week-1/);
+  });
+});
+
+describe('primer link_url trailing-slash normalization', () => {
+  it('leaves the bare root (/) untouched', () => {
+    const primer = { ...PRIMER_1, link_url: '/' };
+    const html = renderHtml([SB_MATCH], SUB, ENV, '2026-06-15', primer, 4);
+    expect(html).toMatch(/href="https:\/\/marbleheaddata\.org\/\?utm_source=digest/);
+  });
+
+  it('passes full URLs through unchanged', () => {
+    const primer = { ...PRIMER_1, link_url: 'https://example.com/external/' };
+    const html = renderHtml([SB_MATCH], SUB, ENV, '2026-06-15', primer, 4);
+    expect(html).toMatch(/href="https:\/\/example\.com\/external\/\?utm_source=digest/);
   });
 });
 

--- a/meeting-digest/worker/src/lib/primer.js
+++ b/meeting-digest/worker/src/lib/primer.js
@@ -6,7 +6,9 @@
 //   ---
 //   week_index: 1                       (required integer)
 //   title: "..."                        (required string)
-//   link_url: /about/                   (required string)
+//   link_url: /the-debate               (required string; plain site pages take
+//                                        no trailing slash. A trailing slash is
+//                                        tolerated and dropped at render time.)
 //   link_label: "..."                   (required string)
 //   ---
 //   Body paragraph 1.

--- a/meeting-digest/worker/src/lib/render.js
+++ b/meeting-digest/worker/src/lib/render.js
@@ -11,10 +11,21 @@ function withUtm(url) {
   return url.includes('?') ? `${url}&${UTM_QUERY}` : `${url}?${UTM_QUERY}`;
 }
 
+// Plain Jekyll pages (e.g. /the-debate) serve without a trailing slash and
+// 404 on /the-debate/. Directory-permalink pages (/meetings/x/, /me/subscription/)
+// 301 from the no-slash form to the slash form, so dropping the slash resolves
+// either way. Drop a trailing slash from author-written site paths; leave the
+// bare root and full URLs alone.
+function normalizeSitePath(path) {
+  if (path === '/') return path;
+  return path.replace(/\/$/, '');
+}
+
 function withPrimerUtm(url, weekIndex, env) {
   const PRIMER_QUERY = `utm_source=digest&utm_medium=email&utm_campaign=primer-week-${weekIndex}`;
-  // Primer link_url may be a path (/about/) or full URL. Resolve against SITE_BASE_URL.
-  const absolute = url.startsWith('http') ? url : `${env.SITE_BASE_URL}${url}`;
+  // Primer link_url may be a path (/the-debate) or a full URL. Resolve paths
+  // against SITE_BASE_URL; pass full URLs through untouched.
+  const absolute = url.startsWith('http') ? url : `${env.SITE_BASE_URL}${normalizeSitePath(url)}`;
   return absolute.includes('?') ? `${absolute}&${PRIMER_QUERY}` : `${absolute}?${PRIMER_QUERY}`;
 }
 


### PR DESCRIPTION
## Problem

Weekly-digest **primer** CTA links 404 on the live site. The renderer resolves a primer's `link_url` against `SITE_BASE_URL` verbatim, and the documented convention (plus every test and the spec example) used a trailing slash: `link_url: /about/`.

But plain Jekyll pages serve **without** a trailing slash and 404 *with* one:

| URL | live |
|---|---|
| `/the-debate` | 200 |
| `/the-debate/` | **404** |

So any primer pointing at an editorial page would ship a dead link in the email. (The meeting and manage-subscription links are unaffected: they match their directory-style permalinks `/meetings/:path/` and `/me/subscription/`, which *do* serve with a slash. Only `01-welcome.md` → `/` is live today, which is why nothing has broken yet.)

## Fix

Drop a trailing slash from author-written site paths at render time (`normalizeSitePath` in `render.js`), leaving the bare root `/` and full URLs untouched. Plain pages now return 200; directory-permalink pages still resolve via their no-slash 301.

Verified live after the change:
- `/the-debate`, `/senior-tax-relief`, `/about`, `/` → all **200**

Docs (`primer.js` contract) and the design spec example updated to the no-slash form.

## Tests

`meeting-digest` suite: **110 passed**. Updated the two primer-URL assertions to expect the stripped slash and added guards for root-preservation and full-URL passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)