### PR TITLE
Auto-ingest meetings (2026-07-05)

### DIFF
--- a/_transcripts/school-committee-2020-07-28.md
+++ b/_transcripts/school-committee-2020-07-28.md
@@ -9,7 +9,158 @@ video_url: "https://www.youtube.com/watch?v=FKHq5qEu36U"
 duration_seconds: 11127
 ai_generated: true
 status: published
-source: youtube-auto
+source: youtube-auto+llm
+
+summary_card:
+  headline: "Marblehead School Committee votes 4-1 to solicit legal counsel proposals; discusses hybrid reopening plan"
+  summary: "The School Committee voted 4-1 to direct the chair, incoming superintendent, and a committee member to draft a letter soliciting proposals from legal firms on the MASC list to review district legal representation. The committee also received an extended presentation from Superintendent-elect John on a hybrid reopening plan featuring cohort-based in-person instruction for PreK–6 and morning/afternoon split sessions for middle and high school. Additional votes approved a schedule of bills totaling approximately $486,000, a one-year elevator maintenance contract with Embry Elevator for $51,400, acceptance of $3,004.75 in summer meal program donations, and a new district letterhead and business card design."
+  decisions:
+    - "Approved motion to take agenda out of order (items 2 and 5 swapped)"
+    - "Approved motion 4-1 to draft and send a legal counsel solicitation letter to MASC-listed firms"
+    - "Approved schedule of bills totaling approximately $486,000"
+    - "Approved one-year elevator maintenance contract with Embry Elevator of Woburn for $51,400 with two one-year extension options"
+    - "Approved acceptance of $3,004.75 in donations for the summer meal program"
+    - "Approved district business card template"
+    - "Approved letterhead option 1"
+  votes:
+    - motion: "Take agenda out of order"
+      result: "in favor (unanimous)"
+    - motion: "Draft and send legal counsel solicitation letter to MASC-listed firms"
+      result: "in favor (4 to 1)"
+    - motion: "Approve schedule of bills (~$486,000)"
+      result: "in favor (unanimous)"
+    - motion: "Award elevator maintenance contract to Embry Elevator ($51,400)"
+      result: "in favor (unanimous)"
+    - motion: "Accept $3,004.75 in summer meal program donations"
+      result: "in favor (unanimous)"
+    - motion: "Approve business card template"
+      result: "in favor (unanimous)"
+    - motion: "Approve letterhead option 1"
+      result: "in favor (unanimous)"
+
+topic_segments:
+  - topic: admin-housekeeping
+    topic_confidence: 0.75
+    start_seconds: 122
+    end_seconds: 815
+    headline: "Committee calls meeting to order, swaps agenda items 2 and 5"
+    dek: "With new superintendent joining and a MASC representative present, the chair moved to reorder the agenda so district governance discussions would precede re-entry planning."
+    summary: "The meeting was called to order at 10:33 a.m. After brief technical difficulties, the chair moved to swap agenda items 2 and 5 so that the school committee communications and district council discussion could occur while MASC representative Dorothy Presser was available. The motion passed unanimously (Sarah Gold, Emily Baron, Sarah Fox, David Harris, Megan Taylor — all yes)."
+    key_speakers: ["Sarah Fox (Chair)", "Dorothy Presser (MASC representative)"]
+  - topic: labor-personnel
+    topic_confidence: 0.85
+    start_seconds: 955
+    end_seconds: 2540
+    featured: true
+    headline: "Committee votes 4-1 to solicit proposals from legal counsel firms; Fox dissents over institutional knowledge concern"
+    dek: "With collective bargaining approaching and a new administration in place, the committee debated whether to shop for new district legal counsel, ultimately voting to send an exploratory letter to MASC-listed school law firms."
+    summary: |
+      The committee discussed whether to review its current legal representation (Valerio Associates) with guidance from MASC representative Dorothy Presser. Presser explained that school committees are not required to issue a formal RFP for legal counsel and that sending a letter to firms on the MASC Council of School Attorneys list is a common approach.
+      
+      Key points in the discussion:
+      - **David Harris** framed it as sound business practice to periodically review legal services, especially with collective bargaining upcoming.
+      - **Megan Taylor** noted the new superintendent has worked extensively with one firm (Miller, in Boston) for 20 years and could recommend them.
+      - **Sarah Fox** expressed concern about switching counsel while complex legal matters from past administrations are ongoing, citing the value of institutional knowledge at a time when neither the committee nor administration is established.
+      - **Superintendent-elect John** noted the conversation is common when there is a change in administration and said he sees a case on both sides.
+      - Presser advised that if an exploratory process proceeds, the current firm (Valerio Dominello & Hillman) should be notified in advance.
+      
+      The motion — to have the chair, Megan Taylor, and the incoming superintendent draft and send a solicitation letter to appropriate firms on the MASC list — passed **4 to 1**, with Sarah Fox voting no.
+    key_speakers: ["Sarah Fox (Chair)", "David Harris", "Megan Taylor", "Dorothy Presser (MASC representative)", "John (incoming Superintendent)"]
+  - topic: admin-housekeeping
+    topic_confidence: 0.8
+    start_seconds: 2540
+    end_seconds: 4903
+    headline: "MASC representative leads governance orientation; committee reviews and defers vote on operating protocols"
+    dek: "Dorothy Presser presented on school committee roles, governance structures, and operating protocols; committee agreed to form a small subgroup to reconcile existing protocols with a draft prepared by the incoming superintendent."
+    summary: |
+      Dorothy Presser gave a presentation on the overarching mission of a school committee (continuous improvement in student achievement), the governance role of the committee versus the management role of the superintendent, and best practices for operating protocols.
+      
+      Key discussion points:
+      - The committee reviewed two documents: the existing operating protocols (developed over two years with MASC) and a new draft compiled by the incoming superintendent from examples at Triton, Beverly, and Acton-Boxborough.
+      - Members generally agreed the existing protocols have served well but that the incoming superintendent was unaware they existed.
+      - **Emily Baron** (new member) found the new draft clarifying for her role.
+      - **Sarah Fox** raised a concern that one provision in the new draft (pre-submitting questions before meetings) could limit spontaneous public deliberation.
+      - Presser recommended a small subgroup combine and revise the two documents rather than wordsmithing in a large group.
+      - The committee agreed to bring a merged draft back for vote at a subsequent meeting, aiming to complete the process by end of summer.
+    key_speakers: ["Dorothy Presser (MASC representative)", "Sarah Fox (Chair)", "Emily Baron", "Megan Taylor", "John (incoming Superintendent)"]
+  - topic: school-budget
+    topic_confidence: 0.95
+    start_seconds: 4966
+    end_seconds: 8097
+    headline: "Superintendent-elect presents hybrid reopening plan featuring cohort-based instruction and daily remote component"
+    dek: "Incoming superintendent John outlined a hybrid model built by teaching and learning subcommittees, with PreK–6 students attending in alternating cohorts approximately three times per week and middle/high school students attending morning or afternoon sessions."
+    summary: |
+      The superintendent-elect stated that a fully in-person return for all students is not feasible given six-foot distancing requirements and building capacity, while a fully remote model is not the district's current direction. A hybrid model was developed through collaborative subcommittees of educators and parents.
+      
+      **PreK–6 model:**
+      - Two cohorts on a two-week rotating schedule; each cohort attends in person approximately five times over ten school days (three days one week, two days the next)
+      - In-person sessions run 8:00–11:50 a.m., focusing on literacy and numeracy
+      - Remote days feature a morning meeting that includes both cohorts, followed by structured asynchronous or supported work overseen by a paraprofessional or tutor
+      - A remote learning liaison is assigned to each school
+      
+      **Middle school:**
+      - Students attend a morning or afternoon session (~2.5 hours each day)
+      
+      **High school:**
+      - Cohort A and Cohort B alternate morning/afternoon sessions
+      
+      Key discussion points raised by committee members:
+      - **Sarah Fox** asked about consistency for families managing childcare and noted two-week rotating schedules are challenging
+      - **Megan Taylor** asked for rationale on why everyday in-person was not feasible; Nan (assistant superintendent) explained teachers prioritized seeing students daily and that building capacity/sanitization constraints eliminated an AM/PM split
+      - **Emily Baron** asked whether sibling cohorts would be aligned and whether there would be weekly reminders of which cohort is in session
+      - The committee discussed calendar flexibility, potential use of the 10 pre-opening professional development days, and concerns about transition to fully remote if necessary
+      - Approximately two-thirds of families surveyed prefer in-person; a majority of staff prefer hybrid
+      - The district plans listening sessions for staff (tomorrow 1–2 p.m.) and families (tomorrow 6–7 p.m. and Thursday sessions)
+      - A preliminary draft plan is due to DESE by Friday; final plan due August 10
+      - The website backtogethermhd.com is being updated in real time
+      
+      **Finance update (Business Manager Michelle):** The district has access to approximately $1.395 million in COVID-related funding:
+      - $454,725 set aside from a town CARES Act allocation of $1.8M
+      - $1,612 ESSER grant (spendable over two years)
+      - ~$680,175 school reopening/coronavirus funding grant (must be spent by December 31)
+      - $168,699 in the district operating budget COVID line
+      - A competitive remote learning technology essentials grant application is being prepared; matching requirement can be drawn from other grants
+    key_speakers: ["John (incoming Superintendent)", "Nan Murphy (Assistant Superintendent)", "Sarah Fox (Chair)", "Megan Taylor", "Emily Baron", "Michelle (Business Manager)"]
+  - topic: bonding-capital
+    topic_confidence: 0.7
+    start_seconds: 8831
+    end_seconds: 8873
+    headline: "Schedule of bills totaling approximately $486,000 approved unanimously"
+    dek: "The committee voted to approve a schedule of bills covering both FY20 and FY21 expenditures."
+    summary: "The committee moved and seconded approval of the identified schedule of bills totaling $486,460.27 (as stated by the chair). The motion passed 5-0."
+    key_speakers: ["Sarah Fox (Chair)", "Michelle (Business Manager)"]
+  - topic: admin-housekeeping
+    topic_confidence: 0.85
+    start_seconds: 8873
+    end_seconds: 9252
+    headline: "Committee awards one-year elevator maintenance contract to Embry Elevator for $51,400"
+    dek: "Following a competitive bid process with three respondents, the low bidder Embry Elevator of Woburn was selected; the contract includes two one-year extension options at the same rate."
+    summary: "The prior contract with City Elevator expired June 30. Three bids were received: City Elevator ($59,090), Embry Elevator ($51,400), and United Elevator Company ($57,710). Embry Elevator was the low bidder; references checked out favorably, including the business manager's prior experience with the firm. The contract is held jointly with the town; the Board of Selectmen will vote concurrently. The motion passed 4-0 (David Harris was absent)."
+    key_speakers: ["Michelle (Business Manager)", "Sarah Fox (Chair)", "Megan Taylor"]
+  - topic: admin-housekeeping
+    topic_confidence: 0.8
+    start_seconds: 9252
+    end_seconds: 9600
+    headline: "Committee accepts $3,004.75 in community donations to cover summer meal program shortfall"
+    dek: "Parent volunteer Samantha Rosado organized a GoFundMe and Venmo campaign; additional donors contributed existing student lunch account balances."
+    summary: "The estimated net cost of the summer meal program after state and federal reimbursement was approximately $2,900. Parent volunteer Samantha Rosado ran a fundraising campaign through GoFundMe, Venmo, and direct checks, and also accepted transfers of existing lunch account balances from other families, raising a total of $3,004.75. The motion to accept the donations passed 4-0. A formal thank-you note was noted as outstanding."
+    key_speakers: ["Michelle (Business Manager)", "Sarah Fox (Chair)"]
+  - topic: admin-housekeeping
+    topic_confidence: 0.75
+    start_seconds: 9600
+    end_seconds: 10120
+    headline: "Committee approves new district business card template and letterhead option 1, designed by high school art teacher"
+    dek: "Visual arts teacher Leah Bortieri designed two letterhead options and a business card; the committee selected the business card and letterhead option 1 (with a line beneath the header) unanimously."
+    summary: "The incoming superintendent requested new business cards and letterhead for central office staff. Visual arts teacher Leah Bortieri at Marblehead High School collaborated with the superintendent's office to create the designs, using an 'M with hat' logo. Two letterhead variations were presented (one with a horizontal rule below the header, one without); the committee preferred option 1 with the rule. Minor feedback included making the logo slightly larger and verifying cost differences for two-sided color printing on business cards. Both motions passed 4-0."
+    key_speakers: ["Sarah Fox (Chair)", "John (incoming Superintendent)", "Emily Baron", "Megan Taylor"]
+  - topic: admin-housekeeping
+    topic_confidence: 0.7
+    start_seconds: 10934
+    end_seconds: 11120
+    headline: "Committee schedules additional meeting Thursday August 6 at 7 p.m. to vote on DESE reopening plan submission"
+    dek: "A preliminary school reopening plan is due to DESE by Friday August 7; committee agreed to meet Thursday August 6 so any revisions can be incorporated before the deadline."
+    summary: "The DESE preliminary reopening plan deadline is Friday; the next previously scheduled meeting is Monday August 10. The committee agreed to hold an additional meeting Thursday August 6 at 7 p.m. to vote on the draft reopening plan before submission, allowing time for minor adjustments. The August 10 meeting will continue as a workshop-style session focused on broader community communication."
+    key_speakers: ["Sarah Fox (Chair)", "John (incoming Superintendent)"]
 ---
 
 > Transcript captured from YouTube auto-captioning. No speaker labels;

--- a/_transcripts/school-committee-2026-02-26.md
+++ b/_transcripts/school-committee-2026-02-26.md
@@ -9,7 +9,164 @@ video_url: "https://www.youtube.com/watch?v=Nd12oEz9BrM"
 duration_seconds: 10097
 ai_generated: true
 status: published
-source: youtube-auto
+source: youtube-auto+llm
+
+summary_card:
+  headline: "Marblehead School Committee holds FY27 budget public hearing on level-funded $49.1M proposal"
+  summary: "The Marblehead School Committee convened a public hearing on Superintendent John Ferrero's proposed FY27 budget of $49,120,285, equal to the current year appropriation. To reach that level-funded number, the district outlined approximately 9.75 teacher FTE reductions across multiple schools. Committee members, teachers, and community residents raised concerns about staffing impacts, the need for a Proposition 2½ override, and the structural deficit facing the district."
+  decisions:
+    - "Approved consent agenda including bills totaling approximately $1,413,617 and February 5, 2026 meeting minutes (4-0, one abstention)"
+    - "Approved motion to close public hearing on FY27 budget and reopen regular meeting (4-1)"
+    - "Approved entry into executive session for collective bargaining strategy and potential litigation (5-0)"
+  votes:
+    - motion: "Close open meeting and open FY27 budget public hearing"
+      result: "in favor (unanimous)"
+    - motion: "Close FY27 budget public hearing and reopen regular meeting"
+      result: "in favor (4 to 1)"
+    - motion: "Consent agenda (bills and meeting minutes)"
+      result: "in favor (4 to 0, one abstention)"
+    - motion: "Enter executive session for collective bargaining strategy and potential litigation"
+      result: "in favor (unanimous)"
+
+topic_segments:
+  - topic: admin-housekeeping
+    topic_confidence: 0.85
+    start_seconds: 33
+    end_seconds: 231
+    headline: "Meeting opens with commendations for custodial staff and MHS student updates"
+    dek: "A student representative highlighted Black History Month activities, an upcoming drama production, playoff sports, and eighth-grade step-up day."
+    summary: "The chair called the meeting to order at 6:03 p.m. on February 26, 2026. Commendations were offered to custodial and maintenance staff for their work clearing schools after a major snowstorm. A Marblehead High School student representative reported on Black History Month morning announcements, the drama club production of *The Mender* (admission $10), winter sports playoffs, an MHS sophomore competing at the All-States wrestling championship as the first girl from Marblehead to do so, and the upcoming eighth-grade step-up day."
+    key_speakers: ["Al Williams (Chair)", "MHS Student Representative"]
+  - topic: school-budget
+    topic_confidence: 0.98
+    start_seconds: 276
+    end_seconds: 9903
+    featured: true
+    headline: "School Committee holds FY27 budget public hearing on level-funded $49.1M proposal with 9.75 teacher FTE cuts"
+    dek: "Superintendent Ferrero presented a level-funded budget requiring staff reductions, and residents urged an override to avoid further cuts."
+    summary: |
+      ## FY27 Superintendent's Proposed Budget
+      
+      The School Committee opened a public hearing on the FY27 superintendent's proposed budget of **$49,120,285**, identical to the current year appropriation. Superintendent John Ferrero and Assistant Superintendent of Finance Michael Piling presented the budget and answered questions.
+      
+      ### Key Budget Drivers
+      
+      - **Negotiated salary increases**: 3% for FY27, 3.5% for FY28 already agreed under collective bargaining
+      - **Special education out-of-district tuition and transportation**: anticipated increase from approximately $6.1M (FY26 budgeted) to approximately $6.6M (FY27), an estimated 8.25% increase — described as a moving target
+      - A level-funded budget (same dollars as current year) **does not equal level services** because costs rise while revenue stays flat
+      
+      ### Reductions to Reach Level-Funded Number
+      
+      **Initial efficiencies already implemented:**
+      - Eliminated summer technology position (~$7,000–$8,000)
+      - Did not fill HR assistant position
+      - Removed teacher-in-charge stipend at Glover
+      - Reduced full-time art teacher to 0.8 FTE
+      - Reduced 1.75 EL teacher FTEs at Village (enrollment-based)
+      - Reduced 1.0 math intervention FTE at Vets
+      
+      **Additional reductions to close approximately $800,000 gap:**
+      
+      | Position | FTE |
+      |---|---|
+      | Elementary teacher | 1.0 |
+      | Teacher at Veterans Middle School | 1.0 |
+      | Teachers at high school | 3.0 |
+      | EL teacher at Glover | 0.4 |
+      | Elementary IIA | 1.0 |
+      | Speech and language | 0.4 |
+      | ABA coordinator (leadership role, not filled) | 1.0 |
+      | Special education teacher at Village | 1.0 |
+      | Maintenance staff | 1.0 |
+      | **Total teacher FTE reduction** | **−9.75** |
+      
+      ### Enrollment Context
+      
+      District enrollment fell from **3,144 students** (October 1, 2016) to **2,435 students** (February 2, 2026) — a 23% decline over approximately 10 years. The superintendent projected approximately **2,349 students** for the start of the 2026–27 school year. Over the same period, teacher FTEs fell from 263.9 to a projected 215.4, a 19% reduction — described as roughly proportionate.
+      
+      The superintendent noted enrollment decline is not unique to Marblehead; statewide enrollment fell by nearly 15,000 students since 2021 due to low birth rates, charter and private school competition, and demographic trends.
+      
+      ### Financial Reserves and Surplus Discussion
+      
+      Mike Piling explained that apparent year-end surpluses arise primarily from:
+      - Budgeting positions that go unfilled (e.g., the math intervention vacancy, worth roughly $75,000)
+      - The district's practice of **prepaying up to approximately $1 million in special education out-of-district tuitions** from year-end surpluses — described as the only legally permitted use of school department surpluses
+      - Utility savings and other underspending
+      
+      The district also draws on several **revolving accounts** (kindergarten/prek tuition, special education tuition, and the international student program) to offset salary costs, providing roughly two to three years of additional runway.
+      
+      A committee member noted the district is in a **structural deficit** and that all efficiencies described provide only short-term relief. A projected reduction in town revenue could require cutting the school appropriation below the current year for the first time in recent memory.
+      
+      ### Public Comment Highlights
+      
+      - **Sarah Matusa (MHS teacher, ~20 years)**: Expressed concern that cutting intervention positions (e.g., math interventionist) will cause at-risk students to slip through the cracks and increase special education referrals.
+      - **Samantha Rosado (resident)**: Called for a fully funded budget and a Proposition 2½ override, noting the last override was in fiscal year 2005 and that the prior level-funding in FY24 had serious consequences.
+      - **Mary (senior citizen/school volunteer)**: Urged broader outreach to senior residents (now approximately 23% of the population, roughly 1,100 more over-65 residents than 10 years ago) and recounted families leaving Marblehead schools following the teacher strike.
+      - **Molly (resident, Finance Committee vice chair)**: Described this as the most difficult budget season in her four years on FinCom and emphasized the importance of school-town collaboration.
+      - **Lee Blander (resident)**: Asked about projected September enrollment and student-teacher ratios; received the 2,349 projection and confirmation that the 11:1 staff-to-student ratio is in line with state averages (noting it includes all licensed staff, not just classroom teachers; average class size is approximately 19.7 K–6).
+      - **Amarie Jordan (virtual, retired educator)**: Encouraged community groups and PTOs to begin an organized public campaign if an override comes to ballot, recalling that grassroots canvassing was decisive in passing the last general override.
+      - **Melissa Theod (parent, district employee)**: Asked about enrollment recapture strategies; administration described earlier kindergarten enrollment outreach, improved high school transition events, and prek wait lists (Brown prek is full).
+      - **Cindy Tower Lohan (virtual)**: Asked all committee members whether they support more school funding; all members indicated support, though they noted the practical challenges of passing an override.
+      - **David Patton (virtual, taxpayer without children in schools)**: Asked about projected enrollment and class sizes; noted cuts might be reasonable if enrollment continues to decline.
+      - **Maggie Pelin (resident, school employee, parent)**: Raised the importance of language around students with disabilities and called for accurate public education about special education classification.
+      
+      ### Essex Tech / Charter School Funding
+      
+      Vocational school (Essex Tech) enrollment rose to approximately 27 Marblehead students this year, more than double the prior year, capped at 37. These costs are **not in the school department budget** — they are funded by the town side. Charter school costs are handled similarly. Both reduce Chapter 70 state aid indirectly.
+      
+      ### Override Discussion
+      
+      Multiple residents asked whether the committee will seek a Proposition 2½ override. Committee members confirmed:
+      - A **placeholder article is already on the town meeting warrant** for a general override
+      - No committee decision to proceed has been made
+      - Multiple overrides have failed since 2005 (most recently in 2023)
+      - The committee's next steps, including whether to bring a higher budget, will be deliberated at a future meeting before town meeting
+      
+      A committee member (Kate) disclosed she had held conversations with town officials about the budget situation, including the possibility that revenue projections could require cutting below the level-funded number; the chair clarified no authority to change the budget was delegated and that any changes must go through the full budget subcommittee and committee.
+    key_speakers: ["Al Williams (Chair)", "Superintendent John Ferrero", "Michael Piling (Assistant Superintendent of Finance)", "Julia Ferrer (Assistant Superintendent of Teaching and Learning)", "Lisa Marie Belo (Assistant Superintendent of Student Services)", "Jen (School Committee member)", "Kate (School Committee member)", "Melissa (School Committee member)", "Henry (School Committee member)", "Sarah Matusa (MHS teacher, public comment)", "Samantha Rosado (resident, public comment)", "Mary (resident/volunteer, public comment)", "Lee Blander (resident, public comment)", "Molly (Finance Committee vice chair, public comment)", "Amarie Jordan (virtual, retired educator, public comment)", "Cindy Tower Lohan (virtual, public comment)", "David Patton (virtual, taxpayer, public comment)", "Maggie Pelin (resident/district employee, public comment)"]
+  - topic: admin-housekeeping
+    topic_confidence: 0.88
+    start_seconds: 9009
+    end_seconds: 9549
+    headline: "Superintendent reports on AP research fair, international student film award, Spain/Morocco trip delay"
+    dek: "A student's lost passport delayed one traveler in Paris; all others expected home by February 27."
+    summary: |
+      Superintendent Ferrero provided district updates:
+      
+      - **School spotlights** featuring student voice will begin at the next meeting, with Glover and Veterans schools presenting.
+      - **AP Research Fair** scheduled for February 27 at MHS, featuring 16 student researchers.
+      - **International film contest**: Max Kane won an international award in the *Coming of Age in the Age of AI* competition (2,500+ entries globally); Georgio Batari was runner-up; Avery Sheridan received honorable mention.
+      - **Spain/Morocco trip**: Students were stranded in Paris for extra days due to a storm. The tour company absorbed hotel, flight change, and meal costs. One student misplaced a passport; an emergency passport meeting at the US embassy was scheduled for the morning, with all students expected home February 27.
+      - **METCO**: Katie Johnson, Marblehead's METCO director, was recognized by the METCO Directors Association.
+    key_speakers: ["Superintendent John Ferrero"]
+  - topic: admin-housekeeping
+    topic_confidence: 0.82
+    start_seconds: 9549
+    end_seconds: 9659
+    headline: "Committee reports on CPAC, communications newsletter, facility walkthroughs, and goals subcommittee"
+    dek: "Subcommittees reported on budget discussions with CPAC, a published newsletter, facility project updates, and strategic planning guidance from NASC."
+    summary: |
+      Committee members reported subcommittee activity:
+      
+      - **CPAC**: Met to discuss the budget; members asked what the committee was coalescing around — a level-funded or increased budget.
+      - **Communications subcommittee**: Published the school committee newsletter; working to expand circulation beyond the district email list.
+      - **Facilities subcommittee**: Discussed the MHS roof and Vets middle school roof projects (the latter on hold due to weather); scheduled building walkthroughs.
+      - **Goals subcommittee**: Met with Alicia Malin from NASC to discuss the school committee's role in strategic planning and the District Improvement Plan (DIP). Key takeaways: the committee should articulate direction, the superintendent determines how to get there; a public-facing summary of the DIP would be helpful; a DIP update is planned for a March meeting.
+    key_speakers: ["Jen (School Committee member)", "Melissa (School Committee member)", "Al Williams (Chair)"]
+  - topic: labor-personnel
+    topic_confidence: 0.95
+    start_seconds: 9659
+    end_seconds: 9960
+    headline: "Committee enters executive session for collective bargaining strategy and potential litigation"
+    dek: "The committee voted 5-0 to enter executive session covering MEA, therapy staff unions, and a potential litigation matter, without intent to return to open session."
+    summary: |
+      The chair called for and the committee approved (5-0) entry into executive session for two purposes:
+      
+      1. **Chapter 30A §21A(3), Purpose 3** — strategy for collective bargaining with the Marblehead Education Association, occupational therapists, physical therapists, board-certified behavior analysts, and related assistants/CNAs, because an open meeting may detrimentally affect the school committee's bargaining position.
+      2. **Chapter 30A §21A(3), Purpose 3** — strategy regarding potential litigation (J. Bucky matter), because an open meeting may detrimentally affect the school committee's litigating position.
+      
+      The chair declared no intent to return to open session.
+    key_speakers: ["Al Williams (Chair)", "Kate (School Committee member)", "Melissa (School Committee member)"]
 ---
 
 > Transcript captured from YouTube auto-captioning. No speaker labels;

--- a/data/vimeo_meetings.json
+++ b/data/vimeo_meetings.json
@@ -1,7 +1,7 @@
 {
-  "last_updated": "2026-07-02T11:51:44.066Z",
+  "last_updated": "2026-07-05T14:06:25.664Z",
   "channel_url": "https://vimeo.com/marbleheadtv",
-  "total_videos": 2819,
+  "total_videos": 2821,
   "meetings": [
     {
       "vimeo_id": "1205809868",

--- a/data/youtube_meetings.json
+++ b/data/youtube_meetings.json
@@ -1,178 +1,8 @@
 {
-  "last_updated": "2026-07-05T13:58:30.506Z",
+  "last_updated": "2026-07-05T14:07:30.413Z",
   "channel_url": "https://www.youtube.com/channel/UC3mmZuBmhKUJsXeWbqwFQJQ",
   "total_videos": 262,
   "meetings": [
-    {
-      "youtube_id": "gYE7TlHvW9o",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-06-23",
-      "date_approximate": true,
-      "duration_seconds": 2717,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "wAD-P3mGpq8",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-06-12",
-      "date_approximate": true,
-      "duration_seconds": 5823,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "hB3gXwRkCzo",
-      "title": "Goals Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-06-11",
-      "date_approximate": true,
-      "duration_seconds": 1290,
-      "raw_title": "Goals Subcommittee"
-    },
-    {
-      "youtube_id": "5HYGeWOE710",
-      "title": "MHS Roof Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-06-03",
-      "date_approximate": true,
-      "duration_seconds": 4558,
-      "raw_title": "MHS Roof Subcommittee"
-    },
-    {
-      "youtube_id": "fdEqLGNzELw",
-      "title": "Policy Subcommittee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-05-29",
-      "date_approximate": true,
-      "duration_seconds": 4415,
-      "raw_title": "Policy Subcommittee Meeting"
-    },
-    {
-      "youtube_id": "5zKYwpmxa7M",
-      "title": "Communications Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-05-28",
-      "date_approximate": true,
-      "duration_seconds": 950,
-      "raw_title": "Communications Subcommittee"
-    },
-    {
-      "youtube_id": "SKCehujHhcw",
-      "title": "Policy Subcommittee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-05-28",
-      "date_approximate": true,
-      "duration_seconds": 61,
-      "raw_title": "Policy Subcommittee Meeting"
-    },
-    {
-      "youtube_id": "RPJmPUs1OtI",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-05-22",
-      "date_approximate": true,
-      "duration_seconds": 8197,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "DGNrNkd3zrw",
-      "title": "Marblehead School Committee Facilities Subcommittee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-05-19",
-      "date_approximate": true,
-      "duration_seconds": 5266,
-      "raw_title": "Marblehead School Committee Facilities Subcommittee Meeting"
-    },
-    {
-      "youtube_id": "JBxGDFA5HRc",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-05-08",
-      "date_approximate": true,
-      "duration_seconds": 5846,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "_h3CUzblslc",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-05-01",
-      "date_approximate": true,
-      "duration_seconds": 5949,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "BzrU-4eQsSc",
-      "title": "Policy Subcommittee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-05-01",
-      "date_approximate": true,
-      "duration_seconds": 2712,
-      "raw_title": "Policy Subcommittee Meeting"
-    },
-    {
-      "youtube_id": "hD5wHlANirY",
-      "title": "Policy Subcommittee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-04-30",
-      "date_approximate": true,
-      "duration_seconds": 63,
-      "raw_title": "Policy Subcommittee Meeting"
-    },
-    {
-      "youtube_id": "1mXR3zTleAg",
-      "title": "School Committee Communications Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-04-16",
-      "date_approximate": true,
-      "duration_seconds": 1762,
-      "raw_title": "School Committee Communications Subcommittee"
-    },
-    {
-      "youtube_id": "ht7QyxvvV8c",
-      "title": "Marblehead School Committee Facilities Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-04-15",
-      "date_approximate": true,
-      "duration_seconds": 3627,
-      "raw_title": "Marblehead School Committee Facilities Subcommittee"
-    },
-    {
-      "youtube_id": "7DEKQ9QazQI",
-      "title": "Marblehead School Committee Facilities Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-04-14",
-      "date_approximate": true,
-      "duration_seconds": 62,
-      "raw_title": "Marblehead School Committee Facilities Subcommittee"
-    },
-    {
-      "youtube_id": "VFf_HUGS1o0",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-04-10",
-      "date_approximate": true,
-      "duration_seconds": 6952,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
     {
       "youtube_id": "UMABNnY3zeQ",
       "title": "Marblehead School Committee Meeting April 9, 2026",
@@ -184,76 +14,6 @@
       "raw_title": "Marblehead School Committee Meeting April 9, 2026"
     },
     {
-      "youtube_id": "pFVpojFNiT0",
-      "title": "MHS Roof Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-04-03",
-      "date_approximate": true,
-      "duration_seconds": 1763,
-      "raw_title": "MHS Roof Subcommittee"
-    },
-    {
-      "youtube_id": "6kHhwWjgRL0",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-03-28",
-      "date_approximate": true,
-      "duration_seconds": 3843,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "nRYkOciL6xo",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-03-20",
-      "date_approximate": true,
-      "duration_seconds": 8056,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "RZzfdBE_ask",
-      "title": "School Committee Facilities Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-03-17",
-      "date_approximate": true,
-      "duration_seconds": 2936,
-      "raw_title": "School Committee Facilities Subcommittee"
-    },
-    {
-      "youtube_id": "4veaOWi4IZg",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-03-13",
-      "date_approximate": true,
-      "duration_seconds": 6922,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "eod9JSODNHw",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-03-06",
-      "date_approximate": true,
-      "duration_seconds": 6362,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "k35-XI4LSok",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-02-27",
-      "date_approximate": true,
-      "duration_seconds": 8778,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
       "youtube_id": "Nd12oEz9BrM",
       "title": "Marblehead School Committee Meeting 2/26/26",
       "board_slug": "school-committee",
@@ -262,196 +22,6 @@
       "date_approximate": false,
       "duration_seconds": 10097,
       "raw_title": "Marblehead School Committee Meeting 2/26/26"
-    },
-    {
-      "youtube_id": "VCRLi_9RX_0",
-      "title": "School Committee Facilities Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-02-14",
-      "date_approximate": true,
-      "duration_seconds": 3497,
-      "raw_title": "School Committee Facilities Subcommittee"
-    },
-    {
-      "youtube_id": "xsoS-2Lt1Nw",
-      "title": "Marblehead School Committee Goals Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-02-14",
-      "date_approximate": true,
-      "duration_seconds": 2486,
-      "raw_title": "Marblehead School Committee Goals Subcommittee"
-    },
-    {
-      "youtube_id": "Dvou973usLI",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-02-06",
-      "date_approximate": true,
-      "duration_seconds": 6163,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "IyMgCaXShNo",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-01-30",
-      "date_approximate": true,
-      "duration_seconds": 4758,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "RDZ43aHKObE",
-      "title": "Marblehead School Committee Budget Subcommittee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-01-30",
-      "date_approximate": true,
-      "duration_seconds": 5608,
-      "raw_title": "Marblehead School Committee Budget Subcommittee Meeting"
-    },
-    {
-      "youtube_id": "azh5gUmyz54",
-      "title": "Policy Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-01-23",
-      "date_approximate": true,
-      "duration_seconds": 3243,
-      "raw_title": "Policy Subcommittee"
-    },
-    {
-      "youtube_id": "uccAc38CpfM",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-01-16",
-      "date_approximate": true,
-      "duration_seconds": 5503,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "oeyWw31z7sI",
-      "title": "Marblehead School Committee Budget Sub-Committee meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2026-01-06",
-      "date_approximate": true,
-      "duration_seconds": 3210,
-      "raw_title": "Marblehead School Committee Budget Sub-Committee meeting"
-    },
-    {
-      "youtube_id": "0iavxpBr4iY",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2025-12-19",
-      "date_approximate": true,
-      "duration_seconds": 13557,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "g3Y1PdO0xWE",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2025-12-05",
-      "date_approximate": true,
-      "duration_seconds": 7802,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "oMpolsuLl4I",
-      "title": "Policy Subcommittee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2025-12-05",
-      "date_approximate": true,
-      "duration_seconds": 1295,
-      "raw_title": "Policy Subcommittee Meeting"
-    },
-    {
-      "youtube_id": "wpU6oFPNz-4",
-      "title": "School Committee Facilities Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2025-12-03",
-      "date_approximate": true,
-      "duration_seconds": 4423,
-      "raw_title": "School Committee Facilities Subcommittee"
-    },
-    {
-      "youtube_id": "OHSv9NM_A4o",
-      "title": "School Committee Communications Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2025-12-02",
-      "date_approximate": true,
-      "duration_seconds": 942,
-      "raw_title": "School Committee Communications Subcommittee"
-    },
-    {
-      "youtube_id": "mNoyNUVy9hA",
-      "title": "Marblehead School Committee Budget Sub-Committee/FinCom School Liaisons Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2025-12-02",
-      "date_approximate": true,
-      "duration_seconds": 6971,
-      "raw_title": "Marblehead School Committee Budget Sub-Committee/FinCom School Liaisons Subcommittee"
-    },
-    {
-      "youtube_id": "bYXk5p5cE8k",
-      "title": "Marblehead School Committee Budget Sub-Committee/FinCom School Liaisons Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2025-12-01",
-      "date_approximate": true,
-      "duration_seconds": 31,
-      "raw_title": "Marblehead School Committee Budget Sub-Committee/FinCom School Liaisons Subcommittee"
-    },
-    {
-      "youtube_id": "Ct6jpfRy61A",
-      "title": "Marblehead School Committee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2025-11-21",
-      "date_approximate": true,
-      "duration_seconds": 7123,
-      "raw_title": "Marblehead School Committee Meeting"
-    },
-    {
-      "youtube_id": "nkL-q6MRxh4",
-      "title": "Policy Subcommittee Meeting",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2025-11-21",
-      "date_approximate": true,
-      "duration_seconds": 5391,
-      "raw_title": "Policy Subcommittee Meeting"
-    },
-    {
-      "youtube_id": "bUIqHbW61sk",
-      "title": "School Committee MHS Roof Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2025-11-19",
-      "date_approximate": true,
-      "duration_seconds": 2456,
-      "raw_title": "School Committee MHS Roof Subcommittee"
-    },
-    {
-      "youtube_id": "2eCG4KFj1fA",
-      "title": "Marblehead School Committee Budget Sub-committee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2025-11-18",
-      "date_approximate": true,
-      "duration_seconds": 6117,
-      "raw_title": "Marblehead School Committee Budget Sub-committee"
     },
     {
       "youtube_id": "W0u8H9YWpnY",
@@ -1634,16 +1204,6 @@
       "raw_title": "2/6/23 Budget Subcommittee"
     },
     {
-      "youtube_id": "C2kdQzHY31E",
-      "title": "Facilities Subcommittee",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2023-01-14",
-      "date_approximate": true,
-      "duration_seconds": 3657,
-      "raw_title": "Facilities Subcommittee"
-    },
-    {
       "youtube_id": "Ug7oA_6BhyE",
       "title": "1/5/2023 school committee",
       "board_slug": "school-committee",
@@ -1652,16 +1212,6 @@
       "date_approximate": false,
       "duration_seconds": 6862,
       "raw_title": "1/5/2023 school committee"
-    },
-    {
-      "youtube_id": "RmmtG0G_g_4",
-      "title": "Budget Subcommittee-Joint with Town",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2022-12-20",
-      "date_approximate": true,
-      "duration_seconds": 3504,
-      "raw_title": "Budget Subcommittee-Joint with Town"
     },
     {
       "youtube_id": "Re0sSoonjec",
@@ -1714,16 +1264,6 @@
       "raw_title": "10.20.2022 SC Meet"
     },
     {
-      "youtube_id": "SFjO9WXDyTM",
-      "title": "School Committee-Budget Priorities Workshop",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2022-10-14",
-      "date_approximate": true,
-      "duration_seconds": 5340,
-      "raw_title": "School Committee-Budget Priorities Workshop"
-    },
-    {
       "youtube_id": "pTapgkwHOYA",
       "title": "10.6.2022 SC Meet",
       "board_slug": "school-committee",
@@ -1752,26 +1292,6 @@
       "date_approximate": false,
       "duration_seconds": 9935,
       "raw_title": "9.7.2022 SC Meet"
-    },
-    {
-      "youtube_id": "g1Mdut5d9qY",
-      "title": "S C  Meeting 04 28 20221",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2022-09-06",
-      "date_approximate": true,
-      "duration_seconds": 7398,
-      "raw_title": "S C  Meeting 04 28 20221"
-    },
-    {
-      "youtube_id": "9f_ugoZLxIk",
-      "title": "S C  04 07 20221",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2022-09-06",
-      "date_approximate": true,
-      "duration_seconds": 8742,
-      "raw_title": "S C  04 07 20221"
     },
     {
       "youtube_id": "fXkNwPFhAoA",
@@ -1842,76 +1362,6 @@
       "date_approximate": false,
       "duration_seconds": 2920,
       "raw_title": "S C  Meeting 5 05 2022"
-    },
-    {
-      "youtube_id": "FNrERBH1aBM",
-      "title": "Sarah Gold she her hers's Personal Meeting Room 2",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2022-04-12",
-      "date_approximate": true,
-      "duration_seconds": 5165,
-      "raw_title": "Sarah Gold she her hers's Personal Meeting Room 2"
-    },
-    {
-      "youtube_id": "5FuO1q0Rv3c",
-      "title": "Sarah Gold she her hers's Personal Meeting Room",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2022-04-12",
-      "date_approximate": true,
-      "duration_seconds": 8064,
-      "raw_title": "Sarah Gold she her hers's Personal Meeting Room"
-    },
-    {
-      "youtube_id": "0QtY4_U5MKs",
-      "title": "Sarah Gold she her hers's Personal Meeting Room 3",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2022-04-12",
-      "date_approximate": true,
-      "duration_seconds": 6177,
-      "raw_title": "Sarah Gold she her hers's Personal Meeting Room 3"
-    },
-    {
-      "youtube_id": "PhyUhBpn8T8",
-      "title": "School Committee   9 23 20201",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2022-04-12",
-      "date_approximate": true,
-      "duration_seconds": 7017,
-      "raw_title": "School Committee   9 23 20201"
-    },
-    {
-      "youtube_id": "qiq_XKRQ6mQ",
-      "title": "Sarah Gold she her hers's Personal Meeting Room 1",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2022-04-12",
-      "date_approximate": true,
-      "duration_seconds": 7358,
-      "raw_title": "Sarah Gold she her hers's Personal Meeting Room 1"
-    },
-    {
-      "youtube_id": "gfeuys2T-nE",
-      "title": "School Committee   9 2 20201",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2022-04-12",
-      "date_approximate": true,
-      "duration_seconds": 7960,
-      "raw_title": "School Committee   9 2 20201"
-    },
-    {
-      "youtube_id": "AT9P2Gs2ZJo",
-      "title": "School Committee   10 7 20201",
-      "board_slug": "school-committee",
-      "board_display": "School Committee",
-      "date": "2022-04-12",
-      "date_approximate": true,
-      "duration_seconds": 8652,
-      "raw_title": "School Committee   10 7 20201"
     },
     {
       "youtube_id": "D8CvAq70TZU",
@@ -2501,9 +1951,269 @@
       "reason": "not a board meeting"
     },
     {
+      "youtube_id": "g1Mdut5d9qY",
+      "raw_title": "S C  Meeting 04 28 20221",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "9f_ugoZLxIk",
+      "raw_title": "S C  04 07 20221",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
       "youtube_id": "9VPdK2Nj5RY",
       "raw_title": "Budget Vote Apr 8, 2021",
       "reason": "not a board meeting"
+    },
+    {
+      "youtube_id": "FNrERBH1aBM",
+      "raw_title": "Sarah Gold she her hers's Personal Meeting Room 2",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "5FuO1q0Rv3c",
+      "raw_title": "Sarah Gold she her hers's Personal Meeting Room",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "0QtY4_U5MKs",
+      "raw_title": "Sarah Gold she her hers's Personal Meeting Room 3",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "PhyUhBpn8T8",
+      "raw_title": "School Committee   9 23 20201",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "qiq_XKRQ6mQ",
+      "raw_title": "Sarah Gold she her hers's Personal Meeting Room 1",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "gfeuys2T-nE",
+      "raw_title": "School Committee   9 2 20201",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "AT9P2Gs2ZJo",
+      "raw_title": "School Committee   10 7 20201",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "gYE7TlHvW9o",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "wAD-P3mGpq8",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "hB3gXwRkCzo",
+      "raw_title": "Goals Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "5HYGeWOE710",
+      "raw_title": "MHS Roof Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "5zKYwpmxa7M",
+      "raw_title": "Communications Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "fdEqLGNzELw",
+      "raw_title": "Policy Subcommittee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "SKCehujHhcw",
+      "raw_title": "Policy Subcommittee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "RPJmPUs1OtI",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "DGNrNkd3zrw",
+      "raw_title": "Marblehead School Committee Facilities Subcommittee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "JBxGDFA5HRc",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "_h3CUzblslc",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "BzrU-4eQsSc",
+      "raw_title": "Policy Subcommittee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "hD5wHlANirY",
+      "raw_title": "Policy Subcommittee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "1mXR3zTleAg",
+      "raw_title": "School Committee Communications Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "ht7QyxvvV8c",
+      "raw_title": "Marblehead School Committee Facilities Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "7DEKQ9QazQI",
+      "raw_title": "Marblehead School Committee Facilities Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "VFf_HUGS1o0",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "pFVpojFNiT0",
+      "raw_title": "MHS Roof Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "6kHhwWjgRL0",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "nRYkOciL6xo",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "RZzfdBE_ask",
+      "raw_title": "School Committee Facilities Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "4veaOWi4IZg",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "eod9JSODNHw",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "k35-XI4LSok",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "VCRLi_9RX_0",
+      "raw_title": "School Committee Facilities Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "xsoS-2Lt1Nw",
+      "raw_title": "Marblehead School Committee Goals Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "Dvou973usLI",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "IyMgCaXShNo",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "RDZ43aHKObE",
+      "raw_title": "Marblehead School Committee Budget Subcommittee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "azh5gUmyz54",
+      "raw_title": "Policy Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "uccAc38CpfM",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "oeyWw31z7sI",
+      "raw_title": "Marblehead School Committee Budget Sub-Committee meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "0iavxpBr4iY",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "g3Y1PdO0xWE",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "oMpolsuLl4I",
+      "raw_title": "Policy Subcommittee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "OHSv9NM_A4o",
+      "raw_title": "School Committee Communications Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "wpU6oFPNz-4",
+      "raw_title": "School Committee Facilities Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "mNoyNUVy9hA",
+      "raw_title": "Marblehead School Committee Budget Sub-Committee/FinCom School Liaisons Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "bYXk5p5cE8k",
+      "raw_title": "Marblehead School Committee Budget Sub-Committee/FinCom School Liaisons Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "Ct6jpfRy61A",
+      "raw_title": "Marblehead School Committee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "nkL-q6MRxh4",
+      "raw_title": "Policy Subcommittee Meeting",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "bUIqHbW61sk",
+      "raw_title": "School Committee MHS Roof Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "2eCG4KFj1fA",
+      "raw_title": "Marblehead School Committee Budget Sub-committee",
+      "reason": "no date in title; upload_date fetch failed"
     },
     {
       "youtube_id": "93BPFsoQ7DY",
@@ -2546,6 +2256,16 @@
       "reason": "not a board meeting"
     },
     {
+      "youtube_id": "C2kdQzHY31E",
+      "raw_title": "Facilities Subcommittee",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
+      "youtube_id": "RmmtG0G_g_4",
+      "raw_title": "Budget Subcommittee-Joint with Town",
+      "reason": "no date in title; upload_date fetch failed"
+    },
+    {
       "youtube_id": "Y8VFCOfajV8",
       "raw_title": "11.10.2022 Finance and Budget Forum",
       "reason": "not a board meeting"
@@ -2554,6 +2274,11 @@
       "youtube_id": "4v4rJFsInS0",
       "raw_title": "11.10.2022 Finance and Budget Forum",
       "reason": "not a board meeting"
+    },
+    {
+      "youtube_id": "SFjO9WXDyTM",
+      "raw_title": "School Committee-Budget Priorities Workshop",
+      "reason": "no date in title; upload_date fetch failed"
     }
   ]
 }


### PR DESCRIPTION
Daily auto-ingest of MHTV meeting transcripts.

**Newly added `_transcripts/` files:**

```

```

**Pipeline:**
1. `scripts/transcripts/pull_vimeo.mjs` refreshed the Vimeo channel index.
2. `scripts/transcripts/backfill_auto.mjs` downloaded the `en-x-autogen` VTT for each new meeting and wrote the stub markdown.
3. `scripts/transcripts/enrich_one.mjs` added `summary_card` + `topic_segments` to each.

Auto-merge is enabled. The PR will land as soon as the required checks (smoke, Secret scan, Content guardrails) pass. If a check fails, this PR stays open for inspection and the next daily run is skipped (gated on the `auto-meetings` label) so the failure does not get buried.
