### PR TITLE
Subscribe links on tracker + contracts pages; Friday->Monday copy fix

### DIFF
--- a/_layouts/transcript.html
+++ b/_layouts/transcript.html
@@ -45,7 +45,7 @@ Vimeo-sourced transcripts predate that field and only have `vimeo_url`.
     <aside class="ms-subscribe" aria-label="Subscribe to meeting summaries">
       <div class="ms-subscribe-copy">
         <p class="ms-subscribe-lead"><strong>Get this in your inbox.</strong></p>
-        <p class="ms-subscribe-body">A Friday digest of meetings that match the boards and topics you care about.</p>
+        <p class="ms-subscribe-body">A Monday digest of meetings that match the boards and topics you care about.</p>
       </div>
       <a class="ms-subscribe-btn" href="{{ '/subscribe/' | relative_url }}">
         Subscribe&nbsp;&rarr;

--- a/labor-contracts.html
+++ b/labor-contracts.html
@@ -341,6 +341,8 @@ scripts: [citations]
     tracker</a> follows the commitments; this page follows the contracts.
     Both update as documents surface, and both link the sources so you can
     check the math. Meeting coverage of the negotiating boards is at
-    <a href="/meetings/">meetings and transcripts</a>.
+    <a href="/meetings/">meetings and transcripts</a>, and the
+    <a href="/subscribe/">Monday email digest</a> flags those meetings as
+    they happen.
   </p>
 </section>

--- a/override-tracker.html
+++ b/override-tracker.html
@@ -389,7 +389,7 @@ scripts: [citations]
 <section class="tk-stop">
   <p class="tk-eye">Quarterly checkpoint</p>
   <h2 class="tk-section-h2">First check-in: early October 2026.</h2>
-  <p class="tk-section-lead">Under the MOU and the June 10 Select Board commitment, the first joint financial review with the School Committee and Finance Committee is scheduled for the first weeks of October, after the close of Q1. This section updates after each quarterly meeting with what changed on the list above.</p>
+  <p class="tk-section-lead">Under the MOU and the June 10 Select Board commitment, the first joint financial review with the School Committee and Finance Committee is scheduled for the first weeks of October, after the close of Q1. This section updates after each quarterly meeting with what changed on the list above. The <a href="/subscribe/">Monday email digest</a> covers those meetings when they happen.</p>
 
   {% assign log = site.data.override_tracker.changelog %}
   {% if log.size > 0 %}


### PR DESCRIPTION
## Summary
- The override tracker's quarterly-checkpoint section and the labor-contracts closing paragraph both promise ongoing updates; each now links /subscribe/ so readers know how to hear about them.
- Transcript-page subscribe CTA said "A Friday digest" but the worker cron sends Monday 7am ET; copy corrected.

## Test plan
- [x] `npm run test:local`: 118 passed, 0 failed
- [ ] Eyeball preview: links render inline, register matches surrounding copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)