### PR TITLE
Auto-ingest meetings (2026-07-02)

### DIFF
--- a/_transcripts/board-of-health-2026-06-29.md
+++ b/_transcripts/board-of-health-2026-06-29.md
@@ -1,0 +1,492 @@
+---
+slug: board-of-health-2026-06-29
+board: board-of-health
+board_display: "Board of Health"
+date: 2026-06-29
+title: "Board of Health: June 29, 2026"
+vimeo_id: 1205809868
+vimeo_url: "https://vimeo.com/1205809868"
+duration_seconds: 5321
+ai_generated: true
+status: published
+source: vimeo-auto+llm
+
+summary_card:
+  headline: "Marblehead Board of Health holds first five-member meeting, votes on fowl permit and trash barrel refund"
+  summary: "The newly expanded five-member Board of Health held its inaugural meeting, discussing organizational structure, meeting schedules, and priorities drawn from the CALM community health survey. The board voted to approve a fowl permit for 18 Stony Brook Road and a $60 refund for a transfer station sticker. The director reported on curbside cart rollout ahead of the July 1st program launch and introduced potential kratom regulations for future discussion."
+  decisions:
+    - "Approved fowl permit for 18 Stony Brook Road (four hens, no rooster)"
+    - "Approved $60 transfer station sticker refund for Rebecca Haskell at 12 West Cottage Street"
+    - "Adopted second and fourth Monday of the month as regular meeting schedule"
+    - "Scheduled next meeting for July 28th"
+  votes:
+    - motion: "Approve fowl permit for 18 Stony Brook Road"
+      result: "in favor (unanimous)"
+    - motion: "Approve $60 refund for Rebecca Haskell"
+      result: "in favor (unanimous)"
+
+topic_segments:
+  - topic: admin-housekeeping
+    topic_confidence: 0.82
+    start_seconds: 0
+    end_seconds: 374
+    headline: "Board discusses proposed outdoor exercise fitness platform for Marblehead"
+    dek: "A federally supported fitness platform program, coordinated through Blue Cross Blue Shield for Massachusetts, was described as potentially costing the town approximately $250,000 with partial grant support."
+    summary: "The chair opened the first meeting of the expanded five-member Board of Health by describing an opportunity to participate in developing an outdoor exercise fitness platform for the town. The program, administered through Blue Cross Blue Shield on behalf of the state, would provide a roughly tennis-court-sized concrete facility with exercise stations. Estimated cost to the town was approximately $250,000, with grant funding anticipated to offset a portion. The board noted a state park grant competition on July 9th as a potential funding avenue. Discussion centered on how the Board of Health could serve as a convener or facilitator rather than an owner or operator of such a facility."
+    key_speakers: ["Board Chair (name not identified)"]
+  - topic: admin-housekeeping
+    topic_confidence: 0.85
+    start_seconds: 374
+    end_seconds: 1435
+    headline: "Board adopts second and fourth Monday meeting schedule and discusses subcommittee structure"
+    dek: "Members agreed to meet on the second and fourth Monday of each month and discussed informal topic areas including community health, transfer station oversight, and research/grant-writing."
+    summary: |
+      The board agreed to hold regular meetings on the second and fourth Monday of each month, acknowledging that several federal holidays fall on Mondays and will require occasional rescheduling. Members discussed whether to form formal subcommittees governed by open meeting law or to informally organize by interest area. Three informal focus areas emerged: community health reporting, transfer station/waste management, and research, evaluation, community input, and grant-writing.
+      
+      The chair raised the idea of eventually establishing a 501(c)(3) 'Friends of Public Health' nonprofit to supplement the department's budget, particularly for mental health and counseling services. Members noted the state filing process is relatively straightforward but the IRS federal designation requires more documentation and likely legal assistance, estimated at $4,000–$5,000 in attorney fees. The board agreed to explore pro bono options and review how existing town nonprofits were established.
+    key_speakers: ["Board Chair", "Board Member (Kristen, name inferred from context)", "Andrew (Health Director)"]
+  - topic: public-comment
+    topic_confidence: 0.75
+    start_seconds: 1435
+    end_seconds: 1500
+    headline: "Board discusses public comment practices and audience engagement approach"
+    dek: "Members reflected on the prior meeting's extended public comment session and considered strategies such as using a whiteboard to track repeated themes."
+    summary: "The board discussed how to structure public comment going forward, noting that the prior meeting included approximately 80 minutes of public comment, with many residents raising similar concerns about trash barrel sizes. Members suggested using a visible whiteboard to log recurring themes in real time, allowing the chair to acknowledge repeated points without cutting off speakers. The chair emphasized the board's educational role and preference for open dialogue, while acknowledging the need to summarize and redirect when comments become repetitive."
+    key_speakers: ["Board Chair", "Andrew (Health Director)"]
+  - topic: health-insurance
+    topic_confidence: 0.45
+    start_seconds: 1869
+    end_seconds: 2186
+    headline: "CHIP planning grant application unsuccessful; board plans to reapply"
+    dek: "The board learned its application for a CHIP coalition planning grant was not funded in a competitive round that drew 182 applications for 20 awards."
+    summary: "The chair reported that the board's application to the CHIP (Community Health Improvement Plan) program was not funded. The grant round was highly competitive, with 182 applications submitted for 20 available grants. The application proposed a 10-organization coalition to study barriers to youth mental health for two years at $50,000 per year, with the intent to follow up with implementation grants of approximately $200,000 per year. The chair expressed interest in resubmitting and noted that many first-time applicants have succeeded on second attempts. The board agreed to seek any available reviewer feedback on the application."
+    key_speakers: ["Board Chair"]
+  - topic: admin-housekeeping
+    topic_confidence: 0.78
+    start_seconds: 2186
+    end_seconds: 4010
+    featured: true
+    headline: "CALM survey results reviewed; board plans September public rollout and Marblehead Cares website relaunch"
+    dek: "The 2,553-respondent CALM community health survey identified seven priority areas including stress, substance use, and social division; the board plans to post full results on the relaunched Marblehead Cares website."
+    summary: |
+      The board reviewed the results of the CALM (Community Assessment for Local Marblehead) survey, which collected responses from 2,553 residents across 43 questions administered in partnership with UMass Boston. A 180-page full report and a 43-page leadership council summary were described as ready for distribution.
+      
+      **Seven highest priorities identified by UMass Boston:**
+      | Priority Area |
+      |---|
+      | Stress |
+      | Parenting |
+      | Caregiving |
+      | Pedestrian and biking safety |
+      | Substance use |
+      | Financial fragility |
+      | Social division |
+      
+      The 40–50 age group (the "sandwich generation") was identified as the most stressed demographic. The board discussed focusing on youth mental health and substance use prevention, with one member describing a 21-year model from Trumbull, Connecticut that SAMHSA recognizes as a national model for reducing underage drinking through community engagement and parent-child communication strategies.
+      
+      The board agreed to post the CALM reports on the relaunched Marblehead Cares website, which the town now controls after a lapsed domain registration was resolved. A September timeline was discussed for a formal public rollout of results. Members acknowledged challenges in reaching younger residents (under 30) through any single communication channel and discussed combining newspaper outreach (72% of CALM respondents cited newspapers as a news source) with social media linking back to the website.
+      
+      The Marblehead Mental Health Task Force, previously a Board of Health subcommittee that moved to the counseling center, has not met for six to nine months following a staff departure. The board indicated interest in bringing mental health coordination back under its umbrella.
+    key_speakers: ["Board Chair", "Board Member (Kristen)", "Andrew (Health Director)", "Resident at mic"]
+  - topic: admin-housekeeping
+    topic_confidence: 0.9
+    start_seconds: 4279
+    end_seconds: 4442
+    headline: "Health director issues tick, West Nile, and heat safety advisories ahead of July 4th"
+    dek: "The community health report flagged mosquito season onset, Massachusetts's first West Nile-positive mosquito detection of the season, and a forecast major heat risk July 1–3."
+    summary: "A board member presented the community health update noting that tick season remains active while mosquito season is beginning. Massachusetts detected its first West Nile virus-positive mosquito of the season the prior week; no human cases were reported. The CDC heat risk dashboard forecast major heat risk for the Marblehead area from July 1st through July 3rd and moderate risk on July 4th–5th. Standard precautions were reviewed including insect repellent use, hydration (at least five ounces every 15–20 minutes during extended outdoor work), and recognition of heat-related illness symptoms."
+    key_speakers: ["Board Member (community health reporter, name not identified)"]
+  - topic: public-safety
+    topic_confidence: 0.72
+    start_seconds: 4442
+    end_seconds: 4524
+    headline: "Director reminds residents to sign up for Regroup reverse-911 and Board of Health notifications"
+    dek: "The health director noted that the community center (COA) and library serve as cooling centers during heat events and urged residents to register for the town's Regroup alert system."
+    summary: "The health director noted that Marblehead does not have a formal cooling center program but that the Council on Aging / community center building is air-conditioned and open five days a week until 5:00 p.m. The Brown School can be activated as a cooling center if needed. Residents were reminded to register for the town's Regroup reverse-911 system through the town website, which supports phone calls, emails, and text alerts for both emergency and general public health notifications including beach closures and trash delays."
+    key_speakers: ["Andrew (Health Director)"]
+  - topic: admin-housekeeping
+    topic_confidence: 0.88
+    start_seconds: 4524
+    end_seconds: 4649
+    headline: "Board unanimously approves fowl permit for 18 Stony Brook Road"
+    dek: "The permit allows four hens and no rooster; the director confirmed coordination with the Mass Department of Agriculture for bird flu surveillance."
+    summary: "The health director presented a fowl permit application for 18 Stony Brook Road. The applicant supplied a plot plan, henhouse and run location, feed storage plan (rodent-proof container), and manure management plan. Neighbor notification was completed. The permit covers four chickens with no rooster. A board member asked about bird flu testing protocols; the director confirmed the department coordinates with the Massachusetts Department of Agriculture, which would conduct testing and, if necessary, destroy affected flocks. The board voted unanimously to approve the permit."
+    key_speakers: ["Andrew (Health Director)"]
+  - topic: trash-dpw
+    topic_confidence: 0.95
+    start_seconds: 4649
+    end_seconds: 4882
+    headline: "Curbside cart program launches July 1; smaller barrels on order with six-week delivery estimate"
+    dek: "The director reported all households have received carts, with smaller 35-gallon barrels ordered for residents who requested them; a $60 sticker refund was approved unanimously."
+    summary: |
+      The health director provided an update on the curbside collection cart program launching July 1st. All households have received town-issued carts, though a small number are still awaiting delivery. Residents who requested smaller barrels are on a waiting list; smaller carts were ordered and are expected to arrive in approximately six weeks. Residents without carts or waiting for a swap may continue using existing containers through the transition. Swap-outs will be conducted once smaller barrels arrive.
+      
+      The director emphasized that in five years, recycling collection may shift to every-other-week pickup, but the town does not plan to exchange barrels at that time. Residents were advised to consider keeping larger carts if they anticipate higher-volume periods such as holidays.
+      
+      The board also voted unanimously to approve a $60 sticker refund for Rebecca Haskell at 12 West Cottage Street.
+      
+      The director noted the transfer station will be open July 3rd (7:30 a.m. to 3:30 p.m., closed for lunch) and closed July 4th (Saturday). Sticker sales have reached approximately 6,780.
+    key_speakers: ["Andrew (Health Director)"]
+  - topic: admin-housekeeping
+    topic_confidence: 0.7
+    start_seconds: 4882
+    end_seconds: 5319
+    headline: "Board schedules next meeting for July 28th after scheduling conflicts cancel July 13th meeting"
+    dek: "Conflicts among members and the health director's absence July 11–27 led the board to skip the mid-July meeting and schedule the next session for Tuesday, July 28th."
+    summary: "The board attempted to set its next meeting date consistent with the newly adopted second-and-fourth Monday schedule. The health director will be away July 11–27, and at least one board member had conflicts on both candidate Mondays (July 14th). After discussion, the board agreed to skip the mid-July meeting and convene next on Tuesday, July 28th. The board also briefly discussed potential kratom regulation, with the director agreeing to provide a draft regulatory proposal for discussion at a future meeting. Members were asked to review both the 180-page CALM full report and the 43-page leadership council summary before the next meeting."
+    key_speakers: ["Andrew (Health Director)", "Board Chair"]
+---
+
+> Transcript captured from MHTV's Vimeo auto-captioning. No speaker labels;
+> proper names and dollar figures occasionally misheard. Click any timecode to
+> jump to that moment in the source video.
+
+**[0:00](https://vimeo.com/1205809868#t=0s)** And which the... Good evening. It is the
+
+**[0:07](https://vimeo.com/1205809868#t=7s)** 29th, 7:00, a little after 7:00, and the Board of Health, the five-member Board of Health, is about to have its first meeting. Not all of us are here quite this minute, but we're going to start. And a couple of us have been involved in a request that was asked of us, whether we are interested in developing an exercise platform for the town of Marblehead. Apparently, the federal government has been supporting exercise locations for, what, 50 years or so. And
+
+**[0:53](https://vimeo.com/1205809868#t=53s)** I think in part because of Calm, somebody told Blue Cross Blue Shield, who's managing it for
+
+**[1:04](https://vimeo.com/1205809868#t=64s)** the state of Massachusetts, that Massachusetts may be interested in an exercise facility and wellness, because we had a wellness fair, it went really well, and all that. So we've met a couple of times with the person who's there to facilitate. Basically, it's a roughly tennis court size facility, concrete-based, that it can be divided into one or two sections. But it has all the locations where you do various exercises, various software associated with it.
+
+**[1:51](https://vimeo.com/1205809868#t=111s)** Bottom line is they think it will cost the town $250,000. They will come with grant money, but certainly not enough grant money. And then, according to them, they will help the town seek money. Like next week, on June 9th, July 9th, there's apparently a competition for park grants out of state of Massachusetts, and some towns have gotten that.
+
+**[2:37](https://vimeo.com/1205809868#t=157s)** And the question, I guess, is whether that's... I think it's within the Board of Health purview to be a participant in something like that. We can't own or run it. Mm-hmm. And
+
+**[2:54](https://vimeo.com/1205809868#t=174s)** we've talked a lot about what does the Board of Health, as a five-person board, it really changes our capacity, I think, a great deal. What should we be doing extra or more than we've done in the past, and how do we maximally add value to the town? And I think from my perspective, one of the way we most add value is by convening, or collaborating, or curating, or facilitating with other agencies or groups in town.
+
+**[3:40](https://vimeo.com/1205809868#t=220s)** It does seem to me that one of the real challenges in Marblehead is we tend to be quite silent. Mm-hmm. And I think, I guess depending on how you believe the election went, but I think the election certainly, the way it went, was because a lot of people got together and pulled for the same outcomes. And I think that more and more we should be moving toward that in Marblehead and the Board of Health, since health sort of shows up in almost anything the town wants to do, that we should be there facilitating.
+
+**[4:27](https://vimeo.com/1205809868#t=267s)** My guess is that that'll take a while to get there, but there ought to be examples, and I think the choice of if we want to do an exercise platform, where we might do it, who would own it, is the kind of thing that we could facilitate as the Board of Health and
+
+**[4:56](https://vimeo.com/1205809868#t=296s)** make things smoother. Mm-hmm. Because if we just went to Parks and Rec, for example, they may have something, but the schools may have some other, and the senior center may have... Oops.
+
+**[5:19](https://vimeo.com/1205809868#t=319s)** Good evening. Sorry, I went to the wrong side of the room. Yeah.
+
+**[5:33](https://vimeo.com/1205809868#t=333s)** We were just beginning to talk about an exercise fitness platform that we've been offered. I was going to give that as an example, but let's go back to the actual agenda and work to that kind of conversation. So each of you should have a sheet of paper in front of you about, I think, three organizational issues- It's a one-page slide. Christine, did you- Yeah.
+
+**[6:14](https://vimeo.com/1205809868#t=374s)** All right.
+
+**[6:16](https://vimeo.com/1205809868#t=376s)** I think it's good for the town and good for all of us to be planning to know when we're going to meet in advance. I think it would be great if we decide these kind of things and publish a regular schedule. Okay. Is twice monthly meeting appropriate and expected, and is everyone on that page? I'm good with it. Yes. Okay. Are the two meetings different in any way? Like is one meeting a decision meeting, it's just twice a month? They could be, but let's go through the logic first. Okay, so twice monthly.
+
+**[7:02](https://vimeo.com/1205809868#t=422s)** Day of the week. We had talked a little bit last time, and it looked like Monday had some thought. My own personal view about Monday, it would be great, except for all the federal and state holidays. So you basically have Patriot's Day, Labor Day, Memorial Day, and so you have to make arrangements for the Monday. And so you're ending up breaking away from the
+
+**[7:32](https://vimeo.com/1205809868#t=452s)** annual schedule. Yep. It's a handful of times, but I have another board that often meets either Tuesdays or Thursdays, so that- And Wednesdays and Thursday nights are tough for me, so that's Monday. Monday. Tuesdays are tough for me. Mondays seems- Yeah. So looks like Monday is where we're going with this- ... and then we'll have to reschedule that hog. Yeah. That's fine with me. And we doing the second and fourth? Because that's what we were doing before.
+
+**[8:02](https://vimeo.com/1205809868#t=482s)** It's up to us. Yeah. Andrew, are you okay with that? Yep. If you do the second and fourth, you at least miss Labor Day. Labor Day. Yeah. You miss Memorial. No, Memorial Day- Memorial Day ... could be on the fourth. All right. And probably with five, there are probably going to be times when one of us is going to miss anyway. Mm-hmm. Like this. So we ought to let Andrew or the chair know if you think you're going to be missing so we know we'll at least have four. I'd hate to have a five-member committee making a lot of decisions with three, and only
+
+**[8:50](https://vimeo.com/1205809868#t=530s)** three votes. That sort of thing. And one of the questions is: how do we divide the work? And this year I've watched the school committee, and it's been very interesting. They have a regular five-member board, but they break down into several formal sub-committees. Each sub-committee has generally two members on board so that they can meet without violating the open meeting law of the mothership,
+
+**[9:38](https://vimeo.com/1205809868#t=578s)** but they are bound to follow the open meeting law. Now, they have a policy committee, they have sub-committee, they have a finance one, they have one for the roof of the high school because they wanted a place where they could bring
+
+**[10:04](https://vimeo.com/1205809868#t=604s)** expert craftsman, other people who know about roofs, to be advising them as to what they were doing and progress and all of that. And that would be a possibility for us. We could have a wellness sub-committee, we could do any thing like that. Or what we can just do is each of us know the kind of things that we're particularly interested in, and we could plan on having on the agenda. I think absolutely your community health report has become a
+
+**[10:53](https://vimeo.com/1205809868#t=653s)** key element of every month. Your tick disease should have been published and distributed to everyone in town. We have to figure out how to do that. And maybe that's what we want to think about, have a couple of vice-chairs who specialize in certain things. What's the thought?
+
+**[11:18](https://vimeo.com/1205809868#t=678s)** Others have been on other boards.
+
+**[11:26](https://vimeo.com/1205809868#t=686s)** Yeah. I'm happy to keep going with the community health. I've been enjoying research and keeping me up to date.
+
+**[11:36](https://vimeo.com/1205809868#t=696s)** And we should certainly keep the transfer station, I think, as its own committee as well. Mm-hmm. And do either of you have other focuses or interests?
+
+**[11:49](https://vimeo.com/1205809868#t=709s)** You want me to go first? I would say, the data pieces and the evaluation work around thinking about... Like your community health, but maybe this is more like health assessment, like the CHIP probably would fall under it, and maybe some of the CALM work. But that's what I've done historically. Okay. I always think last session, you said you had a lot of experience raising money and writing grants and things. I was thinking about maybe a finance subcommittee that could be formal or informal, that could meet regularly and let us... We've tried
+
+**[12:36](https://vimeo.com/1205809868#t=756s)** to see what's out there. But would that make some sense to know where our budget is, to see what money's out there? I don't know if I've mentioned to you all, but I would really like to somehow, over time, develop a 501 [c] [3] where we can get people to donate money for friends of public health. The schools, the senior center, parks and rec, lots of people have these 501 [c] [3] s that provide a very significant amount of their money. 501 [c] [3] , even if we had it, we could not use our own
+
+**[13:23](https://vimeo.com/1205809868#t=803s)** money to develop a 501 [c] [3] because it must be independent. It would be a non-profit. So we would have to go and raise
+
+**[13:36](https://vimeo.com/1205809868#t=816s)** probably $4,000 or $5,000 at least for lawyer fees to petition to the IRS to be identified as a 501 [c] [3] .
+
+**[13:49](https://vimeo.com/1205809868#t=829s)** We can do that by just on an ad hoc regular basis, people that might be interested, or we can formally assign or identify. Not assign.
+
+**[14:06](https://vimeo.com/1205809868#t=846s)** What do you think? I think the 501 [c] [3] s a great idea, honestly. Should we reach out to the community to see if you need lawyers for 5,000? There might be someone in the community that might just do it. I... Oh, you mean pro bono? Yeah. One of the things I met with
+
+**[14:34](https://vimeo.com/1205809868#t=874s)** Jim of- Jim Murray ... Select Board. The bank. Jim Nigh. Yeah. Jim Nigh, and asked if he knew anybody that might help. He didn't have anybody right off. Mm-hmm. What he suggested was to go to the agencies that already had them, see how they developed them, see who their lawyers were, and see what we could do. There's lots of pro bono opportunities to get retired senior volunteers. You might have an attorney that's no longer working that could do it. We're doing this work with Marblehead Racial Justice Team right now. The state filing is very easy. You call the IRS and ask for an EIN
+
+**[15:21](https://vimeo.com/1205809868#t=921s)** number, and then you just fill in paperwork and send it in. I've done that lots. The federal one is a little more complicated. You need to do things like have meeting notes for every meeting. I actually brought meeting notes from our last meeting today. You need to demonstrate who was here, what the conversation was, and what decisions were made. Basically, they want to make sure you're not lobbying. What kind of lawyer does a 501 [c] [3] ? Is it a tax lawyer? Is it... It'd be a tax lawyer for something big. But for something small, probably a basic lawyer who does general things would be able to do it. Just general?
+
+**[16:07](https://vimeo.com/1205809868#t=967s)** I don't think it's a complicated thing. I could ask my brother. I don't know if he's still licensed in Massachusetts. He moved. Okay. So I think what I'm hearing, we should proceed, but it doesn't have to be any more organized than finding how to make it happen together individually. We can make a few inquiries- Mm-hmm ... and see where to go. And I'm happy to think about grant making, but I believe that every grant should be driven by the voices of your community. And I know we are voices of our community, but I feel like you guys are. And the data that we pull is, and tells us what's needed and
+
+**[16:56](https://vimeo.com/1205809868#t=1016s)** drives us to our decision-making. So I think you could put that together, because I don't want us to just say, "Hey, let's go get planting more trees," or whatever. Right. Well, so that's going to sort of dovetail with what's coming on the agenda, which is the report of the- Health ... the health. Right. Clearly there's a need for mental health services and possibly some substance use education. But that's going to, as you said, we need to work with other committees in town. That's going to certainly tie in with the schools, with the police, probably with the Marblehead Council on Aging. Maybe there's probably somebody I'm overlooking, but...
+
+**[17:41](https://vimeo.com/1205809868#t=1061s)** And there's a mental health group, too. That's where I was going with that. Yeah. The counseling center. The counseling center. Right. Yeah. Well, okay. But, a 501 [c] [3] could definitely be focused on raising money to provide services for that. The things I've been hearing informally from people are that they would like to see more mental health and counseling services. And the answer to that is, that's great, but we don't have much budget for that right now. So this would be a way to create a budget for that. Well, it's hard to keep on one track. Right. But we do have Bloom. And what we learned last- Two weeks, four weeks ago, people haven't signed up very much. One of the things I want to get to is navigation
+
+**[18:29](https://vimeo.com/1205809868#t=1109s)** and communication. If there was one thing that Calm showed us, several things it showed us, but is people were asking for things that already exist in the town. Mm-hmm. And not that there's enough mental health services anywhere, but there were people who really thought that we needed this, that, and the other. And we need to
+
+**[18:57](https://vimeo.com/1205809868#t=1137s)** address that. And I'll get back to that with Calm. Okay, so
+
+**[19:10](https://vimeo.com/1205809868#t=1150s)** I think I'm hearing ... Again, please, this is not my decision, it's our decision. That we're going to meet on Monday, second and fourth Monday of the month. Should we in advance knowing which Mondays we're not going to be available, should we try to schedule the alternate day that week well in advance so that we all know that? Mm-hmm. Okay. So, if we're going to do the second and fourth, then Labor Day would be the first Monday. Yeah, I think Labor Day is the next one, so we got a long- Yeah. Okay. Well, all right. So we've made that decision. I don't get the sense that we want to
+
+**[19:57](https://vimeo.com/1205809868#t=1197s)** have formal sub-committees which break down and have to follow
+
+**[20:04](https://vimeo.com/1205809868#t=1204s)** open meeting laws and monitoring and all of that. Mm-hmm. Okay? All right. So I think you ended up with three. Community health, the transfer station or waste management, and sort of the one I proposed, which might be research evaluation, community input and fundraising. And if those were our three, I might suggest that we take one of our two meetings a month and take, I don't know how long we think these meetings are, but we take 30 minutes to
+
+**[20:41](https://vimeo.com/1205809868#t=1241s)** meet in those small groups, and then be up for the other half of the meeting to ... And that might give us the opportunity to have people like these who are interested in coming to a meeting, could also participate in the sub-committee without having to come on two different nights. How do we record at the different separate meetings, though? So yeah, you would just break down your- Right ... meeting to 30-minute sections. Oh, okay. So, the first 30 minutes would be X subject, the second 30... Because you could not break out into small groups, because you're in a public meeting. But if anyone wanted to come to the public meeting- So, like- ... we could always do Zoom besides- So, like- ... this very fancy one. No, so- We could do multiple Zooms. No. We don't have the capacity for that. You're only hosting one meeting.
+
+**[21:29](https://vimeo.com/1205809868#t=1289s)** So you're staying under the guise of one meeting. Now, you can break that meeting down into different sections, but you're under that. Time-wise, but not simultaneously. Yes. But Zoom allows you to break into sub-groups. Right, but again, everything has to be recorded, everything has to be, meeting minutes for everything. You'd have to stick to your quorums and stuff like that. So it becomes problematic when you're breaking down. So again, you could go under one meeting and break down, but it becomes problematic.
+
+**[22:08](https://vimeo.com/1205809868#t=1328s)** So we're here at this meeting. Right. How would you set it up to break out into groups? We would have three big breakout groups on Zoom, which I do all the time, and you can record the breakout groups individually, and we could have two more rooms, which were not as fancy as this with a very fancy camera. Yep. And- A couple things with that. So this is our meeting room. This room is about to go into construction at some point this fall. We will find another location. Most likely it's going to be either Abbott Hall or the library. The likelihood of us having multiple rooms is very unlikely. I see what you're saying, and when everyone's on Zoom, breakout rooms make a lot of sense. When you're all in these meetings, I think just having the simple agenda where you know what's coming where, and then
+
+**[22:56](https://vimeo.com/1205809868#t=1376s)** people show up at whatever time. So it's- Well, also the potential exists for a board member to be on multiple sub-committees. I guess that's true, too.
+
+**[23:07](https://vimeo.com/1205809868#t=1387s)** And how would I, the audience, know... How could I be in three meetings at once if I wanted to know all that was happening? He can't be. He can't. I mean, yeah. All right. Well, okay. So we're going to sort of stick with our regular meeting structure at first, and we'll hopefully evolve. I think smart organizations change as they go. But at least we know where we're starting. The select board and the school board, at least those I know, they go directly to the director first, and hear from the director. I think we do the board a little bit differently. I kind of like the members talking first, but
+
+**[23:55](https://vimeo.com/1205809868#t=1435s)** I talked to Andrew, he doesn't care. But should we hear Andrew's report first and then go to our business? I actually would like to hear Andrew's report first, especially with all that happened with the trash strike- Sure ... and with the trash barrels. That's what mainly what people came to- I agree ... hear. I agree. Okay. So yeah. We can change that up, and a lot of times what we'll do is, with the structure of the agenda is that, so people aren't sitting in the audience for a long time, we will push things to the beginning. Try to take care of those people first, and that way they can choose to stay or they can leave if that- Is that their pleasure? But yeah, I will change it so that I'm more at the beginning of the meeting. Hmm. Okay. Does that mean that public comment moves up front too? So that if-
+
+**[24:41](https://vimeo.com/1205809868#t=1481s)** You can choose to do whatever you want. Again- Like, if he went first, then you could- We've kind of always been casual with public comment. So, if he's done and we just say, "Any comment?" Yeah. I think we do need to talk about public comment because
+
+**[25:00](https://vimeo.com/1205809868#t=1500s)** when I... I don't know when you guys were reading you heard this, but clearly one of the hot spots of the loss of trust in public health during the pandemic was when public comment was either limited or eliminated. Mm-hmm. And I think we've erred in the opposite direction. And as a former case teacher in a number of different schools, I think that's good. Mm-hmm. I
+
+**[25:38](https://vimeo.com/1205809868#t=1538s)** see us... We have to do business for the town in health. But also, given how little people understand about public health in general, I think the role of this board is education as well. And for me, education... Like last week, you gave your, the two weeks, you gave your ticks. I'm sorry. If someone in the audience had a question about ticks, I would be very uncomfortable if they felt that they couldn't either raise their hand or ask you about that. Yes. I did a session on comparative healthcare systems a couple of months ago. Okay.
+
+**[26:24](https://vimeo.com/1205809868#t=1584s)** Steve's not here, but Steve has a son-in-law, brother, I don't know, in Switzerland, and asked particularly about the Swiss healthcare system. I think it added to everybody's comment. Mm-hmm. So I think we're here to serve the town, and then education is part of that. So
+
+**[26:50](https://vimeo.com/1205809868#t=1610s)** if we get another pandemic and if there are really fundamental differences that go beyond courtesy and politeness and respect, we have to be careful. But, at least for me, I sort of see this as an educational experience. I see part of being the chair is academic and educational. And actually, it's the most fun for me, and so I would hate to give it up. Yes. Well, I agree with simple questions, but for example, the last meeting where there was lots of commenting for an hour and
+
+**[27:36](https://vimeo.com/1205809868#t=1656s)** 20 minutes, in fact. There needs to be a point where the chair or whomever, Tom, because either Tom or Andrew were basically field everything. Where you need to stop and summarize. Mm-hmm. Like, "I'm hearing this," and do all the points so that you're not hearing it over and over and over again. I think that there's something in between- There is, yeah ... now. Because you guys were great. I have to, because I was printing a 10, but you were great. But you start hearing the same things over and over and over again. And if you just- Jack Hatridge has a saying in town meeting. Yes, I know. "I think everything's been said, even though
+
+**[28:23](https://vimeo.com/1205809868#t=1703s)** everyone hasn't said-" I think Gary Spees Yeah, Gary ... his predecessor, who said that. Okay. Well, I wasn't here then. I know you weren't, but yeah. No. It's clearly what you're talking about. Right. Yeah. And, yeah. Maybe I should've intervened a little more last time. I'm just saying this- But I'm not here. I didn't hear you ... I got to review it later. I wasn't in the thick of it. So you don't know what's going to happen, but it's going to keep coming. Do you know what I mean? Which it did. Yeah. Yeah. So, yeah. But I think that was good the last time because you had a lot of people that didn't do the homework, and I think they needed to vent. And now you see tonight, I don't see anyone here complaining about the trash yet, unless they're going to come up now. So I think that-
+
+**[29:10](https://vimeo.com/1205809868#t=1750s)** Well ... I don't think you could anticipate. Well. Okay. And- Oh, I just think the other thing that I've thought of, you could also just put up as people say things, in a way, like it's behind you or wherever. I don't know, the fancy camera keeps moving. But put up maybe in a sidebar for people who aren't here, "Here's the five topics that have come up," and just start ticking them. I did that on my notes that I took for myself, and then when I wrote up the meeting minutes, rather than saying it over and over and over again. The 77-year-old woman with the shoulder replacement was the same issue as a woman with a long ill. "I can't manage the- Right ... size of the bins." Okay, so there were two of them, or seven of them.
+
+**[29:55](https://vimeo.com/1205809868#t=1795s)** And I think that's an easy thing to do, and maybe people, maybe not when they're as angry as they were last week, or last meeting, but- Andrew senses the anger is tapering. No, but Andrew solved it because he said he was going to order more barrels. Right. He's going to give them an option. And- And pay less ... they're going to be able to share barrels. Right. So I think that's a big one. Yeah, so that's quite a- I mean, that would've been great to be something that we could've said before the barrel thing came out, but we couldn't- Yeah. So maybe it's simple as we put up a whiteboard and write stuff down so that things that get repeated, you just sort of point at the whiteboard and say... So that you're not being rude, but you can point out that it's already been said. Just as if there's- Visual
+
+**[30:41](https://vimeo.com/1205809868#t=1841s)** So then it comes down to who's going to manage the whiteboard? I'll do it.
+
+**[30:47](https://vimeo.com/1205809868#t=1847s)** It's okay. If she's not here, I'll do it. But you got to remember that was a
+
+**[30:53](https://vimeo.com/1205809868#t=1853s)** breaking audience. The last couple of years, I haven't seen that much participation in this, but there's like three people in here. So, just don't go make all your changes and base it on one thing.
+
+**[31:09](https://vimeo.com/1205809868#t=1869s)** Okay. We're doing well. Thanks. I have bad news in that I got a notice today that we did not get funded, by the CHIP program.
+
+**[31:26](https://vimeo.com/1205809868#t=1886s)** We knew it was going to be competitive. There were 182 applications for 20 groups. Wow. Oh, wow. And- That's too- Rob, I don't know the details, but when I've looked at it in the past, many previous applicants learned or thought more about their proposal and came back again and got it the second time. And that's certainly what you do. I don't know if they have pink sheets. I'm going to try to find if there's a review of our
+
+**[32:07](https://vimeo.com/1205809868#t=1927s)** proposal. Now, our proposal, it's back to the conversation about how I think the Board of Health adds value. Our proposal was to develop a coalition, and the proposal that went in had a coalition of 10. And the coalition was asking for money for two years, $50,000 a year, for that coalition of 10 to look at all the barriers of the town that cause negative youth mental health. And at the end of those two years, if it was fully studied, then the assumption would be that the town would go back
+
+**[32:56](https://vimeo.com/1205809868#t=1976s)** in for not planning grants, but implementation grants, which are a little less than $200,000 a year. So that, I thought, was a worthwhile proposal. We
+
+**[33:14](https://vimeo.com/1205809868#t=1994s)** didn't know the details. We had originally thought it was going to work to look for a teen center. If you drive by Starbucks at 3:00 in the afternoon, you sort of get the sense that it'd be nice if we had a place where the teens were coming together and working together. They gave us feedback early on that they wanted big picture, 30,000 feet. If you eventually said, after two years of study, the highest priority for the town is this, that, and a teen center, they would buy it. So I would very much like to have this board be a facilitator or a convener for that coalition.
+
+**[33:59](https://vimeo.com/1205809868#t=2039s)** The coalition was 10 people. You got most of them. It started with the YMCA, which has an awful lot of things for the teens. The Marblehead,
+
+**[34:20](https://vimeo.com/1205809868#t=2060s)** was it Minority Task Force? MRJT. Yeah. That, I think, was probably with the YMCA, the strongest point because it showed that, in fact, even though everybody thinks Marblehead is a white affluent town, there are people in this community that are thinking hard, working hard, and trying to look for issues regarding racial justice. So I think that was really one. So I would like to see, as we go along, if we can figure out... We had the racial justice group. We had the Y. We had the senior center. We had the
+
+**[35:08](https://vimeo.com/1205809868#t=2108s)** counseling center. We had the selectboard. We had the library. We had us. Anyway, there were 10 of us. And we probably could have gotten more had we had more time to write it. So I would like, over time, to resuscitate that idea, maybe focus a little bit. But that, to me, seems to me a real value added for the Board of Health for the town. Because health, again, everyone thinks about health and wellness in a slightly different way, but it interfaces everywhere.
+
+**[35:54](https://vimeo.com/1205809868#t=2154s)** So if that's okay, I would try to
+
+**[35:59](https://vimeo.com/1205809868#t=2159s)** see what we could do about resuscitating that. We have a few dollars left in a grant from the past, and we could use it if we had to. But the budget was kind of poetic anyway. We figured out how to put $100,000 on paper and make it work. So I'd like to try that. So the final question that I have about organization, you mentioned CALD. Now,
+
+**[36:26](https://vimeo.com/1205809868#t=2186s)** CALM has been, I think, an enormous positive effort for the town. We got 2,553 people to answer 43 questions, and they were more than 43 simple questions. There were subdivisions. The UMass Boston people were terrific. We worked very hard at getting as much as we can Well, I don't need more props, but we have a 180-page final report from them. We have a 43-page
+
+**[37:13](https://vimeo.com/1205809868#t=2233s)** report that I sent to everyone, that went to the leadership council. And we are ready, I think, to start setting town pri-- or board of health priorities based on that. How do we communicate the robustness of COM, given the reality that we learned last week that even though we've been talking about 95 and 65 gallon tubs for four months and people said they never heard about it, what can we do? As a background, one of the things that until last year, we had a subcommittee in the Board of Health
+
+**[38:01](https://vimeo.com/1205809868#t=2281s)** called the Marblehead Mental Health Task Force. Last summer, they decided they wanted to move, that it made sense for them to move the counseling center. So they moved to the counseling center, but then the counseling center contact person has since left the counseling center. So I think the Marblehead Mental Health Task Force has not met for six or eight or nine months. I think we move back mental health into, as a board of health, an issue for the town. Part of what the Marblehead Mental Health Task Force had done was it set up a website, an information website called Marblehead Cares.
+
+**[38:46](https://vimeo.com/1205809868#t=2326s)** Somehow that, we first heard it was hacked, but it really wasn't hacked in a bad sense, but apparently you have to pay for website licenses or names. We forgot, whoever worked on it didn't know to pay. It dropped out. Somebody then attached, somebody else said they owned Marblehead Cares and came to us and asked if we would pay them for our website. When we said no, they left it open again. And we have now gone, Andrew has now, Andrew and Marty have now gone in. We now own Marblehead Cares
+
+**[39:33](https://vimeo.com/1205809868#t=2373s)** website. And hopefully by... Did you get the things to Peter? Yeah, he should have stuff. Okay, within the next week or so, Marblehead Cares' website should be up and saying, "We are now under construction for a new and better website." So,
+
+**[39:56](https://vimeo.com/1205809868#t=2396s)** this is the simplest thing I can think of. I've got this 180-page final report from COM, and I've got the
+
+**[40:06](https://vimeo.com/1205809868#t=2406s)** 40-page report to the leadership council that you all have seen. We will put both of those things on the Marblehead Cares website, and we will then, what we need to do is figure out how to get people interested enough in COM that they want to hear more. Now, I thought we
+
+**[40:34](https://vimeo.com/1205809868#t=2434s)** just finished with UMass Boston. It seems to me, for us to try to start educating about COM in the summer months is probably a little optimistic. Mm-hmm. So that if we, and I've talked to many people on the leadership council, and everybody agrees, that if we're prepared in September to come back and really go back and
+
+**[41:08](https://vimeo.com/1205809868#t=2468s)** describe why COM was important, what it told us, and what we want to build on, it's the best way to sell. Whoever wants to, I think we'll do whatever's necessary. We can put columns in both of the newspapers. The UMass Boston...
+
+**[41:49](https://vimeo.com/1205809868#t=2509s)** Oh. It's margin.
+
+**[41:53](https://vimeo.com/1205809868#t=2513s)** Okay, UMass Boston suggested the seven highest priorities of the town should be stress, parenting, caregiving, pedestrian and biking safety, substance use, financial fragility of the population, and social division. Now,
+
+**[42:19](https://vimeo.com/1205809868#t=2539s)** my reading of it, I'd have a little bit different priority, but the more important thing, there's probably not a lot of things that the Board of Health can do about pedestrian safety and bike safety. Mm-mm. We can sort of volunteer to go to a transportation subcommittee that somebody else has, or we can report every- There's a traffic safety There's traffic safety. Then that's new, actually. It's within the last couple of years. Yeah, I went to that because my neighbor had two little kids and wanted a crosswalk in front of the... So I went and said, so yeah, they meet. So that kind of thing, I think we should be aware. But clearly substance use, mental health, stress, anxiety, all of those issues should be core
+
+**[43:08](https://vimeo.com/1205809868#t=2588s)** Core
+
+**[43:11](https://vimeo.com/1205809868#t=2591s)** activities that the Board of Health really is the convener, the curator, and seeks other partners from other parts of the town to work with us on.
+
+**[43:29](https://vimeo.com/1205809868#t=2609s)** Should we deal with mental health as an entity or... My bias as a pediatrician, youth mental health, very different than the highest. There's no question, if you looked at the data, the highest stress age decile was the 40-year-old to 50-year-old, and they blew it out of the park. That's the sandwich generation. I guess they're raising kids and they probably have senior parents. Some of them have senior parents. It's tough, and they're still making their careers and all of that. What can we do creatively
+
+**[44:14](https://vimeo.com/1205809868#t=2654s)** to encourage the town to work with us to make that better?
+
+**[44:25](https://vimeo.com/1205809868#t=2665s)** Do we separate youth and general, or...?
+
+**[44:34](https://vimeo.com/1205809868#t=2674s)** I have a case study I'd like to propose. It's work I did in Connecticut. It's now been going on for
+
+**[44:45](https://vimeo.com/1205809868#t=2685s)** 21 years because I was pregnant when I started it with my youngest. And Trumbull, which I have to say, Trumbull, Connecticut, looks very much like Marblehead. It is wealthy, largely white, but near a larger city that is much more diverse. It is a place where parents have to commute, where parents want all of their children to-- They have a list of 10 schools that their kids could go to for college. And the level of stress among our teens in Trumbull, I didn't live there, I lived in the scary city next door and was their health director, but there, what we found was that kids were really stressed.
+
+**[45:32](https://vimeo.com/1205809868#t=2732s)** And at our first year, I think 43% of our high school students, and among juniors and seniors it was much higher, reported getting into a car with someone who was drunk in the past 30 days. Not year, 30 days. So this community really took on this challenge. They centered parents and children and did amazing things. SAMHSA considers them the national model, and I started it, and now my closest friend in Connecticut still runs it. She would come. She would help us do community meetings, present it as a case study,
+
+**[46:17](https://vimeo.com/1205809868#t=2777s)** present some of the calm data, and I would say, what I used to say is, "In any place where two or more are gathered, I will go present the data." And we would go, and we did it over and over again. At PTA meetings, we did it at Girl Scout meetings. We did it in the senior honors system. Anywhere where we could find people who were in our target groups, we went and presented it over and over again and started a community conversation that led to things that I never would have picked. The number one thing that would change kids' behavior was if their parents talked to them openly and honestly about
+
+**[47:05](https://vimeo.com/1205809868#t=2825s)** drinking their own, around boundaries, and around the fact that they had expectations of them beyond, "You've got to go to Harvard or Yale," that were about safety. And we had parents, we had those contracts on every refrigerator that were sticky. I know everything's stainless steel now, so we wouldn't have to do Post-its. But every household of every seventh to 12th grader had that contract on the wall or on their fridges. "Here's where I'm going. Here's what our safe word is. Here's when I expect to be back. You can track my location." Very clear. "And here's what I'm going to call," or,
+
+**[47:50](https://vimeo.com/1205809868#t=2870s)** "Here's what you're going to need to call if I text you and say my head hurts," or whatever you choose. Your parents knew, and they would call and be nasty on the phone. "I can't believe I just walked into your room and it's a disaster. I'm coming to pick you up. We're getting you home. And you're grounded for a week." But it allowed parents and children to become partners in the effort. And Trumbull Partnership Against Underage Drinking, everything they developed was with-- They've now had, it's been 20 years, I think 14.5 million students work. And their underage drinking rates now among their seventh to 12th graders, past 30-day rates are less than 5%. We changed a community. Took 20 years.
+
+**[48:39](https://vimeo.com/1205809868#t=2919s)** But it is considered the national model for doing the work. That's great. So that's an inspiring story. What I'm hearing is the first step is communication. Right. Assemble the data and get it out there. That's got to be step one. And then have them, whether it's the parents or the kids, or the teachers, tell you, "This is how you're going to fix it." It wouldn't be our decision. And that's what I would think about for research assessment and then grant writing committee would do. We would go out and do those meetings and then begin those conversations.
+
+**[49:16](https://vimeo.com/1205809868#t=2956s)** I've been trying to sell this in Marblehead since I moved here five years ago, and no one's interested in doing it. It sounds like you've got to find buyers. Poor buyers. And I can send you guys the links. Well, there's probably a difference in today's world, today's kids, in the screens issue- iPhone ... social media issue, cannabis, all of those things are there. But I think we start somewhere. And with your knowledge, with your background, and the COM data is pretty clear, then we do anyone who wants to listen to us. But in addition though, I think we have to have a couple of formal
+
+**[50:02](https://vimeo.com/1205809868#t=3002s)** places. I would like to have a session in the senior center for sure. Senior center, we'll do afternoon stuff or evenings if we can do it. Rotary supported us, we'll go to Rotary. humane society supported us, we go there. We just go, as you say, anywhere who wants to listen. Okay, but are you saying
+
+**[50:29](https://vimeo.com/1205809868#t=3029s)** do the youth thing for mental health in general, or do we have youth- I would ask the people who we know from the COM data are struggling what would be most useful, and have them send us, drive what to do first. Parents may say, "If you could take me worried about my kid not coming home from a party on a Friday night, that's enough for me. And then if that's off my plate, or if you tell me how to do it more appropriately..." They may say, "Do the kids first." Or kids may say, "My parents are idiots, and I'm not going to listen to them." And you- I don't know what the community would say. Yeah. I
+
+**[51:14](https://vimeo.com/1205809868#t=3074s)** agree. I think if you get their buy-in, it's going to be the most effective, so obviously soliciting them to be engaged. But, I'm just looking at the list of things that were identified as the seven highest priorities. And you also identified the 40 to 50-year-old age group as the most stressed. And when you look down the list, the reason they're the most stressed is because all seven of these hot button issues hit them. But, I agree with what Kristen's saying, that if you could... People are going to be the most invested in their kids, of all those things. And if you can take a huge piece of that worry off their list, or reduce it, that's going to probably be pretty effective.
+
+**[52:00](https://vimeo.com/1205809868#t=3120s)** My thought. Maybe it begins with asset mapping. Look at the list. Let's look at the existing services that we know are available, but people don't know about. Maybe that becomes part of the community presentation when you say, "Hey, you're struggling with, I don't know, paying your light bill. My light bill was outrageous last month." Here's the people who are doing that work. And that becomes something that starts to go out along with her TikTok notes on our Facebook or Instagram page. But that may also require hiring someone, not him, to manage our Facebook or Instagram or website page and get those things up. Well, Marblehead CARES, at least on their present plan,
+
+**[52:48](https://vimeo.com/1205809868#t=3168s)** isn't going to be TikTok or Instagram. It's going to be its own thing. A website. Right. Yeah. People need to know that- That doesn't mean we shouldn't have it, but I don't know how to help with that People need to know that it exists. And that TikTok and Instagram- That's how you get people- I have a crazy idea to bring up later. You'll get tons of really good ideas. You're going to have the seven priorities, and then you're just going to have to start to work on them. This was the whole idea with the public health assessment, was to create the strategic plan. Right. And so you're going to have these, and then you're just going to have to categorize them. List them one through seven, and then start at the top. List all the priority ones and then start to work down. And you're going to have things that cross over. So like information. We need more information on all
+
+**[53:34](https://vimeo.com/1205809868#t=3214s)** these different subjects. Let's concentrate on the website. Let's decide on how information's going to get pushed out. But you're going to have to hit each one, but you're going to have to go in order. You only have so much time. Yeah. Yeah. But I think a big piece of it has to be communication. Oh, yeah. And that's going to be a piece across the board for every one- For everything. Right. Exactly. How do we communicate about stress and parenting? What is going to be our platform? Where are we going to get that information out? So you're going to start to show yourself, all right, we really need to work on this piece first. We need a website that we can update on a regular basis, that's user-friendly, that people feel comfortable with. Do we want to use social media, or do we think social media is not the greatest public health thing, and so we're going to go back to the website and say, "This is really where we want everybody to get their information."
+
+**[54:23](https://vimeo.com/1205809868#t=3263s)** Right. No, I was just advocating for social media as a way to get people to the website. Oh, yeah. Yeah. But then, who's going to be doing that? How is that going to be pushed out? What's going to be pushed out? There's a generation out there that's only reading paper things they get in the mail. Okay? Yep. Then there's another generation that's reading emails. And then there's another generation that doesn't do either one of those things, and it's social media all the way. Yeah. 60% of Americans get most of their news- Right ... on Instagram or TikTok.
+
+**[54:57](https://vimeo.com/1205809868#t=3297s)** COM showed that 72% of COM answerers, newspapers. We got an old people. So, yes. Oh yeah, by far. Social- But none of them- Social media was in the 40, what? 45, 50. It was significant But we were both, and certainly the newspapers were pleased to see that the people who filled out... Maybe because we bought ads selling cubs in the newspapers of people who read the newspaper. And again, your point's totally correct. Not everybody's reading the newspaper, so how are you going to find those extra people? How are you trying to serve the most number of people? Is it a combination of websites and other information, just like you said, "Hey, on
+
+**[55:44](https://vimeo.com/1205809868#t=3344s)** Instagram, please go read our website," and have the connection there so you can get the members. And we can write pieces for the newspapers, The Current, The Independent, The Weekly Reader, the weekly whatcha-ma-call-its. Yeah. And again, you have an Instagram post that says, "More information here, link." So again, with all this stuff, you're going to have to create a priority list. Right. And then you're going to have to come up with a policy on who can write these, how do they get published. Does anybody have to agree to it? You need to come up with a policy to outline all this as well. So, do we need a communications committee? I think- Yeah ... I sent the leadership group the 40 slides from Caitlin. What's the leadership group, the leadership council? Is that us?
+
+**[56:31](https://vimeo.com/1205809868#t=3391s)** No, it couldn't be because of the open meeting law.
+
+**[56:36](https://vimeo.com/1205809868#t=3396s)** It started out with a group of six that it had to customize the traditional questions that UMass Boston wanted to use on the survey. UMass Boston has done 80 of these. We're the first ones, first town or facility that's ever gone below 50. They are gerontologists. So when we decided we wanted to go down to 18, we had to start over. We put together, I like to say we put together... We were lucky. We found six people who were interested, caring, respectful,
+
+**[57:22](https://vimeo.com/1205809868#t=3442s)** and just pleasant to work with. We met three times, four hours, going over every question. Even Caitlin said she'd never seen any group like that. So that was started with the leadership group. After that, we added Terry McDonough from counseling center. We added a couple of other people. But that's where we are. But now we can talk. We're no longer forbidden. We can talk about COM here, and we can talk about COM on the outside, one-on-one at least. So if I can ask, if you don't have what I sent, or maybe I'll just resend it, the- Okay ... report that she sent, and that
+
+**[58:11](https://vimeo.com/1205809868#t=3491s)** each of us come next meeting with our sense of whether the priorities that she identified from the intensity of that data. I think there needs to be a little bit of questioning about what the Board of Health can really do. You can't really- Right. There was no question that sidewalk and roads around Abbott Hall was almost the highest thing there. But we can't change that much. So if I would resend- Well, in the same sense- I'll resend that You can look at that and say, "There's a lot of people talking about how I get around this community.
+
+**[58:57](https://vimeo.com/1205809868#t=3537s)** Do we need to talk about fitness? Do we need to talk about these are the best places to exercise? We recommend you go here, go there." Or again, we got a lot of information, and we should share some of that with the traffic advisory committee. Do you want the 180-page full report too? Yeah, I would actually. Okay. I'll send both tomorrow. And at least- Can I grab it on paper because I'm old? Yeah. Oh, I like to circle things and put post-its on. Oh, so do I. I'm older, by far older than you are. But I don't want to print 180 on my little printer. Maybe if we really want a couple- Yeah. So if you really want it, just email me and I'll print it out a copy for you.
+
+**[59:44](https://vimeo.com/1205809868#t=3584s)** All right. So action item for me at the end of this will be to make sure that everybody has all the information that we have on COM, and maybe I'll try, if I have some time, to come up with maybe an outline of an executive summary that might go to the newspapers right after we meet next time. And one of the things that came up with COM is that we do have a group that we can't reach. So like the- The young- ... 20-year-olds ... kids We couldn't get a... Yeah, we could not communicate well with them at all. And so again, communications like a high priority. How do we make sure we can- Reach them? Yeah. How do we reach them? Starbucks. That's a good thing. But it's a- But it's three blocks ... but it's until we... And it's not... No.
+
+**[1:00:31](https://vimeo.com/1205809868#t=3631s)** But you haven't really went to 18. What? We only went to 18. Yeah, we're only allowed to go to 18.
+
+**[1:00:38](https://vimeo.com/1205809868#t=3638s)** How did it go with the focus groups? Mixed. Mixed. Okay. There were a total of 65 people who sat in on five focus groups, but one was 20 or 25, the most senior that had the time. And I think three types of data for the COM. One was the survey. Two was the demographic stuff that the State of Massachusetts has, which is fantastic. It's not so great for mental health, but it's really great for physical health. And third was focus groups, and they didn't get as much from the
+
+**[1:01:26](https://vimeo.com/1205809868#t=3686s)** focus groups as they had hoped This is a common problem in public health, trying to get people to fill out surveys. People are doing so many surveys now, they're like, "No, thank you." A lot of surveys are being incentivized now. Gift cards, stuff like that. If you're looking at a certain population, food gift cards, market basket, those go a long way. Again, we don't have a budget for that, but those are a lot of the things that are being done in other communities, and that's a new tool for public health to get people to do surveys. Who paid for it? Sorry? Who paid for it? Donations and grant money. Well, it's public. Yeah. How we got our first support was
+
+**[1:02:12](https://vimeo.com/1205809868#t=3732s)** the Afternoon Rotary. Second support was Pima Humane Society, and then Morning Rotary, and then The Mariner.
+
+**[1:02:26](https://vimeo.com/1205809868#t=3746s)** And Helene, who was chair during all that time, every week told me what a bad fundraiser I was. And she's right. I never knew how to do that except for write grants. But once we got enough money to pay, I stopped going around asking for money. But I think ultimately if we can show how valuable this could be to the town, because it goes beyond
+
+**[1:02:53](https://vimeo.com/1205809868#t=3773s)** bacteria at the beach. It really expands the nature of public health. That public health is what we do to make people healthier, and people don't see it that way. And the COM data, UMass Boston was very pleased. They thought that we would have to work very hard to get 10%. We got 15%. They said that's one of the best. Certainly, they've had some where they were very narrow, they delivered to the home, and they did all that. But we did okay. So let's use the data, let's make it work, and let's make what I would-- If we can take the next half an hour or the next couple of meetings to really talk about
+
+**[1:03:41](https://vimeo.com/1205809868#t=3821s)** how we communicate COM, what we communicate and how, how we get to the Gen Zs, how we get to the sandwich generation, how we get to the ready-to-retire or early retire. We broke it all down. It's there. And the idea with data-driven is that you completed this survey. You have your seven priority areas. You complete work over the next five years, and then you do the survey again. Are you making a difference? What are the five priorities or seven priorities in five years? Do you need to shift? And try to stay up with what the community's asking us to do and proceed that way.
+
+**[1:04:27](https://vimeo.com/1205809868#t=3867s)** At this point, the state of Connecticut's the only state in the country that does it. But there's a statewide, it's called a Community Wellness Survey, done, and if you want to know what that data is for your comm-- It's done every two years. If you want to know, if you say, "Hey, I live in Marblehead and I want to know what's going on here," you push this little ask Mark button. Mark is the guy who runs it, and they run the data for you. And they'll tell you as many times as you want. They'll tell you for every two years. It's now 12 years old, I think. It started in New Haven. It is so useful. And we should also be asking our
+
+**[1:05:14](https://vimeo.com/1205809868#t=3914s)** state to give us. You said this data from the state was great. I don't know why no one will give me the frigging YRBS data from Marblehead schools. So, obviously once it becomes public, you can get the data and stuff like that, once they give a presentation. The other piece that occurs in Massachusetts, our hospitals are required to do a public health assessment for their region. Now, that doesn't mean it's Marblehead specific. Yeah. Well, that's federal. That's just- But we're a tiny department. Right. We're little. Historically, the question of YRBS, apparently the schools didn't want to do it, and- Yeah, so we had a history of parents not wanting the school to ask their child certain questions, so they avoided it for a long time.
+
+**[1:06:01](https://vimeo.com/1205809868#t=3961s)** We've had it for at least the last five years now. There is a lot of great data there. So yeah, the idea is that you can look at the YRBS surveys and pull some of that into- The most recent one was published in The Current last week, or- Yep ... and- Yes, that was completed last year ... even though it was a little... But the YRBS that's done here is not as robust. In New Mexico, we asked an awful lot more questions. We didn't ask the school districts, we just wanted them. There's really nothing about sexual activity at all in- I'm forgetting every question on it, but yes ... It's mostly alcohol and substance. Substance.
+
+**[1:06:47](https://vimeo.com/1205809868#t=4007s)** But anyway,
+
+**[1:06:50](https://vimeo.com/1205809868#t=4010s)** I think this is the core of the agenda that a new five-member board can run with to really make a difference in this town. We're different enough with different enough backgrounds, and I hope that we can get 15 people who want to come and listen to some of our conversations. Do we have anybody on Zoom? Yeah, there's six people on Zoom. Oh, okay, good. Mm. All right. Well, so I'll send out those for the next couple of weeks. We'll have how do we communicate The benefits and the next steps will come.
+
+**[1:07:36](https://vimeo.com/1205809868#t=4056s)** So yeah, again, with open meeting law, you have to be careful with communication on email. So again, you shouldn't be making any comments about it. You can receive the information, but you really shouldn't be making comments. Comments should be reserved for meetings.
+
+**[1:07:55](https://vimeo.com/1205809868#t=4075s)** Comments from the floor.
+
+**[1:07:58](https://vimeo.com/1205809868#t=4078s)** I was wondering if the 180-page document and the 43-page one are for other people to read outside of the board, or? I'm sorry? The comp survey, the 180, if the public's able to read it. Sure. Yeah, we had-
+
+**[1:08:17](https://vimeo.com/1205809868#t=4097s)** But it hasn't been made public yet, right? Completely. You're going to put it on the website. Is that the idea? It will eventually be posted. That's the take home. You want to see the survey itself? No, I was asking if the report is- Oh, right. We can put the report. See. We can certainly give you a copy of the report. But we'll put the report from the reports from UMass Boston on the Marblehead Cares website, then everyone will have access. Right. Did they give an executive summary of it or? Is that the 40-page one? Yeah, they did. But it's- Yeah, it- I mean, because of 40 page... I mean, think about it. How many people are going to sit down and read 40 page or 180 pages? No,
+
+**[1:09:03](https://vimeo.com/1205809868#t=4143s)** that's the challenge. I don't think many, to be honest with you. Actually, the 40-page document isn't that... I had a five-hour train ride- ... and I thought, "Oh, this will occupy me." It really doesn't take that long. There's a lot of graphs and pictures. Right. Yeah, but you did mention the schools. The problem with the schools is they're only in session 180 days a year, and the kids like all summer long. I noticed last week on the police log the kids down the Landfall Apartments are throwing balloons in front of cars in the streets and stuff. And yet, you've got Groton Road, and you got Barnneck Park, and you got a lot of kids that don't have a lot of resources, and the town doesn't have much for them to do during the day. They don't even have a splash pad- Mm-hmm ... in this town for the kids to run through.
+
+**[1:09:49](https://vimeo.com/1205809868#t=4189s)** That's why we started running a teen center. Yeah. So what they need to do, and, I've heard this from people that work at the counseling center in Clifton L., they don't have a great relationship with the police department to help these kids out a lot of times. Mm-hmm. And, it's sort of too bad. If you keep the kids busy, they'll be sleeping at night instead of getting killed at 2:00 in the morning on Atlantic Ave at 13 years old. So, I think that's part of the health issue is to try to come up with programs to give the kids. Not everyone can go on vacation during the summer in this town and stuff. You have a population of some people, that don't have the resources to do that. It would be nice
+
+**[1:10:34](https://vimeo.com/1205809868#t=4234s)** to think about them. Okay. Well, that's the chair's report. Social chair for Wade. No bills. No bills. And social chair for community health. So just a few brief notes I put together. So, we're still at the height of tick season, and ED visits for tick bites, so still want to do the tick checks and use EPA-approved repellent and wear long pants when hiking and do tick checks and shower after being outdoors. But we're entering mosquito season,
+
+**[1:11:19](https://vimeo.com/1205809868#t=4279s)** and the two that are in our region are, two mosquito-borne diseases are, the West Nile and Eastern equine encephalitis. And Massachusetts detected its first West Nile virus-positive mosquito, not a first human case, just last week. So, Massachusetts is on it. But it's very rare. I think there were just about nine cases last year. And fortunately, most people who are infected with West Nile do not have symptoms. About 20% develop mild illness, fever, headache, body aches, swollen lymph nodes, and very few develop neurological disease. The main thing to do is use insect repellent if you're going to be spending a lot of time outdoors,
+
+**[1:12:07](https://vimeo.com/1205809868#t=4327s)** especially this time of night, from dusk to dawn. That's really when mosquitoes come out. And avoid any standing water on your property.
+
+**[1:12:17](https://vimeo.com/1205809868#t=4337s)** And the big thing coming up is just heat safety as we get ready to celebrate July 4th. We're getting into a heat wave, and CDC has a great heat risk dashboard, and it's forecasting our area to that we'll be in a major heat risk from July 1st through the 3rd, and moderate on July 4th through 5th. So, drink plenty of water, limit strenuous activity outside, take frequent breaks in air conditioning and shade, wear light, loose-fitting clothing. And then if you're going to be doing extended work outdoors, make sure you're drinking at least five ounces every 15 to 20 minutes, which sounds like a lot, but the body rapidly loses water with sweating outside. And then watch for heat-related illness,
+
+**[1:13:02](https://vimeo.com/1205809868#t=4382s)** including muscle cramps, heavy sweating, fatigue, weakness, dizziness, or irritability. And then you want to go to a cool place, apply compresses, and don't hesitate to reach out and seek medical attention if symptoms worsen.
+
+**[1:13:17](https://vimeo.com/1205809868#t=4397s)** That's all I have. So just to add to that, so Marblehead does not have a history of opening up cooling centers. But we want to remind everybody that our community center, the COA, the park and rec building, is air conditioned. That is open five days a week to 5:00 every evening, so people can seek shelter there and cool off The library is another good location for that. If there is an individual or several individuals that are in need of cooling, they can reach out to dispatch. We have the capability of opening the Brown School as a cooling center. Again, talking about communication, we want to remind everybody to sign up for the reverse 911. So if you go to the town website,
+
+**[1:14:02](https://vimeo.com/1205809868#t=4442s)** we want you to sign up for that notification system. It's both a phone and an email alert. But we also want to remind everybody to sign up for Board of Health or Health Department information. We do a lot of information blasts around the transfer station, trash delays, anything other public health related, beach closures, all that information. But you need to sign up to receive that information. And where do we sign up? The town website.
+
+**[1:14:34](https://vimeo.com/1205809868#t=4474s)** At Regroup. Yeah, it's Regroup now. Okay. So that's the reverse 911 system, and you can choose phone call, you can choose both emergency side, general side, phone call, emails, text messages, all that is available to you, along with the Board of Health or Health Department email lists. We can do it just through that and stuff like that. It does not have to be an emergency.
+
+**[1:15:03](https://vimeo.com/1205809868#t=4503s)** And it'll blast to the residents? Like- Yes. We used to have a very large list for people that are interested in trash notifications and stuff like that. But yes, you can use it for anything related to public health. I don't know. Anybody online that has public comment?
+
+**[1:15:24](https://vimeo.com/1205809868#t=4524s)** No public comment. Nobody with their hand raised at this time. We want to go to the director's report. Sure. A couple of things first. Fowl permit. So I have a fowl permit for 18 Stony Brook Road. The way fowl permits work is that individuals are allowed to submit applications. They give us a plot plan of where they're going to put their henhouse, their chicken coop, their run, where they're going to store their feed. We want to make sure it's stored in a rodent-proof container. We want to talk about how they're going to do manure management plan. So they're going to gather the manure up, generally they're going to bring it up to the transfer station, dispose of it in their yard waste area. Things like that. They will talk to their neighbors. We suggest they get sign-offs from the neighbors, but it's not required. Once we have all the information, they're allowed to be put on the agenda.
+
+**[1:16:10](https://vimeo.com/1205809868#t=4570s)** And so we have 18 Stony Brook Road before you. They've supplied all the necessary requirements. This is for four chickens. No rooster. But I recommend that you approve this fowl application. So I do need a vote for 18 Stony Brook Road for a fowl permit. I'll make a motion to approve. There's Bill. So in case there are more cases of bird flu, do we ever do testing of- So yeah. So we are connected with the Mass Department of Agriculture. Yeah, so if we had a suspect case of bird flu, we would contact them in. They would be doing testing. They would be destroying the flocks. They would probably be destroying all the flocks in the community.
+
+**[1:16:56](https://vimeo.com/1205809868#t=4616s)** But yes, there's regular communication between us and them regarding that. That's why this is a permitted activity. And so Mass Department of Agriculture knows where all the permits are. Sorry, who would destroy the flock if there were a disease? The Department of Agriculture? Yes. Yep. That is the kind of the protocol now for bird flu. Okay. Discussion approved. Any further discussion? All in favor of supporting the application? Unanimous.
+
+**[1:17:29](https://vimeo.com/1205809868#t=4649s)** Great.
+
+**[1:17:32](https://vimeo.com/1205809868#t=4652s)** Tobacco control. I went to my car. My blood sugar's 51. I'm just going to get... Do you want me to help you? No, I just got to walk to my car and get- Okay ... what I need. Okay. Tobacco control. The Board of Health sets the tobacco control in Marblehead. It's done community to community. We have a public health coalition in this area, with several communities surrounding us for the departments. We are currently looking at regulations around kratom, versus natural and synthetic, but I can provide the board with a proposed regulations, the board can discuss that. Is that something that the board would like to work on?
+
+**[1:18:18](https://vimeo.com/1205809868#t=4698s)** Okay. So I will provide you guys with a draft regulation. We can talk about it at the next meetings. You guys can make suggestions about changes, other directions, where you want to go. But we can continue to have that on the agenda. Curbside collection, again, July 1st is coming up. We have distributed barrels to all households in Marblehead. There are a few households that have not received barrels. We're working to get them barrels. There are several households that are requesting small barrels. So what we're asking for July 1st is that everybody should try their best to put the material out curbside in the town-issued carts. If you have not received your barrel or you're waiting for a smaller barrel, you
+
+**[1:19:05](https://vimeo.com/1205809868#t=4745s)** can continue to use what you have. We have ordered the smaller barrels. Those will be in in six weeks. We have the ongoing list of the requests. Once those barrels have been delivered, we will begin delivery to the actual residents and stuff like that. Any questions? Again, we have had questions about the size of barrel, both, "This barrel is too small, I need something bigger. I have a family of six, this isn't big enough." Or the other way, "This is huge, I need something smaller." We're trying to accommodate everybody. And again, what we need to always remind people is that there is a possibility that in five years we would be going to recycling collection every other week. Yeah. People could change barrels at that point. No. No. So again, we are not looking to change out barrels every five years.
+
+**[1:19:54](https://vimeo.com/1205809868#t=4794s)** That is a tremendous cost. Got it. Okay. And so if people have requested a different size barrel, do they then return the one that they already have? Yes. Okay. Yep. So we do a swap out. But we are trying to remind people to remember that in five years, or during the holiday season, during times, items cannot be left outside of the carts. Everything has to be into the cart. So again, if you think the 35 works for you, but you might have days where that 65 is going to be better, go for that 65. It's really not any more weight of the barrel itself, it's the weight of the material in there. So you can kind of guide yourself on how much material you put in there. But yeah. Just circling back to the kratom thing. I know very little about kratom, but
+
+**[1:20:41](https://vimeo.com/1205809868#t=4841s)** everything I hear is negative. But then I have heard- Yep ... people use it to get off opioids. Correct. So can we get the whole picture instead of- Yeah ... just the one side? We can. I just want to learn about it. I won't necessarily have all the information regarding the use of it for opioid recovery. Yeah. But that's something that the board should do research on and try to find great articles to bring forward and share and say, "Hey, this is what I found for research. This is a scientific journal. I believe in this, I think this is accurate. Let's discuss that here at the table." Mm-hmm.
+
+**[1:21:22](https://vimeo.com/1205809868#t=4882s)** The only other thing, so obviously, 4th of July, the transfer station is open on Friday, but they will be closed on Saturday. So we will be open on July 3rd from 7:30 to 3:30, closed for lunch. But we will be closed on Saturday. We've been going through a lot of sticker sales, both for the transfer station and some of the beach. I think I saw the number of 6,780 today. So doing very well with sticker sales. I do have a refund that I need the board to vote on. So this is a $60 refund for Rebecca Haskell at 12 West Cottage Street. So I just need the board to issue the refund. Motion to approve.
+
+**[1:22:07](https://vimeo.com/1205809868#t=4927s)** Second. It's been seconded. Any discussion? No discussion. All in favor? approved. Are we...
+
+**[1:22:20](https://vimeo.com/1205809868#t=4940s)** Go ahead. No, I'm all set. Okay. We had talked about moving to Monday meetings. Is our next meeting on a Monday? No. Yeah. Let's talk about our next meeting. She's just found out, so there should be- She went out to the car to get something, so I don't know if she's going to bring it up before you adjourn.
+
+**[1:22:41](https://vimeo.com/1205809868#t=4961s)** I don't know. She said...
+
+**[1:22:47](https://vimeo.com/1205809868#t=4967s)** You're away that week, aren't you? So yeah, I'm away from the 11th through the 27th. Oh, so two weeks. Yep. So we'll meet the week of the 11th without Andrew.
+
+**[1:23:02](https://vimeo.com/1205809868#t=4982s)** runs that.
+
+**[1:23:05](https://vimeo.com/1205809868#t=4985s)** So yeah, if you're sticking to your schedule- Will you be the 13th? The 13th and the 27th. You'll be back by the 27th, right? I will be back on the 27th, yeah. Okay, so to post it, we- The meeting has to be posted by July 9th or on the 9th. Can Marty help with posting? Yeah. So I will be here to post that for you. Oh, okay. Yep. Perfect. Who can run the meeting? So the chair can run the meeting. You- You saw the electronic- Yeah. You guys are going to have to set that up.
+
+**[1:23:39](https://vimeo.com/1205809868#t=5019s)** That's what I'm worried about.
+
+**[1:23:43](https://vimeo.com/1205809868#t=5023s)** But if it doesn't work, you can still have the meeting because- No, you cannot ... there's electronic. I've done it before. We are in a different situation now. Well- The Zoom gives us the 88 capacity ... today.
+
+**[1:23:58](https://vimeo.com/1205809868#t=5038s)** Oh, okay. What do you think? I would love to, but- Yeah, you should be able to just start it and stuff like that, but I do not have anybody to take my place for it.
+
+**[1:24:13](https://vimeo.com/1205809868#t=5053s)** Skip one?
+
+**[1:24:16](https://vimeo.com/1205809868#t=5056s)** If I'm going to be attending, I mean, I don't need the Zoom information. You could type it in, but I could help turn on the- So that is a possibility. I mean, I did all the time in Johns Hopkins. Yes. I can show you how to do it, too. Yeah. Yeah. We can meet here. As long as someone's confident. I'm not confident. That's for the 13th, right? July 13th? Yeah. Quite a nice gesture. Yes. Thank you very much. Oh, I can't hear then. Does someone have your- You have another person that's knocking at the end. Yeah. I actually can't do the next two Mondays, but those are the only Mondays that I can foresee. I'm confident with Zoom. All right. Okay. It's just a different control than Zoom.
+
+**[1:25:02](https://vimeo.com/1205809868#t=5102s)** Do we want to try to... Are you out for the whole week or two? No, just the Monday. Just the Monday is the problem for you. Mm-hmm. Just the next two. 14th.
+
+**[1:25:14](https://vimeo.com/1205809868#t=5114s)** Tuesday the 14th. The 14th? Could you do the 14th? It's fine for me.
+
+**[1:25:20](https://vimeo.com/1205809868#t=5120s)** It was sort of nice how you were alternating Monday and Tuesday, so if some people, the public that may be out of town, they might be able to catch one of the meetings. I can do the- So 14th So can you do the 14th, Phil? Yes. Mm-hmm. So I have a problem the 14th.
+
+**[1:25:41](https://vimeo.com/1205809868#t=5141s)** Well, in some ways, I'd say skip that week, but Andrew's away the second week, too. No, I'm back the 27th. So let's- Yeah, but that's two weeks. 14th. Yeah. So you're meeting the first and the fourth
+
+**[1:25:55](https://vimeo.com/1205809868#t=5155s)** Mm. I mean the second and the fourth. Yeah.
+
+**[1:26:01](https://vimeo.com/1205809868#t=5161s)** So we cannot have an open meeting without that? No, you cannot have an open meeting here without this.
+
+**[1:26:11](https://vimeo.com/1205809868#t=5171s)** Can we meet
+
+**[1:26:14](https://vimeo.com/1205809868#t=5174s)** at the
+
+**[1:26:19](https://vimeo.com/1205809868#t=5179s)** library? Or- You could, I just have never met there, so I don't know what the meeting setup is like. We'd have to- Yeah. It's just like this, in the, um, little room.
+
+**[1:26:36](https://vimeo.com/1205809868#t=5196s)** But I hate to skip the whole- I think they're open Wednesday nights. I don't know if they're- I'm not sure they're open Monday nights. Yeah. The library. They would probably not appreciate. They're only open Wednesday nights till 9:00, I think. Yeah, I don't...
+
+**[1:26:57](https://vimeo.com/1205809868#t=5217s)** So do we want to skip that week, and the next meeting be- I think it's kind of looking that way ... the next meeting be- The 27th ... the 27th? Do that date. But, um, but that's fine.
+
+**[1:27:11](https://vimeo.com/1205809868#t=5231s)** And no one here about the new trash barrels.
+
+**[1:27:18](https://vimeo.com/1205809868#t=5238s)** Yes. 28th. Hold on. Correction. I'm just checking. The library is open on Monday. Mondays and Wednesdays till 9:00. Uh-huh.
+
+**[1:27:30](https://vimeo.com/1205809868#t=5250s)** Well, then go into Tuesday the 25th to 28th. Tuesday the 28th, does that work for people? That'll be all right.
+
+**[1:27:43](https://vimeo.com/1205809868#t=5263s)** The 28th is good for me. Is that okay for you? Yes, I do the 28th. It's fine for me. I already did my summer.
+
+**[1:27:53](https://vimeo.com/1205809868#t=5273s)** You can do it, Kristen? Mm-hmm. So we can all do the 28th. Mm-hmm. Okay. The 13th. The 13th is out. Looks like. Looks like we're going to have a week off. A refrigeration off. Um.
+
+**[1:28:12](https://vimeo.com/1205809868#t=5292s)** That is the end. Is that the end? That the end here, and you will all have the comp material. We'll have so much time to write our reports. Yeah.
+
+**[1:28:25](https://vimeo.com/1205809868#t=5305s)** I guess I have a standing motion to adjourn me. All in favor? Yeah. Okay. All right, we're on our way.
+
+**[1:28:39](https://vimeo.com/1205809868#t=5319s)** Thank you, everyone

--- a/data/vimeo_meetings.json
+++ b/data/vimeo_meetings.json
@@ -1,8 +1,16 @@
 {
-  "last_updated": "2026-06-26T11:55:03.697Z",
+  "last_updated": "2026-07-02T11:51:44.066Z",
   "channel_url": "https://vimeo.com/marbleheadtv",
-  "total_videos": 2812,
+  "total_videos": 2819,
   "meetings": [
+    {
+      "vimeo_id": "1205809868",
+      "title": "Marblehead Board of Health Meeting: 6-29-26",
+      "board_slug": "board-of-health",
+      "board_display": "Board of Health",
+      "date": "2026-06-29",
+      "raw_title": "Marblehead Board of Health Meeting: 6-29-26"
+    },
     {
       "vimeo_id": "1204626570",
       "title": "Marblehead Select Board Meeting: 6-24-26",


### PR DESCRIPTION
Daily auto-ingest of MHTV meeting transcripts.

**Newly added `_transcripts/` files:**

```
_transcripts/board-of-health-2026-06-29.md
```

**Pipeline:**
1. `scripts/transcripts/pull_vimeo.mjs` refreshed the Vimeo channel index.
2. `scripts/transcripts/backfill_auto.mjs` downloaded the `en-x-autogen` VTT for each new meeting and wrote the stub markdown.
3. `scripts/transcripts/enrich_one.mjs` added `summary_card` + `topic_segments` to each.

Auto-merge is enabled. The PR will land as soon as the required checks (smoke, Secret scan, Content guardrails) pass. If a check fails, this PR stays open for inspection and the next daily run is skipped (gated on the `auto-meetings` label) so the failure does not get buried.
