### PR TITLE
Cap per-run LLM enrichment at 25 transcripts

### DIFF
--- a/.github/workflows/ingest-meetings.yml
+++ b/.github/workflows/ingest-meetings.yml
@@ -119,7 +119,17 @@ jobs:
           shopt -s nullglob
           enriched=0
           failed=0
+          # Cap per-run enrichment. A large unenriched backlog (e.g. the 134
+          # transcripts from the YouTube backfill) would otherwise exceed the
+          # 30-minute job timeout, the job would die before the commit step,
+          # and the next run would re-enrich from scratch: repeated API spend
+          # with no progress. Capped, each daily run commits what it finished.
+          cap=25
           for f in _transcripts/*.md; do
+            if [ "$enriched" -ge "$cap" ]; then
+              echo "Per-run enrichment cap ($cap) reached; the rest continue tomorrow."
+              break
+            fi
             # Already enriched on a previous run.
             if grep -q '^summary_card:' "$f"; then continue; fi
             # Hand-crafted entries (frontmatter starts with `ingest:`) are


### PR DESCRIPTION
## Summary
- The ingest workflow's enrichment loop now stops after 25 successful enrichments per run. Without a cap, the 134 unenriched transcripts arriving in #969 would blow the 30-minute job timeout; the job would die before committing, and every subsequent run would re-enrich the same files from scratch (repeated API spend, zero progress).
- Failures don't consume the cap, so a single bad transcript can't stall the queue.
- Should merge before #969 so the first post-backfill daily run is already capped.

## Test plan
- [x] Bash logic reviewed; no untrusted input in run block
- [ ] After #969 merges, daily run logs should show "Per-run enrichment cap (25) reached" until the queue drains (~6 days), each run committing its 25

🤖 Generated with [Claude Code](https://claude.com/claude-code)